### PR TITLE
Update STING tag configuration with enhanced parameters and warnings

### DIFF
--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
@@ -13,17 +13,19 @@ TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Walls
 8,T2,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, PER_FIRE_RATING_HR, """")"
 9,T2,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, PER_ACOUSTIC_STC_RATING, """")"
 10,T2,BLE_FINISH_EXT_TXT,Fin:,,,,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, BLE_FINISH_EXT_TXT, """")"
-11,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 11,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-12,T3,ARCH_TAG_7_PARA_WALL_TXT,,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_WALL_TXT, """")"
-13,T3,BLE_WALL_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_WALL_MATERIAL_TXT, """")"
-14,T3,BLE_WALL_CORE_MATERIAL_TXT,Core:,,,,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, BLE_WALL_CORE_MATERIAL_TXT, """")"
-15,T3,BLE_WALL_INSULATION_TXT,| Insul:,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, BLE_WALL_INSULATION_TXT, """")"
-16,T3,PER_CONDENSATION_RISK_BOOL,Cond Risk:,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, PER_CONDENSATION_RISK_BOOL, """")"
-17,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
-18,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-19,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
-20,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
-21,T3,CST_LOCAL_MAT_BOOL,| Local:,,,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
+11,T2,BLE_WALL_CONSTRUCTION_TXT,Const:,,,✓,Common,Text,Show Tier 2 - 11,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_CONSTRUCTION_TXT, """")"
+12,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 12,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+13,T3,ARCH_TAG_7_PARA_WALL_TXT,,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_WALL_TXT, """")"
+14,T3,BLE_WALL_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, BLE_WALL_MATERIAL_TXT, """")"
+15,T3,BLE_WALL_CORE_MATERIAL_TXT,Core:,,,,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, BLE_WALL_CORE_MATERIAL_TXT, """")"
+16,T3,BLE_WALL_INSULATION_TXT,| Insul:,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, BLE_WALL_INSULATION_TXT, """")"
+17,T3,PER_CONDENSATION_RISK_BOOL,Cond Risk:,,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, PER_CONDENSATION_RISK_BOOL, """")"
+18,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+19,T3,BLE_WALL_WATERPROOF_TXT,WP:,,,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, BLE_WALL_WATERPROOF_TXT, """")"
+20,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+21,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+22,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
+23,T3,CST_LOCAL_MAT_BOOL,| Local:,,,✓,Common,Text,Show Tier 3 - 23,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS,U > 0.70 W/m²K,Building Regs Part L2A / Uganda ES,Common,Text,⚠ Warning: Wall U-Value,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS, """")"
@@ -44,18 +46,22 @@ TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Floors
 7,T2,PER_THERM_U_VALUE_W_M2K,,W/m²K,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, PER_THERM_U_VALUE_W_M2K, """")"
 8,T2,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, PER_FIRE_RATING_HR, """")"
 9,T2,BLE_FINISH_TOP_TXT,Fin:,,,,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, BLE_FINISH_TOP_TXT, """")"
-10,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-11,T3,ARCH_TAG_7_PARA_FLOOR_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_FLOOR_TXT, """")"
-12,T3,BLE_FLOOR_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_FLOOR_MATERIAL_TXT, """")"
-13,T3,BLE_FLOOR_LOAD_KN_M2,Load:,kN/m²,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_FLOOR_LOAD_KN_M2, """")"
-14,T3,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, PER_ACOUSTIC_STC_RATING, """")"
-15,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
-16,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-17,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+10,T2,BLE_FLOOR_SLIP_RESISTANCE_TXT,Slip:,,,✓,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, BLE_FLOOR_SLIP_RESISTANCE_TXT, """")"
+11,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 11,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+12,T3,ARCH_TAG_7_PARA_FLOOR_TXT,,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_FLOOR_TXT, """")"
+13,T3,BLE_FLOOR_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_FLOOR_MATERIAL_TXT, """")"
+14,T3,BLE_FLOOR_LOAD_KN_M2,Load:,kN/m²,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, BLE_FLOOR_LOAD_KN_M2, """")"
+15,T3,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, PER_ACOUSTIC_STC_RATING, """")"
+16,T3,BLE_FLOOR_CONSTRUCTION_METHOD_TXT,Const:,,,,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, BLE_FLOOR_CONSTRUCTION_METHOD_TXT, """")"
+17,T3,BLE_FLOOR_WATERPROOF_TXT,| WP:,,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, BLE_FLOOR_WATERPROOF_TXT, """")"
+18,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+19,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+20,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS,U > 0.25 W/m²K,Building Regs Part L2A,Common,Text,⚠ Warning: Floor U-Value,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS, """")"
 2,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_FLOORS,Fire rating < 1.0 hr,Building Regs Part B / BS 9999,Common,Text,⚠ Warning: Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_FLOORS, """")"
+3,HIGH,WARN_BLE_FLOOR_SLIP_RESISTANCE_FLOORS,Slip resistance < PTV 36 (wet),BS 7976-2 / UK Slip Resistance Group,Common,Text,⚠ Warning: Slip Resistance,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_FLOOR_SLIP_RESISTANCE_FLOORS, """")"
 
 Tag Family #3: STING - Ceiling Tag
 TAG7: ARCH_TAG_7_PARA_CEIL_TXT  •  Category: Ceilings
@@ -67,15 +73,19 @@ TAG7: ARCH_TAG_7_PARA_CEIL_TXT  •  Category: Ceilings
 5,T2,BLE_CEILING_HEIGHT_MM,Ht:,mm,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_CEILING_HEIGHT_MM, """")"
 6,T2,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, PER_FIRE_RATING_HR, """")"
 7,T2,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, PER_ACOUSTIC_STC_RATING, """")"
-8,T2,BLE_FINISH_TOP_TXT,Fin:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, BLE_FINISH_TOP_TXT, """")"
-9,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-10,T3,ARCH_TAG_7_PARA_CEIL_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_CEIL_TXT, """")"
-11,T3,BLE_CEILING_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, BLE_CEILING_MATERIAL_TXT, """")"
-12,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-13,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+8,T2,PER_ACOUSTIC_NRC_RATING,NRC:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, PER_ACOUSTIC_NRC_RATING, """")"
+9,T2,BLE_FINISH_TOP_TXT,Fin:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, BLE_FINISH_TOP_TXT, """")"
+10,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+11,T3,ARCH_TAG_7_PARA_CEIL_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_CEIL_TXT, """")"
+12,T3,BLE_CEILING_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_CEILING_MATERIAL_TXT, """")"
+13,T3,BLE_CEILING_GRID_TXT,Grid:,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_CEILING_GRID_TXT, """")"
+14,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+15,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+16,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_CEILINGS,Fire rating < 0.5 hr,Building Regs Part B,Common,Text,⚠ Warning: Ceiling Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_CEILINGS, """")"
+2,MEDIUM,WARN_PER_ACOUSTIC_NRC_RATING_CEILINGS,NRC < 0.55,ASHRAE / CIBSE Guide B,Common,Text,⚠ Warning: Ceiling Acoustic NRC,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_ACOUSTIC_NRC_RATING_CEILINGS, """")"
 
 Tag Family #4: STING - Roof Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roofs
@@ -88,18 +98,22 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roofs
 6,T2,PER_THERM_U_VALUE_W_M2K,,W/m²K,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, PER_THERM_U_VALUE_W_M2K, """")"
 7,T2,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, PER_FIRE_RATING_HR, """")"
 8,T2,BLE_ROOF_SLOPE_DEG,Slope:,°,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_SLOPE_DEG, """")"
-9,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-10,T3,ARCH_TAG_7_PARA_ROOF_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_ROOF_TXT, """")"
-11,T3,BLE_ROOF_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOF_MATERIAL_TXT, """")"
-12,T3,PER_CONDENSATION_RISK_BOOL,Cond:,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, PER_CONDENSATION_RISK_BOOL, """")"
-13,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
-14,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-15,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+9,T2,BLE_ROOF_AREA_SQ_M,,m²,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_AREA_SQ_M, """")"
+10,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+11,T3,ARCH_TAG_7_PARA_ROOF_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_ROOF_TXT, """")"
+12,T3,BLE_ROOF_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOF_MATERIAL_TXT, """")"
+13,T3,BLE_ROOF_DRAINAGE_TXT,Drain:,,,,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOF_DRAINAGE_TXT, """")"
+14,T3,PER_CONDENSATION_RISK_BOOL,| Cond:,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, PER_CONDENSATION_RISK_BOOL, """")"
+15,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+16,T3,BLE_ROOF_WATERPROOF_TXT,WP:,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOF_WATERPROOF_TXT, """")"
+17,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+18,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS,U > 0.20 W/m²K,Building Regs Part L2A,Common,Text,⚠ Warning: Roof U-Value,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS, """")"
 2,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_ROOFS,Fire rating < 1.0 hr,Building Regs Part B,Common,Text,⚠ Warning: Roof Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_ROOFS, """")"
 3,HIGH,WARN_PER_CONDENSATION_RISK_BOOL_ROOFS,Condensation risk = TRUE,BS 5250:2021,Common,Text,⚠ Warning: Condensation Risk,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_CONDENSATION_RISK_BOOL_ROOFS, """")"
+4,MEDIUM,WARN_BLE_ROOF_DRAINAGE_ROOFS,No drainage provision or fall < 1:80,BS EN 12056-3 / BS 6229,Common,Text,⚠ Warning: Roof Drainage,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_ROOF_DRAINAGE_ROOFS, """")"
 
 Tag Family #5: STING - Door Tag
 TAG7: ARCH_TAG_7_PARA_DOOR_TXT  •  Category: Doors
