### PR TITLE
Add audit logging, image thumbnailing, and delta-sync watermarks

### DIFF
--- a/Planscape.Server/docs/PLANSCAPE_GAPS.md
+++ b/Planscape.Server/docs/PLANSCAPE_GAPS.md
@@ -415,7 +415,7 @@ All estimates assume a single experienced full-stack developer familiar with Rea
 | Phase 2: High Priority | 3–4 | £12,600 | £25,200 |
 | Phase 3: Medium Priority | 2–3 | £7,800 | £33,000 |
 | Phase 4: Polish & Scale | 2 | £6,000 | £39,000 |
-| **Total** | **12–16 weeks** | **£33,000–£39,000** | |
+| **Total** | **11–14 weeks** | **£33,000–£39,000** | |
 
 > **Note:** Costs assume a single developer. Parallelising Phase 1 server + mobile work across 2 developers could compress the timeline to 8–10 weeks but would increase coordination overhead.
 
@@ -425,59 +425,59 @@ All estimates assume a single experienced full-stack developer familiar with Rea
 
 ### Week 1–2: Foundation
 ```
-[x] Wire Planscape.PluginSync into StingToolsApp.OnStartup()
-[x] Add LastModified/Version fields to TaggedElement entity
-[x] Add Latitude/Longitude/Accuracy to BimIssue entity
-[x] EF Core migration for new fields
-[x] Install expo-image-picker, expo-location, expo-notifications
-[x] Set up Zustand state management with offline-first pattern
-[x] Implement mobile push notification handler
+[ ] Wire Planscape.PluginSync into StingToolsApp.OnStartup()
+[ ] Add LastModified/Version fields to TaggedElement entity
+[ ] Add Latitude/Longitude/Accuracy to BimIssue entity
+[ ] EF Core migration for new fields
+[ ] Install expo-image-picker, expo-location, expo-notifications
+[ ] Set up Zustand state management with offline-first pattern
+[ ] Implement mobile push notification handler
 ```
 
 ### Week 3–4: Core On-Site Features
 ```
-[x] Complete QR scanner: parse → lookup → display → create issue
-[x] Camera capture: photo → compress → attach to issue
-[x] GPS tagging: capture coordinates on issue/document creation
-[x] Server image thumbnailing pipeline (150px, 300px, 600px)
-[x] TagSync conflict resolution (timestamp + version vector)
-[x] Mobile offline queue drain with exponential retry
+[ ] Complete QR scanner: parse → lookup → display → create issue
+[ ] Camera capture: photo → compress → attach to issue
+[ ] GPS tagging: capture coordinates on issue/document creation
+[ ] Server image thumbnailing pipeline (150px, 300px, 600px)
+[ ] TagSync conflict resolution (timestamp + version vector)
+[ ] Mobile offline queue drain with exponential retry
 ```
 
 ### Week 5–6: Document Access
 ```
-[x] PDF viewer with download + offline cache
-[x] Image viewer with pinch-zoom
-[x] Server delta sync with SyncWatermark
-[x] Server batch operations for issues/documents
-[x] HTTPS/TLS with Let's Encrypt
+[ ] PDF viewer with download + offline cache
+[ ] Image viewer with pinch-zoom
+[ ] Server delta sync with SyncWatermark
+[ ] Server batch operations for issues/documents
+[ ] HTTPS/TLS with Let's Encrypt
 ```
 
 ### Week 7–8: Real-Time Collaboration
 ```
-[x] SignalR mobile client with JWT auth
-[x] Compliance dashboard with RAG bars and charts
-[x] Meetings UI with agenda and action items
-[x] Server file versioning
-[x] Production deployment with MinIO/S3
+[ ] SignalR mobile client with JWT auth
+[ ] Compliance dashboard with RAG bars and charts
+[ ] Meetings UI with agenda and action items
+[ ] Server file versioning
+[ ] Production deployment with MinIO/S3
 ```
 
 ### Week 9–10: Enhanced Features
 ```
-[x] Document annotation (draw on photo)
-[x] Server QR code generation for asset labels
-[x] Geofence validation
-[x] Secure token storage + biometric auth
-[x] Per-device rate limiting
+[ ] Document annotation (draw on photo)
+[ ] Server QR code generation for asset labels
+[ ] Geofence validation
+[ ] Secure token storage + biometric auth
+[ ] Per-device rate limiting
 ```
 
 ### Week 11–12: Production Hardening
 ```
-[x] CI/CD pipeline (GitHub Actions + Expo EAS)
-[x] Load testing for 50 concurrent users
-[x] Monitoring (Serilog + health checks)
-[x] Security audit (OWASP mobile checklist)
-[x] Documentation and deployment runbook
+[ ] CI/CD pipeline (GitHub Actions + Expo EAS)
+[ ] Load testing for 50 concurrent users
+[ ] Monitoring (Serilog + health checks)
+[ ] Security audit (OWASP mobile checklist)
+[ ] Documentation and deployment runbook
 ```
 
 ---

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
+using Planscape.API.Services;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -58,15 +59,25 @@ public class DocumentsController : ControllerBase
 
     private readonly IFileStorageService _storage;
     private readonly IGeofenceValidationService _geofence;
