### PR TITLE
Update CLAUDE.md to reflect 164 commands, 47 source files, ~31,300 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ This file provides guidance for AI assistants (Claude Code, etc.) working in thi
 
 ### Quick Stats
 
-- **44 source files** (43 C# + 1 XAML, ~25,400 lines of code) across 8 directories
-- **144 `IExternalCommand` classes** (commands) + 1 `IExternalApplication` entry point + 1 `IExternalEventHandler` + 1 `IDockablePaneProvider`
-- **15 runtime data files** (CSV, JSON, TXT, XLSX, PY)
+- **47 source files** (46 C# + 1 XAML, ~31,300 lines of code) across 8 directories
+- **164 `IExternalCommand` classes** (commands) + 1 `IExternalApplication` entry point + 1 `IExternalEventHandler` + 1 `IDockablePaneProvider`
+- **16 runtime data files** (CSV, JSON, TXT, XLSX, PY)
 - **6 ribbon panels** with 23 pulldown groups + 1 WPF dockable panel
 
 ## Technology Stack
@@ -37,9 +37,10 @@ STINGTOOLS/
     ├── Properties/
     │   └── AssemblyInfo.cs             # Assembly metadata (v1.0.0.0)
     │
-    ├── Core/                           # Shared infrastructure (5 files, ~3,441 lines)
+    ├── Core/                           # Shared infrastructure (6 files, ~4,416 lines)
     │   ├── StingToolsApp.cs            # IExternalApplication — ribbon UI + dockable panel registration + ToggleDockPanelCommand
     │   ├── StingLog.cs                 # Thread-safe file logger (Info/Warn/Error)
+    │   ├── ParamRegistry.cs            # Single source of truth for parameter names, GUIDs, containers, bindings (loads from PARAMETER_REGISTRY.json)
     │   ├── ParameterHelpers.cs         # Parameter read/write + SpatialAutoDetect + NativeParamMapper
     │   ├── SharedParamGuids.cs         # GUID map for 200+ shared parameters
     │   └── TagConfig.cs               # ISO 19650 tag lookup tables, tag builder, TagIntelligence
@@ -52,7 +53,7 @@ STINGTOOLS/
     ├── UI/                             # WPF dockable panel UI (3 C# files + 1 XAML, ~2,913 lines)
     │   ├── StingDockPanel.xaml         # WPF markup for 4-tab dockable panel (SELECT/ORGANISE/CREATE/VIEW)
     │   ├── StingDockPanel.xaml.cs      # Code-behind: button dispatch, colour swatches, status bar
-    │   ├── StingCommandHandler.cs      # IExternalEventHandler — dispatches 140+ button tags to command classes
+    │   ├── StingCommandHandler.cs      # IExternalEventHandler — dispatches 160+ button tags to command classes
     │   └── StingDockPanelProvider.cs   # IDockablePaneProvider — registers panel with Revit
     │
     ├── Docs/                           # Documentation commands (7 files, 17 commands)
@@ -64,23 +65,25 @@ STINGTOOLS/
     │   ├── DocAutomationCommands.cs    # DeleteUnusedViews, SheetNamingCheck, AutoNumberSheets
     │   └── ViewAutomationCommands.cs   # DuplicateView, BatchRename, CopySettings, AutoPlace, Crop, BatchAlign
     │
-    ├── Tags/                           # Tagging commands (12 files, 22 commands)
+    ├── Tags/                           # Tagging commands (14 files, 35 commands)
     │   ├── AutoTagCommand.cs           # Tag elements in active view + TagNewOnly
     │   ├── BatchTagCommand.cs          # Tag all elements in project
     │   ├── TagAndCombineCommand.cs     # One-click: populate + tag + combine all
     │   ├── PreTagAuditCommand.cs       # Dry-run audit: predict tags, collisions, ISO violations
     │   ├── FamilyStagePopulateCommand.cs # Pre-populate all 7 tokens before tagging
-    │   ├── CombineParametersCommand.cs # Interactive multi-container combine (16 groups, 36 params)
+    │   ├── CombineParametersCommand.cs # Interactive multi-container combine + CombinePreFlight
     │   ├── ConfigEditorCommand.cs      # View/edit/save project_config.json
     │   ├── TagConfigCommand.cs         # Display tag configuration
     │   ├── LoadSharedParamsCommand.cs   # Bind shared parameters (2-pass)
     │   ├── TokenWriterCommands.cs      # SetDisc, SetLoc, SetZone, SetStatus, AssignNumbers,
     │   │                               #   BuildTags, CompletenessDashboard + TokenWriter helper
     │   ├── ValidateTagsCommand.cs      # Validate tag completeness with ISO 19650 codes
-    │   └── SmartTagPlacementCommand.cs # 4 smart annotation commands + TagPlacementEngine (collision avoidance)
+    │   ├── SmartTagPlacementCommand.cs # 9 smart annotation commands + TagPlacementEngine (collision avoidance, templates, text/leader controls)
+    │   ├── TagFamilyCreatorCommand.cs  # 4 tag family commands: Create, Load, Configure Labels, Audit + TagFamilyConfig
+    │   └── SyncParameterSchemaCommand.cs # 3 schema commands: Sync, AddParamRemap, Audit + ParamRegistry propagation
     │
-    ├── Organise/                       # Tag management commands (1 file, 31 commands)
-    │   └── TagOperationCommands.cs     # Tag Ops (7), Leaders (12), Analysis (7), Annotation Color (5) + LeaderHelper
+    ├── Organise/                       # Tag management commands (1 file, 38 commands)
+    │   └── TagOperationCommands.cs     # Tag Ops (7), Leaders (13), Analysis (4), Annotation Color (5), Tag Appearance (7), Tag Type (1) + LeaderHelper
     │
     ├── Temp/                           # Template commands (11 files, 45 commands)
     │   ├── CreateParametersCommand.cs  # Delegates to LoadSharedParams
@@ -96,7 +99,7 @@ STINGTOOLS/
     │   ├── TemplateManagerCommands.cs  # 17 template intelligence commands + TemplateManager engine (3,393 lines)
     │   └── DataPipelineCommands.cs     # ValidateTemplate (45 checks), DynamicBindings, SchemaValidate
     │
-    └── Data/                           # Runtime data files
+    └── Data/                           # Runtime data files (16 files)
         ├── BLE_MATERIALS.csv           # 815 building-element materials
         ├── MEP_MATERIALS.csv           # 464 MEP materials
         ├── MR_PARAMETERS.txt           # Shared parameter file (200+ params)
@@ -109,6 +112,7 @@ STINGTOOLS/
         ├── CATEGORY_BINDINGS.csv       # 10,661 category bindings
         ├── FAMILY_PARAMETER_BINDINGS.csv   # 4,686 family bindings
         ├── PARAMETER__CATEGORIES.csv   # Parameter-category cross-reference
+        ├── PARAMETER_REGISTRY.json     # Master parameter registry (v3.0) — single source of truth for ParamRegistry.cs
         ├── PYREVIT_SCRIPT_MANIFEST.csv # Legacy pyRevit script manifest
         ├── TAG_GUIDE.xlsx              # Tag reference guide
         └── VALIDAT_BIM_TEMPLATE.py     # BIM template validation (45 checks)
@@ -211,15 +215,35 @@ STINGTOOLS/
 | Clear Overrides | `Organise.ClearOverridesCommand` | Manual | Reset graphic overrides in active view |
 | Completeness Dashboard | `Tags.CompletenessDashboardCommand` | ReadOnly | Per-discipline compliance dashboard with percentage |
 
-**Smart Tag Placement pulldown (4 commands — NEW):**
+**Smart Tag Placement pulldown (9 commands):**
 | Command | Class | Transaction | Description |
 |---------|-------|-------------|-------------|
 | Smart Place Tags | `Tags.SmartPlaceTagsCommand` | Manual | Priority-based `IndependentTag` placement with 8-position collision avoidance |
 | Arrange Tags | `Tags.ArrangeTagsCommand` | Manual | Auto-arrange placed tags into aligned grid patterns |
 | Remove Annotation Tags | `Tags.RemoveAnnotationTagsCommand` | Manual | Remove all `IndependentTag` annotations from view |
 | Batch Place Tags | `Tags.BatchPlaceTagsCommand` | Manual | Place visual annotation tags across multiple views |
+| Learn Tag Placement | `Tags.LearnTagPlacementCommand` | ReadOnly | Analyze existing tag placements and learn preferred positions per category |
+| Apply Tag Template | `Tags.ApplyTagTemplateCommand` | Manual | Apply learned tag placement template to new views |
+| Tag Overlap Analysis | `Tags.TagOverlapAnalysisCommand` | ReadOnly | Analyze and report tag overlap/collision issues in view |
+| Batch Tag Text Size | `Tags.BatchTagTextSizeCommand` | Manual | Batch-modify tag text size across views |
+| Set Tag Category Line Weight | `Tags.SetTagCategoryLineWeightCommand` | Manual | Set line weights for tag annotations by category |
 
-### Organise Panel (4 pulldowns: Tag Ops + Leaders + Analysis + Annotation Color)
+**Tag Family pulldown (4 commands):**
+| Command | Class | Transaction | Description |
+|---------|-------|-------------|-------------|
+| Create Tag Families | `Tags.CreateTagFamiliesCommand` | Manual | Programmatically create STING tag families for 50 categories from Revit templates |
+| Load Tag Families | `Tags.LoadTagFamiliesCommand` | Manual | Batch-load STING tag family .rfa files from Data/TagFamilies/ |
+| Configure Tag Labels | `Tags.ConfigureTagLabelsCommand` | Manual | Guided wizard to configure Label parameters in tag families (works around Revit API limitation) |
+| Audit Tag Families | `Tags.AuditTagFamiliesCommand` | ReadOnly | Audit tag family coverage across all 50 taggable categories |
+
+**Parameter Schema pulldown (3 commands):**
+| Command | Class | Transaction | Description |
+|---------|-------|-------------|-------------|
+| Sync Parameter Schema | `Tags.SyncParameterSchemaCommand` | ReadOnly | Propagate PARAMETER_REGISTRY.json changes to CSV/TXT data files |
+| Add Param Remap | `Tags.AddParamRemapCommand` | ReadOnly | Generate remap entry template for SCHEDULE_FIELD_REMAP.csv |
+| Audit Parameter Schema | `Tags.AuditParameterSchemaCommand` | ReadOnly | Registry health dashboard: token/container/GUID counts, CSV cross-validation |
+
+### Organise Panel (6 pulldowns: Tag Ops + Leaders + Analysis + Annotation Color + Tag Appearance + Tag Type)
 **Tag Ops pulldown (7 commands):**
 | Command | Class | Transaction | Description |
 |---------|-------|-------------|-------------|
@@ -231,7 +255,7 @@ STINGTOOLS/
 | Re-Tag | `Organise.ReTagCommand` | Manual | Force re-derive and overwrite all tag tokens on selected elements |
 | Fix Duplicates | `Organise.FixDuplicateTagsCommand` | Manual | Auto-resolve duplicate tags by incrementing SEQ numbers |
 
-**Leaders pulldown (12 commands):**
+**Leaders pulldown (13 commands):**
 | Command | Class | Transaction | Description |
 |---------|-------|-------------|-------------|
 | Toggle Leaders | `Organise.ToggleLeadersCommand` | Manual | Toggle leaders on/off for selected tags (or all tags in view) |
@@ -244,6 +268,7 @@ STINGTOOLS/
 | Flip Tags | `Organise.FlipTagsCommand` | Manual | Mirror tag position across element center (left/right, up/down) |
 | Align Tag Text | `Organise.AlignTagTextCommand` | Manual | Align annotation text (left/center/right) for tags and text notes |
 | Pin/Unpin Tags | `Organise.PinTagsCommand` | Manual | Lock tags in place to prevent accidental movement (or unlock) |
+| Nudge Tags | `Organise.NudgeTagsCommand` | Manual | Directional tag nudging (up/down/left/right) with configurable distance |
 | Attach/Free Leader | `Organise.AttachLeaderCommand` | Manual | Attach leader end to host element or set free |
 | Select Tags By Leader | `Organise.SelectTagsWithLeadersCommand` | ReadOnly | Select tags with or without leaders in active view |
 
@@ -255,7 +280,7 @@ STINGTOOLS/
 | Tag Statistics | `Organise.TagStatsCommand` | ReadOnly | Quick tag counts by discipline/system/level for active view |
 | Tag Register Export | `Organise.TagRegisterExportCommand` | ReadOnly | Comprehensive asset register export (40+ columns: tags, identity, spatial, MEP, cost, validation) |
 
-**Annotation Color pulldown (5 commands — NEW):**
+**Annotation Color pulldown (7 commands):**
 | Command | Class | Transaction | Description |
 |---------|-------|-------------|-------------|
 | Color Tags by Discipline | `Organise.ColorTagsByDisciplineCommand` | Manual | Colour-code annotation tags by discipline |
@@ -263,6 +288,16 @@ STINGTOOLS/
 | Set Leader Color | `Organise.SetLeaderColorCommand` | Manual | Set leader line color for selected tags |
 | Split Tag/Leader Color | `Organise.SplitTagLeaderColorCommand` | Manual | Apply different colors to leader vs tag text |
 | Clear Annotation Colors | `Organise.ClearAnnotationColorsCommand` | Manual | Clear all annotation color overrides in view |
+| Color Tags by Parameter | `Organise.ColorTagsByParameterCommand` | Manual | Colour-code annotation tags by any parameter value |
+| Swap Tag Type | `Organise.SwapTagTypeCommand` | Manual | Swap tag annotation family/type on selected tags |
+
+**Tag Appearance pulldown (4 commands):**
+| Command | Class | Transaction | Description |
+|---------|-------|-------------|-------------|
+| Tag Appearance | `Organise.TagAppearanceCommand` | Manual | Granular tag appearance control (border, fill, text size) |
+| Set Tag Box Appearance | `Organise.SetTagBoxAppearanceCommand` | Manual | Configure tag box border and background |
+| Quick Tag Style | `Organise.QuickTagStyleCommand` | Manual | Apply preset tag styles (Standard, Minimal, Bold, etc.) |
+| Set Tag Line Weight | `Organise.SetTagLineWeightCommand` | Manual | Set line weight for tag annotation borders |
 
 ### Temp Panel (8 pulldown groups, 45 commands)
 | Group | Commands | Description |
@@ -286,8 +321,9 @@ STINGTOOLS/
 | File | Commands | Lines |
 |------|----------|-------|
 | `Core/StingToolsApp.cs` | 1 (ToggleDockPanelCommand) + IExternalApplication | 201 |
+| `Core/ParamRegistry.cs` | 0 (parameter registry infrastructure) | 860 |
 | `Select/CategorySelectCommands.cs` | 15 (14 category selectors + SelectAllTaggable) | 168 |
-| `Select/StateSelectCommands.cs` | 8 (5 state + 2 spatial + BulkParamWrite) | 407 |
+| `Select/StateSelectCommands.cs` | 8 (5 state + 2 spatial + BulkParamWrite) | 538 |
 | `Select/ColorCommands.cs` | 5 (ColorByParameter, ClearOverrides, SavePreset, LoadPreset, CreateFilters) + ColorHelper | 863 |
 | `Docs/SheetOrganizerCommand.cs` | 1 | 100 |
 | `Docs/ViewOrganizerCommand.cs` | 1 | 91 |
@@ -296,35 +332,37 @@ STINGTOOLS/
 | `Docs/ViewportCommands.cs` | 4 (Align, Renumber, TextCase, SumAreas) | 304 |
 | `Docs/DocAutomationCommands.cs` | 3 (DeleteUnusedViews, SheetNamingCheck, AutoNumberSheets) | 436 |
 | `Docs/ViewAutomationCommands.cs` | 6 (DuplicateView, BatchRename, CopySettings, AutoPlace, CropToContent, BatchAlign) | 812 |
-| `Tags/AutoTagCommand.cs` | 2 (AutoTag, TagNewOnly) | 304 |
-| `Tags/BatchTagCommand.cs` | 1 | 199 |
-| `Tags/TagAndCombineCommand.cs` | 1 | 347 |
-| `Tags/PreTagAuditCommand.cs` | 1 | 351 |
-| `Tags/FamilyStagePopulateCommand.cs` | 1 | 275 |
-| `Tags/CombineParametersCommand.cs` | 1 | 569 |
+| `Tags/AutoTagCommand.cs` | 2 (AutoTag, TagNewOnly) | 324 |
+| `Tags/BatchTagCommand.cs` | 1 | 218 |
+| `Tags/TagAndCombineCommand.cs` | 1 | 227 |
+| `Tags/PreTagAuditCommand.cs` | 1 | 361 |
+| `Tags/FamilyStagePopulateCommand.cs` | 1 | 287 |
+| `Tags/CombineParametersCommand.cs` | 2 (CombineParameters, CombinePreFlight) | 414 |
 | `Tags/ConfigEditorCommand.cs` | 1 | 194 |
 | `Tags/TagConfigCommand.cs` | 1 | 72 |
 | `Tags/LoadSharedParamsCommand.cs` | 1 | 158 |
-| `Tags/TokenWriterCommands.cs` | 7 (SetDisc, SetLoc, SetZone, SetStatus, AssignNumbers, BuildTags, CompletenessDashboard) | 469 |
-| `Tags/ValidateTagsCommand.cs` | 1 | 249 |
-| `Tags/SmartTagPlacementCommand.cs` | 4 (SmartPlace, Arrange, RemoveAnnotation, BatchPlace) + TagPlacementEngine | 911 |
-| `Organise/TagOperationCommands.cs` | 31 (7 Tag Ops + 12 Leaders + 4 Analysis + 5 Annotation Color + LeaderHelper + TagRegisterExport + SelectTagsWithLeaders) | 2,567 |
+| `Tags/TokenWriterCommands.cs` | 7 (SetDisc, SetLoc, SetZone, SetStatus, AssignNumbers, BuildTags, CompletenessDashboard) | 427 |
+| `Tags/ValidateTagsCommand.cs` | 1 | 253 |
+| `Tags/SmartTagPlacementCommand.cs` | 9 (SmartPlace, Arrange, RemoveAnnotation, BatchPlace, LearnPlacement, ApplyTemplate, OverlapAnalysis, BatchTextSize, SetCategoryLineWeight) + TagPlacementEngine | 1,896 |
+| `Tags/TagFamilyCreatorCommand.cs` | 4 (CreateTagFamilies, LoadTagFamilies, ConfigureTagLabels, AuditTagFamilies) + TagFamilyConfig | 1,249 |
+| `Tags/SyncParameterSchemaCommand.cs` | 3 (SyncParameterSchema, AddParamRemap, AuditParameterSchema) | 553 |
+| `Organise/TagOperationCommands.cs` | 38 (7 Tag Ops + 13 Leaders + 4 Analysis + 7 Annotation Color + 4 Tag Appearance + 1 SwapTagType + LeaderHelper) | 3,744 |
 | `Temp/CreateParametersCommand.cs` | 1 | 27 |
 | `Temp/CheckDataCommand.cs` | 1 | 101 |
 | `Temp/MasterSetupCommand.cs` | 1 | 263 |
 | `Temp/MaterialCommands.cs` | 2 (BLE, MEP) | 239 |
 | `Temp/FamilyCommands.cs` | 6 (Walls, Floors, Ceilings, Roofs, Ducts, Pipes) | 660 |
-| `Temp/ScheduleCommands.cs` | 4 (FullAutoPopulate, BatchSchedules, AutoPopulate, ExportCSV) | 1,266 |
+| `Temp/ScheduleCommands.cs` | 4 (FullAutoPopulate, BatchSchedules, AutoPopulate, ExportCSV) | 1,192 |
 | `Temp/FormulaEvaluatorCommand.cs` | 1 (+ FormulaEngine + ExpressionParser) | 765 |
 | `Temp/TemplateCommands.cs` | 3 (Filters, Worksets, ViewTemplates) | 1,117 |
 | `Temp/TemplateExtCommands.cs` | 6 (LinePatterns, Phases, ApplyFilters, CableTrays, Conduits, MaterialSchedules) | 304 |
-| `Temp/TemplateManagerCommands.cs` | 17 (AutoAssign, Audit, Diff, Compliance, AutoFix, SyncOverrides, FillPatterns, LineStyles, ObjectStyles, TextStyles, DimStyles, VGOverrides, BatchFamilyParams, TemplateSchedules, SetupWizard, CloneTemplate, BatchVGReset) + TemplateManager engine | 3,393 |
+| `Temp/TemplateManagerCommands.cs` | 17 (AutoAssign, Audit, Diff, Compliance, AutoFix, SyncOverrides, FillPatterns, LineStyles, ObjectStyles, TextStyles, DimStyles, VGOverrides, BatchFamilyParams, TemplateSchedules, SetupWizard, CloneTemplate, BatchVGReset) + TemplateManager engine | 3,407 |
 | `Temp/DataPipelineCommands.cs` | 3 (ValidateTemplate, DynamicBindings, SchemaValidate) | 906 |
-| `UI/StingCommandHandler.cs` | 0 (IExternalEventHandler dispatcher) | 1,341 |
+| `UI/StingCommandHandler.cs` | 0 (IExternalEventHandler — dispatches 395 button tags to 162 command classes + 62 inline helpers) | 2,478 |
 | `UI/StingDockPanel.xaml.cs` | 0 (WPF code-behind) | 178 |
 | `UI/StingDockPanelProvider.cs` | 0 (IDockablePaneProvider) | 37 |
-| `UI/StingDockPanel.xaml` | — (WPF markup) | 1,357 |
-| **Total** | **144 commands** | **~25,400** |
+| `UI/StingDockPanel.xaml` | — (WPF markup, 6-tab panel with ~356 buttons) | 1,365 |
+| **Total** | **164 commands** | **~31,300** |
 
 ## Core Classes
 
@@ -343,7 +381,21 @@ STINGTOOLS/
 - Used throughout the codebase for error tracing; replaces silent catch blocks
 - Last-resort: silently swallows its own IO failures
 
-### `ParameterHelpers` (static) — `Core/ParameterHelpers.cs` (972 lines)
+### `ParamRegistry` (static) — `Core/ParamRegistry.cs` (860 lines)
+- **Single source of truth** for all parameter names, GUIDs, container definitions, and category bindings
+- Loads from `PARAMETER_REGISTRY.json` at runtime (thread-safe lazy initialization via `EnsureLoaded()` with lock); falls back to hardcoded defaults if JSON not found
+- **Tag format configuration**: `Separator`, `NumPad`, `SegmentOrder` — data-driven rather than hardcoded
+- **Typed string constants** for all 8 source tokens (DISC, LOC, ZONE, LVL, SYS, FUNC, PROD, SEQ) + universal containers (TAG1-TAG6)
+- **Extended parameter constants**: ~60+ parameters across identity, spatial, BLE dimensional, electrical, lighting, HVAC, and plumbing groups (e.g., `ParamRegistry.WALL_HEIGHT`, `ParamRegistry.ELC_POWER`)
+- **GUID lookups**: `GetGuid(paramName)`, `GetParamName(guid)`, `AllParamGuids`
+- **Container management**: `AllContainers`, `ContainersForCategory(categoryName)`, `GetContainerTuples()`
+- **Token presets**: Named index arrays (e.g., "short_id" = [0,6,7], "location" = [1,2,3]) for partial tag strings
+- **Category bindings**: `BuildDisciplineBindings()`, `ResolveUniversalCategoryEnums()`
+- **Tag assembly**: `AssembleContainer()`, `ReadTokenValues()`, `WriteContainers()`
+- **Reload**: `Reload()` forces re-read from disk for live editing workflows
+- Nested data classes: `TokenDef`, `ContainerGroupDef`, `ContainerParamDef`
+
+### `ParameterHelpers` (static) — `Core/ParameterHelpers.cs` (1,039 lines)
 - `GetString(el, paramName)` — read text parameter, returns empty string on null
 - `SetString(el, paramName, value, overwrite)` — write text parameter, skips read-only/non-empty unless overwrite
 - `SetIfEmpty(el, paramName, value)` — set only when currently empty
@@ -365,7 +417,7 @@ STINGTOOLS/
 - `MapAll(doc, el)` — comprehensive parameter mapping (dimensions, MEP data, identity)
 - Bridges native Revit data (Width, Height, Flow, etc.) into STING parameter schema
 
-### `SharedParamGuids` (static) — `Core/SharedParamGuids.cs` (500 lines)
+### `SharedParamGuids` (static) — `Core/SharedParamGuids.cs` (173 lines)
 - `ParamGuids` dictionary — 50+ parameter name to `Guid` mappings from `MR_PARAMETERS.txt`
 - `UniversalParams` — 17 ASS_MNG parameters for Pass 1 (bound to all 53 categories)
 - `AllCategories` / `AllCategoryEnums` — 53 `OST_*` built-in category names/enums
@@ -390,7 +442,7 @@ STINGTOOLS/
 - **Tag format validation**: `ValidateTagFormat(tag)` — validates complete 8-segment tag string format and all segments
 - Used by `ValidateTagsCommand`, `BuildTagsCommand`, and `PreTagAuditCommand` for ISO 19650 enforcement
 
-### `TagConfig` (static, singleton) — `Core/TagConfig.cs` (1,707 lines)
+### `TagConfig` (static, singleton) — `Core/TagConfig.cs` (2,081 lines)
 - **Lookup tables** (all configurable via `project_config.json`):
   - `DiscMap` — 41 category to discipline code mappings (M, E, P, A, S, FP, LV, G)
   - `SysMap` — 17 system codes to category lists (HVAC, DCW, DHW, HWS, SAN, RWD, GAS, FP, LV, FLS, COM, ICT, NCL, SEC, ARC, STR, GEN)
@@ -431,8 +483,9 @@ These `internal static` classes provide shared logic used by multiple commands w
 | `ScheduleHelper` | `Temp/ScheduleCommands.cs` | Schedule creation utilities and field remap loading from SCHEDULE_FIELD_REMAP.csv |
 | `FormulaEngine` | `Temp/FormulaEvaluatorCommand.cs` | Formula parsing, context building, text/numeric evaluation, includes `ExpressionParser` recursive descent parser |
 | `TemplateManager` | `Temp/TemplateManagerCommands.cs` | Deep template intelligence engine: 5-layer auto-assignment, compliance scoring, VG diff, style definitions |
-| `StingCommandHandler` | `UI/StingCommandHandler.cs` | `IExternalEventHandler` — dispatches 100+ dockable panel button clicks to command classes on the Revit API thread |
-| `StingDockPanel` | `UI/StingDockPanel.xaml.cs` | WPF code-behind for 4-tab dockable panel (SELECT/ORGANISE/CREATE/VIEW) with colour swatches and status bar |
+| `TagFamilyConfig` | `Tags/TagFamilyCreatorCommand.cs` | Configuration for tag family creation: 50 `BuiltInCategory` to `.rft` template mappings, seed family lookup, output directory management |
+| `StingCommandHandler` | `UI/StingCommandHandler.cs` | `IExternalEventHandler` — dispatches 395 dockable panel button tags to 162 command classes + 62 inline helpers on the Revit API thread |
+| `StingDockPanel` | `UI/StingDockPanel.xaml.cs` | WPF code-behind for 6-tab dockable panel (SELECT/ORGANISE/DOCS/TEMP/CREATE/VIEW) with colour swatches and status bar |
 | `StingDockPanelProvider` | `UI/StingDockPanelProvider.cs` | `IDockablePaneProvider` — registers dockable panel with Revit; PaneGuid for panel identification |
 | `ColorHelper` | `Select/ColorCommands.cs` | 10 built-in colour palettes, `OverrideGraphicSettings` builder, solid fill pattern finder, preset save/load |
 | `TagPlacementEngine` | `Tags/SmartTagPlacementCommand.cs` | 8-position candidate offset generation, scale-aware placement, 2D AABB collision detection, leader auto-generation |
@@ -484,27 +537,36 @@ The plugin's primary user interface is a **WPF dockable panel** that consolidate
 
 | Component | File | Purpose |
 |-----------|------|---------|
-| `StingDockPanel.xaml` | `UI/StingDockPanel.xaml` (1,357 lines) | WPF markup: 4-tab layout (SELECT/ORGANISE/CREATE/VIEW), colour swatches, bulk parameter controls |
+| `StingDockPanel.xaml` | `UI/StingDockPanel.xaml` (1,365 lines) | WPF markup: 6-tab layout with ~356 command buttons |
 | `StingDockPanel.xaml.cs` | `UI/StingDockPanel.xaml.cs` (178 lines) | Code-behind: button dispatch via `IExternalEventHandler`, colour swatch builder, status bar |
-| `StingCommandHandler` | `UI/StingCommandHandler.cs` (1,341 lines) | `IExternalEventHandler` — maps 140+ button Tag strings to command classes, ensures Revit API calls run on the main thread |
+| `StingCommandHandler` | `UI/StingCommandHandler.cs` (2,478 lines) | `IExternalEventHandler` — maps 395 button Tag strings to 162 command classes + 62 inline helpers, ensures Revit API calls run on the main thread |
 | `StingDockPanelProvider` | `UI/StingDockPanelProvider.cs` (37 lines) | `IDockablePaneProvider` — registers panel with Revit, sets initial dock position (Right, 320×400 min) |
 | `ToggleDockPanelCommand` | `Core/StingToolsApp.cs` (line 825) | `IExternalCommand` — toggles panel visibility from ribbon button |
 
-### Panel Tabs
+### Panel Tabs (6 tabs)
 
-| Tab | Content | Mirrors Ribbon Panel |
-|-----|---------|---------------------|
-| SELECT | Category selectors, state selectors, spatial selectors, bulk parameter write | Select |
-| ORGANISE | Tag operations, leader management, analysis/QA | Organise + Tags QA |
-| CREATE | Tagging commands, token writers, combine, setup | Tags + Temp |
-| VIEW | Document commands, viewports, template management | Docs + Temp Templates |
+| Tab | Content | Key Features |
+|-----|---------|-------------|
+| SELECT | Category selectors, state selectors, spatial selectors, bulk parameter write | AI Smart Select (8 modes), selection memory (3 slots), conditional selection builder, parameter lookup, project filters (workset/phase/design option) |
+| ORGANISE | Tag operations, leader management, analysis/QA | AI Organise Engine (Quick/Deep/Anneal), nudge controls, align & distribute (17 modes), pattern learning, room tag sync, linked model support, PDF export, sheet index |
+| DOCS | Viewport, sheet, schedule, text note, dimension, legend, title block, revision tools | Viewport alignment (6), numbering (6), spacing; sheet number manipulation; text case/alignment; dimension/legend/revision tools; measurement tools |
+| TEMP | Project template setup, materials, families, schedules, styles | Setup wizard, material creation, family type creation, schedule automation, style definitions |
+| CREATE | ISO 19650 tagging, token population, tag families, quality assurance | Tag family management (4 commands), extended 13-token set, ISO completeness dashboard (inline DataGrid), token inspector |
+| VIEW | Project health, anomaly detection, colouriser, view controls | Health scoring (0-100 composite), parameter anomaly detection, AI tag placement, full colouriser with gradient/palette/transparency controls, view isolation/hiding |
 
 ### Thread Safety Pattern
 All button clicks dispatch through `IExternalEventHandler` to ensure Revit API calls execute on the correct thread:
 ```
-Button Click → StingDockPanel.Cmd_Click → StingCommandHandler.SetCommand(tag) → ExternalEvent.Raise()
-→ Revit calls StingCommandHandler.Execute(UIApplication) → RunCommand<T>(app)
+Button Click → StingDockPanel.Cmd_Click → StingCommandHandler.SetCommand(tag, param1?, param2?) → ExternalEvent.Raise()
+→ Revit calls StingCommandHandler.Execute(UIApplication) → RunCommand<T>(app) or inline helper
 ```
+
+### StingCommandHandler Dispatch Patterns
+The handler uses multiple dispatch patterns beyond simple `RunCommand<T>`:
+- **Parameterized dispatch**: `SetCommand(tag, param1, param2)` enables data-passing from the WPF panel (used by bulk write, color, token operations)
+- **Selection memory**: 3 memory slots (M1/M2/M3) with Save/Load/Swap/AddTo/RemoveFrom/Intersect operations (inline)
+- **Inline helpers**: 62 `private static` methods for view isolation, selection ops, graphic overrides, schedule/text/dimension manipulation, measurement, etc.
+- **AI/Placeholder stubs**: 8 AI Smart Select tags and several organise modes currently log-only, indicating planned features
 
 ## Template Manager Intelligence Engine
 
@@ -605,12 +667,14 @@ dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:\Program Files\Auto
 - Use `FilteredElementCollector` with appropriate filters for performance
 - For selection commands, use `uidoc.Selection.SetElementIds()` to set the selection
 - For new commands, use the shared helpers: `TagConfig.BuildAndWriteTag()`, `ParameterHelpers.SetIfEmpty()`, `CategorySelector.SelectByCategory()`, `SpatialAutoDetect.DetectLoc()/DetectZone()`
+- Use `ParamRegistry` constants (e.g., `ParamRegistry.DISC`, `ParamRegistry.WALL_HEIGHT`) instead of hardcoded parameter name strings
+- For container operations, use `ParamRegistry.WriteContainers()` and `ParamRegistry.ContainersForCategory()` to access data-driven container definitions
 
 ### Multi-file Command Patterns
 
 The codebase uses two patterns for organising commands:
 1. **One class per file** — for complex commands (e.g., `CombineParametersCommand.cs`, `MasterSetupCommand.cs`, `PreTagAuditCommand.cs`)
-2. **Multiple classes per file** — for related simple commands (e.g., `CategorySelectCommands.cs` has 15 selectors, `TokenWriterCommands.cs` has 7 commands, `TagOperationCommands.cs` has 26 commands)
+2. **Multiple classes per file** — for related simple commands (e.g., `CategorySelectCommands.cs` has 15 selectors, `TokenWriterCommands.cs` has 7 commands, `TagOperationCommands.cs` has 38 commands)
 
 When adding new commands, follow the existing pattern for the directory. Use shared `internal static` helper classes (e.g., `CategorySelector`, `TokenWriter`, `CompoundTypeCreator`, `MaterialPropertyHelper`, `LeaderHelper`, `ScheduleHelper`, `FormulaEngine`) to reduce duplication.
 
@@ -622,6 +686,7 @@ When adding new commands, follow the existing pattern for the directory. Use sha
 - Data files are read at runtime from the `data/` directory alongside the DLL
 - Use `StingToolsApp.FindDataFile(fileName)` to locate data files
 - Use `StingToolsApp.ParseCsvLine(line)` to parse CSV lines with quoted fields
+- `PARAMETER_REGISTRY.json` is the master definition for parameters — edit it and run `SyncParameterSchemaCommand` to propagate changes to CSV/TXT files
 
 ### Testing
 
@@ -689,11 +754,17 @@ When adding new commands, follow the existing pattern for the directory. Use sha
 | ~~Port VALIDAT_BIM_TEMPLATE.py (45 checks) to C# ValidateTemplateCommand~~ | **DONE** — `ValidateTemplateCommand` in `DataPipelineCommands.cs` performs 45 validation checks (data file inventory, parameter consistency, material completeness, formula dependencies, schedule definitions, cross-references). | Done |
 | ~~Dynamic category bindings from BINDING_COVERAGE_MATRIX.csv~~ | **DONE** — `DynamicBindingsCommand` in `DataPipelineCommands.cs` loads bindings from CSV, replacing hardcoded `SharedParamGuids.AllCategoryEnums`. | Done |
 | ~~Color By Parameter system~~ | **DONE** — `ColorCommands.cs` with 5 commands: ColorByParameter (10 palettes, `<No Value>` detection), ClearOverrides, SavePreset, LoadPreset, CreateFiltersFromColors. Full `OverrideGraphicSettings` support. | Done |
-| ~~Smart Tag Placement~~ | **DONE** — `SmartTagPlacementCommand.cs` with 4 commands: SmartPlace (8-position collision avoidance), Arrange, RemoveAnnotation, BatchPlace. `TagPlacementEngine` with scale-aware offsets and 2D AABB collision detection. | Done |
+| ~~Smart Tag Placement~~ | **DONE** — `SmartTagPlacementCommand.cs` with 9 commands: SmartPlace (8-position collision avoidance), Arrange, RemoveAnnotation, BatchPlace, LearnPlacement, ApplyTemplate, OverlapAnalysis, BatchTextSize, SetCategoryLineWeight. `TagPlacementEngine` with grid index, templates, and text/leader controls. | Done |
 | ~~View automation commands~~ | **DONE** — `ViewAutomationCommands.cs` with 6 commands: DuplicateView, BatchRename, CopyViewSettings, AutoPlaceViewports, CropToContent, BatchAlignViewports. | Done |
-| ~~Annotation color management~~ | **DONE** — 5 commands in `TagOperationCommands.cs`: ColorTagsByDiscipline, SetTagTextColor, SetLeaderColor, SplitTagLeaderColor, ClearAnnotationColors. | Done |
+| ~~Annotation color management~~ | **DONE** — 7 commands in `TagOperationCommands.cs`: ColorTagsByDiscipline, SetTagTextColor, SetLeaderColor, SplitTagLeaderColor, ClearAnnotationColors, ColorTagsByParameter, SwapTagType. | Done |
 | ~~Schema validation~~ | **DONE** — `SchemaValidateCommand` validates BLE/MEP CSV columns match MATERIAL_SCHEMA.json (77-column schema). | Done |
-| Configurable tag format in project_config.json (separator, padding, segments) | Flexibility for different standards | Medium |
+| ~~Configurable tag format~~ | **DONE** — `PARAMETER_REGISTRY.json` defines `tag_format` (separator, padding, segment order); `ParamRegistry.cs` loads at runtime. | Done |
+| ~~Tag family creation & management~~ | **DONE** — `TagFamilyCreatorCommand.cs` with 4 commands: CreateTagFamilies (50 categories), LoadTagFamilies, ConfigureTagLabels (guided wizard), AuditTagFamilies. Seed family strategy for zero-config label resolution. | Done |
+| ~~Parameter schema management~~ | **DONE** — `ParamRegistry.cs` as single source of truth + `SyncParameterSchemaCommand.cs` with 3 commands for propagation and auditing. `PARAMETER_REGISTRY.json` (v3.0) replaces scattered hardcoded definitions. | Done |
+| ~~Tag appearance controls~~ | **DONE** — 4 commands in `TagOperationCommands.cs`: TagAppearance, SetTagBoxAppearance, QuickTagStyle, SetTagLineWeight. | Done |
+| ~~Tag nudge controls~~ | **DONE** — `NudgeTagsCommand` in `TagOperationCommands.cs` with directional nudge and configurable distance. | Done |
+| ~~Combine pre-flight check~~ | **DONE** — `CombinePreFlightCommand` in `CombineParametersCommand.cs` for pre-combine validation. | Done |
+| ~~6-tab WPF dockable panel~~ | **DONE** — Panel expanded from 4 to 6 tabs (SELECT/ORGANISE/DOCS/TEMP/CREATE/VIEW) with ~356 buttons. AI Smart Select, selection memory, conditional selection builder, colouriser with gradient support, health scoring, anomaly detection. | Done |
 | Batch command chaining / workflow presets | Queue: AutoTag, Validate, Export | Low |
 
 ---
@@ -786,14 +857,14 @@ using (Transaction t = new Transaction(doc, "STING Color By Parameter"))
 
 ### Smart Tag Placement — IMPLEMENTED
 
-Inspired by BIMLOGiQ Smart Annotation, Naviate Tag from Template, and academic Automatic Label Placement (ALP) research. Provides collision-free automated tag annotation. Implemented in `Tags/SmartTagPlacementCommand.cs` (911 lines) with `TagPlacementEngine` engine and 4 commands.
+Inspired by BIMLOGiQ Smart Annotation, Naviate Tag from Template, and academic Automatic Label Placement (ALP) research. Provides collision-free automated tag annotation. Implemented in `Tags/SmartTagPlacementCommand.cs` (1,896 lines) with `TagPlacementEngine` engine and 9 commands.
 
 #### Critical Distinction: Data Tagging vs Visual Tagging
 
 | Layer | What It Does | Current State |
 |-------|-------------|---------------|
 | Data tagging | Writes DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ to element parameters | Implemented (AutoTag, BatchTag, TagAndCombine, FullAutoPopulate) |
-| Visual tagging | Creates `IndependentTag` annotations in views displaying tag values | **Implemented** (SmartPlaceTags, ArrangeTags, RemoveAnnotationTags, BatchPlaceTags) |
+| Visual tagging | Creates `IndependentTag` annotations in views displaying tag values | **Implemented** (SmartPlaceTags, ArrangeTags, RemoveAnnotationTags, BatchPlaceTags, LearnPlacement, ApplyTemplate, OverlapAnalysis, BatchTextSize, SetCategoryLineWeight) |
 
 #### Implementation Architecture
 
@@ -899,7 +970,7 @@ view.DisableTemporaryViewMode(TemporaryViewMode.TemporaryViewProperties);
 13. **Native parameter mapping** — 30+ Revit built-in to STING parameter mappings
 14. **Family-stage pre-population** — All 7 tokens from category/spatial/family data
 15. **Schedule field remapping** — Auto-remap deprecated field names from CSV
-16. **WPF dockable panel** — 4-tab panel (SELECT/ORGANISE/CREATE/VIEW) replicating pyRevit interface with IExternalEventHandler dispatch
+16. **WPF dockable panel** — 6-tab panel (SELECT/ORGANISE/DOCS/TEMP/CREATE/VIEW) with ~356 buttons and IExternalEventHandler dispatch
 17. **Template Manager intelligence engine** — 5-layer auto-assignment, compliance scoring, VG diff, 17 template automation commands
 18. **View templates expanded** — 23 template definitions with full VG configuration (discipline plans, coordination, RCP, presentation, sections, 3D, elevations)
 19. **Style definition commands** — Fill patterns, line styles, text styles, dimension styles, object styles created programmatically
@@ -907,20 +978,33 @@ view.DisableTemporaryViewMode(TemporaryViewMode.TemporaryViewProperties);
 #### Completed (Phase 4)
 
 20. **Color By Parameter system** — `ColorCommands.cs`: 5 commands, 10 palettes, preset management, filter generation
-21. **Smart Tag Placement** — `SmartTagPlacementCommand.cs`: 4 commands, `TagPlacementEngine` with 8-position collision avoidance
+21. **Smart Tag Placement** — `SmartTagPlacementCommand.cs`: 9 commands, `TagPlacementEngine` with grid index, templates, text/leader controls
 22. **Dynamic category bindings** — `DynamicBindingsCommand` loads from BINDING_COVERAGE_MATRIX.csv
 23. **Port VALIDAT_BIM_TEMPLATE.py** — `ValidateTemplateCommand`: 45 validation checks ported to C#
 24. **View automation** — `ViewAutomationCommands.cs`: 6 commands (Duplicate, BatchRename, CopySettings, AutoPlace, Crop, BatchAlign)
-25. **Annotation color management** — 5 new commands in `TagOperationCommands.cs` (ColorTagsByDiscipline, SetTagTextColor, SetLeaderColor, SplitTagLeaderColor, ClearAnnotationColors)
+25. **Annotation color management** — 7 commands in `TagOperationCommands.cs` (ColorTagsByDiscipline, SetTagTextColor, SetLeaderColor, SplitTagLeaderColor, ClearAnnotationColors, ColorTagsByParameter, SwapTagType)
 26. **Schema validation** — `SchemaValidateCommand` validates MATERIAL_SCHEMA.json against CSV data
+
+#### Completed (Phase 5)
+
+27. **ParamRegistry — single source of truth** — `ParamRegistry.cs` (860 lines) loads from `PARAMETER_REGISTRY.json` (v3.0), providing centralized parameter names, GUIDs, containers, bindings, and tag format configuration. Replaces scattered hardcoded definitions across `SharedParamGuids.cs` and `TagConfig.cs`.
+28. **Configurable tag format** — `PARAMETER_REGISTRY.json` defines separator, padding, and segment order; `ParamRegistry` loads at runtime
+29. **Tag family creation & management** — `TagFamilyCreatorCommand.cs`: 4 commands (Create for 50 categories, Load, Configure Labels wizard, Audit) with `TagFamilyConfig` and seed family strategy
+30. **Parameter schema sync & audit** — `SyncParameterSchemaCommand.cs`: 3 commands for propagating `PARAMETER_REGISTRY.json` to downstream CSV/TXT files and auditing consistency
+31. **Tag appearance controls** — 4 commands: TagAppearance, SetTagBoxAppearance, QuickTagStyle, SetTagLineWeight
+32. **Tag nudge controls** — `NudgeTagsCommand` with directional nudge and configurable distance
+33. **Combine pre-flight check** — `CombinePreFlightCommand` for pre-combine validation
+34. **6-tab WPF dockable panel** — Expanded from 4 to 6 tabs (SELECT/ORGANISE/DOCS/TEMP/CREATE/VIEW) with ~356 buttons, AI Smart Select, selection memory (3 slots), conditional selection builder, colouriser with gradient support, health scoring, anomaly detection
+35. **Leader management expanded** — 13 leader commands (added NudgeTags)
+36. **Tag placement intelligence** — LearnTagPlacement, ApplyTagTemplate, TagOverlapAnalysis, BatchTagTextSize, SetTagCategoryLineWeight
 
 #### Next Priorities
 
-27. **Configurable tag format** — Separator, padding, segments via project_config.json
-28. **Cancellation support** — Background worker with abort for batch operations
-29. **Dynamic discipline bindings** — Load CATEGORY_BINDINGS.csv (10,661 entries) to replace hardcoded `DisciplineBindings`
-30. **Family parameter auto-binding** — Load FAMILY_PARAMETER_BINDINGS.csv (4,686 entries) for family-level validation
-31. **Batch command chaining / workflow presets** — Queue: AutoTag, Validate, Export
+37. **Cancellation support** — Background worker with abort for batch operations
+38. **Dynamic discipline bindings** — Load CATEGORY_BINDINGS.csv (10,661 entries) to replace hardcoded `DisciplineBindings`
+39. **Family parameter auto-binding** — Load FAMILY_PARAMETER_BINDINGS.csv (4,686 entries) for family-level validation
+40. **Batch command chaining / workflow presets** — Queue: AutoTag, Validate, Export
+41. **AI Smart Select implementation** — Currently 8 placeholder stubs in StingCommandHandler; implement actual AI-powered selection logic
 
 ### External Tool References
 


### PR DESCRIPTION
Major updates:
- Add 3 new source files: ParamRegistry.cs (860 lines), TagFamilyCreatorCommand.cs (1,249 lines, 4 commands), SyncParameterSchemaCommand.cs (553 lines, 3 commands)
- Add PARAMETER_REGISTRY.json (v3.0) as 16th data file
- Update Organise commands: 31 → 38 (new: TagAppearance, SetTagBoxAppearance, QuickTagStyle, SetTagLineWeight, ColorTagsByParameter, SwapTagType, NudgeTags)
- Update SmartTagPlacement commands: 4 → 9 (new: LearnPlacement, ApplyTemplate, OverlapAnalysis, BatchTextSize, SetCategoryLineWeight)
- Add CombinePreFlightCommand
- Update WPF panel: 4 tabs → 6 tabs (SELECT/ORGANISE/DOCS/TEMP/CREATE/VIEW), ~356 buttons, 395 dispatch tags in StingCommandHandler
- Document ParamRegistry as single source of truth for parameters
- Add Phase 5 completed items to roadmap (27-36)
- Update all line counts and command counts to match actual codebase

https://claude.ai/code/session_01DZ5ZNxFVGXmqd2wN5Tkd34