@@ -110,19 +124,24 @@ TAG7: ARCH_TAG_7_PARA_DOOR_TXT  •  Category: Doors
 4,T2,BLE_DOOR_WIDTH_MM,W:,mm,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_DOOR_WIDTH_MM, """")"
 5,T2,BLE_DOOR_HEIGHT_MM,× H:,mm,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_DOOR_HEIGHT_MM, """")"
 6,T2,BLE_DOOR_TYPE_TXT,Type:,,,,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_DOOR_TYPE_TXT, """")"
-7,T2,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, PER_FIRE_RATING_HR, """")"
-8,T2,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, PER_ACOUSTIC_STC_RATING, """")"
-9,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-10,T3,ARCH_TAG_7_PARA_DOOR_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_DOOR_TXT, """")"
-11,T3,BLE_DOOR_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_MATERIAL_TXT, """")"
-12,T3,BLE_DOOR_HARDWARE_TXT,HW:,,,,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_HARDWARE_TXT, """")"
-13,T3,BLE_DOOR_GLAZING_BOOL,| Glazed:,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_GLAZING_BOOL, """")"
-14,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-15,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+7,T2,BLE_DOOR_OPERATION_TXT,Op:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, BLE_DOOR_OPERATION_TXT, """")"
+8,T2,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, PER_FIRE_RATING_HR, """")"
+9,T2,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, PER_ACOUSTIC_STC_RATING, """")"
+10,T2,BLE_DOOR_CLEAR_WIDTH_MM,Clear:,mm,,✓,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, BLE_DOOR_CLEAR_WIDTH_MM, """")"
+11,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 11,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+12,T3,ARCH_TAG_7_PARA_DOOR_TXT,,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_DOOR_TXT, """")"
+13,T3,BLE_DOOR_MATERIAL_TXT,,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_MATERIAL_TXT, """")"
+14,T3,BLE_DOOR_HARDWARE_TXT,HW:,,,,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_HARDWARE_TXT, """")"
+15,T3,BLE_DOOR_GLAZING_BOOL,| Glazed:,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_GLAZING_BOOL, """")"
+16,T3,BLE_DOOR_THRESHOLD_TXT,Thresh:,,,,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_THRESHOLD_TXT, """")"
+17,T3,BLE_DOOR_CLOSER_TXT,| Closer:,,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, BLE_DOOR_CLOSER_TXT, """")"
+18,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+19,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_DOORS,Fire door rating < required,Building Regs Part B / BS 476,Common,Text,⚠ Warning: Door Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_DOORS, """")"
 2,HIGH,WARN_BLE_DOOR_WIDTH_MM_ACCESSIBILITY,Clear width < 800mm,Building Regs Part M / BS 8300,Common,Text,⚠ Warning: Door Width,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_DOOR_WIDTH_MM_ACCESSIBILITY, """")"
+3,HIGH,WARN_BLE_DOOR_THRESHOLD_DOORS,Threshold level difference > 15mm,Building Regs Part M / BS 8300-2,Common,Text,⚠ Warning: Door Threshold,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_DOOR_THRESHOLD_DOORS, """")"
 
 Tag Family #6: STING - Window Tag
 TAG7: ARCH_TAG_7_PARA_WIN_TXT  •  Category: Windows
@@ -133,19 +152,22 @@ TAG7: ARCH_TAG_7_PARA_WIN_TXT  •  Category: Windows
 4,T2,BLE_WIN_WIDTH_MM,W:,mm,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WIN_WIDTH_MM, """")"
 5,T2,BLE_WIN_HEIGHT_MM,× H:,mm,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_WIN_HEIGHT_MM, """")"
 6,T2,BLE_WIN_TYPE_TXT,Type:,,,,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_WIN_TYPE_TXT, """")"
-7,T2,PER_THERM_U_VALUE_W_M2K,,W/m²K,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, PER_THERM_U_VALUE_W_M2K, """")"
-8,T2,PER_SOLAR_G_VALUE,g:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, PER_SOLAR_G_VALUE, """")"
-9,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-10,T3,ARCH_TAG_7_PARA_WIN_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_WIN_TXT, """")"
-11,T3,BLE_WIN_FRAME_MATERIAL_TXT,Frame:,,,,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, BLE_WIN_FRAME_MATERIAL_TXT, """")"
-12,T3,BLE_WIN_GLAZING_TYPE_TXT,| Glaze:,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_WIN_GLAZING_TYPE_TXT, """")"
-13,T3,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, PER_ACOUSTIC_STC_RATING, """")"
-14,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-15,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+7,T2,BLE_WIN_OPENING_TYPE_TXT,Op:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, BLE_WIN_OPENING_TYPE_TXT, """")"
+8,T2,PER_THERM_U_VALUE_W_M2K,,W/m²K,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, PER_THERM_U_VALUE_W_M2K, """")"
+9,T2,PER_SOLAR_G_VALUE,g:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, PER_SOLAR_G_VALUE, """")"
+10,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+11,T3,ARCH_TAG_7_PARA_WIN_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_WIN_TXT, """")"
+12,T3,BLE_WIN_FRAME_MATERIAL_TXT,Frame:,,,,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_WIN_FRAME_MATERIAL_TXT, """")"
+13,T3,BLE_WIN_GLAZING_TYPE_TXT,| Glaze:,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_WIN_GLAZING_TYPE_TXT, """")"
+14,T3,BLE_WIN_VENT_AREA_SQ_M,Vent:,m²,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, BLE_WIN_VENT_AREA_SQ_M, """")"
+15,T3,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, PER_ACOUSTIC_STC_RATING, """")"
+16,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+17,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_PER_THERM_U_VALUE_W_M2K_NR_WINDOWS,U > 2.00 W/m²K,Building Regs Part L2A,Common,Text,⚠ Warning: Window U-Value,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_WINDOWS, """")"
 2,MEDIUM,WARN_PER_SOLAR_G_VALUE_NR_WINDOWS,g-value > 0.40,Building Regs Part L / CIBSE Guide A,Common,Text,⚠ Warning: Solar Gain,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SOLAR_G_VALUE_NR_WINDOWS, """")"
+3,HIGH,WARN_BLE_WIN_VENT_AREA_WINDOWS,Ventilation area < 1/20 floor area,Building Regs Part F / BS EN 16798,Common,Text,⚠ Warning: Ventilation Area,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_WIN_VENT_AREA_WINDOWS, """")"
 
 Tag Family #7: STING - Room Tag
 TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Rooms
@@ -157,17 +179,21 @@ TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Rooms
 5,T2,BLE_ROOM_DEPARTMENT_TXT,Dept:,,,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOM_DEPARTMENT_TXT, """")"
 6,T2,BLE_ROOM_OCCUPANCY_NR,| Occ:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOM_OCCUPANCY_NR, """")"
 7,T2,BLE_HEADROOM_MM,Ht:,mm,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, BLE_HEADROOM_MM, """")"
-8,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-9,T3,ARCH_TAG_7_PARA_ROOM_TXT,,,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_ROOM_TXT, """")"
-10,T3,BLE_ROOM_FLOOR_FINISH_TXT,Floor Fin:,,,,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOM_FLOOR_FINISH_TXT, """")"
-11,T3,BLE_ROOM_WALL_FINISH_TXT,| Wall Fin:,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOM_WALL_FINISH_TXT, """")"
-12,T3,BLE_ROOM_CEILING_FINISH_TXT,| Ceil Fin:,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOM_CEILING_FINISH_TXT, """")"
-13,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-14,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+8,T2,BLE_ROOM_VENTILATION_RATE_LPS,Vent:,L/s,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOM_VENTILATION_RATE_LPS, """")"
+9,T2,BLE_ROOM_LIGHTING_LUX,Lux:,lx,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOM_LIGHTING_LUX, """")"
+10,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 10,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+11,T3,ARCH_TAG_7_PARA_ROOM_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_ROOM_TXT, """")"
+12,T3,BLE_ROOM_FLOOR_FINISH_TXT,Floor Fin:,,,,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOM_FLOOR_FINISH_TXT, """")"
+13,T3,BLE_ROOM_WALL_FINISH_TXT,| Wall Fin:,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOM_WALL_FINISH_TXT, """")"
+14,T3,BLE_ROOM_CEILING_FINISH_TXT,| Ceil Fin:,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOM_CEILING_FINISH_TXT, """")"
+15,T3,BLE_ROOM_FIRE_ESCAPE_CAPACITY_NR,Esc Cap:,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, BLE_ROOM_FIRE_ESCAPE_CAPACITY_NR, """")"
+16,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+17,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_BLE_HEADROOM_MM_NR_ROOMS,Headroom < 2100mm,Building Regs Part K / BS 8300,Common,Text,⚠ Warning: Room Headroom,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_HEADROOM_MM_NR_ROOMS, """")"
 2,MEDIUM,WARN_BLE_ROOM_AREA_SQ_M_ROOMS,Area < minimum for use,Building Regs Approved Doc,Common,Text,⚠ Warning: Room Area,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_ROOM_AREA_SQ_M_ROOMS, """")"
+3,HIGH,WARN_BLE_ROOM_VENTILATION_ROOMS,Ventilation rate < 10 L/s/person,Building Regs Part F / CIBSE Guide A,Common,Text,⚠ Warning: Room Ventilation,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_ROOM_VENTILATION_ROOMS, """")"
 
 Tag Family #8: STING - Stair Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stairs
@@ -179,14 +205,20 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stairs
 5,T2,BLE_STAIR_RISER_MM,R:,mm,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_RISER_MM, """")"
 6,T2,BLE_STAIR_GOING_MM,| G:,mm,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_GOING_MM, """")"
 7,T2,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, PER_FIRE_RATING_HR, """")"
-8,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-9,T3,ARCH_TAG_7_PARA_STAIR_TXT,,,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_STAIR_TXT, """")"
-10,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-11,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+8,T2,BLE_STAIR_HEADROOM_MM,Hd:,mm,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_HEADROOM_MM, """")"
+9,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+10,T3,ARCH_TAG_7_PARA_STAIR_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_STAIR_TXT, """")"
+11,T3,BLE_STAIR_HANDRAIL_TXT,Handrail:,,,,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, BLE_STAIR_HANDRAIL_TXT, """")"
+12,T3,BLE_STAIR_NOSING_TXT,| Nosing:,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, BLE_STAIR_NOSING_TXT, """")"
+13,T3,BLE_STAIR_TREAD_MATERIAL_TXT,Mat:,,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, BLE_STAIR_TREAD_MATERIAL_TXT, """")"
+14,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+15,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_BLE_STAIR_RISER_MM_STAIRS,Riser > 220mm or < 150mm,Building Regs Part K,Common,Text,⚠ Warning: Stair Riser,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_RISER_MM_STAIRS, """")"
 2,HIGH,WARN_BLE_STAIR_GOING_MM_STAIRS,Going < 220mm,Building Regs Part K,Common,Text,⚠ Warning: Stair Going,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_GOING_MM_STAIRS, """")"
+3,CRITICAL,WARN_BLE_STAIR_HEADROOM_MM_STAIRS,Headroom < 2000mm,Building Regs Part K,Common,Text,⚠ Warning: Stair Headroom,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_HEADROOM_MM_STAIRS, """")"
+4,HIGH,WARN_BLE_STAIR_WIDTH_MM_STAIRS,Width < 1000mm (escape stair),Building Regs Part B / BS 9999,Common,Text,⚠ Warning: Stair Width,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_WIDTH_MM_STAIRS, """")"
 
 Tag Family #9: STING - Ramp Tag
 TAG7: ARCH_TAG_7_PARA_RAMP_TXT  •  Category: Ramps
@@ -196,13 +228,17 @@ TAG7: ARCH_TAG_7_PARA_RAMP_TXT  •  Category: Ramps
 3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
 4,T2,BLE_RAMP_SLOPE_PCT,Slope:,%,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAMP_SLOPE_PCT, """")"
 5,T2,BLE_RAMP_WIDTH_MM,W:,mm,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_RAMP_WIDTH_MM, """")"