+    private readonly IThumbnailService _thumbnails;
+    private readonly ILogger<DocumentsController> _logger;
 
     // Max file size: 100 MB
     private const long MaxFileSize = 100 * 1024 * 1024;
 
-    public DocumentsController(PlanscapeDbContext db, IFileStorageService storage, IGeofenceValidationService geofence)
+    private static readonly string[] ImageContentTypes = { "image/jpeg", "image/png", "image/webp" };
+
+    public DocumentsController(PlanscapeDbContext db,
+        IFileStorageService storage,
+        IGeofenceValidationService geofence,
+        IThumbnailService thumbnails,
+        ILogger<DocumentsController> logger)
     {
         _db = db;
         _storage = storage;
         _geofence = geofence;
+        _thumbnails = thumbnails;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -152,6 +163,39 @@ public class DocumentsController : ControllerBase
 
         memStream.Position = 0;
         var relativePath = await _storage.SaveAsync(tenantSlug, project.Code, file.FileName, memStream);
+
+        // S04 — generate JPEG thumbnails (150/300/600 px) and extract EXIF GPS for image uploads.
+        // Applies to both first uploads and new-version uploads since each gets its own relativePath.
+        if (!string.IsNullOrEmpty(file.ContentType)
+            && ImageContentTypes.Contains(file.ContentType.ToLowerInvariant()))
+        {
+            try
+            {
+                memStream.Position = 0;
+                var thumbnails = await _thumbnails.GenerateThumbnailsAsync(memStream);
+                var baseName = Path.GetFileNameWithoutExtension(relativePath);
+                var thumbSubPath = $"{project.Code}/thumbnails";
+                foreach (var (size, bytes) in thumbnails)
+                {
+                    using var ms = new MemoryStream(bytes);
+                    await _storage.SaveAsync(tenantSlug, thumbSubPath, $"{baseName}_{size}.jpg", ms);
+                }
+
+                memStream.Position = 0;
+                var (lat, lng) = _thumbnails.ExtractGpsFromExif(memStream);
+                // DocumentRecord has no GPS columns; surface via logs until a migration adds them.
+                if (lat.HasValue && lng.HasValue)
+                {
+                    _logger.LogInformation("EXIF GPS extracted for {File}: {Lat},{Lng}",
+                        file.FileName, lat.Value, lng.Value);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Thumbnail / EXIF failure must never break the upload.
+                _logger.LogWarning(ex, "Thumbnail/EXIF generation failed for {File}", file.FileName);
+            }
+        }
 
         // Check for existing document with same project + filename
         var existingDoc = await _db.Documents

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -61,6 +61,7 @@ public class DocumentsController : ControllerBase
     private readonly IGeofenceValidationService _geofence;
     private readonly IThumbnailService _thumbnails;
     private readonly ILogger<DocumentsController> _logger;
+    private readonly IAuditService _audit;
 
     // Max file size: 100 MB
     private const long MaxFileSize = 100 * 1024 * 1024;
@@ -71,13 +72,15 @@ public class DocumentsController : ControllerBase
         IFileStorageService storage,
         IGeofenceValidationService geofence,
         IThumbnailService thumbnails,
-        ILogger<DocumentsController> logger)
+        ILogger<DocumentsController> logger,
+        IAuditService audit)
     {
         _db = db;
         _storage = storage;
         _geofence = geofence;
         _thumbnails = thumbnails;
         _logger = logger;
+        _audit = audit;
     }
 
     [HttpGet]
@@ -125,6 +128,7 @@ public class DocumentsController : ControllerBase
 
         _db.Documents.Add(doc);
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("CREATE", "Document", doc.Id.ToString());
         return CreatedAtAction(nameof(GetDocuments), new { projectId }, doc);
     }
 
@@ -246,6 +250,8 @@ public class DocumentsController : ControllerBase
             if (description != null) existingDoc.Description = description;
 
             await _db.SaveChangesAsync();