-6,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-7,T3,ARCH_TAG_7_PARA_RAMP_TXT,,,,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_RAMP_TXT, """")"
-8,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-9,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+6,T2,BLE_RAMP_LENGTH_MM,L:,mm,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_RAMP_LENGTH_MM, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,ARCH_TAG_7_PARA_RAMP_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_RAMP_TXT, """")"
+9,T3,BLE_RAMP_LANDING_TXT,Landing:,,,,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, BLE_RAMP_LANDING_TXT, """")"
+10,T3,BLE_RAMP_HANDRAIL_BOOL,| Handrail:,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, BLE_RAMP_HANDRAIL_BOOL, """")"
+11,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+12,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_BLE_RAMP_SLOPE_PCT_RAMPS,Slope > 1:12 (8.33%),Building Regs Part M / BS 8300-2,Common,Text,⚠ Warning: Ramp Slope,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAMP_SLOPE_PCT_RAMPS, """")"
+2,HIGH,WARN_BLE_RAMP_LENGTH_MM_RAMPS,Length > 10000mm without landing,Building Regs Part M / BS 8300-2,Common,Text,⚠ Warning: Ramp Length,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAMP_LENGTH_MM_RAMPS, """")"
 
 Tag Family #10: STING - Railing Tag
 TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Railings
@@ -212,13 +248,17 @@ TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Railings
 3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
 4,T2,BLE_RAILING_HEIGHT_MM,Ht:,mm,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_HEIGHT_MM, """")"
 5,T2,BLE_RAILING_TYPE_TXT,Type:,,,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_TYPE_TXT, """")"
-6,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-7,T3,ARCH_TAG_7_PARA_RAILING_TXT,,,,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_RAILING_TXT, """")"
-8,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-9,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+6,T2,BLE_RAILING_MATERIAL_TXT,Mat:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_MATERIAL_TXT, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,ARCH_TAG_7_PARA_RAILING_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_RAILING_TXT, """")"
+9,T3,BLE_RAILING_INFILL_TXT,Infill:,,,,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, BLE_RAILING_INFILL_TXT, """")"
+10,T3,BLE_RAILING_BALUSTER_SPACING_MM,| Bal:,mm,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, BLE_RAILING_BALUSTER_SPACING_MM, """")"
+11,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+12,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_BLE_RAILING_HEIGHT_MM_RAILINGS,Height < 1100mm (balustrade) or < 900mm (stair),Building Regs Part K,Common,Text,⚠ Warning: Railing Height,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAILING_HEIGHT_MM_RAILINGS, """")"
+2,HIGH,WARN_BLE_RAILING_BALUSTER_RAILINGS,Baluster spacing > 100mm,Building Regs Part K / BS 6180,Common,Text,⚠ Warning: Baluster Spacing,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAILING_BALUSTER_RAILINGS, """")"
 
 Tag Family #11: STING - Furniture Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture
@@ -228,10 +268,16 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture
 3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")"
 5,T2,ASS_MODEL_NR_TXT,| ,,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ASS_MODEL_NR_TXT, """")"
-6,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-7,T3,ARCH_TAG_7_PARA_FURNITURE_TXT,,,,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_FURNITURE_TXT, """")"
-8,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-9,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+6,T2,BLE_FURNITURE_FINISH_TXT,Fin:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_FURNITURE_FINISH_TXT, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,ARCH_TAG_7_PARA_FURNITURE_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_FURNITURE_TXT, """")"
+9,T3,PER_FIRE_RATING_HR,,hr,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, PER_FIRE_RATING_HR, """")"
+10,T3,ASS_EXPECTED_LIFE_YEARS_YRS,Life:,yrs,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ASS_EXPECTED_LIFE_YEARS_YRS, """")"
+11,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+12,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_BLE_FURNITURE_FIRE_FURNITURE,Furniture fire resistance not rated,BS 7176 / BS 5852 (upholstered),Common,Text,⚠ Warning: Furniture Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_FURNITURE_FIRE_FURNITURE, """")"
 
 Tag Family #12: STING - Casework Tag
 TAG7: ARCH_TAG_7_PARA_CASEWORK_TXT  •  Category: Casework
@@ -241,10 +287,16 @@ TAG7: ARCH_TAG_7_PARA_CASEWORK_TXT  •  Category: Casework
 3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
 4,T2,BLE_CASEWORK_TYPE_TXT,Type:,,,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_CASEWORK_TYPE_TXT, """")"
 5,T2,BLE_CASEWORK_MATERIAL_TXT,Mat:,,,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_CASEWORK_MATERIAL_TXT, """")"
-6,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-7,T3,ARCH_TAG_7_PARA_CASEWORK_TXT,,,,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_CASEWORK_TXT, """")"
-8,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-9,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+6,T2,BLE_CASEWORK_COUNTERTOP_TXT,Top:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_CASEWORK_COUNTERTOP_TXT, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,ARCH_TAG_7_PARA_CASEWORK_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_CASEWORK_TXT, """")"
+9,T3,BLE_CASEWORK_HARDWARE_TXT,HW:,,,,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, BLE_CASEWORK_HARDWARE_TXT, """")"
+10,T3,BLE_CASEWORK_ACCESSIBLE_BOOL,| Access:,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, BLE_CASEWORK_ACCESSIBLE_BOOL, """")"
+11,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+12,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_BLE_CASEWORK_ACCESSIBLE_CASEWORK,Accessible unit clearance < 850mm,Building Regs Part M / BS 8300-2,Common,Text,⚠ Warning: Casework Accessibility,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_CASEWORK_ACCESSIBLE_CASEWORK, """")"
 
 Tag Family #13: STING - Curtain Panel Tag
 TAG7: ARCH_TAG_7_PARA_CURTAIN_TXT  •  Category: Curtain Panels
@@ -255,10 +307,12 @@ TAG7: ARCH_TAG_7_PARA_CURTAIN_TXT  •  Category: Curtain Panels
 4,T2,BLE_PANEL_WIDTH_MM,W:,mm,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_PANEL_WIDTH_MM, """")"
 5,T2,BLE_PANEL_HEIGHT_MM,× H:,mm,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_PANEL_HEIGHT_MM, """")"
 6,T2,PER_THERM_U_VALUE_W_M2K,,W/m²K,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, PER_THERM_U_VALUE_W_M2K, """")"
-7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-8,T3,ARCH_TAG_7_PARA_CURTAIN_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_CURTAIN_TXT, """")"
-9,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-10,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+7,T2,PER_SOLAR_G_VALUE,g:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, PER_SOLAR_G_VALUE, """")"
+8,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+9,T3,ARCH_TAG_7_PARA_CURTAIN_TXT,,,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_CURTAIN_TXT, """")"
+10,T3,BLE_PANEL_GLASS_TYPE_TXT,Glass:,,,,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, BLE_PANEL_GLASS_TYPE_TXT, """")"
+11,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+12,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_PER_THERM_U_VALUE_W_M2K_NR_CURTAIN,U > 2.20 W/m²K,Building Regs Part L2A (curtain wall),Common,Text,⚠ Warning: Curtain Wall U-Value,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_CURTAIN, """")"
@@ -271,7 +325,45 @@ TAG7: ARCH_TAG_7_PARA_MULLION_TXT  •  Category: Curtain Wall Mullions
 3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
 4,T2,BLE_MULLION_DEPTH_MM,D:,mm,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_MULLION_DEPTH_MM, """")"
 5,T2,BLE_MULLION_MATERIAL_TXT,Mat:,,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_MULLION_MATERIAL_TXT, """")"
-6,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-7,T3,ARCH_TAG_7_PARA_MULLION_TXT,,,,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_MULLION_TXT, """")"
-8,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-9,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+6,T2,BLE_MULLION_FINISH_TXT,Fin:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_MULLION_FINISH_TXT, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,ARCH_TAG_7_PARA_MULLION_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_MULLION_TXT, """")"
+9,T3,PER_THERM_U_VALUE_W_M2K,,W/m²K,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, PER_THERM_U_VALUE_W_M2K, """")"
+10,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+11,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+
+Tag Family #15: STING - Signage Tag
+TAG7: ARCH_TAG_7_PARA_SIGNAGE_TXT  •  Category: Signage
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
+1,T1,ASS_TAG_1_TXT,,,,✓,---,---,---,Add directly
+2,T2,ASS_TAG_2_TXT,,,,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
+4,T2,BLE_SIGN_TYPE_TXT,Type:,,,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_SIGN_TYPE_TXT, """")"
+5,T2,BLE_SIGN_ILLUMINATED_BOOL,Illum:,,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_SIGN_ILLUMINATED_BOOL, """")"
+6,T2,MNT_HGT_MM,Ht:,mm,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,ARCH_TAG_7_PARA_SIGNAGE_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_SIGNAGE_TXT, """")"
+9,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+10,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_BLE_SIGN_FIRE_EXIT_SIGNAGE,Fire exit sign not illuminated,Building Regs Part B / BS 5499-4,Common,Text,⚠ Warning: Fire Exit Sign,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_SIGN_FIRE_EXIT_SIGNAGE, """")"
+
+Tag Family #16: STING - Parking Tag
+TAG7: ARCH_TAG_7_PARA_PARKING_TXT  •  Category: Parking
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
+1,T1,ASS_TAG_1_TXT,,,,✓,---,---,---,Add directly
+2,T2,ASS_TAG_2_TXT,,,,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
+4,T2,BLE_PARK_BAY_WIDTH_MM,W:,mm,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_PARK_BAY_WIDTH_MM, """")"
+5,T2,BLE_PARK_BAY_LENGTH_MM,× L:,mm,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, BLE_PARK_BAY_LENGTH_MM, """")"
+6,T2,BLE_PARK_TYPE_TXT,Type:,,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, BLE_PARK_TYPE_TXT, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,ARCH_TAG_7_PARA_PARKING_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_PARKING_TXT, """")"
+9,T3,BLE_PARK_ACCESSIBLE_BOOL,Access:,,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, BLE_PARK_ACCESSIBLE_BOOL, """")"
+10,T3,BLE_PARK_EV_CHARGING_BOOL,| EV:,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, BLE_PARK_EV_CHARGING_BOOL, """")"
+11,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+12,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_BLE_PARK_BAY_WIDTH_PARKING,Accessible bay width < 3600mm,Building Regs Part M / BS 8300-1,Common,Text,⚠ Warning: Accessible Bay Width,"if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_PARK_BAY_WIDTH_PARKING, """")"

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
@@ -15,6 +15,9 @@ TAG7: HVC_TAG_7_PARA_AT_TXT  •  Category: Air Terminals
 10,T3,HVC_DCT_TERMINAL_SZ_TXT,,,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, HVC_DCT_TERMINAL_SZ_TXT, """")"
 11,T3,HVC_TERMINAL_MAT_TXT,,m,1,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, HVC_TERMINAL_MAT_TXT, """")"
 12,T3,HVC_TERMINAL_FINISH_TXT,,,0,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, HVC_TERMINAL_FINISH_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_HVC_NOISE_NC_AIR_TERMINALS,Noise level > NC 30,ASHRAE Ch 48 / CIBSE Guide B5,Common,Text,⚠ Warning: Air Terminal Noise,"if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_NOISE_NC_AIR_TERMINALS, """")"
 Tag Family #2: STING - Duct Accessory Tag
 TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Accessories
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -24,6 +27,9 @@ TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Accessories
 4,T2,HVC_DCT_PROPERTY_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_PROPERTY_TXT, """")"
 5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 6,T3,HVC_TAG_7_PARA_DCTACC_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_DCTACC_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_HVC_DCT_PROPERTY_DUCT_ACC,Check parameter value,CIBSE Guide B3,Common,Text,⚠ Warning: Duct Accessory Check,"if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_DCT_PROPERTY_DUCT_ACC, """")"
 Tag Family #3: STING - Duct Fitting Tag
 TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -32,7 +38,10 @@ TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Fittings
 3,T2,HVC_DCT_PROPERTY_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_PROPERTY_TXT, """")"
 4,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 5,T3,HVC_TAG_7_PARA_DCTACC_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_DCTACC_TXT, """")"
-6,T3,HVC_DUCT_CLASS_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, HVC_DUCT_CLASS_TXT, """")"
+6,T3,HVC_DUCT_CLASS_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, HVC_DUCT_CLASS_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_HVC_DUCT_CLASS_DUCT_FITTINGS,Duct class mismatch,CIBSE DW/144 / SMACNA,Common,Text,⚠ Warning: Duct Fitting Class,"if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_DUCT_CLASS_DUCT_FITTINGS, """")"
 Tag Family #4: STING - Duct Tag
 TAG7: HVC_TAG_7_PARA_DUCT_TXT  •  Category: Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -46,7 +55,7 @@ TAG7: HVC_TAG_7_PARA_DUCT_TXT  •  Category: Ducts
 8,T2,HVC_INSULATION_TXT,| Insul:,,0,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, HVC_INSULATION_TXT, """")"
 9,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 10,T3,HVC_TAG_7_PARA_DUCT_TXT,,,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_DUCT_TXT, """")"
-11,T3,HVC_DUCT_CLASS_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, HVC_DUCT_CLASS_TXT, """")"
+11,T3,HVC_DUCT_CLASS_TXT,,,0,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, HVC_DUCT_CLASS_TXT, """")"
 12,T3,HVC_DUCT_LINING_TXT,,,0,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, HVC_DUCT_LINING_TXT, """")"
 13,T3,HVC_DUCT_AREA_SQ_M,,m²,1,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, HVC_DUCT_AREA_SQ_M, """")"
 14,T3,HVC_DUCT_FLOWRATE_M3H,,m³/h,1,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, HVC_DUCT_FLOWRATE_M3H, """")"
@@ -63,6 +72,10 @@ TAG7: HVC_TAG_7_PARA_DUCT_TXT  •  Category: Ducts
 25,T3,CST_CALC_LENGTH_M,Length:,m,0,,Common,Text,Show Tier 3 - 25,"if(TAG_PARA_STATE_3_BOOL, CST_CALC_LENGTH_M, """")"
 26,T3,CST_CALC_AREA_M2,| Area:,m²,0,✓,Common,Text,Show Tier 3 - 26,"if(TAG_PARA_STATE_3_BOOL, CST_CALC_AREA_M2, """")"
 27,T3,CST_LOCAL_MAT_BOOL,Local:,,0,,Common,Text,Show Tier 3 - 27,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_HVC_VEL_MPS_DUCTS,Velocity > 10 m/s,CIBSE Guide B3 / ASHRAE,Common,Text,⚠ Warning: Duct Velocity,"if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_VEL_MPS_DUCTS, """")"
+2,HIGH,WARN_HVC_PIPE_PRESSURE_KPA_DUCTS,Pressure drop exceeds design limit,CIBSE Guide B3,Common,Text,⚠ Warning: Duct Pressure Drop,"if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_PIPE_PRESSURE_KPA_DUCTS, """")"
 Tag Family #5: STING - Flex Duct Tag
 TAG7: HVC_TAG_7_PARA_FLEXDUCT_TXT  •  Category: Flex Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -95,9 +108,9 @@ TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Mechanical Equipment
 15,T3,HVC_EQP_TAG_01_TXT,,,0,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, HVC_EQP_TAG_01_TXT, """")"
 16,T3,HVC_EQP_TAG_02_TXT,,,0,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, HVC_EQP_TAG_02_TXT, """")"
 17,T3,HVC_EQP_TAG_03_TXT,,,0,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, HVC_EQP_TAG_03_TXT, """")"
-18,T3,HVC_CAP_TR,,°C,0,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, HVC_CAP_TR, """")"
+18,T3,HVC_CAP_TR,,TR,0,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, HVC_CAP_TR, """")"
 19,T3,HVC_VLT_V,,V,1,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, HVC_VLT_V, """")"
-20,T3,HVC_CONTROL_TYPE_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, HVC_CONTROL_TYPE_TXT, """")"
+20,T3,HVC_CONTROL_TYPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, HVC_CONTROL_TYPE_TXT, """")"
 21,T3,ASS_SERIAL_NR_TXT,,,0,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, ASS_SERIAL_NR_TXT, """")"
 22,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
 23,T3,ASS_SYSTEM_TYPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 23,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")"
@@ -126,6 +139,9 @@ TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Flex Pipes
 5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 6,T3,PLM_TAG_7_PARA_PIPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, PLM_TAG_7_PARA_PIPE_TXT, """")"
 7,T3,PLM_PPE_LENGTH_M,,m,1,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, PLM_PPE_LENGTH_M, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_PLM_PPE_LENGTH_FLEX_PIPE,Flex pipe length > 1.5 m,BS EN 806 / CIBSE Guide G,Common,Text,⚠ Warning: Flex Pipe Length,"if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PPE_LENGTH_FLEX_PIPE, """")"
 Tag Family #8: STING - Pipe Accessory Tag
 TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Accessories
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -135,6 +151,9 @@ TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Accessories
 4,T2,ASS_DESCRIPTION_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
 5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 6,T3,PLM_TAG_7_PARA_PIPEACC_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, PLM_TAG_7_PARA_PIPEACC_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_PLM_PPE_SZ_PIPE_ACC,Check pipe accessory sizing,BS EN 806,Common,Text,⚠ Warning: Pipe Accessory Size,"if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PPE_SZ_PIPE_ACC, """")"
 Tag Family #9: STING - Pipe Fitting Tag
 TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -145,6 +164,9 @@ TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Fittings
 5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 6,T3,PLM_TAG_7_PARA_PIPEACC_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, PLM_TAG_7_PARA_PIPEACC_TXT, """")"
 7,T3,PLM_PPE_PSR_RATING_BAR,,bar,1,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, PLM_PPE_PSR_RATING_BAR, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_PLM_PPE_PSR_RATING_PIPE_FITTINGS,Pressure exceeds fitting rating,BS EN 1254 / ASME B16,Common,Text,⚠ Warning: Pipe Fitting Pressure,"if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PPE_PSR_RATING_PIPE_FITTINGS, """")"
 Tag Family #10: STING - Pipe Tag
 TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Pipes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -174,9 +196,10 @@ TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Pipes
 24,T3,PLM_PPE_HANGER_TYPE_TXT,Hanger:,,0,,Common,Text,Show Tier 3 - 24,"if(TAG_PARA_STATE_3_BOOL, PLM_PPE_HANGER_TYPE_TXT, """")"
 25,T3,CST_CALC_LENGTH_M,| Length:,m,0,✓,Common,Text,Show Tier 3 - 25,"if(TAG_PARA_STATE_3_BOOL, CST_CALC_LENGTH_M, """")"
 26,T3,CST_LOCAL_MAT_BOOL,Local:,,0,,Common,Text,Show Tier 3 - 26,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
-"⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓, Calculated Value gates visibility)"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
-1,MEDIUM,WARN_PLM_PPE_FLW_LPS_PIPES__HOT_WATE,Flow rate exceeded,BS EN 806,Common,Text,⚠ Warning: Pipe Flow Rate,"if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PPE_FLW_LPS_PIPES__HOT_WATE, """")"
+1,MEDIUM,WARN_PLM_PPE_FLW_LPS_PIPES,Flow rate exceeded,BS EN 806 / CIBSE Guide G,Common,Text,⚠ Warning: Pipe Flow Rate,"if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PPE_FLW_LPS_PIPES, """")"
+2,MEDIUM,WARN_PLM_VEL_MPS_PIPES,Velocity > 2.0 m/s (hot) or > 3.0 m/s (cold),CIBSE Guide G / BS EN 806-3,Common,Text,⚠ Warning: Pipe Velocity,"if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_VEL_MPS_PIPES, """")"
 Tag Family #11: STING - Plumbing Fixture Tag
 TAG7: PLM_TAG_7_PARA_FIXTURE_TXT  •  Category: Plumbing Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -200,6 +223,9 @@ TAG7: PLM_TAG_7_PARA_FIXTURE_TXT  •  Category: Plumbing Fixtures
 18,T3,PER_SUST_WATER_RATING_TXT,| Water:,,0,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, PER_SUST_WATER_RATING_TXT, """")"
 19,T3,CST_LOCAL_MAT_BOOL,Local:,,0,,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
 20,T3,CST_DELIVERY_LEAD_TIME_DAYS,| Lead:,days,0,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_PLM_FIXTURE_WATER_EFFICIENCY,Water usage exceeds efficiency rating,WELS / BS EN 200 / EDGE,Common,Text,⚠ Warning: Fixture Water Efficiency,"if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_FIXTURE_WATER_EFFICIENCY, """")"
 6E — Fire Protection
 Tag Family #12: STING - Fire Alarm Device Tag
 TAG7: FLS_TAG_7_PARA_FA_TXT  •  Category: Fire Alarm Devices
@@ -255,9 +281,10 @@ TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Tray Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
 1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
-3,T2,ELC_CTR_MAT_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")"
-4,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-5,T3,ELC_TAG_7_PARA_TRAY_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_TRAY_TXT, """")"
+3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
+4,T2,ELC_CTR_MAT_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")"
+5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+6,T3,ELC_TAG_7_PARA_TRAY_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_TRAY_TXT, """")"
 Tag Family #15: STING - Cable Tray Tag
 TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Trays
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -275,14 +302,18 @@ TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Trays
 12,T3,ELC_CBT_SUPPORT_SPACING_MM,| Supt:,mm,0,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ELC_CBT_SUPPORT_SPACING_MM, """")"
 13,T3,CST_CALC_LENGTH_M,Length:,m,0,,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, CST_CALC_LENGTH_M, """")"
 14,T3,CST_LOCAL_MAT_BOOL,| Local:,,0,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_ELC_CTR_FILL_PCT_CABLE_TRAYS,Cable tray fill > 50%,IEC 61537 / BS EN 61537,Common,Text,⚠ Warning: Cable Tray Fill,"if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_PCT_CABLE_TRAYS, """")"
 Tag Family #16: STING - Conduit Fitting Tag
 TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduit Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
 1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