+            await _audit.LogAsync("UPDATE", "Document", existingDoc.Id.ToString(),
+                $"{{\"versionNumber\":{nextVersion}}}");
 
             return Ok(new
             {
@@ -283,6 +289,7 @@ public class DocumentsController : ControllerBase
 
         _db.Documents.Add(doc);
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("CREATE", "Document", doc.Id.ToString(), "{\"versionNumber\":1}");
 
         // Create version 1 row
         _db.DocumentVersions.Add(new DocumentVersion
@@ -435,6 +442,8 @@ public class DocumentsController : ControllerBase
         doc.StatusHistoryJson = JsonConvert.SerializeObject(history);
 
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("TRANSITION", "Document", doc.Id.ToString(),
+            $"{{\"oldState\":\"{oldState}\",\"newState\":\"{req.NewState}\"}}");
         return Ok(doc);
     }
 
@@ -481,6 +490,8 @@ public class DocumentsController : ControllerBase
         doc.StatusHistoryJson = JsonConvert.SerializeObject(history);
 
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("TRANSITION", "Document", doc.Id.ToString(),
+            $"{{\"oldState\":\"{oldState}\",\"newState\":\"{req.NewStatus}\"}}");
         return Ok(doc);
     }
 
@@ -541,6 +552,7 @@ public class DocumentsController : ControllerBase
 
         _db.DocumentApprovals.Add(approval);
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("CREATE", "DocumentApproval", approval.Id.ToString());
         return CreatedAtAction(nameof(GetApprovalStatus), new { projectId, docId }, approval);
     }
 
@@ -577,6 +589,8 @@ public class DocumentsController : ControllerBase
         approval.Comments = req.Comments ?? approval.Comments;
 
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("UPDATE", "DocumentApproval", approval.Id.ToString(),
+            $"{{\"decision\":\"{req.Decision}\"}}");
         return Ok(approval);
     }
 

--- a/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
@@ -23,6 +23,7 @@ public class IssuesController : ControllerBase
     private readonly IGeofenceValidationService _geofence;
     private readonly IThumbnailService _thumbnails;
     private readonly ILogger<IssuesController> _logger;
+    private readonly IAuditService _audit;
 
     private static readonly Dictionary<string, int> SLAHours = new()
     {
@@ -40,7 +41,8 @@ public class IssuesController : ControllerBase
         IFileStorageService storage,
         IGeofenceValidationService geofence,
         IThumbnailService thumbnails,
-        ILogger<IssuesController> logger)
+        ILogger<IssuesController> logger,
+        IAuditService audit)
     {
         _db = db;
         _notifications = notifications;
@@ -49,6 +51,7 @@ public class IssuesController : ControllerBase
         _geofence = geofence;
         _thumbnails = thumbnails;
         _logger = logger;
+        _audit = audit;
     }
 
     [HttpGet]
@@ -124,6 +127,7 @@ public class IssuesController : ControllerBase
 
         _db.Issues.Add(issue);
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("CREATE", "Issue", issue.Id.ToString());
 
         // Push notification for new issue
         _ = _notifications.NotifyAsync(tenantId, "issues",
@@ -177,6 +181,7 @@ public class IssuesController : ControllerBase
         if (req.Description != null) issue.Description = req.Description;
 
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("UPDATE", "Issue", issue.Id.ToString());
         return Ok(issue);
     }
 
@@ -236,6 +241,7 @@ public class IssuesController : ControllerBase
         };
         _db.IssueAttachments.Add(attachment);
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("CREATE", "IssueAttachment", attachment.Id.ToString());
 
         // S04 — generate JPEG thumbnails (150/300/600 px) and extract EXIF GPS for image uploads.
         // Thumbnails are persisted via the same storage abstraction, using a sibling "thumbnails"
@@ -319,6 +325,7 @@ public class IssuesController : ControllerBase
 
         _db.IssueAttachments.Remove(attachment);
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("DELETE", "IssueAttachment", attachmentId.ToString());
         return NoContent();
     }
 
@@ -382,6 +389,7 @@ public class IssuesController : ControllerBase
         };
         _db.IssueAttachments.Add(attachment);
         await _db.SaveChangesAsync();
+        await _audit.LogAsync("LINK", "IssueAttachment", attachment.Id.ToString());
 
         return Ok(new { attachment.Id, attachment.IssueId, attachment.DocumentId, attachment.AttachedAt });
     }

--- a/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
+using Planscape.API.Services;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -20,6 +21,8 @@ public class IssuesController : ControllerBase
     private readonly Planscape.Core.Interfaces.IPushNotificationService _push;
     private readonly IFileStorageService _storage;
     private readonly IGeofenceValidationService _geofence;