-3,T2,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_SZ_MM, """")"
-4,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
-5,T3,ELC_TAG_7_PARA_CONDUIT_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_CONDUIT_TXT, """")"
+3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
+4,T2,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_SZ_MM, """")"
+5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+6,T3,ELC_TAG_7_PARA_CONDUIT_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_CONDUIT_TXT, """")"
 Tag Family #17: STING - Conduit Tag
 TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduits
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -296,10 +327,10 @@ TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduits
 8,T2,ELC_CBL_INSTALL_METHOD_TXT,Install:,,0,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, ELC_CBL_INSTALL_METHOD_TXT, """")"
 9,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 10,T3,ELC_TAG_7_PARA_CONDUIT_TXT,,,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_CONDUIT_TXT, """")"
-11,T3,ELC_CDT_INSTALL_METHOD_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_INSTALL_METHOD_TXT, """")"
+11,T3,ELC_CDT_INSTALL_METHOD_TXT,,,0,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_INSTALL_METHOD_TXT, """")"
 12,T3,ELC_CDT_CBL_FILL_PCT,,%,0,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_CBL_FILL_PCT, """")"
-13,T3,ELC_CDT_TAG_01_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_TAG_01_TXT, """")"
-14,T3,ELC_CDT_TAG_02_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_TAG_02_TXT, """")"
+13,T3,ELC_CDT_TAG_01_TXT,,,0,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_TAG_01_TXT, """")"
+14,T3,ELC_CDT_TAG_02_TXT,,,0,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_TAG_02_TXT, """")"
 15,T3,ELC_CBL_NUM_OF_CORES_NR,,,0,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ELC_CBL_NUM_OF_CORES_NR, """")"
 16,T3,ELC_CKT_PHASE_COUNT_NR,,,0,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, ELC_CKT_PHASE_COUNT_NR, """")"
 17,T3,ELC_CDT_FAB_METHOD_TXT,Fab:,,0,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_FAB_METHOD_TXT, """")"
@@ -307,6 +338,9 @@ TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduits
 19,T3,ELC_CDT_SUPPORT_SPACING_MM,| Supt:,mm,0,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, ELC_CDT_SUPPORT_SPACING_MM, """")"
 20,T3,CST_CALC_LENGTH_M,Length:,m,0,,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, CST_CALC_LENGTH_M, """")"
 21,T3,CST_LOCAL_MAT_BOOL,| Local:,,0,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_ELC_CDT_CBL_FILL_PCT_CONDUITS,Conduit fill > 40%,IEC 60364 / BS 7671 Table 4C1,Common,Text,⚠ Warning: Conduit Fill,"if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_CBL_FILL_PCT_CONDUITS, """")"
 Tag Family #18: STING - Electrical Equipment Tag
 TAG7: ELC_TAG_7_PARA_PANEL_TXT  •  Category: Electrical Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -374,7 +408,10 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Devices
 5,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")"
 6,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 7,T3,ELC_TAG_7_PARA_CIRCUIT_TXT,,,0,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_CIRCUIT_TXT, """")"
-8,T3,LTG_CTRL_TYPE_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, LTG_CTRL_TYPE_TXT, """")"
+8,T3,LTG_CTRL_TYPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, LTG_CTRL_TYPE_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_LTG_CTRL_TYPE_LIGHTING_DEVICES,Control type unassigned,CIBSE LG7 / BS EN 15232,Common,Text,⚠ Warning: Lighting Control Type,"if(TAG_WARN_VISIBLE_BOOL, WARN_LTG_CTRL_TYPE_LIGHTING_DEVICES, """")"
 Tag Family #21: STING - Lighting Fixture Tag
 TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -394,12 +431,16 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Fixtures
 14,T3,LTG_FIX_TAG_01_TXT,,,0,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, LTG_FIX_TAG_01_TXT, """")"
 15,T3,LTG_FIX_TAG_02_TXT,,,0,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, LTG_FIX_TAG_02_TXT, """")"
 16,T3,LTG_EMRG_TYPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, LTG_EMRG_TYPE_TXT, """")"
-17,T3,LTG_CLR_RENDERING_INDEX_NR,,°C,0,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, LTG_CLR_RENDERING_INDEX_NR, """")"
-18,T3,LTG_CKT_NR_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, LTG_CKT_NR_TXT, """")"
-19,T3,LTG_CTRL_TYPE_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, LTG_CTRL_TYPE_TXT, """")"
+17,T3,LTG_CLR_RENDERING_INDEX_NR,CRI:,,0,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, LTG_CLR_RENDERING_INDEX_NR, """")"
+18,T3,LTG_CKT_NR_TXT,Ckt:,,0,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, LTG_CKT_NR_TXT, """")"
+19,T3,LTG_CTRL_TYPE_TXT,Ctrl:,,0,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, LTG_CTRL_TYPE_TXT, """")"
 20,T3,LTG_DESIGN_ILLUMINANCE_LUX,,lux,1,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, LTG_DESIGN_ILLUMINANCE_LUX, """")"
 21,T3,ASS_EXPECTED_LIFE_YEARS_YRS,,,0,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, ASS_EXPECTED_LIFE_YEARS_YRS, """")"
 22,T3,PER_SUST_ENERGY_RATING_TXT,,,0,✓,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, PER_SUST_ENERGY_RATING_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_LTG_EFFICACY_LM_W_LIGHTING,Efficacy < 80 lm/W,CIBSE LG7 / ASHRAE 90.1,Common,Text,⚠ Warning: Lighting Efficacy,"if(TAG_WARN_VISIBLE_BOOL, WARN_LTG_EFFICACY_LM_W_LIGHTING, """")"
+2,HIGH,WARN_LTG_DESIGN_ILLUMINANCE_LUX,Illuminance below task requirement,CIBSE SLL / BS EN 12464-1,Common,Text,⚠ Warning: Illuminance Below Standard,"if(TAG_WARN_VISIBLE_BOOL, WARN_LTG_DESIGN_ILLUMINANCE_LUX, """")"
 6G — LV / ICT
 Tag Family #22: STING - Communication Device Tag
 TAG7: COM_TAG_7_PARA_BMS_TXT  •  Category: Communication Devices
@@ -412,12 +453,15 @@ TAG7: COM_TAG_7_PARA_BMS_TXT  •  Category: Communication Devices
 6,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 7,T3,COM_TAG_7_PARA_BMS_TXT,,,0,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, COM_TAG_7_PARA_BMS_TXT, """")"
 8,T3,COM_DEV_TAG_01_TXT,,,0,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, COM_DEV_TAG_01_TXT, """")"
-9,T3,COM_C_DEV_TYPE_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, COM_C_DEV_TYPE_TXT, """")"
-10,T3,COM_C_MEASUREMENT_RANGE_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, COM_C_MEASUREMENT_RANGE_TXT, """")"
+9,T3,COM_C_DEV_TYPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, COM_C_DEV_TYPE_TXT, """")"
+10,T3,COM_C_MEASUREMENT_RANGE_TXT,,,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, COM_C_MEASUREMENT_RANGE_TXT, """")"
 11,T3,COM_C_PWR_SUPPLY_V,,V,1,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, COM_C_PWR_SUPPLY_V, """")"
 12,T3,COM_BMS_RANGE_TXT,,,0,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, COM_BMS_RANGE_TXT, """")"
-13,T3,COM_C_DEV_BACNET_INSTANCE_INT,,°C,0,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, COM_C_DEV_BACNET_INSTANCE_INT, """")"
-14,T3,COM_C_DEV_CONTROLLER_NAME_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, COM_C_DEV_CONTROLLER_NAME_TXT, """")"
+13,T3,COM_C_DEV_BACNET_INSTANCE_INT,,,0,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, COM_C_DEV_BACNET_INSTANCE_INT, """")"
+14,T3,COM_C_DEV_CONTROLLER_NAME_TXT,,,0,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, COM_C_DEV_CONTROLLER_NAME_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_COM_C_PROTOCOL_COMM_DEVICES,Protocol mismatch with BMS,BACnet / Modbus / ASHRAE 135,Common,Text,⚠ Warning: Comms Protocol Mismatch,"if(TAG_WARN_VISIBLE_BOOL, WARN_COM_C_PROTOCOL_COMM_DEVICES, """")"
 Tag Family #23: STING - Data Device Tag
 TAG7: ICT_TAG_7_PARA_DATA_TXT  •  Category: Data Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -428,6 +472,9 @@ TAG7: ICT_TAG_7_PARA_DATA_TXT  •  Category: Data Devices
 5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 6,T3,ICT_TAG_7_PARA_DATA_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, ICT_TAG_7_PARA_DATA_TXT, """")"
 7,T3,ICT_DEV_TAG_01_TXT,,,0,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, ICT_DEV_TAG_01_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_ICT_OUTLET_TYPE_DATA_DEVICES,Outlet category unassigned,TIA-568 / BS EN 50173,Common,Text,⚠ Warning: Data Outlet Type,"if(TAG_WARN_VISIBLE_BOOL, WARN_ICT_OUTLET_TYPE_DATA_DEVICES, """")"
 Tag Family #24: STING - Nurse Call Device Tag
 TAG7: NCL_TAG_7_PARA_NURSECALL_TXT  •  Category: Nurse Call Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -437,6 +484,9 @@ TAG7: NCL_TAG_7_PARA_NURSECALL_TXT  •  Category: Nurse Call Devices
 4,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")"
 5,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 6,T3,NCL_TAG_7_PARA_NURSECALL_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, NCL_TAG_7_PARA_NURSECALL_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_NCL_ZONE_NURSE_CALL,Zone coverage gap,HTM 08-03 / BS 6839-1,Common,Text,⚠ Warning: Nurse Call Zone Coverage,"if(TAG_WARN_VISIBLE_BOOL, WARN_NCL_ZONE_NURSE_CALL, """")"
 Tag Family #25: STING - Security Device Tag
 TAG7: SEC_TAG_7_PARA_SECURITY_TXT  •  Category: Security Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -447,6 +497,9 @@ TAG7: SEC_TAG_7_PARA_SECURITY_TXT  •  Category: Security Devices
 5,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")"
 6,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 7,T3,SEC_TAG_7_PARA_SECURITY_TXT,,,0,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, SEC_TAG_7_PARA_SECURITY_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_SEC_DEV_ZONE_SECURITY,Security zone unassigned,BS EN 50131 / BS 7671,Common,Text,⚠ Warning: Security Zone Unassigned,"if(TAG_WARN_VISIBLE_BOOL, WARN_SEC_DEV_ZONE_SECURITY, """")"
 Tag Family #26: STING - Telephone Devices Tag
 TAG7: ICT_TAG_7_PARA_TEL_TXT  •  Category: Telephone Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -460,6 +513,9 @@ TAG7: ICT_TAG_7_PARA_TEL_TXT  •  Category: Telephone Devices
 8,T3,ICT_TAG_7_PARA_TEL_TXT,,,0,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ICT_TAG_7_PARA_TEL_TXT, """")"
 9,T3,ICT_TEL_OUTLET_QTY_NR,,,0,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ICT_TEL_OUTLET_QTY_NR, """")"
 10,T3,ICT_TEL_PORT_TYPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ICT_TEL_PORT_TYPE_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_ICT_OUTLET_TYPE_TELEPHONE,Port type unassigned,TIA-568 / BS EN 50173,Common,Text,⚠ Warning: Telephone Port Type,"if(TAG_WARN_VISIBLE_BOOL, WARN_ICT_OUTLET_TYPE_TELEPHONE, """")"
 6H — General
 Tag Family #27: STING - Generic Model Tag
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Generic Models
@@ -472,7 +528,7 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Generic Models
 6,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")"
 7,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 8,T3,ASS_TAG_7_PARA_EQUIPMENT_TXT,,,0,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, ASS_TAG_7_PARA_EQUIPMENT_TXT, """")"
-9,T3,ASS_CAT_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_CAT_TXT, """")"
+9,T3,ASS_CAT_TXT,,,0,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_CAT_TXT, """")"
 10,T3,ASS_SERIAL_NR_TXT,,,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ASS_SERIAL_NR_TXT, """")"
 11,T3,ASS_CST_QUANTITY_NR,,,0,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_QUANTITY_NR, """")"
 12,T3,ASS_CST_UNIT_PRICE_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_UNIT_PRICE_UGX_NR, """")"
@@ -481,6 +537,9 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Generic Models
 15,T3,CST_IMPORT_REQUIRED_BOOL,Import:,,0,,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, CST_IMPORT_REQUIRED_BOOL, """")"
 16,T3,PER_SUST_EPD_REF_TXT,| EPD:,,0,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, PER_SUST_EPD_REF_TXT, """")"
 17,T3,RGL_QA_STD_COMPLY_TXT,Standard:,,0,,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_STD_COMPLY_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_ASS_DESCRIPTION_GENERIC_MODEL,Description missing,ISO 19650 / COBie,Common,Text,⚠ Warning: Generic Model Description,"if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_DESCRIPTION_GENERIC_MODEL, """")"
 Tag Family #28: STING - Specialty Equipment Tag
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -495,7 +554,7 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 9,T3,ASS_SERIAL_NR_TXT,,,0,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, ASS_SERIAL_NR_TXT, """")"
 10,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
 11,T3,ASS_SYSTEM_TYPE_TXT,,,0,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")"
-12,T3,ASS_CAT_TXT,,°C,0,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CAT_TXT, """")"
+12,T3,ASS_CAT_TXT,,,0,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, ASS_CAT_TXT, """")"
 13,T3,ASS_ID_TXT,,,0,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, ASS_ID_TXT, """")"
 14,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 15,T3,ASS_CRITICALITY_RATING_NR,,,0,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CRITICALITY_RATING_NR, """")"
@@ -506,7 +565,10 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 20,T3,CST_IMPORT_REQUIRED_BOOL,Import:,,0,,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, CST_IMPORT_REQUIRED_BOOL, """")"
 21,T3,CST_SPECIAL_EQUIPMENT_TXT,| Special:,,0,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, CST_SPECIAL_EQUIPMENT_TXT, """")"
 22,T3,RGL_QA_COMMISSIONING_REQ_TXT,Comm:,,0,,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_COMMISSIONING_REQ_TXT, """")"
-6D — MEP
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_ASS_CRITICALITY_SPECIALTY_EQUIP,Criticality rating > 3 without commissioning plan,ISO 55000 / PAS 1192-3,Common,Text,⚠ Warning: Specialty Equipment Criticality,"if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_CRITICALITY_SPECIALTY_EQUIP, """")"
+6I — MEP Fabrication & Materials
 Tag Family #29: STING - Duct Insulation Tag
 TAG7: HVC_TAG_7_PARA_DUCT_INSULATION_TXT  •  Category: Duct Insulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -523,6 +585,11 @@ TAG7: HVC_TAG_7_PARA_DUCT_LINING_TXT  •  Category: Duct Lining
 1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly
 2,T1,INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")"
+5,T3,HVC_TAG_7_PARA_DUCT_LINING_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_DUCT_LINING_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_INS_THICKNESS_DUCT_LINING,Lining thickness < minimum,CIBSE DW/144 / ASHRAE,Common,Text,⚠ Warning: Duct Lining Thickness,"if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_DUCT_LINING, """")"
 Tag Family #31: STING - Pipe Insulation Tag
 TAG7: PLM_TAG_7_PARA_PIPE_INSULATION_TXT  •  Category: Pipe Insulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -530,14 +597,23 @@ TAG7: PLM_TAG_7_PARA_PIPE_INSULATION_TXT  •  Category: Pipe Insulation
 2,T1,INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
 4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")"
+5,T3,PLM_TAG_7_PARA_PIPE_INSULATION_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, PLM_TAG_7_PARA_PIPE_INSULATION_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_INS_THICKNESS_PIPE_INSULATION,Insulation thickness < minimum,CIBSE Guide C / ASHRAE 90.1,Common,Text,⚠ Warning: Pipe Insulation Thickness,"if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_PIPE_INSULATION, """")"
 Tag Family #32: STING - Plumbing Equipment Tag
 TAG7: PLM_TAG_7_PARA_PLM_EQUIP_TXT  •  Category: Plumbing Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
 1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
-3,T2,PLM_EQP_CAPACITY_L,Cap:,L,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_EQP_CAPACITY_L, """")"
-4,T3,PLM_EQP_PRESSURE_KPA,P:,kPa,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, PLM_EQP_PRESSURE_KPA, """")"
-5,T3,PLM_HOTWTR_STORAGE_CAP_GAL_NR,,°C,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, PLM_HOTWTR_STORAGE_CAP_GAL_NR, """")"
+3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
+4,T2,PLM_EQP_CAPACITY_L,Cap:,L,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_EQP_CAPACITY_L, """")"
+5,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")"
+6,T2,ASS_MODEL_NR_TXT,|,,0,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, ASS_MODEL_NR_TXT, """")"
+7,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,PLM_TAG_7_PARA_PLM_EQUIP_TXT,,,0,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, PLM_TAG_7_PARA_PLM_EQUIP_TXT, """")"
+9,T3,PLM_EQP_PRESSURE_KPA,P:,kPa,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, PLM_EQP_PRESSURE_KPA, """")"
+5,T3,PLM_HOTWTR_STORAGE_CAP_GAL_NR,,L,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, PLM_HOTWTR_STORAGE_CAP_GAL_NR, """")"
 6,T3,PLM_HOTWTR_INPUT_PWR_KW,,kW,1,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, PLM_HOTWTR_INPUT_PWR_KW, """")"
 7,T3,PLM_HOTWTR_TEMP_C,,°C,0,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, PLM_HOTWTR_TEMP_C, """")"
 8,T3,PLM_CAP_CU_M,,m³,1,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, PLM_CAP_CU_M, """")"
@@ -559,12 +635,19 @@ TAG7: HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT  •  Category: Mechanical Control Device
 2,T1,MEC_CTRL_FUNCTION_TXT,,,0,✓,---,---,---,Add directly
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
 4,T2,MEC_CTRL_SIGNAL_TXT,Signal:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MEC_CTRL_SIGNAL_TXT, """")"
+5,T3,HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_MEC_CTRL_SIGNAL_CTRL_DEV,Signal type unassigned,ASHRAE / CIBSE Guide H,Common,Text,⚠ Warning: Control Signal Type,"if(TAG_WARN_VISIBLE_BOOL, WARN_MEC_CTRL_SIGNAL_CTRL_DEV, """")"
 Tag Family #34: STING - Mechanical Equipment Sets Tag
 TAG7: HVC_TAG_7_PARA_MECH_EQUIP_SETS_TXT  •  Category: Mechanical Equipment Sets
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
 1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
 3,T3,MEC_SET_CAPACITY_KW,Capacity:,kW,0,✓,Common,Text,Show Tier 3 - 3,"if(TAG_PARA_STATE_3_BOOL, MEC_SET_CAPACITY_KW, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_MEC_SET_CAPACITY_EQUIP_SETS,Capacity exceeds design,ASHRAE / CIBSE Guide B,Common,Text,⚠ Warning: Equipment Set Capacity,"if(TAG_WARN_VISIBLE_BOOL, WARN_MEC_SET_CAPACITY_EQUIP_SETS, """")"
 Tag Family #35: STING - Electrical Connectors Tag
 TAG7: ELC_TAG_7_PARA_ELC_CONNECTORS_TXT  •  Category: Electrical Connectors
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -572,6 +655,10 @@ TAG7: ELC_TAG_7_PARA_ELC_CONNECTORS_TXT  •  Category: Electrical Connectors
 2,T1,ELC_CONN_TYPE_TXT,,,0,✓,---,---,---,Add directly
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
 4,T2,ELC_CONN_RATING_A,,A,1,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CONN_RATING_A, """")"
+5,T3,ELC_TAG_7_PARA_ELC_CONNECTORS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_ELC_CONNECTORS_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,HIGH,WARN_ELC_CONN_RATING_CONNECTORS,Rating exceeded,IEC 60309 / BS EN 60309,Common,Text,⚠ Warning: Connector Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CONN_RATING_CONNECTORS, """")"
 Tag Family #36: STING - Fire Protection Tag
 TAG7: FLS_TAG_7_PARA_FIRE_PROT_TXT  •  Category: Fire Protection
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -579,7 +666,7 @@ TAG7: FLS_TAG_7_PARA_FIRE_PROT_TXT  •  Category: Fire Protection
 2,T1,FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN,,min,1,✓,---,---,---,Add directly
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
 4,T2,FLS_PROT_PRODUCT_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FLS_PROT_PRODUCT_TXT, """")"
-5,T3,FLS_PROT_CORROSION_PROT_LVL_NR,,°C,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, FLS_PROT_CORROSION_PROT_LVL_NR, """")"
+5,T3,FLS_PROT_CORROSION_PROT_LVL_NR,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, FLS_PROT_CORROSION_PROT_LVL_NR, """")"
 6,T3,FLS_PROT_FLS_ESCAPE_STAIR_TXT,,,0,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, FLS_PROT_FLS_ESCAPE_STAIR_TXT, """")"
 7,T3,FLS_EXIT_TRAVEL_DIST_M,,m,1,✓,Common,Text,Show Tier 3 - 7,"if(TAG_PARA_STATE_3_BOOL, FLS_EXIT_TRAVEL_DIST_M, """")"
 8,T3,FLS_EVACUATION_TIME_MIN,,m,1,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, FLS_EVACUATION_TIME_MIN, """")"