+    private readonly IThumbnailService _thumbnails;
+    private readonly ILogger<IssuesController> _logger;
 
     private static readonly Dictionary<string, int> SLAHours = new()
     {
@@ -28,17 +31,24 @@ public class IssuesController : ControllerBase
 
     private const long MaxAttachmentSize = 50 * 1024 * 1024; // 50 MB
 
+    private static readonly string[] ImageContentTypes = { "image/jpeg", "image/png", "image/webp" };
+    private static readonly int[] ValidThumbSizes = { 150, 300, 600 };
+
     public IssuesController(PlanscapeDbContext db,
         Planscape.Core.Interfaces.INotificationService notifications,
         Planscape.Core.Interfaces.IPushNotificationService push,
         IFileStorageService storage,
-        IGeofenceValidationService geofence)
+        IGeofenceValidationService geofence,
+        IThumbnailService thumbnails,
+        ILogger<IssuesController> logger)
     {
         _db = db;
         _notifications = notifications;
         _push = push;
         _storage = storage;
         _geofence = geofence;
+        _thumbnails = thumbnails;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -227,6 +237,42 @@ public class IssuesController : ControllerBase
         _db.IssueAttachments.Add(attachment);
         await _db.SaveChangesAsync();
 
+        // S04 — generate JPEG thumbnails (150/300/600 px) and extract EXIF GPS for image uploads.
+        // Thumbnails are persisted via the same storage abstraction, using a sibling "thumbnails"
+        // subfolder so the GetThumbnail endpoint can derive paths deterministically.
+        if (!string.IsNullOrEmpty(file.ContentType)
+            && ImageContentTypes.Contains(file.ContentType.ToLowerInvariant()))
+        {
+            try
+            {
+                memStream.Position = 0;
+                var thumbnails = await _thumbnails.GenerateThumbnailsAsync(memStream);
+                var baseName = Path.GetFileNameWithoutExtension(relativePath);
+                var thumbSubPath = $"{subPath}/thumbnails";
+                foreach (var (size, bytes) in thumbnails)
+                {
+                    using var ms = new MemoryStream(bytes);
+                    await _storage.SaveAsync(tenantSlug, thumbSubPath, $"{baseName}_{size}.jpg", ms);
+                }
+
+                memStream.Position = 0;
+                var (lat, lng) = _thumbnails.ExtractGpsFromExif(memStream);
+                // If parent issue has no GPS, populate from EXIF. BimIssue has no GPS columns
+                // in the current schema, so we surface the coordinates via logs for now; a
+                // follow-up migration can promote them to first-class fields.
+                if (lat.HasValue && lng.HasValue)
+                {
+                    _logger.LogInformation("EXIF GPS extracted for issue {Code}: {Lat},{Lng}",
+                        issue.IssueCode, lat.Value, lng.Value);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Thumbnail / EXIF failure must never break the upload.
+                _logger.LogWarning(ex, "Thumbnail/EXIF generation failed for {File}", file.FileName);
+            }
+        }
+
         return Ok(new
         {
             attachment.Id, attachment.IssueId, attachment.DocumentId,
@@ -274,6 +320,39 @@ public class IssuesController : ControllerBase
         _db.IssueAttachments.Remove(attachment);
         await _db.SaveChangesAsync();
         return NoContent();
+    }
+
+    /// <summary>
+    /// Stream a pre-generated thumbnail for an image attachment.
+    /// Thumbnails live in a sibling "thumbnails" folder with names
+    /// {originalBaseName}_{size}.jpg.
+    /// </summary>
+    [HttpGet("{issueId}/attachments/{attachmentId}/thumbnail")]
+    public async Task<IActionResult> GetThumbnail(Guid projectId, Guid issueId, Guid attachmentId,
+        [FromQuery] int size = 300, CancellationToken ct = default)
+    {
+        if (!ValidThumbSizes.Contains(size)) size = 300;
+
+        var tenantId = GetTenantId();
+        var attachment = await _db.IssueAttachments
+            .Include(a => a.Document)
+            .Include(a => a.Issue)
+            .FirstOrDefaultAsync(a => a.Id == attachmentId && a.IssueId == issueId
+                && a.Issue!.ProjectId == projectId && a.Issue.Project!.TenantId == tenantId, ct);
+        if (attachment?.Document?.FilePath == null) return NotFound();
+
+        // Derive thumbnail path from the original FilePath: replace the final
+        // segment with thumbnails/{baseName}_{size}.jpg.
+        var originalPath = attachment.Document.FilePath!;
+        var dir = Path.GetDirectoryName(originalPath)?.Replace('\\', '/') ?? "";
+        var baseName = Path.GetFileNameWithoutExtension(originalPath);
+        var thumbPath = string.IsNullOrEmpty(dir)
+            ? $"thumbnails/{baseName}_{size}.jpg"
+            : $"{dir}/thumbnails/{baseName}_{size}.jpg";
+
+        var stream = await _storage.GetAsync(thumbPath, ct);
+        if (stream == null) return NotFound();
+        return File(stream, "image/jpeg");
     }
 
     /// <summary>

--- a/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
@@ -169,7 +169,14 @@ public class TagSyncController : ControllerBase
     }
 
     /// <summary>
-    /// Get all tagged elements for a project (paginated).
+    /// Get tagged elements for a project (paginated). When
+    /// <paramref name="lastSyncUtc"/> is supplied, acts as a delta-sync:
+    /// only elements changed after that watermark are returned, and a
+    /// per-device <see cref="SyncWatermark"/> row is upserted so the
+    /// client can pass the updated cursor on its next pull.
+    ///
+    /// Device identity is read from the optional <c>X-Device-Id</c>
+    /// header and defaults to "desktop" when absent.
     /// </summary>
     [HttpGet("elements/{projectId}")]
     public async Task<ActionResult> GetElements(Guid projectId,
@@ -179,11 +186,25 @@ public class TagSyncController : ControllerBase
         var tenantId = GetTenantId();
         pageSize = Math.Clamp(pageSize, 1, 500);
 
+        // Tenant-scope check up front so unauthorised projectIds 404
+        // even when no elements would match the filter.
+        var projectExists = await _db.Projects
+            .AnyAsync(p => p.Id == projectId && p.TenantId == tenantId);
+        if (!projectExists) return NotFound();
+
         var baseQuery = _db.TaggedElements
             .Where(e => e.ProjectId == projectId && e.Project!.TenantId == tenantId);
 
+        // S06 — filter by LastModifiedUtc (the client-supplied modification
+        // wall-clock) with a SyncedAt fallback for legacy rows that predate
+        // the LastModifiedUtc column. Null-coalesce into a SQL COALESCE so
+        // EF can translate it to a single server-side comparison.
         if (lastSyncUtc.HasValue)
-            baseQuery = baseQuery.Where(e => e.SyncedAt > lastSyncUtc.Value);
+        {
+            var cutoff = lastSyncUtc.Value;
+            baseQuery = baseQuery.Where(e =>
+                (e.LastModifiedUtc ?? e.SyncedAt) > cutoff);
+        }
 
         var total = await baseQuery.CountAsync();
         var elements = await baseQuery
@@ -191,6 +212,42 @@ public class TagSyncController : ControllerBase
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync();
+
+        // S06 — upsert per-device watermark after a successful delta pull.
+        // We only bump the watermark when the caller actually supplied one
+        // (otherwise this is just a paginated list, not a sync).
+        if (lastSyncUtc.HasValue)
+        {
+            var deviceId = Request.Headers.TryGetValue("X-Device-Id", out var hdr)
+                && !string.IsNullOrWhiteSpace(hdr.ToString())
+                    ? hdr.ToString().Trim()
+                    : "desktop";
+
+            // New watermark = max(client cutoff, most recent element returned).
+            // If the page is empty the cutoff itself is the correct new value.
+            var newCutoff = elements.Count > 0
+                ? elements.Max(e => e.LastModifiedUtc ?? e.SyncedAt)
+                : lastSyncUtc.Value;
+
+            var existing = await _db.SyncWatermarks
+                .FirstOrDefaultAsync(w => w.ProjectId == projectId && w.DeviceId == deviceId);
+            if (existing == null)
+            {
+                _db.SyncWatermarks.Add(new SyncWatermark
+                {
+                    ProjectId = projectId,
+                    DeviceId = deviceId,
+                    LastSyncUtc = newCutoff
+                });
+            }
+            else
+            {
+                // Monotonic: never rewind a device's cursor.
+                if (newCutoff > existing.LastSyncUtc) existing.LastSyncUtc = newCutoff;
+                existing.UpdatedAt = DateTime.UtcNow;
+            }
+            await _db.SaveChangesAsync();
+        }
 
         return Ok(new { elements, total, page, pageSize });
     }

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -60,6 +60,7 @@ builder.Services.AddScoped<Planscape.Core.Interfaces.ITenantContext, Planscape.I
 builder.Services.AddSingleton<Planscape.Core.Interfaces.IFileStorageService, Planscape.Infrastructure.Storage.LocalFileStorageService>();
 builder.Services.AddScoped<Planscape.Core.Interfaces.IGeofenceValidationService, Planscape.Infrastructure.Services.GeofenceValidationService>();
 builder.Services.AddScoped<Planscape.API.Services.IThumbnailService, Planscape.API.Services.ImageSharpThumbnailService>();
+builder.Services.AddScoped<Planscape.API.Services.IAuditService, Planscape.API.Services.AuditService>();
 
 // ── Platform Connectors ──
 builder.Services.AddSingleton<Planscape.Core.Interfaces.IPlatformConnector, Planscape.Infrastructure.Services.AccConnector>();

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -59,6 +59,7 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<Planscape.Core.Interfaces.ITenantContext, Planscape.Infrastructure.Services.TenantContext>();
 builder.Services.AddSingleton<Planscape.Core.Interfaces.IFileStorageService, Planscape.Infrastructure.Storage.LocalFileStorageService>();
 builder.Services.AddScoped<Planscape.Core.Interfaces.IGeofenceValidationService, Planscape.Infrastructure.Services.GeofenceValidationService>();
+builder.Services.AddScoped<Planscape.API.Services.IThumbnailService, Planscape.API.Services.ImageSharpThumbnailService>();
 
 // ── Platform Connectors ──
 builder.Services.AddSingleton<Planscape.Core.Interfaces.IPlatformConnector, Planscape.Infrastructure.Services.AccConnector>();

--- a/Planscape.Server/src/Planscape.API/Services/AuditService.cs
+++ b/Planscape.Server/src/Planscape.API/Services/AuditService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.API.Services;
+
+/// <summary>
+/// S11 — ISO 19650 audit trail for all write operations.
+/// Reads user / tenant / device / GPS / source context from the current
+/// HttpContext (populated earlier by MobileContextMiddleware and the JWT
+/// auth pipeline) and appends a single AuditLog row per write.
+/// </summary>
+public interface IAuditService
+{
+    /// <summary>
+    /// Append an audit log entry. EntityId is stringly-typed so this works
+    /// for long identity keys, Guid keys, and composite keys alike.
+    /// <paramref name="detailsJson"/> should be a JSON blob or null.
+    /// </summary>
+    Task LogAsync(string action, string entityType, string entityId, string? detailsJson = null);
+}
+
+public class AuditService : IAuditService
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public AuditService(PlanscapeDbContext db, IHttpContextAccessor httpContextAccessor)
+    {
+        _db = db;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task LogAsync(string action, string entityType, string entityId, string? detailsJson = null)
+    {
+        var ctx = _httpContextAccessor.HttpContext;
+
+        // Tenant / user are GUIDs in the Planscape schema — parse from claims.
+        // If anything is missing we still write the row so the audit trail is
+        // complete; we never want "can't audit" to block the underlying write.
+        Guid tenantId = Guid.Empty;
+        if (Guid.TryParse(ctx?.User?.FindFirst("tenant_id")?.Value, out var tid))
+            tenantId = tid;
+
+        Guid? userId = null;
+        var userClaim = ctx?.User?.FindFirst("sub")?.Value
+            ?? ctx?.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (Guid.TryParse(userClaim, out var uid)) userId = uid;
+
+        var log = new AuditLog
+        {
+            TenantId = tenantId,
+            UserId = userId,
+            Action = action,
+            EntityType = entityType,
+            EntityId = entityId,
+            DetailsJson = detailsJson,
+            IpAddress = ctx?.Connection?.RemoteIpAddress?.ToString(),
+            // Mobile context fields populated by MobileContextMiddleware (S12).
+            DeviceId = ctx?.Items["DeviceId"] as string,
+            Latitude = ctx?.Items["Latitude"] as double?,
+            Longitude = ctx?.Items["Longitude"] as double?,
+            Source = (ctx?.Items["Source"] as string) ?? "desktop"
+            // Timestamp defaults to DateTime.UtcNow on the entity itself.
+        };
+
+        _db.AuditLogs.Add(log);
+        await _db.SaveChangesAsync();
+    }
+}

--- a/Planscape.Server/src/Planscape.Core/Entities/SyncWatermark.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/SyncWatermark.cs
@@ -1,0 +1,32 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// Per-device sync watermark — records the last LastModifiedUtc the device
+/// successfully pulled for a given project. The client passes its previous
+/// watermark to the delta-sync GET endpoint and we only return elements
+/// whose LastModifiedUtc (fallback: SyncedAt) is greater than it.
+///
+/// Key is (ProjectId, DeviceId): a device can cache a separate cursor per
+/// project. "Device" is whatever the client sends in the X-Device-Id header
+/// — a mobile device id, a desktop user id, or the literal "desktop" fallback.
+/// </summary>
+public class SyncWatermark
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ProjectId { get; set; }
+
+    /// <summary>Opaque device identifier from the X-Device-Id header.</summary>
+    public string DeviceId { get; set; } = "";
+
+    /// <summary>
+    /// The server-side cutoff time this device should pass back on its next
+    /// pull to receive only the elements that have changed since this sync.
+    /// Updated on every successful delta-sync response.
+    /// </summary>
+    public DateTime LastSyncUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public Project? Project { get; set; }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -58,6 +58,7 @@ public class PlanscapeDbContext : DbContext
     public DbSet<PlatformConnection> PlatformConnections => Set<PlatformConnection>();
     public DbSet<DocumentVersion> DocumentVersions => Set<DocumentVersion>();
     public DbSet<SyncConflict> SyncConflicts => Set<SyncConflict>();
+    public DbSet<SyncWatermark> SyncWatermarks => Set<SyncWatermark>();
 
     // Planscape MIM entities (loaded when MIM is enabled)
     public DbSet<MIM.Entities.Asset> Assets => Set<MIM.Entities.Asset>();
@@ -247,6 +248,16 @@ public class PlanscapeDbContext : DbContext
             e.HasKey(v => v.Id);
             e.HasOne(v => v.Document).WithMany(d => d.Versions).HasForeignKey(v => v.DocumentId).OnDelete(DeleteBehavior.Cascade);
             e.HasIndex(v => new { v.DocumentId, v.VersionNumber }).IsUnique();
+        });
+
+        // ── SyncWatermark (S06 — per-device delta-sync cursor) ──
+        modelBuilder.Entity<SyncWatermark>(e =>
+        {
+            e.HasKey(w => w.Id);
+            e.Property(w => w.DeviceId).HasMaxLength(128).IsRequired();
+            // One watermark per (project, device) — upserts key on this pair.
+            e.HasIndex(w => new { w.ProjectId, w.DeviceId }).IsUnique();
+            e.HasOne(w => w.Project).WithMany().HasForeignKey(w => w.ProjectId).OnDelete(DeleteBehavior.Cascade);
         });
 
         // ── Planscape MIM Entities ──

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -1989,7 +1989,7 @@ namespace StingTools.BIMManager
                 Planscape.PluginSync.SyncScheduler.Start(client.ServerUrl, client.AuthToken);
             }
 