@@ -595,6 +682,9 @@ TAG7: ELC_TAG_7_PARA_FAB_CONTAINMENT_TXT  •  Category: MEP Fabrication Contain
 2,T1,FAB_CONTAINMENT_W_MM,,×,0,,---,---,---,Add directly
 3,T1,FAB_CONTAINMENT_D_MM,,mm,0,✓,---,---,---,Add directly
 4,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_FAB_CONTAINMENT_DIMENSIONS,Containment size mismatch,IEC 61537,Common,Text,⚠ Warning: Containment Size,"if(TAG_WARN_VISIBLE_BOOL, WARN_FAB_CONTAINMENT_DIMENSIONS, """")"
 Tag Family #38: STING - MEP Fabrication Ductwork Tag
 TAG7: HVC_TAG_7_PARA_FAB_DUCTWORK_TXT  •  Category: MEP Fabrication Ductwork
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -602,12 +692,18 @@ TAG7: HVC_TAG_7_PARA_FAB_DUCTWORK_TXT  •  Category: MEP Fabrication Ductwork
 2,T1,FAB_DCT_W_MM,,×,0,,---,---,---,Add directly
 3,T1,FAB_DCT_H_MM,,mm,0,✓,---,---,---,Add directly
 4,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_FAB_DCT_DIMENSIONS_DUCTWORK,Fabrication duct size mismatch,CIBSE DW/144 / SMACNA,Common,Text,⚠ Warning: Fab Duct Dimensions,"if(TAG_WARN_VISIBLE_BOOL, WARN_FAB_DCT_DIMENSIONS_DUCTWORK, """")"
 Tag Family #39: STING - MEP Fabrication Ductwork Stiffeners Tag
 TAG7: HVC_TAG_7_PARA_FAB_DCT_STIFFENERS_TXT  •  Category: MEP Fabrication Ductwork Stiffeners
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
 1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly
 2,T1,FAB_STIFF_TYPE_TXT,,,0,✓,---,---,---,Add directly
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_FAB_STIFF_TYPE_STIFFENERS,Stiffener type unassigned,SMACNA HVAC Duct,Common,Text,⚠ Warning: Stiffener Type,"if(TAG_WARN_VISIBLE_BOOL, WARN_FAB_STIFF_TYPE_STIFFENERS, """")"
 Tag Family #40: STING - MEP Fabrication Hangers Tag
 TAG7: MEP_TAG_7_PARA_FAB_HANGERS_TXT  •  Category: MEP Fabrication Hangers
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -624,6 +720,9 @@ TAG7: PLM_TAG_7_PARA_FAB_PIPEWORK_TXT  •  Category: MEP Fabrication Pipework
 1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly
 2,T1,FAB_PIPE_DN_MM,DN,,0,✓,---,---,---,Add directly
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_FAB_PIPE_DN_PIPEWORK,Pipe DN mismatch with design,BS EN 10255 / ASME B36,Common,Text,⚠ Warning: Fab Pipe DN,"if(TAG_WARN_VISIBLE_BOOL, WARN_FAB_PIPE_DN_PIPEWORK, """")"
 Tag Family #42: STING - Materials Tag
 TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
@@ -645,3 +744,7 @@ TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 16,T3,PER_SUST_RECYCLABILITY_PCT,Recyclable:,%,0,,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, PER_SUST_RECYCLABILITY_PCT, """")"
 17,T3,PER_SUST_EPD_REF_TXT,| EPD:,,0,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, PER_SUST_EPD_REF_TXT, """")"
 18,T3,RGL_QA_CERTIFICATION_TXT,Cert:,,0,,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_CERTIFICATION_TXT, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,MEDIUM,WARN_PROP_FIRE_RATING_MATERIALS,Fire rating not specified,Building Regs Part B / BS 9999,Common,Text,⚠ Warning: Material Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PROP_FIRE_RATING_MATERIALS, """")"
+2,MEDIUM,WARN_PER_SUST_EPD_MATERIALS,EPD reference missing,ISO 14025 / EN 15804,Common,Text,⚠ Warning: Material EPD Missing,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_EPD_MATERIALS, """")"

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
@@ -20,12 +20,13 @@ TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Structural Columns
 15,T3,STR_FIRE_PROTECTION_TYPE_TXT,FP:,,,,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, STR_FIRE_PROTECTION_TYPE_TXT, """")"
 16,T3,STR_COL_BASE_PLATE_TXT,| BP:,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, STR_COL_BASE_PLATE_TXT, """")"
 17,T3,STR_WEIGHT_KG,,kg,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, STR_WEIGHT_KG, """")"
-18,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
-19,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-20,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
-21,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
-22,T3,CST_LOCAL_MAT_BOOL,| Local:,,,✓,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
-23,T3,RGL_QA_COMMISSIONING_REQ_TXT,Comm:,,,✓,Common,Text,Show Tier 3 - 23,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_COMMISSIONING_REQ_TXT, """")"
+18,T3,STR_COL_MOMENT_CAPACITY_KNM,Mom:,kNm,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, STR_COL_MOMENT_CAPACITY_KNM, """")"
+19,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+20,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+21,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+22,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
+23,T3,CST_LOCAL_MAT_BOOL,| Local:,,,✓,Common,Text,Show Tier 3 - 23,"if(TAG_PARA_STATE_3_BOOL, CST_LOCAL_MAT_BOOL, """")"
+24,T3,RGL_QA_COMMISSIONING_REQ_TXT,Comm:,,,✓,Common,Text,Show Tier 3 - 24,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_COMMISSIONING_REQ_TXT, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_STR_COLUMNS,Fire rating < 1.0 hr,Building Regs Part B / BS 9999 Table 10,Common,Text,⚠ Warning: Column Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_STR_COLUMNS, """")"
@@ -52,12 +53,13 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Framing
 15,T3,STR_BEAM_DEFLECTION_LIM_TXT,Defl:,,,,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, STR_BEAM_DEFLECTION_LIM_TXT, """")"
 16,T3,STR_FIRE_PROTECTION_TYPE_TXT,| FP:,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, STR_FIRE_PROTECTION_TYPE_TXT, """")"
 17,T3,STR_WEIGHT_KG,,kg,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, STR_WEIGHT_KG, """")"
-18,T3,STR_BEAM_WEB_OPENING_TXT,Web:,,,,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, STR_BEAM_WEB_OPENING_TXT, """")"
-19,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
-20,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-21,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
-22,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
-23,T3,RGL_QA_COMMISSIONING_REQ_TXT,| Comm:,,,✓,Common,Text,Show Tier 3 - 23,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_COMMISSIONING_REQ_TXT, """")"
+18,T3,STR_BEAM_MOMENT_CAPACITY_KNM,Mom:,kNm,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, STR_BEAM_MOMENT_CAPACITY_KNM, """")"
+19,T3,STR_BEAM_WEB_OPENING_TXT,Web:,,,,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, STR_BEAM_WEB_OPENING_TXT, """")"
+20,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+21,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+22,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+23,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 23,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
+24,T3,RGL_QA_COMMISSIONING_REQ_TXT,| Comm:,,,✓,Common,Text,Show Tier 3 - 24,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_COMMISSIONING_REQ_TXT, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_STR_BEAMS,Fire rating < 1.0 hr,Building Regs Part B / BS 9999,Common,Text,⚠ Warning: Beam Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_STR_BEAMS, """")"
@@ -83,16 +85,19 @@ TAG7: STR_TAG_7_PARA_FDN_TXT  •  Category: Structural Foundations
 14,T3,STR_FDN_WATERPROOF_TXT,WP:,,,,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, STR_FDN_WATERPROOF_TXT, """")"
 15,T3,STR_FDN_EXPOSURE_CLASS_TXT,| Exp:,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, STR_FDN_EXPOSURE_CLASS_TXT, """")"
 16,T3,STR_WEIGHT_KG,,kg,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, STR_WEIGHT_KG, """")"
-17,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
-18,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-19,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
-20,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
-21,T3,RGL_QA_COMMISSIONING_REQ_TXT,| Comm:,,,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_COMMISSIONING_REQ_TXT, """")"
+17,T3,STR_FDN_SETTLEMENT_MM,Settl:,mm,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, STR_FDN_SETTLEMENT_MM, """")"
+18,T3,STR_FDN_PILE_TYPE_TXT,Pile:,,,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, STR_FDN_PILE_TYPE_TXT, """")"
+19,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 19,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+20,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 20,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+21,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 21,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+22,T3,CST_DELIVERY_LEAD_TIME_DAYS,Lead:,days,,,Common,Text,Show Tier 3 - 22,"if(TAG_PARA_STATE_3_BOOL, CST_DELIVERY_LEAD_TIME_DAYS, """")"
+23,T3,RGL_QA_COMMISSIONING_REQ_TXT,| Comm:,,,✓,Common,Text,Show Tier 3 - 23,"if(TAG_PARA_STATE_3_BOOL, RGL_QA_COMMISSIONING_REQ_TXT, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,CRITICAL,WARN_STR_FDN_BEARING_KN_M2,Bearing pressure exceeds soil capacity,BS EN 1997-1 / EC7,Common,Text,⚠ Warning: Foundation Bearing,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_FDN_BEARING_KN_M2, """")"
 2,HIGH,WARN_STR_FDN_COVER_MM,Cover < minimum for exposure class,BS EN 1992-1-1 Table 4.4N / EC2,Common,Text,⚠ Warning: Concrete Cover,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_FDN_COVER_MM, """")"
 3,HIGH,WARN_STR_FDN_DEPTH_MM_FROST,Depth < 450mm (frost susceptible),BS EN 1997-1 / NHBC Standards Ch4.2,Common,Text,⚠ Warning: Foundation Depth,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_FDN_DEPTH_MM_FROST, """")"
+4,HIGH,WARN_STR_FDN_SETTLEMENT_MM,Settlement > 25mm,BS EN 1997-1 / EC7,Common,Text,⚠ Warning: Foundation Settlement,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_FDN_SETTLEMENT_MM, """")"
 
 Tag Family #4: STING - Structural Slab Tag
 TAG7: STR_TAG_7_PARA_SLAB_TXT  •  Category: Floors (Structural)
@@ -109,15 +114,17 @@ TAG7: STR_TAG_7_PARA_SLAB_TXT  •  Category: Floors (Structural)
 10,T3,STR_TAG_7_PARA_SLAB_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_SLAB_TXT, """")"
 11,T3,STR_SLAB_REBAR_TXT,Rebar:,,,,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, STR_SLAB_REBAR_TXT, """")"
 12,T3,STR_SLAB_MESH_TXT,| Mesh:,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, STR_SLAB_MESH_TXT, """")"
-13,T3,STR_FDN_COVER_MM,Cover:,mm,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, STR_FDN_COVER_MM, """")"
-14,T3,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, PER_ACOUSTIC_STC_RATING, """")"
-15,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
-16,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
-17,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+13,T3,STR_SLAB_COVER_MM,Cover:,mm,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, STR_SLAB_COVER_MM, """")"
+14,T3,STR_SLAB_DEFLECTION_LIMIT_TXT,Defl:,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, STR_SLAB_DEFLECTION_LIMIT_TXT, """")"
+15,T3,PER_ACOUSTIC_STC_RATING,STC:,,,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, PER_ACOUSTIC_STC_RATING, """")"
+16,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 16,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
+17,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 17,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+18,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 18,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_STR_SLABS,Fire rating < 1.0 hr,Building Regs Part B / BS EN 1992-1-2,Common,Text,⚠ Warning: Slab Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_STR_SLABS, """")"
 2,HIGH,WARN_STR_SLAB_DEFLECTION,Deflection exceeds L/250 (total),BS EN 1992-1-1 / EC2 7.4.1,Common,Text,⚠ Warning: Slab Deflection,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_SLAB_DEFLECTION, """")"
+3,HIGH,WARN_STR_SLAB_COVER_MM,Cover < minimum for exposure class,BS EN 1992-1-1,Common,Text,⚠ Warning: Slab Cover,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_SLAB_COVER_MM, """")"
 
 Tag Family #5: STING - Structural Wall Tag
 TAG7: STR_TAG_7_PARA_WALL_TXT  •  Category: Walls (Structural/Load-bearing)
@@ -133,7 +140,7 @@ TAG7: STR_TAG_7_PARA_WALL_TXT  •  Category: Walls (Structural/Load-bearing)
 9,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 9,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
 10,T3,STR_TAG_7_PARA_WALL_TXT,,,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_WALL_TXT, """")"
 11,T3,STR_WALL_REBAR_TXT,Rebar:,,,,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, STR_WALL_REBAR_TXT, """")"
-12,T3,STR_FDN_COVER_MM,| Cover:,mm,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, STR_FDN_COVER_MM, """")"
+12,T3,STR_WALL_COVER_MM,| Cover:,mm,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, STR_WALL_COVER_MM, """")"
 13,T3,PER_EMBODIED_CARBON_KG_CO2_M2,,kgCO₂/m²,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, PER_EMBODIED_CARBON_KG_CO2_M2, """")"
 14,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
 15,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
@@ -161,3 +168,50 @@ TAG7: STR_TAG_7_PARA_BRACE_TXT  •  Category: Structural Framing (Bracing)
 ⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_STR_BRACE_SLENDERNESS,Slenderness ratio exceeds 200,BS EN 1993-1-1 / EC3 6.3.1.2,Common,Text,⚠ Warning: Brace Slenderness,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BRACE_SLENDERNESS, """")"
+2,CRITICAL,WARN_PER_FIRE_RATING_HR_NR_STR_BRACES,Fire rating < 1.0 hr,Building Regs Part B,Common,Text,⚠ Warning: Brace Fire Rating,"if(TAG_WARN_VISIBLE_BOOL, WARN_PER_FIRE_RATING_HR_NR_STR_BRACES, """")"
+
+Tag Family #7: STING - Structural Rebar Tag
+TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
+1,T1,ASS_TAG_1_TXT,,,,✓,---,---,---,Add directly
+2,T2,ASS_TAG_2_TXT,,,,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
+4,T2,STR_REBAR_SIZE_MM,Size:,mm,,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")"
+5,T2,STR_REBAR_GRADE_TXT,Gr:,,,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_GRADE_TXT, """")"
+6,T2,STR_REBAR_SPACING_MM,Spc:,mm,,✓,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SPACING_MM, """")"
+7,T2,STR_REBAR_COVER_MM,Cover:,mm,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_COVER_MM, """")"
+8,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 8,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+9,T3,STR_TAG_7_PARA_REBAR_TXT,,,,✓,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_REBAR_TXT, """")"
+10,T3,STR_REBAR_SHAPE_TXT,Shape:,,,,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, STR_REBAR_SHAPE_TXT, """")"
+11,T3,STR_REBAR_LAP_LENGTH_MM,| Lap:,mm,,✓,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, STR_REBAR_LAP_LENGTH_MM, """")"
+12,T3,STR_REBAR_HOOK_TYPE_TXT,Hook:,,,,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, STR_REBAR_HOOK_TYPE_TXT, """")"
+13,T3,STR_WEIGHT_KG,,kg,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, STR_WEIGHT_KG, """")"
+14,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+15,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,CRITICAL,WARN_STR_REBAR_COVER_MM,Cover < minimum for exposure class,BS EN 1992-1-1 Table 4.4N,Common,Text,⚠ Warning: Rebar Cover,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_REBAR_COVER_MM, """")"
+2,HIGH,WARN_STR_REBAR_LAP_LENGTH_MM,Lap length < required,BS EN 1992-1-1 / EC2 8.7,Common,Text,⚠ Warning: Rebar Lap Length,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_REBAR_LAP_LENGTH_MM, """")"
+
+Tag Family #8: STING - Structural Connection Tag
+TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Structural Connections
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula
+1,T1,ASS_TAG_1_TXT,,,,✓,---,---,---,Add directly
+2,T2,ASS_TAG_2_TXT,,,,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")"
+3,T2,ASS_DESCRIPTION_TXT,,,,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")"
+4,T2,STR_CONN_TYPE_TXT,Type:,,,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_CONN_TYPE_TXT, """")"
+5,T2,STR_CONN_CAPACITY_KN,Cap:,kN,,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, STR_CONN_CAPACITY_KN, """")"
+6,T2,STR_CONN_BOLT_SIZE_TXT,Bolt:,,,,Common,Text,Show Tier 2 - 6,"if(TAG_PARA_STATE_2_BOOL, STR_CONN_BOLT_SIZE_TXT, """")"
+7,T2,RGL_STD_TXT,Std:,,,✓,Common,Text,Show Tier 2 - 7,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")"
+8,T3,STR_TAG_7_PARA_CONN_TXT,,,,✓,Common,Text,Show Tier 3 - 8,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_CONN_TXT, """")"
+9,T3,STR_CONN_WELD_TYPE_TXT,Weld:,,,,Common,Text,Show Tier 3 - 9,"if(TAG_PARA_STATE_3_BOOL, STR_CONN_WELD_TYPE_TXT, """")"
+10,T3,STR_CONN_PLATE_THICKNESS_MM,| Plt:,mm,,✓,Common,Text,Show Tier 3 - 10,"if(TAG_PARA_STATE_3_BOOL, STR_CONN_PLATE_THICKNESS_MM, """")"
+11,T3,STR_CONN_ROTATION_CAPACITY_TXT,Rot:,,,,Common,Text,Show Tier 3 - 11,"if(TAG_PARA_STATE_3_BOOL, STR_CONN_ROTATION_CAPACITY_TXT, """")"
+12,T3,STR_FIRE_PROTECTION_TYPE_TXT,FP:,,,✓,Common,Text,Show Tier 3 - 12,"if(TAG_PARA_STATE_3_BOOL, STR_FIRE_PROTECTION_TYPE_TXT, """")"
+13,T3,STR_WEIGHT_KG,,kg,,✓,Common,Text,Show Tier 3 - 13,"if(TAG_PARA_STATE_3_BOOL, STR_WEIGHT_KG, """")"
+14,T3,ASS_STATUS_TXT,,,,✓,Common,Text,Show Tier 3 - 14,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")"
+15,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 15,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")"
+⚠ WARNING PARAMETERS — add after all Tier rows (Break = ✓ Calculated Value gates visibility)
+#,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
+1,CRITICAL,WARN_STR_CONN_CAPACITY_KN,Capacity < applied load,BS EN 1993-1-8 / EC3,Common,Text,⚠ Warning: Connection Capacity,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_CONN_CAPACITY_KN, """")"
+2,HIGH,WARN_STR_CONN_WELD_SIZE,Weld size < minimum,BS EN 1993-1-8 / EC3 4.5,Common,Text,⚠ Warning: Weld Size,"if(TAG_WARN_VISIBLE_BOOL, WARN_STR_CONN_WELD_SIZE, """")"


### PR DESCRIPTION
## Summary
This PR updates the STING tag configuration files across Architecture, MEP, and Structural disciplines to add new parameters, reorganize existing ones, and introduce additional warning thresholds for improved building element documentation and compliance checking.

## Key Changes

### Architecture (STING_TAG_CONFIG_v5_0_ARCH.csv)
- **Walls**: Added `BLE_WALL_CONSTRUCTION_TXT` (Const:) at Tier 2 and `BLE_WALL_WATERPROOF_TXT` (WP:) at Tier 3
- **Floors**: Added `BLE_FLOOR_SLIP_RESISTANCE_TXT` (Slip:) at Tier 2, plus `BLE_FLOOR_CONSTRUCTION_METHOD_TXT` and `BLE_FLOOR_WATERPROOF_TXT` at Tier 3; new warning for slip resistance compliance (BS 7976-2)
- **Ceilings**: Added `PER_ACOUSTIC_NRC_RATING` (NRC:) at Tier 2 and `BLE_CEILING_GRID_TXT` (Grid:) at Tier 3; new warning for acoustic NRC rating (ASHRAE/CIBSE)
- **Roofs**: Added `BLE_ROOF_AREA_SQ_M` at Tier 2, plus `BLE_ROOF_DRAINAGE_TXT` and `BLE_ROOF_WATERPROOF_TXT` at Tier 3; new warning for roof drainage provisions (BS EN 12056-3)
- **Doors**: Added `BLE_DOOR_OPERATION_TXT` (Op:) and `BLE_DOOR_CLEAR_WIDTH_MM` (Clear:) at Tier 2; added `BLE_DOOR_THRESHOLD_TXT` and `BLE_DOOR_CLOSER_TXT` at Tier 3; new warning for door threshold accessibility (Building Regs Part M)
- **Windows**: Added `BLE_WIN_OPENING_TYPE_TXT` (Op:) at Tier 2 and `BLE_WIN_VENT_AREA_SQ_M` (Vent:) at Tier 3; new warning for ventilation area compliance (Building Regs Part F)
- **Rooms**: Added `BLE_ROOM_VENTILATION_RATE_LPS` (Vent:) and `BLE_ROOM_LIGHTING_LUX` (Lux:) at Tier 2; added `BLE_ROOM_FIRE_ESCAPE_CAPACITY_NR` at Tier 3

### MEP (STING_TAG_CONFIG_v5_0_MEP.csv)
- **Air Terminals**: Added warning for noise level compliance (ASHRAE Ch 48/CIBSE Guide B5)
- **Duct Accessories**: Added warning for parameter value verification (CIBSE Guide B3)
- **Duct Fittings**: Fixed suffix for `HVC_DUCT_CLASS_TXT` (removed °C); added warning for duct class mismatch
- **Ducts**: Fixed suffix for `HVC_DUCT_CLASS_TXT`; added warnings for velocity and pressure drop limits (CIBSE Guide B3)
- **Flex Pipes**: Added warning for flex pipe length limits (BS EN 806)
- **Pipe Accessories**: Added warning for sizing verification (BS EN 806)
- **Pipe Fittings**: Added warning for pressure rating compliance (BS EN 1254)
- **Pipes**: Renamed warning parameter from `WARN_PLM_PPE_FLW_LPS_PIPES__HOT_WATE` to `WARN_PLM_PPE_FLW_LPS_PIPES`; added velocity warning (CIBSE Guide G)
- **Plumbing Fixtures**: Added warning for water efficiency compliance (WELS/BS EN 200)
- **Mechanical Equipment**: Fixed suffix for `HVC_CAP_TR` (changed from °C to TR) and `HVC_CONTROL_TYPE

https://claude.ai/code/session_01V3qKYXF48RAHcXdkr8Arix