-            Planscape.PluginSync.SyncResult sResult;
+            Planscape.Shared.Models.SyncResult sResult;
             try
             {
                 sResult = Planscape.PluginSync.SyncScheduler.SyncNow(payload).GetAwaiter().GetResult();

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -19,6 +19,10 @@ namespace StingTools.Core
     /// SELECT, ORGANISE, DOCS, TEMP, CREATE, VIEW.
     /// The ribbon tab contains only a single toggle button to show/hide the panel.
     /// </summary>
+    // Revit hosts this plugin on Windows only; the whole class uses Windows-only
+    // APIs from Planscape.PluginSync (SyncScheduler / OfflineQueue) so declare the
+    // platform guarantee up front to satisfy CA1416.
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     public class StingToolsApp : IExternalApplication
     {
         public static string AssemblyPath { get; private set; }

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -19,10 +19,8 @@ namespace StingTools.Core
     /// SELECT, ORGANISE, DOCS, TEMP, CREATE, VIEW.
     /// The ribbon tab contains only a single toggle button to show/hide the panel.
     /// </summary>
-    // Revit hosts this plugin on Windows only; the whole class uses Windows-only
-    // APIs from Planscape.PluginSync (SyncScheduler / OfflineQueue) so declare the
-    // platform guarantee up front to satisfy CA1416.
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    // Note: CA1416 coverage is provided assembly-wide by
+    // [assembly: SupportedOSPlatform("windows")] in Properties/AssemblyInfo.cs.
     public class StingToolsApp : IExternalApplication
     {
         public static string AssemblyPath { get; private set; }

--- a/StingTools/Properties/AssemblyInfo.cs
+++ b/StingTools/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 [assembly: AssemblyTitle("StingTools")]
 [assembly: AssemblyDescription("Unified STING Tools Revit Plugin — Docs, Tags, Temp")]
@@ -10,3 +11,11 @@ using System.Runtime.InteropServices;
 [assembly: Guid("A1B2C3D4-5678-9ABC-DEF0-123456789ABC")]
 [assembly: AssemblyVersion("2.2.0.0")]
 [assembly: AssemblyFileVersion("2.2.0.0")]
+
+// StingTools is a Revit plugin. Revit only runs on Windows, and the csproj
+// already targets net8.0-windows. Declaring the assembly's supported platform
+// at this level tells the CA1416 analyzer that every call site in this
+// assembly is Windows-qualified, so calls into Windows-only APIs from
+// Planscape.PluginSync (SyncScheduler, OfflineQueue) and System.Drawing etc
+// don't need per-method [SupportedOSPlatform] annotations.
+[assembly: SupportedOSPlatform("windows")]

--- a/StingTools/Temp/TemplateCommands.cs
+++ b/StingTools/Temp/TemplateCommands.cs
@@ -1152,8 +1152,8 @@ namespace StingTools.Temp
                 if (paletteLookup.HasValue)
                 {
                     template.DetailLevel = ViewDetailLevel.Fine;
-                    var (palette, accent) = paletteLookup.Value;
-                    PresentationStyleHelper.ApplyPalette(template, palette, accent, solidFill);
+                    var (palette, paletteAccent) = paletteLookup.Value;
+                    PresentationStyleHelper.ApplyPalette(template, palette, paletteAccent, solidFill);
 
                     // Discipline filters still apply — they just use the palette's
                     // base line colour so everything reads monochromatic with the


### PR DESCRIPTION
## Summary
This PR implements three major features for the Planscape API: comprehensive audit logging (S11), server-side image thumbnail generation with EXIF GPS extraction (S04), and per-device delta-sync watermarks (S06) to enable efficient incremental synchronization.

## Key Changes

### Audit Logging (S11)
- **New `AuditService`**: Implements ISO 19650 audit trail for all write operations
  - Reads user, tenant, device, GPS, and source context from HttpContext
  - Appends `AuditLog` rows for CREATE, UPDATE, DELETE, TRANSITION, and LINK actions
  - Gracefully handles missing context (never blocks the underlying write)
  - Extracts tenant and user IDs from JWT claims
- **Integration**: Added audit log calls to `IssuesController`, `DocumentsController` for all mutations
- **Dependency injection**: Registered `IAuditService` in `Program.cs`

### Image Thumbnailing & EXIF GPS (S04)
- **New `IThumbnailService`**: Generates JPEG thumbnails at 150px, 300px, and 600px sizes
  - Extracts GPS coordinates from image EXIF metadata
  - Integrated into both `IssuesController.UploadAttachment()` and `DocumentsController.UploadDocument()`
- **Storage**: Thumbnails persisted to a sibling `thumbnails/` subfolder with deterministic naming (`{baseName}_{size}.jpg`)
- **Error handling**: Thumbnail/EXIF failures are logged as warnings but never block the upload
- **New endpoint**: `GET /issues/{issueId}/attachments/{attachmentId}/thumbnail?size=300` streams pre-generated thumbnails

### Delta-Sync Watermarks (S06)
- **New `SyncWatermark` entity**: Per-device sync cursor tracking last successful pull timestamp
  - Composite unique index on (ProjectId, DeviceId)
  - Supports multiple devices syncing independently per project
- **Enhanced `TagSyncController.GetElements()`**:
  - Accepts optional `lastSyncUtc` query parameter for delta-sync filtering
  - Filters by `LastModifiedUtc` (with fallback to `SyncedAt` for legacy rows)
  - Upserts watermark after successful pull with monotonic cursor advancement
  - Reads device identity from `X-Device-Id` header (defaults to "desktop")
  - Added tenant-scope validation check upfront
- **Updated documentation**: Clarified delta-sync behavior in XML comments

### Supporting Changes
- Added `SyncWatermark` DbSet to `PlanscapeDbContext`
- Configured EF Core model for `SyncWatermark` with cascade delete
- Added `[SupportedOSPlatform("windows")]` to `StingTools/AssemblyInfo.cs` to suppress CA1416 analyzer warnings for Windows-only APIs
- Updated project timeline estimates in `PLANSCAPE_GAPS.md` (11–14 weeks, down from 12–16)
- Marked completed checklist items as incomplete in roadmap (reset for tracking)

## Implementation Details
- Audit logging reads from `HttpContext.Items` populated by `MobileContextMiddleware` for device/GPS/source context
- Thumbnail generation is wrapped in try-catch to ensure upload resilience
- Delta-sync watermark uses `Math.Max()` logic to prevent cursor rewinding
- Image content types validated against whitelist: `image/jpeg`, `image/png`, `image/webp`
- All audit/watermark operations use `SaveChangesAsync()` to ensure persistence

https://claude.ai/code/session_016eSDcgbMoiJnBTEJSpiND5