### PR TITLE
Add tenant branding, i18n, and observability stack (FLEX-03/07/15, MON-01/02/03)

### DIFF
--- a/Planscape.Server/docker/docker-compose.yml
+++ b/Planscape.Server/docker/docker-compose.yml
@@ -65,6 +65,54 @@ services:
       - redis
     restart: unless-stopped
 
+  # ── Observability stack (MON-01/02/03) ─────────────────────────────────
+  # Opt-in via profile so they never run by default:
+  #   docker compose --profile observability up -d
+  # Then set in appsettings.*.json or env:
+  #   Serilog__Seq__ServerUrl=http://seq:5341
+  #   (Prometheus scrapes http://api:8080/metrics automatically via prometheus.yml)
+  seq:
+    image: datalust/seq:2024.3
+    profiles: ["observability"]
+    environment:
+      ACCEPT_EULA: "Y"
+    volumes:
+      - seqdata:/data
+    ports:
+      - "5341:80"   # UI + ingestion
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    profiles: ["observability"]
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - promdata:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=15d'
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    profiles: ["observability"]
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-planscape}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
 volumes:
   pgdata:
   redisdata:
+  seqdata:
+  promdata:
+  grafanadata:

--- a/Planscape.Server/docker/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/Planscape.Server/docker/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,14 @@
+# MON-03 — Dashboard provisioning config. Drops any JSON files in the mounted
+# dashboards/ directory into Grafana on startup.
+apiVersion: 1
+
+providers:
+  - name: Planscape
+    orgId: 1
+    folder: Planscape
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/Planscape.Server/docker/monitoring/grafana/provisioning/dashboards/planscape-api.json
+++ b/Planscape.Server/docker/monitoring/grafana/provisioning/dashboards/planscape-api.json
@@ -1,0 +1,81 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Requests / second",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_received_total[1m])) by (method)",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "title": "P95 latency",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, endpoint))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "title": "Error rate (4xx + 5xx)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_received_total{code=~\"4..|5..\"}[5m])) by (code)",
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "title": "In-flight requests",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "http_requests_in_progress",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["planscape", "api"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Planscape API — Overview",
+  "uid": "planscape-api-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/Planscape.Server/docker/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/Planscape.Server/docker/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+# MON-03 — Grafana auto-provisions Prometheus as the default datasource.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/Planscape.Server/docker/monitoring/prometheus.yml
+++ b/Planscape.Server/docker/monitoring/prometheus.yml
@@ -1,0 +1,20 @@
+# MON-03 — Prometheus scrape config for the Planscape API.
+# Metrics exposed at /metrics by prometheus-net.AspNetCore.
+# Enable /disable in appsettings.*.json via Monitoring:ExposeMetrics.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    app: planscape
+
+scrape_configs:
+  - job_name: 'planscape-api'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api:8080']
+        labels:
+          service: api
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/Planscape.Server/docs/IMPLEMENTED_FROM_SCREENSHOT.md
+++ b/Planscape.Server/docs/IMPLEMENTED_FROM_SCREENSHOT.md
@@ -1,5 +1,11 @@
 # Screenshot follow-up — implementation notes
 
+> **Update (round 2):** The four previously-deferred "wants product decision"
+> items (OCR, NLP auto-link, Tenant switcher, Custom fields UI) were greenlit
+> after the product-decision survey. See sections 4–7 below.
+
+
+
 Reference: the "What remains and why I didn't ship it" review table called out
 eight items that had been deferred from the previous sprint. This branch closes
 four of them; the remaining four stay deferred for the reasons already captured
@@ -102,6 +108,89 @@ the reverse proxy instead.
 
 ---
 
+## 4. OCR on-device scaffold (decisions 1.1=b, 1.2=a, 1.3=tag+serial+drawing+mfr, 1.4=issue-upload, 1.5=b/90%)
+
+Zero-dependency scaffold that activates as soon as a native OCR module is
+added. Picks up `NativeModules.PlanscapeVisionOcr` (iOS) or
+`NativeModules.MLKitTextRecognition` (Android); cleanly no-ops otherwise so
+Expo Go + existing builds keep working.
+
+**Files added**
+
+- `Planscape/src/services/ocr.ts` — abstraction + ISO tag regex (O→0, I→1 fix-ups), drawing number, serial, manufacturer heuristics.
+- `Planscape/src/services/ocr.md` — wiring guide for Apple Vision Swift module + `@react-native-ml-kit/text-recognition`.
+- `Planscape/src/components/OcrConfirmModal.tsx` — "did you mean?" UI shown when `extractionConfidence < 0.9`.
+
+## 5. NLP auto-link (decisions 2.1=d rules+LLM, 2.2=issue+search, 2.3=tag+grid+fuzzy, 2.4=b, 2.5=redact)
+
+Rule-based resolver with optional LLM fallback (off by default). Redacts PII
+before any cloud call. Auto-link threshold = 0.9; candidates below auto-link
+still come back ranked for the "did you mean?" picker.
+
+**Files added**
+
+- `Planscape.Server/src/Planscape.Core/Interfaces/INlpResolver.cs` — `NlpResolution`, `NlpCandidate`, `INlpLlmResolver` interfaces.
+- `Planscape.Server/src/Planscape.Infrastructure/Services/NlpResolver.cs` — regex (ISO tag, grid) + Levenshtein fuzzy family match + LLM fallback hook.
+- `Planscape.Server/src/Planscape.Infrastructure/Services/PiiRedactor.cs` — email / phone / NI / card / guid / long-digit runs → `[redacted]`.
+- `Planscape.Server/src/Planscape.API/Controllers/NlpController.cs` — `POST /api/nlp/resolve`.
+- `NullLlmResolver` in the same file — default no-op; swap in Azure OpenAI / OpenAI / Anthropic impl when credentials land.
+
+Config: `Nlp:EnableLlmFallback=true` gates the LLM path even when a real
+provider is registered. Per-request `allowCloudFallback: false` lets clients
+opt out per call.
+
+## 6. Tenant switcher (decisions 3.1=c adaptive, 3.2=b per-tenant JWTs, 3.3=drain+warn)
+
+Server endpoints re-issue a JWT for any tenant the user's email belongs to.
+Mobile stores tokens per tenant in SecureStore and offers an adaptive UI
+(hidden at 1, list at 2-5, search at 6+).
+
+**Server files**
+
+- `Planscape.Server/src/Planscape.API/Controllers/AuthController.cs` — added `GET /api/auth/tenants` + `POST /api/auth/switch-tenant`.
+  - Security: `SwitchTenant` returns 403 if no active `AppUser` row exists for the user's email + target `tenantId` + `IsActive=true`.
+
+**Mobile files**
+
+- `Planscape/src/stores/tenantStore.ts` — Zustand store with `presentation()` (`hidden`/`list`/`search`).
+- `Planscape/src/api/tenants.ts` — `fetchMemberships`, `switchTenant`, per-tenant `SecureStore` key helpers (`planscape_token:{tenantId}`).
+- `Planscape/src/components/TenantSwitcher.tsx` — header badge + adaptive modal picker with mid-switch offline-queue warning.
+- `Planscape/app/(tabs)/_layout.tsx` — `headerRight: () => <TenantSwitcher />` + memberships bootstrap on tab mount.
+
+Mid-switch behaviour: checks `pendingCount()` in the offline queue, warns
+before proceeding, then clears the queue on confirmation so the next tenant
+doesn't replay the previous tenant's actions.
+
+## 7. Custom fields (decisions 4.1=issues-only, 4.2=9 types, 4.3=b simple table, 4.4=b collapsible, 4.5=c JSONB+GIN, 4.6=archive+rename-in-place+banner+exports-include)
+
+Per-project schema table + JSONB column on `BimIssue` with a GIN index for
+fast path queries. Admin CRUD is `Admin,Owner` only; end users see only the
+active-schema list via `GET`.
+
+**Server files**
+
+- `Planscape.Server/src/Planscape.Core/Entities/IssueCustomFieldSchema.cs` — schema entity + `CustomFieldType` enum (9 types).
+- `Planscape.Server/src/Planscape.Core/Entities/BimIssue.cs` — added `CustomFields` string column.
+- `Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs` — entity config + GIN index declaration.
+- `Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260418000000_AddIssueCustomFields.cs` — migration + raw SQL for the GIN index.
+- `Planscape.Server/src/Planscape.API/Controllers/IssueCustomFieldsController.cs` — `GET/POST/PUT/DELETE/POST:reorder` under `/api/projects/{projectId}/custom-fields`.
+- `Planscape.Server/src/Planscape.Infrastructure/Services/CustomFieldsPurgeJob.cs` — nightly Hangfire job purges fields deleted > 30 days ago and scrubs their values from `BimIssue.CustomFields`.
+
+**Mobile files**
+
+- `Planscape/src/types/customFields.ts` — types + `parseOptions()` + `validateAgainstSchema()`.
+- `Planscape/src/api/customFields.ts` — `fetchSchema` for end users + admin CRUD helpers.
+- `Planscape/src/components/CustomFieldInput.tsx` — dynamic renderer for all 9 field types + `<CustomFieldsSection>` collapsible wrapper.
+
+Admin rename-in-place is supported — unique `(ProjectId, Key)` constraint
+blocks duplicates. Deleting a field soft-archives it (`IsActive=false`,
+`DeletedAt=now`); values are preserved on existing issues until the 30-day
+purge job runs (schedule: `15 3 * * *` UTC). Exports include custom fields by
+default — `BimIssue.CustomFields` is a string column so whatever CSV/COBie/BCF
+exporter serialises the entity already picks it up.
+
+---
+
 ## Out-of-scope (still deferred)
 
 | Row | Reason | Unblocked by |
@@ -109,5 +198,3 @@ the reverse proxy instead.
 | Apple / Play / Firebase / DNS | External accounts | Following §A.1-A.4 of `OPERATIONS_AND_PLAN.md` (lead time 1–7 days) |
 | `dotnet build` verification | No .NET SDK in sandbox; `https://dot.net` blocked by allowlist | CI workflow `.github/workflows/planscape-server.yml` handles this on PR open |
 | ACC OAuth, BCF, COBie w/ attachments | Need vendor credentials + test files | Dedicated PR per connector |
-| OCR / NLP auto-link | ML model choice pending | Product decision + spike |
-| Tenant switcher, custom fields UI | UX redesign | Product decision |

--- a/Planscape.Server/docs/IMPLEMENTED_FROM_SCREENSHOT.md
+++ b/Planscape.Server/docs/IMPLEMENTED_FROM_SCREENSHOT.md
@@ -1,0 +1,113 @@
+# Screenshot follow-up — implementation notes
+
+Reference: the "What remains and why I didn't ship it" review table called out
+eight items that had been deferred from the previous sprint. This branch closes
+four of them; the remaining four stay deferred for the reasons already captured
+in [`OPERATIONS_AND_PLAN.md`](./OPERATIONS_AND_PLAN.md).
+
+| Screenshot row | Status | Notes |
+|----|----|----|
+| Apple / Play / Firebase / DNS | **Still deferred** | External accounts required — nothing the sandbox can reach. Process + credentials already documented in `OPERATIONS_AND_PLAN.md §A.1–A.4`. |
+| Server `dotnet build` verification | **Still deferred (but CI gate in place)** | Sandbox has no .NET SDK and `https://dot.net` is out of allowlist. Any C# change pushed to GitHub is compile-gated by `.github/workflows/planscape-server.yml`, which runs `dotnet build` + `dotnet test` on every PR. |
+| ACC OAuth, BCF round-trip, COBie w/ attachments | **Still deferred** | Need real third-party credentials + test data — both out of scope for this sandbox. |
+| OCR, NLP auto-link to Revit | **Still deferred** | 3-day pieces each; better as focused PRs with a specific model/vendor decision. |
+| Tenant switcher, custom-fields UI | **Still deferred** | Significant UX — wants product direction first. |
+| **Tenant branding + email templates** | **Shipped ✅** | See below. |
+| **i18n** | **Shipped (scaffolding + 3 locales) ✅** | See below. |
+| **Monitoring stack wiring (Seq/Elastic/Prometheus/Grafana)** | **Shipped ✅** | See below. |
+
+---
+
+## 1. Monitoring stack (MON-01, MON-02, MON-03)
+
+**Files added/changed**
+
+- `src/Planscape.API/Planscape.API.csproj` — `Serilog.Sinks.Seq`, `Serilog.Sinks.Elasticsearch`, `prometheus-net.AspNetCore`.
+- `src/Planscape.API/Program.cs` — conditional Seq + Elastic sinks on top of the existing console/file sinks; `UseHttpMetrics()` + `MapMetrics("/metrics")`.
+- `src/Planscape.API/appsettings.json` — `Serilog:Seq`, `Serilog:Elastic`, `Monitoring:ExposeMetrics` sections (all inert until configured).
+- `src/Planscape.API/appsettings.Production.template.json` — production overlay.
+- `docker/docker-compose.yml` — `seq`, `prometheus`, `grafana` services behind the `observability` profile.
+- `docker/monitoring/prometheus.yml` — API scrape config.
+- `docker/monitoring/grafana/provisioning/datasources/prometheus.yml` — auto-configured datasource.
+- `docker/monitoring/grafana/provisioning/dashboards/planscape-api.json` — starter dashboard (request rate, p95 latency, error rate, in-flight).
+
+**Activating locally**
+
+```bash
+cd Planscape.Server/docker
+docker compose --profile observability up -d seq prometheus grafana
+
+# Tell the API to log into Seq too:
+export Serilog__Seq__ServerUrl=http://localhost:5341
+dotnet run --project ../src/Planscape.API
+```
+
+Seq UI on <http://localhost:5341>, Grafana on <http://localhost:3001> (`admin` /
+`$GRAFANA_ADMIN_PASSWORD`, default `planscape`), Prometheus on
+<http://localhost:9090>. `/metrics` on the API exposes Prometheus exposition
+format — set `Monitoring:ExposeMetrics=false` if you want to bind-block it at
+the reverse proxy instead.
+
+## 2. Tenant branding + email templates (FLEX-03, FLEX-07)
+
+**Files added**
+
+- `src/Planscape.Core/Entities/TenantBranding.cs` — per-tenant row.
+- `src/Planscape.Core/Interfaces/ITenantBrandingService.cs` — resolves branding with the fallback chain `row → appsettings → hardcoded`.
+- `src/Planscape.Infrastructure/Services/TenantBrandingService.cs` — DB-backed implementation with 5-minute cache.
+- `src/Planscape.Infrastructure/Services/EmailTemplateRenderer.cs` — minimal `{{placeholder}}` / `{{#if}}` engine. Zero external deps.
+- `src/Planscape.API/EmailTemplates/_layout.en.html` — shared layout.
+- `src/Planscape.API/EmailTemplates/invite.*`, `password-reset.*`, `issue-assigned.*` — default templates (subject, html, txt).
+- `src/Planscape.API/Controllers/TenantBrandingController.cs` — `GET/PUT/DELETE /api/tenant/branding` + `POST /api/tenant/branding/templates/reload`.
+- `src/Planscape.Infrastructure/Data/Migrations/20260417000000_AddTenantBranding.cs` — EF migration for the new table.
+
+**Files changed**
+
+- `src/Planscape.Infrastructure/Services/SmtpEmailService.cs` — renders via the new engine, pulls branding from `ITenantBrandingService`, respects per-tenant `EmailFromName`/`EmailFromAddress`. Falls back to a built-in legacy layout when the renderer is unavailable, so a misconfigured host never silently fails to send.
+- `src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs` — new DbSet + model config.
+- `src/Planscape.API/appsettings*.json` — `Tenant:DefaultBranding` section (ProductName, AccentColor, HeaderColor, LogoUrl, SupportEmail, EmailSignature, DefaultLanguage).
+- `src/Planscape.API/Planscape.API.csproj` — `<None Include="EmailTemplates/**" CopyToOutputDirectory="PreserveNewest" />`.
+- `src/Planscape.API/Program.cs` — DI registrations.
+
+**Ready to extend**
+
+- Add a locale: drop `invite.fr.html`/`.subject`/`.txt` into `EmailTemplates/` and it gets picked up automatically (fallback: language → `en` → no-suffix).
+- Tenant admin can override any field via `PUT /api/tenant/branding`; non-set fields inherit from `Tenant:DefaultBranding` and ultimately hardcoded defaults. `InvalidateCache()` is called automatically on save.
+
+## 3. i18n (FLEX-15)
+
+**Server**
+
+- `src/Planscape.API/I18n/{en,de,es}.json` — dotted-key resource bundles (errors, notifications, audit verbs, email subjects).
+- `src/Planscape.Core/Interfaces/II18nService.cs`.
+- `src/Planscape.Infrastructure/Services/I18nService.cs` — flat-key JSON loader, `{placeholder}` substitution, fallback through `language → "en" → literal key`.
+- `src/Planscape.API/Middleware/LocaleMiddleware.cs` — resolves the caller's language from (`X-Language` header → `?language=` → `Accept-Language` → `en`), stores it on `HttpContext.Items["Language"]`, and echoes it on the `Content-Language` response header.
+- `src/Planscape.API/Controllers/I18nController.cs` — `GET /api/i18n`, `GET /api/i18n/{lang}`, `POST /api/i18n/reload`.
+- `src/Planscape.API/Planscape.API.csproj` — `<None Include="I18n/**" CopyToOutputDirectory="PreserveNewest" />`.
+- `Program.cs` wires both the service and the middleware.
+
+**Mobile**
+
+- `Planscape/src/i18n/index.ts` — zero-dependency `t(key, vars)` / `useT()` / `setLanguage()` / `getLanguage()` / `initI18n()`. Uses AsyncStorage for persistence and falls back to the device locale.
+- `Planscape/src/i18n/locales/{en,de,es}.json` — bundle set.
+- `Planscape/src/i18n/README.md` — how to add a language.
+- `Planscape/src/api/client.ts` — sends `X-Language: {getLanguage()}` on every authenticated request so the server returns locale-aware errors and server-initiated pushes.
+- `Planscape/app/_layout.tsx` — calls `initI18n()` before the first render.
+- `Planscape/tsconfig.json` — `resolveJsonModule: true`.
+
+**Ready to extend**
+
+- Add `fr.json` on either side — no code change on the mobile side besides `import fr from "./locales/fr.json"`; server picks it up automatically from the filesystem.
+- Swap the mobile implementation for `i18next` later without touching call sites — the public API (`t`, `useT`, `setLanguage`, `getLanguage`, `initI18n`) is the same shape.
+
+---
+
+## Out-of-scope (still deferred)
+
+| Row | Reason | Unblocked by |
+|---|---|---|
+| Apple / Play / Firebase / DNS | External accounts | Following §A.1-A.4 of `OPERATIONS_AND_PLAN.md` (lead time 1–7 days) |
+| `dotnet build` verification | No .NET SDK in sandbox; `https://dot.net` blocked by allowlist | CI workflow `.github/workflows/planscape-server.yml` handles this on PR open |
+| ACC OAuth, BCF, COBie w/ attachments | Need vendor credentials + test files | Dedicated PR per connector |
+| OCR / NLP auto-link | ML model choice pending | Product decision + spike |
+| Tenant switcher, custom fields UI | UX redesign | Product decision |

--- a/Planscape.Server/docs/MODEL_VIEWER.md
+++ b/Planscape.Server/docs/MODEL_VIEWER.md
@@ -1,0 +1,181 @@
+# 3D model viewer
+
+End-to-end scaffold that puts a **glTF/GLB 3D model viewer in the Planscape
+mobile app**, backed by a Planscape-server model registry and populated by a
+**new Revit plugin command** that captures the element-to-ISO-tag map.
+
+## Why this exists
+
+Before this change:
+- Mobile app had a PDF viewer but no 3D model support.
+- Server stored documents generically — no first-class 3D asset type.
+- The Revit plugin exported IFC but didn't publish renderable geometry or
+  bridge element identity to STING tags.
+
+After:
+- Mobile users tap an issue's model pin or open the model directly, rotate /
+  zoom / pan the 3D geometry, tap an element to see its ISO 19650 tag +
+  discipline + level, long-press to raise an issue pinned to that exact XYZ.
+- Office / coordinator users publish their Revit view directly to Planscape
+  from the plugin's BIM tab ("Publish Model to Planscape").
+- All assets live behind the tenant-isolated `/api/projects/{id}/models`
+  endpoint — same auth + rate limits as every other resource.
+
+## Architecture
+
+```
+  Revit plugin                     Planscape server                  Mobile app
+  ────────────                     ────────────────                  ──────────
+  PublishModelCommand              POST /api/projects/{id}/models    ModelViewer (WebView)
+    ├── user picks .glb/.gltf      ├── ProjectModel row created        ├── assets/viewer/viewer.html
+    ├── scans visible elements     ├── storage via                     │     (three.js + GLTFLoader
+    │   in the active view         │     IFileStorageService           │      + OrbitControls)
+    ├── writes element-map JSON    │     (local FS / MinIO / S3)       │
+    │   (guid → tag / cat / disc)  └── element-map sidecar             ├── RN ↔ WebView bridge
+    └── PlanscapeServerClient      └── thumbnail sidecar               │     (pick / measure /
+        .UploadModelAsync                                              │      section / pins)
+                                                                       └── long-press → new issue
+                                                                             anchored to guid+XYZ
+```
+
+## Server
+
+### New entity: `ProjectModel`
+
+See `Planscape.Core/Entities/ProjectModel.cs`. One row per uploaded model.
+
+Columns:
+- `ProjectId` — tenant-isolated via `Projects.TenantId` join
+- `Name / Description / Discipline / Revision`
+- `FileName / Format (Glb|Gltf|Ifc|Rvt|Obj|Fbx) / StoragePath / ContentHash`
+- `FileSizeBytes / ThumbnailPath / ElementMapPath / ElementCount`
+- Bounds: `BoundsMin{X,Y,Z}` / `BoundsMax{X,Y,Z}` (model units, for viewer auto-frame)
+- `Units` (mm / m / ft) / `UploadedBy / UploadedAt / DeletedAt`
+
+### Issue model anchor
+
+`BimIssue` gains nullable `ModelId / ModelElementGuid / ModelX / ModelY /
+ModelZ`. Any existing flow ignores them; the viewer reads them to render pins.
+
+### Controller: `ModelsController`
+
+Routes under `/api/projects/{projectId}/models`:
+| Method | Path                                     | Role          | Purpose                         |
+|--------|------------------------------------------|---------------|---------------------------------|
+| GET    | `/`                                      | any authed    | list active models              |
+| GET    | `/{modelId}`                             | any authed    | metadata                        |
+| POST   | `/`                                      | Admin/Owner/Coordinator | upload (multipart)     |
+| GET    | `/{modelId}/file`                        | any authed    | stream geometry (range-enabled) |
+| GET    | `/{modelId}/element-map`                 | any authed    | stream JSON sidecar             |
+| GET    | `/{modelId}/thumbnail`                   | any authed    | PNG preview                     |
+| DELETE | `/{modelId}`                             | Admin/Owner/Coordinator | soft delete            |
+
+Upload limits: 200 MB geometry, 5 MB element map, 2 MB thumbnail.
+Content SHA-256 hashed on upload → duplicate uploads return HTTP 409 with the
+existing model id (saves bandwidth on repeat publishes).
+
+### Migration
+
+`20260419000000_AddProjectModelsAndIssueAnchors.cs` adds the table + the 5
+`Issues.Model*` columns + the `IX_Issues_ModelId` index. EF's model snapshot
+will auto-regenerate on the next `dotnet ef migrations add` — we didn't
+hand-edit the snapshot here.
+
+## Mobile
+
+### `react-native-webview`
+
+New dep (`package.json`). The viewer is HTML + JS delivered via the WebView
+rather than an `expo-gl` native renderer — zero native build steps, works in
+Expo Go, and swapping the WebView HTML is a text edit.
+
+### Bundled viewer: `assets/viewer/viewer.html`
+
+Self-contained three.js scene:
+- OrbitControls (1-finger rotate, 2-finger pan + pinch zoom)
+- GLTFLoader for glb/gltf
+- Ray-pick on tap → highlights + emits element GUID + XYZ
+- Long-press on mesh → emits `placeIssue` to RN with the mesh GUID + meta
+- Measure tool (two-tap distance)
+- Horizontal section plane with slider
+- Issue pins (billboards, colour-coded by priority)
+- Discipline layer toggle (read from the element map)
+
+Three.js itself is pinned to r160 and fetched via `curl` into
+`assets/viewer/` (see that directory's README). The viewer shows a clear
+error page if those files are missing rather than a blank WebView.
+
+### `ModelViewer` React component
+
+`Planscape/src/components/ModelViewer.tsx`. Imperative handle exposes:
+- `setTool("pick"|"measure"|"section"|"pin")`
+- `fit()` / `clearMeasure()` / `clearHighlight()`
+- `setPins(pins)` / `addPin(pin)` / `clearPins()`
+- `setDisciplineVisible(code, visible)`
+
+Event callbacks: `onPick`, `onPlaceIssue`, `onPinTap`, `onMeasure`,
+`onToolChanged`, `onError`.
+
+### Screens
+
+- `app/models/index.tsx` — list models with thumbnail / size / uploader / date
+- `app/models/[id].tsx` — full-screen viewer, wires API metadata + element-map
+  fetch + existing-issue-pin population + "create issue here" navigation to
+  `/issues/new` with the 3D anchor params preloaded
+- `app/models/_layout.tsx` — stack navigator shell
+
+Routes live outside `(tabs)` so the viewer is full-screen; add a tile / menu
+entry on Dashboard or Documents to surface them.
+
+### Dependencies
+
+`package.json` adds:
+- `react-native-webview`
+- `expo-asset` (for resolving the bundled HTML to a file URI)
+
+Run `npm install` once — no native configuration needed.
+
+### `metro.config.js`
+
+Teaches Metro to treat `.html / .gltf / .glb / .bin / .ifc` as static assets so
+`require("../../assets/viewer/viewer.html")` resolves to an asset ref.
+
+## Revit plugin
+
+### `PublishModelCommand`
+
+`StingTools/BIMManager/PublishModelCommand.cs`. Workflow:
+1. Refuses if the user hasn't signed in to Planscape.
+2. Lists Planscape projects, user picks one.
+3. Open-file dialog for the geometry (glb / gltf / ifc / obj / fbx). Revit
+   doesn't ship a glTF writer — any external exporter that preserves the
+   Revit UniqueId under `userData.extras.guid` works (SimLab, rvt2gltf,
+   Dynamo "Rhythm.ExportToGltf", APS Model Derivative).
+4. Scans the active 3D view's visible elements via `FilteredElementCollector`,
+   writes an element-map JSON (`{ guid → { tag, name, category, discipline,
+   level, elementId } }`) alongside the geometry.
+5. Uploads both to `/api/projects/{id}/models` via the new
+   `PlanscapeServerClient.UploadModelAsync`.
+
+Command tag: `PublishModelToPlanscape` — wired in `StingCommandHandler.cs`.
+
+## Known follow-ups
+
+- **Server-side IFC→glTF conversion.** The upload endpoint accepts IFC, but
+  the mobile viewer only renders glTF/GLB. Add a Hangfire job that calls
+  `IfcConvert` / Autodesk APS to produce a renderable `.glb` sidecar when a
+  user uploads IFC.
+- **Thumbnail auto-generation.** Currently the plugin / admin uploads a PNG;
+  in production we'd render one headlessly on upload (e.g. with `three.js`
+  in a Node sidecar) so mobile list loads a preview without downloading the
+  whole glb.
+- **Progressive download.** For 100 MB+ models, hand the WebView a
+  Draco-compressed + meshopt-encoded glb so the first-paint is quick even on
+  3G. The viewer already supports Draco if the loaders include
+  `DRACOLoader.js` next to `GLTFLoader.js`.
+- **AR mode (iOS).** `viewer.html` could call `WebXR` when available to put
+  the model in the user's site — gated by device support, not shipped here.
+- **Mobile issue-anchor rendering.** Currently the `/issues/new` screen
+  receives `modelId / modelElementGuid / modelX / modelY / modelZ` via query
+  params; wire these into the existing create modal once it's refactored to
+  accept initial values.

--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -233,6 +233,98 @@ public class AuthController : ControllerBase
         });
     }
 
+    // ── Tenant switcher (TENANT-SWITCH) ────────────────────────────────────────
+
+    /// <summary>List all tenants the authenticated user's email is a member of.</summary>
+    /// <remarks>
+    /// Used by the mobile header badge + picker. An email can have multiple <see cref="AppUser"/>
+    /// rows (one per tenant) — this endpoint surfaces all of them so the UI can let the
+    /// consultant switch organisations without logging out.
+    /// </remarks>
+    [HttpGet("tenants")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult> GetMemberships()
+    {
+        var subClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        var activeUserId = Guid.TryParse(subClaim, out var id) ? id : Guid.Empty;
+
+        var active = await _db.Users.AsNoTracking()
+            .Include(u => u.Tenant)
+            .FirstOrDefaultAsync(u => u.Id == activeUserId);
+        if (active == null) return NotFound();
+
+        // Same email across tenants — common when consultants are invited to
+        // multiple client orgs.
+        var memberships = await _db.Users.AsNoTracking()
+            .Include(u => u.Tenant)
+            .Where(u => u.Email == active.Email && u.IsActive)
+            .OrderBy(u => u.Tenant!.Name)
+            .Select(u => new
+            {
+                userId = u.Id,
+                tenantId = u.TenantId,
+                tenantName = u.Tenant!.Name,
+                tenantSlug = u.Tenant.Slug,
+                tenantTier = u.Tenant.Tier.ToString(),
+                mimEnabled = u.Tenant.MimEnabled,
+                role = u.Role.ToString(),
+                isActiveTenant = u.Id == activeUserId,
+            })
+            .ToListAsync();
+
+        return Ok(memberships);
+    }
+
+    /// <summary>Re-issue a JWT for a different tenant the user belongs to.</summary>
+    /// <response code="200">New JWT + refresh token — apply in SecureStore under a per-tenant key.</response>
+    /// <response code="403">User is not a member of the requested tenant.</response>
+    [HttpPost("switch-tenant")]
+    [Authorize]
+    [ProducesResponseType(typeof(AuthLoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<AuthLoginResponse>> SwitchTenant([FromBody] SwitchTenantRequest req)
+    {
+        var subClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        var activeUserId = Guid.TryParse(subClaim, out var id) ? id : Guid.Empty;
+
+        var active = await _db.Users.AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == activeUserId);
+        if (active == null) return Unauthorized();
+
+        var target = await _db.Users
+            .Include(u => u.Tenant)
+            .FirstOrDefaultAsync(u =>
+                u.Email == active.Email &&
+                u.TenantId == req.TenantId &&
+                u.IsActive);
+        if (target == null)
+        {
+            // Do not reveal whether the tenant exists — return 403.
+            return Forbid();
+        }
+
+        var token = GenerateJwt(target);
+        var refreshToken = Guid.NewGuid().ToString("N");
+        target.RefreshToken = refreshToken;
+        target.RefreshTokenExpiresAt = DateTime.UtcNow.AddDays(30);
+        target.LastLoginAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        return Ok(new AuthLoginResponse
+        {
+            AccessToken = token,
+            RefreshToken = refreshToken,
+            ExpiresAt = DateTime.UtcNow.AddHours(8),
+            UserName = target.DisplayName,
+            Role = target.Role.ToString(),
+            Tier = target.Tenant?.Tier.ToString() ?? "Starter",
+            MimEnabled = target.Tenant?.MimEnabled ?? false
+        });
+    }
+
     // ── Licence activation ─────────────────────────────────────────────────────
 
     /// <summary>Activate a licence key to unlock a tier (Professional / Premium / Enterprise).</summary>
@@ -367,3 +459,5 @@ public class AuthController : ControllerBase
     public static string HashPassword(string password)
         => BCrypt.Net.BCrypt.HashPassword(password, workFactor: 12);
 }
+
+public record SwitchTenantRequest(Guid TenantId);

--- a/Planscape.Server/src/Planscape.API/Controllers/I18nController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/I18nController.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Planscape.Core.Interfaces;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// FLEX-15 — Internationalisation endpoints.
+///
+///   GET /api/i18n                → list of supported language codes + resolved language for the caller
+///   GET /api/i18n/{language}     → full translation map for a language (mobile prefetch)
+///   POST /api/i18n/reload        → hot-reload resource files (Admin only)
+/// </summary>
+[ApiController]
+[Route("api/i18n")]
+public class I18nController : ControllerBase
+{
+    private readonly II18nService _i18n;
+    private readonly IHostEnvironment _env;
+
+    public I18nController(II18nService i18n, IHostEnvironment env)
+    {
+        _i18n = i18n;
+        _env = env;
+    }
+
+    [HttpGet]
+    [AllowAnonymous]
+    public ActionResult GetSupported()
+    {
+        var resolved = (HttpContext.Items["Language"] as string) ?? "en";
+        return Ok(new
+        {
+            supported = _i18n.SupportedLanguages,
+            resolved,
+            fallback = "en",
+        });
+    }
+
+    [HttpGet("{language}")]
+    [AllowAnonymous]
+    public ActionResult GetBundle(string language, CancellationToken ct)
+    {
+        // Return the raw JSON file so the mobile app can use i18next with HTTP backend
+        // or cache it under AsyncStorage. We only serve files the service has already
+        // validated at startup (prevents path traversal on arbitrary filenames).
+        if (!_i18n.SupportedLanguages.Contains(language.ToLowerInvariant()))
+            return NotFound(new { error = "unsupported_language", requested = language });
+
+        var root = Path.Combine(_env.ContentRootPath, "I18n");
+        var file = Path.Combine(root, $"{language}.json");
+        if (!System.IO.File.Exists(file)) return NotFound();
+        var content = System.IO.File.ReadAllText(file);
+        return Content(content, "application/json");
+    }
+
+    [HttpPost("reload")]
+    [Authorize(Roles = "Admin,Owner")]
+    public IActionResult Reload()
+    {
+        _i18n.Reload();
+        return Ok(new { reloaded = true, languages = _i18n.SupportedLanguages });
+    }
+}

--- a/Planscape.Server/src/Planscape.API/Controllers/IssueCustomFieldsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IssueCustomFieldsController.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// FLEX-13 — Issue custom-field schema CRUD.
+///
+/// Admin/Owner-only. End users see the resolved schema via GET (authenticated)
+/// and submit values on the standard Issues POST under the <c>customFields</c>
+/// JSON object key.
+/// </summary>
+[ApiController]
+[Route("api/projects/{projectId:guid}/custom-fields")]
+[Authorize]
+public class IssueCustomFieldsController : ControllerBase
+{
+    private readonly PlanscapeDbContext _db;
+
+    private static readonly Regex KeyPattern = new("^[a-z][a-z0-9_]{0,78}[a-z0-9]$", RegexOptions.Compiled);
+
+    public IssueCustomFieldsController(PlanscapeDbContext db) => _db = db;
+
+    /// <summary>Return the active schema for rendering forms (end-user readable).</summary>
+    [HttpGet]
+    public async Task<ActionResult> Get(Guid projectId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var rows = await _db.IssueCustomFieldSchemas.AsNoTracking()
+            .Where(s => s.ProjectId == projectId && s.IsActive && s.DeletedAt == null)
+            .OrderBy(s => s.SortOrder).ThenBy(s => s.Label)
+            .Select(s => new SchemaDto(
+                s.Id, s.Key, s.Label, s.FieldType.ToString(), s.HelpText,
+                s.DefaultValueJson, s.OptionsJson, s.Required, s.SortOrder))
+            .ToListAsync(ct);
+        return Ok(rows);
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<ActionResult<SchemaDto>> Create(Guid projectId, [FromBody] UpsertSchemaRequest req, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var error = Validate(req);
+        if (error != null) return BadRequest(new { error });
+
+        if (await _db.IssueCustomFieldSchemas
+                .AnyAsync(s => s.ProjectId == projectId && s.Key == req.Key && s.DeletedAt == null, ct))
+            return Conflict(new { error = "duplicate_key" });
+
+        if (!Enum.TryParse<CustomFieldType>(req.FieldType, true, out var fieldType))
+            return BadRequest(new { error = "invalid_field_type", allowed = Enum.GetNames<CustomFieldType>() });
+
+        var row = new IssueCustomFieldSchema
+        {
+            ProjectId = projectId,
+            Key = req.Key!,
+            Label = req.Label!,
+            FieldType = fieldType,
+            HelpText = req.HelpText,
+            DefaultValueJson = Normalise(req.DefaultValueJson),
+            OptionsJson = Normalise(req.OptionsJson),
+            Required = req.Required ?? false,
+            SortOrder = req.SortOrder ?? NextSortOrder(projectId),
+            UpdatedByUserId = CurrentUserId(),
+        };
+        _db.IssueCustomFieldSchemas.Add(row);
+        await _db.SaveChangesAsync(ct);
+        return Ok(ToDto(row));
+    }
+
+    [HttpPut("{fieldId:guid}")]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<ActionResult<SchemaDto>> Update(Guid projectId, Guid fieldId, [FromBody] UpsertSchemaRequest req, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var error = Validate(req);
+        if (error != null) return BadRequest(new { error });
+
+        var row = await _db.IssueCustomFieldSchemas
+            .FirstOrDefaultAsync(s => s.Id == fieldId && s.ProjectId == projectId, ct);
+        if (row == null) return NotFound();
+
+        // Decision 4.6 row 2 — in-place rename preserves data. Key can change
+        // if it still matches the regex and is unique.
+        if (!string.Equals(row.Key, req.Key, StringComparison.Ordinal) &&
+            await _db.IssueCustomFieldSchemas
+                .AnyAsync(s => s.ProjectId == projectId && s.Key == req.Key && s.Id != fieldId && s.DeletedAt == null, ct))
+            return Conflict(new { error = "duplicate_key" });
+
+        if (!Enum.TryParse<CustomFieldType>(req.FieldType, true, out var fieldType))
+            return BadRequest(new { error = "invalid_field_type" });
+
+        row.Key = req.Key!;
+        row.Label = req.Label!;
+        row.FieldType = fieldType;
+        row.HelpText = req.HelpText;
+        row.DefaultValueJson = Normalise(req.DefaultValueJson);
+        row.OptionsJson = Normalise(req.OptionsJson);
+        row.Required = req.Required ?? row.Required;
+        row.SortOrder = req.SortOrder ?? row.SortOrder;
+        row.UpdatedAt = DateTime.UtcNow;
+        row.UpdatedByUserId = CurrentUserId();
+        await _db.SaveChangesAsync(ct);
+        return Ok(ToDto(row));
+    }
+
+    /// <summary>Soft-delete — archives values for 30 days before purge (decision 4.6 row 1).</summary>
+    [HttpDelete("{fieldId:guid}")]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<IActionResult> Delete(Guid projectId, Guid fieldId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var row = await _db.IssueCustomFieldSchemas
+            .FirstOrDefaultAsync(s => s.Id == fieldId && s.ProjectId == projectId, ct);
+        if (row == null) return NotFound();
+        row.IsActive = false;
+        row.DeletedAt = DateTime.UtcNow;
+        row.UpdatedAt = DateTime.UtcNow;
+        row.UpdatedByUserId = CurrentUserId();
+        await _db.SaveChangesAsync(ct);
+        return NoContent();
+    }
+
+    /// <summary>Reorder multiple fields in one call.</summary>
+    [HttpPost("reorder")]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<IActionResult> Reorder(Guid projectId, [FromBody] ReorderRequest req, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var rows = await _db.IssueCustomFieldSchemas
+            .Where(s => s.ProjectId == projectId).ToListAsync(ct);
+        var lookup = rows.ToDictionary(r => r.Id);
+        foreach (var item in req.Items)
+        {
+            if (lookup.TryGetValue(item.Id, out var r))
+            {
+                r.SortOrder = item.SortOrder;
+                r.UpdatedAt = DateTime.UtcNow;
+            }
+        }
+        await _db.SaveChangesAsync(ct);
+        return NoContent();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static string? Validate(UpsertSchemaRequest req)
+    {
+        if (string.IsNullOrWhiteSpace(req.Key)) return "key_required";
+        if (!KeyPattern.IsMatch(req.Key)) return "invalid_key_format (snake_case, a-z0-9_, 2-80 chars)";
+        if (string.IsNullOrWhiteSpace(req.Label)) return "label_required";
+        if (string.IsNullOrWhiteSpace(req.FieldType)) return "field_type_required";
+        return null;
+    }
+
+    private static string? Normalise(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try { using var _ = JsonDocument.Parse(json); return json; }
+        catch { return null; }
+    }
+
+    private int NextSortOrder(Guid projectId)
+    {
+        // 10-spaced so future inserts land without renumbering.
+        var max = _db.IssueCustomFieldSchemas
+            .Where(s => s.ProjectId == projectId)
+            .Max(s => (int?)s.SortOrder) ?? 0;
+        return max + 10;
+    }
+
+    private async Task<bool> ProjectInTenant(Guid projectId, CancellationToken ct)
+    {
+        var tenantId = Guid.TryParse(User.FindFirst("tenant_id")?.Value, out var id) ? id : Guid.Empty;
+        if (tenantId == Guid.Empty) return false;
+        return await _db.Projects.AnyAsync(p => p.Id == projectId && p.TenantId == tenantId, ct);
+    }
+
+    private Guid? CurrentUserId() =>
+        Guid.TryParse(User.FindFirst("sub")?.Value, out var id) ? id : null;
+
+    private static SchemaDto ToDto(IssueCustomFieldSchema s) =>
+        new(s.Id, s.Key, s.Label, s.FieldType.ToString(), s.HelpText,
+            s.DefaultValueJson, s.OptionsJson, s.Required, s.SortOrder);
+}
+
+public record UpsertSchemaRequest(
+    string? Key,
+    string? Label,
+    string? FieldType,
+    string? HelpText,
+    string? DefaultValueJson,
+    string? OptionsJson,
+    bool? Required,
+    int? SortOrder);
+
+public record SchemaDto(
+    Guid Id,
+    string Key,
+    string Label,
+    string FieldType,
+    string? HelpText,
+    string? DefaultValueJson,
+    string? OptionsJson,
+    bool Required,
+    int SortOrder);
+
+public record ReorderRequest(ReorderItem[] Items);
+public record ReorderItem(Guid Id, int SortOrder);

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -1,0 +1,325 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// MODEL-VIEWER — 3D model CRUD for a project.
+///
+///   GET    /api/projects/{projectId}/models            — list
+///   GET    /api/projects/{projectId}/models/{modelId}  — metadata
+///   POST   /api/projects/{projectId}/models            — upload (multipart)
+///   GET    /api/projects/{projectId}/models/{modelId}/file        — download the geometry
+///   GET    /api/projects/{projectId}/models/{modelId}/element-map — download the JSON sidecar
+///   GET    /api/projects/{projectId}/models/{modelId}/thumbnail   — PNG preview (optional)
+///   DELETE /api/projects/{projectId}/models/{modelId}  — soft delete
+///
+/// Tenant isolation is enforced on every call — the project must belong to the
+/// caller's tenant. Files are streamed via <see cref="IFileStorageService"/>
+/// so S3 / MinIO / local FS all work without controller changes.
+/// </summary>
+[ApiController]
+[Route("api/projects/{projectId:guid}/models")]
+[Authorize]
+public class ModelsController : ControllerBase
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly IFileStorageService _storage;
+    private readonly ILogger<ModelsController> _logger;
+
+    // Upload cap — glTF can be large but anything over this is almost certainly
+    // an uncompressed IFC or a federated model that should be split.
+    private const long MaxModelSizeBytes = 200L * 1024 * 1024;
+
+    public ModelsController(
+        PlanscapeDbContext db,
+        IFileStorageService storage,
+        ILogger<ModelsController> logger)
+    {
+        _db = db;
+        _storage = storage;
+        _logger = logger;
+    }
+
+    // ── List / metadata ────────────────────────────────────────────────
+
+    [HttpGet]
+    public async Task<ActionResult> List(Guid projectId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var rows = await _db.ProjectModels.AsNoTracking()
+            .Where(m => m.ProjectId == projectId && m.DeletedAt == null)
+            .OrderByDescending(m => m.UploadedAt)
+            .Select(m => ToMetaDto(m))
+            .ToListAsync(ct);
+        return Ok(rows);
+    }
+
+    [HttpGet("{modelId:guid}")]
+    public async Task<ActionResult> Get(Guid projectId, Guid modelId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var row = await _db.ProjectModels.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == modelId && m.ProjectId == projectId && m.DeletedAt == null, ct);
+        if (row == null) return NotFound();
+        return Ok(ToMetaDto(row));
+    }
+
+    // ── Upload ─────────────────────────────────────────────────────────
+
+    [HttpPost]
+    [RequestSizeLimit(MaxModelSizeBytes)]
+    [Authorize(Roles = "Admin,Owner,Coordinator")]
+    public async Task<ActionResult> Upload(
+        Guid projectId,
+        [FromForm] UploadModelRequest req,
+        CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        if (req.File == null || req.File.Length == 0)
+            return BadRequest(new { error = "file_required" });
+        if (req.File.Length > MaxModelSizeBytes)
+            return BadRequest(new { error = "file_too_large", maxMb = MaxModelSizeBytes / 1024 / 1024 });
+
+        var format = InferFormat(req.File.FileName);
+        var project = await _db.Projects.AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == projectId, ct);
+        if (project == null) return NotFound(new { error = "project_not_found" });
+
+        var tenantSlug = await TenantSlug(ct);
+        var projectCode = string.IsNullOrWhiteSpace(project.Code) ? project.Id.ToString("N") : project.Code;
+
+        // Hash first so we can short-circuit duplicate uploads.
+        string hash;
+        using (var hashStream = req.File.OpenReadStream())
+        {
+            hash = await ComputeHashAsync(hashStream, ct);
+        }
+        var existing = await _db.ProjectModels.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.ProjectId == projectId && m.ContentHash == hash && m.DeletedAt == null, ct);
+        if (existing != null)
+        {
+            _logger.LogInformation("Model upload skipped — duplicate hash {Hash} for project {ProjectId}", hash, projectId);
+            return Conflict(new { error = "duplicate_content", id = existing.Id });
+        }
+
+        // Store geometry.
+        string geometryPath;
+        using (var fs = req.File.OpenReadStream())
+        {
+            geometryPath = await _storage.SaveAsync(tenantSlug, $"{projectCode}/models", req.File.FileName, fs, ct);
+        }
+
+        // Optional element-map + thumbnail sidecars uploaded in the same request.
+        string? mapPath = null;
+        if (req.ElementMap != null && req.ElementMap.Length > 0)
+        {
+            if (req.ElementMap.Length > 5 * 1024 * 1024)
+                return BadRequest(new { error = "element_map_too_large", maxMb = 5 });
+            using var s = req.ElementMap.OpenReadStream();
+            mapPath = await _storage.SaveAsync(tenantSlug, $"{projectCode}/models", req.ElementMap.FileName, s, ct);
+        }
+        string? thumbnailPath = null;
+        if (req.Thumbnail != null && req.Thumbnail.Length > 0)
+        {
+            if (req.Thumbnail.Length > 2 * 1024 * 1024)
+                return BadRequest(new { error = "thumbnail_too_large", maxMb = 2 });
+            using var s = req.Thumbnail.OpenReadStream();
+            thumbnailPath = await _storage.SaveAsync(tenantSlug, $"{projectCode}/models", req.Thumbnail.FileName, s, ct);
+        }
+
+        var row = new ProjectModel
+        {
+            ProjectId = projectId,
+            Name = string.IsNullOrWhiteSpace(req.Name) ? Path.GetFileNameWithoutExtension(req.File.FileName) : req.Name!,
+            Description = req.Description,
+            Discipline = req.Discipline,
+            FileName = req.File.FileName,
+            Format = format,
+            StoragePath = geometryPath,
+            ContentHash = hash,
+            FileSizeBytes = req.File.Length,
+            ThumbnailPath = thumbnailPath,
+            ElementMapPath = mapPath,
+            ElementCount = req.ElementCount,
+            Units = string.IsNullOrWhiteSpace(req.Units) ? "mm" : req.Units!,
+            Revision = req.Revision,
+            BoundsMinX = req.BoundsMinX,
+            BoundsMinY = req.BoundsMinY,
+            BoundsMinZ = req.BoundsMinZ,
+            BoundsMaxX = req.BoundsMaxX,
+            BoundsMaxY = req.BoundsMaxY,
+            BoundsMaxZ = req.BoundsMaxZ,
+            UploadedBy = User.FindFirst("display_name")?.Value ?? User.Identity?.Name ?? "",
+            UploadedByUserId = CurrentUserId(),
+            UploadedAt = DateTime.UtcNow,
+        };
+        _db.ProjectModels.Add(row);
+        await _db.SaveChangesAsync(ct);
+        _logger.LogInformation("Model uploaded — {ModelId} {Format} {Size} bytes for project {ProjectId}",
+            row.Id, row.Format, row.FileSizeBytes, projectId);
+
+        return CreatedAtAction(nameof(Get), new { projectId, modelId = row.Id }, ToMetaDto(row));
+    }
+
+    // ── Downloads ──────────────────────────────────────────────────────
+
+    [HttpGet("{modelId:guid}/file")]
+    public async Task<IActionResult> DownloadFile(Guid projectId, Guid modelId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var row = await _db.ProjectModels.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == modelId && m.ProjectId == projectId && m.DeletedAt == null, ct);
+        if (row == null) return NotFound();
+        var stream = await _storage.GetAsync(row.StoragePath, ct);
+        if (stream == null) return NotFound();
+        return File(stream, GetMimeType(row.Format), row.FileName, enableRangeProcessing: true);
+    }
+
+    [HttpGet("{modelId:guid}/element-map")]
+    public async Task<IActionResult> DownloadElementMap(Guid projectId, Guid modelId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var row = await _db.ProjectModels.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == modelId && m.ProjectId == projectId && m.DeletedAt == null, ct);
+        if (row == null || row.ElementMapPath == null) return NotFound();
+        var stream = await _storage.GetAsync(row.ElementMapPath, ct);
+        if (stream == null) return NotFound();
+        return File(stream, "application/json", $"{row.Name}-elements.json", enableRangeProcessing: true);
+    }
+
+    [HttpGet("{modelId:guid}/thumbnail")]
+    public async Task<IActionResult> DownloadThumbnail(Guid projectId, Guid modelId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var row = await _db.ProjectModels.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == modelId && m.ProjectId == projectId && m.DeletedAt == null, ct);
+        if (row == null || row.ThumbnailPath == null) return NotFound();
+        var stream = await _storage.GetAsync(row.ThumbnailPath, ct);
+        if (stream == null) return NotFound();
+        return File(stream, "image/png", enableRangeProcessing: true);
+    }
+
+    // ── Delete ─────────────────────────────────────────────────────────
+
+    [HttpDelete("{modelId:guid}")]
+    [Authorize(Roles = "Admin,Owner,Coordinator")]
+    public async Task<IActionResult> Delete(Guid projectId, Guid modelId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var row = await _db.ProjectModels
+            .FirstOrDefaultAsync(m => m.Id == modelId && m.ProjectId == projectId && m.DeletedAt == null, ct);
+        if (row == null) return NotFound();
+        row.DeletedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync(ct);
+        return NoContent();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static ModelMetaDto ToMetaDto(ProjectModel m) => new(
+        m.Id, m.ProjectId, m.Name, m.Description, m.Discipline, m.FileName,
+        m.Format.ToString(), m.FileSizeBytes, m.ContentHash,
+        m.ElementMapPath != null, m.ThumbnailPath != null,
+        m.ElementCount, m.Units, m.Revision,
+        m.BoundsMinX, m.BoundsMinY, m.BoundsMinZ,
+        m.BoundsMaxX, m.BoundsMaxY, m.BoundsMaxZ,
+        m.UploadedBy, m.UploadedAt);
+
+    private static ModelFormat InferFormat(string fileName)
+    {
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+        return ext switch
+        {
+            ".glb"  => ModelFormat.Glb,
+            ".gltf" => ModelFormat.Gltf,
+            ".ifc"  => ModelFormat.Ifc,
+            ".rvt"  => ModelFormat.Rvt,
+            ".obj"  => ModelFormat.Obj,
+            ".fbx"  => ModelFormat.Fbx,
+            _ => ModelFormat.Glb,
+        };
+    }
+
+    private static string GetMimeType(ModelFormat f) => f switch
+    {
+        ModelFormat.Glb  => "model/gltf-binary",
+        ModelFormat.Gltf => "model/gltf+json",
+        ModelFormat.Ifc  => "application/x-step",
+        ModelFormat.Obj  => "model/obj",
+        ModelFormat.Fbx  => "application/octet-stream",
+        ModelFormat.Rvt  => "application/octet-stream",
+        _ => "application/octet-stream",
+    };
+
+    private static async Task<string> ComputeHashAsync(Stream stream, CancellationToken ct)
+    {
+        using var sha = SHA256.Create();
+        var hashBytes = await sha.ComputeHashAsync(stream, ct);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    private async Task<bool> ProjectInTenant(Guid projectId, CancellationToken ct)
+    {
+        var tenantId = Guid.TryParse(User.FindFirst("tenant_id")?.Value, out var id) ? id : Guid.Empty;
+        if (tenantId == Guid.Empty) return false;
+        return await _db.Projects.AnyAsync(p => p.Id == projectId && p.TenantId == tenantId, ct);
+    }
+
+    private async Task<string> TenantSlug(CancellationToken ct)
+    {
+        var tenantId = Guid.TryParse(User.FindFirst("tenant_id")?.Value, out var id) ? id : Guid.Empty;
+        if (tenantId == Guid.Empty) return "unknown";
+        return (await _db.Tenants.AsNoTracking()
+            .Where(t => t.Id == tenantId)
+            .Select(t => t.Slug)
+            .FirstOrDefaultAsync(ct)) ?? "unknown";
+    }
+
+    private Guid? CurrentUserId() =>
+        Guid.TryParse(User.FindFirst("sub")?.Value, out var id) ? id : null;
+}
+
+public class UploadModelRequest
+{
+    public IFormFile? File { get; set; }
+    public IFormFile? ElementMap { get; set; }
+    public IFormFile? Thumbnail { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public string? Discipline { get; set; }
+    public int? ElementCount { get; set; }
+    public string? Units { get; set; }
+    public string? Revision { get; set; }
+    public double? BoundsMinX { get; set; }
+    public double? BoundsMinY { get; set; }
+    public double? BoundsMinZ { get; set; }
+    public double? BoundsMaxX { get; set; }
+    public double? BoundsMaxY { get; set; }
+    public double? BoundsMaxZ { get; set; }
+}
+
+public record ModelMetaDto(
+    Guid Id,
+    Guid ProjectId,
+    string Name,
+    string? Description,
+    string? Discipline,
+    string FileName,
+    string Format,
+    long FileSizeBytes,
+    string? ContentHash,
+    bool HasElementMap,
+    bool HasThumbnail,
+    int? ElementCount,
+    string Units,
+    string? Revision,
+    double? BoundsMinX, double? BoundsMinY, double? BoundsMinZ,
+    double? BoundsMaxX, double? BoundsMaxY, double? BoundsMaxZ,
+    string UploadedBy,
+    DateTime UploadedAt);

--- a/Planscape.Server/src/Planscape.API/Controllers/NlpController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/NlpController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Planscape.Core.Interfaces;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// NLP-AUTO-LINK — /api/nlp/resolve. Accepts free text + project id, returns
+/// a ranked list of structured references the mobile client can auto-link
+/// (top candidate &gt;= 0.9) or show as a "did you mean?" picker.
+/// </summary>
+[ApiController]
+[Route("api/nlp")]
+[Authorize]
+public class NlpController : ControllerBase
+{
+    private readonly INlpResolver _resolver;
+
+    public NlpController(INlpResolver resolver) => _resolver = resolver;
+
+    [HttpPost("resolve")]
+    public async Task<ActionResult<NlpResolution>> Resolve(
+        [FromBody] ResolveRequest req, CancellationToken ct)
+    {
+        if (req == null || string.IsNullOrWhiteSpace(req.Text))
+            return BadRequest(new { error = "text_required" });
+        if (req.ProjectId == Guid.Empty)
+            return BadRequest(new { error = "project_required" });
+        if (req.Text.Length > 4000)
+            return BadRequest(new { error = "text_too_long", maxLength = 4000 });
+
+        var language = (HttpContext.Items["Language"] as string) ?? req.Language;
+        var request = new NlpResolveRequest(
+            ProjectId: req.ProjectId,
+            Text: req.Text,
+            Language: language,
+            AllowCloudFallback: req.AllowCloudFallback ?? true,
+            MaxCandidates: Math.Clamp(req.MaxCandidates ?? 10, 1, 25));
+
+        var result = await _resolver.ResolveAsync(request, ct);
+        return Ok(result);
+    }
+}
+
+public record ResolveRequest(
+    Guid ProjectId,
+    string Text,
+    string? Language = null,
+    bool? AllowCloudFallback = null,
+    int? MaxCandidates = null);

--- a/Planscape.Server/src/Planscape.API/Controllers/TenantBrandingController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TenantBrandingController.cs
@@ -1,0 +1,140 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// FLEX-03 — tenant branding CRUD.
+///
+///   GET    /api/tenant/branding           → resolved branding for current user (any authenticated)
+///   PUT    /api/tenant/branding           → persist branding (Admin / Owner only)
+///   DELETE /api/tenant/branding           → revert to config defaults
+///   POST   /api/tenant/branding/templates/reload → bust the template cache (Admin)
+///
+/// Mobile should call GET on cold start and cache the result locally. Web dashboard
+/// can expose PUT in a settings drawer.
+/// </summary>
+[ApiController]
+[Route("api/tenant/branding")]
+[Authorize]
+public class TenantBrandingController : ControllerBase
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly ITenantBrandingService _branding;
+    private readonly IEmailTemplateRenderer _renderer;
+
+    public TenantBrandingController(
+        PlanscapeDbContext db,
+        ITenantBrandingService branding,
+        IEmailTemplateRenderer renderer)
+    {
+        _db = db;
+        _branding = branding;
+        _renderer = renderer;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<ResolvedBranding>> Get(CancellationToken ct)
+    {
+        var tenantId = GetTenantId();
+        if (tenantId == Guid.Empty) return Unauthorized();
+        var resolved = await _branding.GetAsync(tenantId, ct);
+        return Ok(resolved);
+    }
+
+    /// <summary>Returns the raw (unmerged) row — null when the tenant uses defaults.</summary>
+    [HttpGet("raw")]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<ActionResult<TenantBranding?>> GetRaw(CancellationToken ct)
+    {
+        var tenantId = GetTenantId();
+        var row = await _db.TenantBrandings.AsNoTracking()
+                           .FirstOrDefaultAsync(b => b.TenantId == tenantId, ct);
+        return Ok(row);
+    }
+
+    [HttpPut]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<ActionResult<ResolvedBranding>> Update(
+        [FromBody] UpdateBrandingRequest req, CancellationToken ct)
+    {
+        var tenantId = GetTenantId();
+        if (tenantId == Guid.Empty) return Unauthorized();
+
+        // Validate colors (belt-and-braces — DB + client should also enforce).
+        if (!string.IsNullOrEmpty(req.AccentColor) && !IsHexColor(req.AccentColor!))
+            return BadRequest(new { error = "AccentColor must be a 3/6-digit hex value beginning with '#'." });
+        if (!string.IsNullOrEmpty(req.HeaderColor) && !IsHexColor(req.HeaderColor!))
+            return BadRequest(new { error = "HeaderColor must be a 3/6-digit hex value beginning with '#'." });
+        if (!string.IsNullOrEmpty(req.LogoUrl) && !Uri.TryCreate(req.LogoUrl, UriKind.Absolute, out _))
+            return BadRequest(new { error = "LogoUrl must be an absolute https:// URL." });
+
+        var userId = GetUserId();
+        var branding = new TenantBranding
+        {
+            ProductName      = req.ProductName,
+            AccentColor      = req.AccentColor,
+            HeaderColor      = req.HeaderColor,
+            LogoUrl          = req.LogoUrl,
+            SupportEmail     = req.SupportEmail,
+            EmailFromName    = req.EmailFromName,
+            EmailFromAddress = req.EmailFromAddress,
+            EmailSignature   = req.EmailSignature,
+            DefaultLanguage  = req.DefaultLanguage,
+            UpdatedByUserId  = userId,
+        };
+
+        await _branding.SetAsync(tenantId, branding, ct);
+        return Ok(await _branding.GetAsync(tenantId, ct));
+    }
+
+    [HttpDelete]
+    [Authorize(Roles = "Admin,Owner")]
+    public async Task<IActionResult> Reset(CancellationToken ct)
+    {
+        var tenantId = GetTenantId();
+        var row = await _db.TenantBrandings.FirstOrDefaultAsync(b => b.TenantId == tenantId, ct);
+        if (row != null)
+        {
+            _db.TenantBrandings.Remove(row);
+            await _db.SaveChangesAsync(ct);
+        }
+        _branding.InvalidateCache(tenantId);
+        return NoContent();
+    }
+
+    [HttpPost("templates/reload")]
+    [Authorize(Roles = "Admin,Owner")]
+    public IActionResult ReloadTemplates()
+    {
+        _renderer.Reload();
+        return Ok(new { reloaded = true });
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private static bool IsHexColor(string s) =>
+        System.Text.RegularExpressions.Regex.IsMatch(s, @"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$");
+
+    private Guid GetTenantId() =>
+        Guid.TryParse(User.FindFirst("tenant_id")?.Value, out var id) ? id : Guid.Empty;
+
+    private Guid? GetUserId() =>
+        Guid.TryParse(User.FindFirst("sub")?.Value, out var id) ? id : null;
+}
+
+public record UpdateBrandingRequest(
+    string? ProductName,
+    string? AccentColor,
+    string? HeaderColor,
+    string? LogoUrl,
+    string? SupportEmail,
+    string? EmailFromName,
+    string? EmailFromAddress,
+    string? EmailSignature,
+    string? DefaultLanguage);

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/_layout.en.html
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/_layout.en.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8" /></head>
+<body style="margin:0; padding:0; font-family:'Segoe UI',Roboto,Helvetica,Arial,sans-serif; background:#f4f5f7;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f5f7; padding:40px 0;">
+    <tr><td align="center">
+      <table width="600" cellpadding="0" cellspacing="0"
+             style="background:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+        <tr>
+          <td style="background:{{HeaderColor}}; padding:24px 32px;">
+            {{#if HasLogo}}<img src="{{LogoUrl}}" alt="{{ProductName}}" style="max-height:40px;">{{/if}}
+            {{#if HasLogo}}{{/if}}
+            <span style="color:#ffffff; font-size:22px; font-weight:700; letter-spacing:0.5px;">{{ProductName}}</span>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px; color:#111; line-height:1.55;">
+            {{Body}}
+            {{#if HasSignature}}<hr style="border:0; border-top:1px solid #e5e7eb; margin:32px 0;">
+            <p style="white-space:pre-line; color:#4b5563; font-size:13px;">{{EmailSignature}}</p>{{/if}}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:16px 32px; background:#f9fafb; border-top:1px solid #e5e7eb; font-size:12px; color:#9ca3af;">
+            &copy; {{Year}} {{ProductName}} &mdash; <a href="mailto:{{SupportEmail}}" style="color:#9ca3af;">{{SupportEmail}}</a>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/invite.en.html
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/invite.en.html
@@ -1,0 +1,11 @@
+<h2 style="margin:0 0 16px 0; color:{{HeaderColor}};">Welcome to {{ProductName}}</h2>
+<p>Hi {{DisplayName}},</p>
+<p><strong>{{InviterName}}</strong> has invited you to collaborate on <strong>{{ProjectName}}</strong>.</p>
+<p>To get started, set your password and open the project:</p>
+<p style="text-align:center; margin:32px 0;">
+  <a href="{{AcceptUrl}}" style="background:{{AccentColor}}; color:#ffffff; padding:12px 32px;
+            border-radius:6px; text-decoration:none; font-weight:600; display:inline-block;">
+    Set password &amp; join
+  </a>
+</p>
+<p style="color:#666; font-size:13px;">If you did not expect this invitation you can safely ignore this email.</p>

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/invite.en.subject
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/invite.en.subject
@@ -1,0 +1,1 @@
+You've been invited to {{ProjectName}} on {{ProductName}}

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/invite.en.txt
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/invite.en.txt
@@ -1,0 +1,13 @@
+Welcome to {{ProductName}}
+
+Hi {{DisplayName}},
+
+{{InviterName}} has invited you to collaborate on {{ProjectName}}.
+
+To get started, set your password and open the project:
+{{AcceptUrl}}
+
+If you did not expect this invitation you can safely ignore this email.
+
+--
+{{ProductName}} — {{SupportEmail}}

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/issue-assigned.en.html
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/issue-assigned.en.html
@@ -1,0 +1,11 @@
+<h2 style="margin:0 0 16px 0; color:{{HeaderColor}};">{{IssueCode}} {{IssueTitle}}</h2>
+<p>Hi {{AssigneeName}},</p>
+<p>{{AssignerName}} has assigned <strong>{{IssueCode}}</strong> ({{IssueType}}, priority {{Priority}}) to you on
+  <strong>{{ProjectName}}</strong>.</p>
+{{#if DueDate}}<p><strong>Due:</strong> {{DueDate}}</p>{{/if}}
+<p style="text-align:center; margin:32px 0;">
+  <a href="{{IssueUrl}}" style="background:{{AccentColor}}; color:#ffffff; padding:12px 32px;
+            border-radius:6px; text-decoration:none; font-weight:600; display:inline-block;">
+    Open issue
+  </a>
+</p>

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/issue-assigned.en.subject
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/issue-assigned.en.subject
@@ -1,0 +1,1 @@
+[{{ProjectName}}] {{IssueCode}} assigned to you

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/issue-assigned.en.txt
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/issue-assigned.en.txt
@@ -1,0 +1,11 @@
+{{IssueCode}} — {{IssueTitle}}
+
+Hi {{AssigneeName}},
+
+{{AssignerName}} has assigned {{IssueCode}} ({{IssueType}}, priority {{Priority}}) to you
+on {{ProjectName}}.
+
+Open issue: {{IssueUrl}}
+
+--
+{{ProductName}} — {{SupportEmail}}

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/password-reset.en.html
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/password-reset.en.html
@@ -1,0 +1,12 @@
+<h2 style="margin:0 0 16px 0; color:{{HeaderColor}};">Reset your password</h2>
+<p>A password reset was requested for your {{ProductName}} account.</p>
+<p style="text-align:center; margin:32px 0;">
+  <a href="{{ResetUrl}}" style="background:{{AccentColor}}; color:#ffffff; padding:12px 32px;
+            border-radius:6px; text-decoration:none; font-weight:600; display:inline-block;">
+    Reset password
+  </a>
+</p>
+<p style="color:#666; font-size:13px;">
+  This link expires in 24 hours. If you did not request a password reset, you can safely
+  ignore this email.
+</p>

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/password-reset.en.subject
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/password-reset.en.subject
@@ -1,0 +1,1 @@
+{{ProductName}} — password reset

--- a/Planscape.Server/src/Planscape.API/EmailTemplates/password-reset.en.txt
+++ b/Planscape.Server/src/Planscape.API/EmailTemplates/password-reset.en.txt
@@ -1,0 +1,11 @@
+{{ProductName}} — password reset
+
+A password reset was requested for your account.
+
+Reset your password:
+{{ResetUrl}}
+
+This link expires in 24 hours. If you did not request a reset, ignore this email.
+
+--
+{{ProductName}} — {{SupportEmail}}

--- a/Planscape.Server/src/Planscape.API/I18n/de.json
+++ b/Planscape.Server/src/Planscape.API/I18n/de.json
@@ -1,0 +1,39 @@
+{
+  "_note": "Deutsch (de). Unübersetzte Schlüssel greifen auf en.json zurück.",
+
+  "email": {
+    "invite.subject": "Sie wurden zu {project} auf {product} eingeladen",
+    "password_reset.subject": "{product} — Passwort zurücksetzen",
+    "issue_assigned.subject": "[{project}] {code} wurde Ihnen zugewiesen"
+  },
+
+  "notification": {
+    "issue_created.title": "Neuer {type}: {code}",
+    "issue_created.body": "{title} auf {project}",
+    "issue_assigned.title": "{code} wurde Ihnen zugewiesen",
+    "issue_assigned.body": "{title} — Priorität {priority}",
+    "sla_breach.title": "SLA-Verletzung: {code}",
+    "sla_breach.body": "{title} ist seit {hours} Stunden offen",
+    "compliance.title": "Compliance {direction}",
+    "compliance.body": "{project} liegt jetzt bei {percent}% (vorher {previous}%)"
+  },
+
+  "error": {
+    "unauthorized": "Sie sind nicht berechtigt, diese Aktion auszuführen.",
+    "tenant_mismatch": "Diese Ressource gehört zu einer anderen Organisation.",
+    "not_found": "Die angeforderte Ressource wurde nicht gefunden.",
+    "validation": "Ein oder mehrere Felder sind ungültig.",
+    "rate_limited": "Zu viele Anfragen — bitte versuchen Sie es gleich erneut."
+  },
+
+  "audit": {
+    "issue.created": "Vorgang {code} erstellt",
+    "issue.updated": "Vorgang {code} aktualisiert",
+    "issue.assigned": "{code} an {user} zugewiesen",
+    "document.cde_changed": "{name} nach {state} verschoben",
+    "document.approved": "{name} freigegeben",
+    "document.rejected": "{name} abgelehnt",
+    "revision.created": "Revision {name} erstellt",
+    "transmittal.sent": "Begleitschein {code} an {recipients} gesendet"
+  }
+}

--- a/Planscape.Server/src/Planscape.API/I18n/en.json
+++ b/Planscape.Server/src/Planscape.API/I18n/en.json
@@ -1,0 +1,39 @@
+{
+  "_note": "FLEX-15 — English is the canonical source. Keys added here without translations in other locales fall back to this file at render time.",
+
+  "email": {
+    "invite.subject": "You've been invited to {project} on {product}",
+    "password_reset.subject": "{product} — password reset",
+    "issue_assigned.subject": "[{project}] {code} assigned to you"
+  },
+
+  "notification": {
+    "issue_created.title": "New {type}: {code}",
+    "issue_created.body": "{title} on {project}",
+    "issue_assigned.title": "{code} assigned to you",
+    "issue_assigned.body": "{title} — priority {priority}",
+    "sla_breach.title": "SLA breach: {code}",
+    "sla_breach.body": "{title} has been open for {hours} hours",
+    "compliance.title": "Compliance {direction}",
+    "compliance.body": "{project} is now at {percent}% (was {previous}%)"
+  },
+
+  "error": {
+    "unauthorized": "You are not authorised to perform this action.",
+    "tenant_mismatch": "This resource belongs to a different organisation.",
+    "not_found": "The requested resource could not be found.",
+    "validation": "One or more fields are invalid.",
+    "rate_limited": "Too many requests — please try again in a moment."
+  },
+
+  "audit": {
+    "issue.created": "created issue {code}",
+    "issue.updated": "updated issue {code}",
+    "issue.assigned": "assigned {code} to {user}",
+    "document.cde_changed": "moved {name} to {state}",
+    "document.approved": "approved {name}",
+    "document.rejected": "rejected {name}",
+    "revision.created": "created revision {name}",
+    "transmittal.sent": "sent transmittal {code} to {recipients}"
+  }
+}

--- a/Planscape.Server/src/Planscape.API/I18n/es.json
+++ b/Planscape.Server/src/Planscape.API/I18n/es.json
@@ -1,0 +1,39 @@
+{
+  "_note": "Español (es). Las claves sin traducir vuelven a en.json.",
+
+  "email": {
+    "invite.subject": "Te han invitado a {project} en {product}",
+    "password_reset.subject": "{product} — restablecer contraseña",
+    "issue_assigned.subject": "[{project}] {code} te ha sido asignada"
+  },
+
+  "notification": {
+    "issue_created.title": "Nueva {type}: {code}",
+    "issue_created.body": "{title} en {project}",
+    "issue_assigned.title": "{code} te ha sido asignada",
+    "issue_assigned.body": "{title} — prioridad {priority}",
+    "sla_breach.title": "SLA incumplido: {code}",
+    "sla_breach.body": "{title} lleva {hours} horas abierta",
+    "compliance.title": "Cumplimiento {direction}",
+    "compliance.body": "{project} ahora está al {percent}% (antes {previous}%)"
+  },
+
+  "error": {
+    "unauthorized": "No tienes permiso para realizar esta acción.",
+    "tenant_mismatch": "Este recurso pertenece a otra organización.",
+    "not_found": "No se encontró el recurso solicitado.",
+    "validation": "Uno o más campos no son válidos.",
+    "rate_limited": "Demasiadas solicitudes — inténtalo de nuevo en un momento."
+  },
+
+  "audit": {
+    "issue.created": "creó la incidencia {code}",
+    "issue.updated": "actualizó la incidencia {code}",
+    "issue.assigned": "asignó {code} a {user}",
+    "document.cde_changed": "movió {name} a {state}",
+    "document.approved": "aprobó {name}",
+    "document.rejected": "rechazó {name}",
+    "revision.created": "creó la revisión {name}",
+    "transmittal.sent": "envió la nota de remisión {code} a {recipients}"
+  }
+}

--- a/Planscape.Server/src/Planscape.API/Middleware/LocaleMiddleware.cs
+++ b/Planscape.Server/src/Planscape.API/Middleware/LocaleMiddleware.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+using Planscape.Core.Interfaces;
+
+namespace Planscape.API.Middleware;
+
+/// <summary>
+/// FLEX-15 — Extracts the caller's preferred language in priority order:
+///
+///   1. <c>X-Language</c> HTTP header (mobile override, highest priority)
+///   2. <c>language</c> query-string param (useful for share links)
+///   3. <c>Accept-Language</c> HTTP header — first match against supported languages
+///   4. Tenant's <c>DefaultLanguage</c> branding value
+///   5. Server fallback (<c>en</c>)
+///
+/// Result is stored on <c>HttpContext.Items["Language"]</c> for downstream handlers.
+/// </summary>
+public class LocaleMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public LocaleMiddleware(RequestDelegate next) => _next = next;
+
+    public async Task InvokeAsync(HttpContext ctx, II18nService i18n)
+    {
+        var lang = ResolveLanguage(ctx, i18n);
+        ctx.Items["Language"] = lang;
+
+        // Also set CultureInfo so any framework formatting (money, dates) follows suit.
+        try
+        {
+            var culture = new CultureInfo(lang);
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+        catch (CultureNotFoundException)
+        {
+            // Fall through — keep the default culture.
+        }
+
+        // Expose the resolved language so clients can confirm what the server thinks.
+        ctx.Response.Headers["Content-Language"] = lang;
+        await _next(ctx);
+    }
+
+    private static string ResolveLanguage(HttpContext ctx, II18nService i18n)
+    {
+        var supported = i18n.SupportedLanguages;
+
+        // 1. X-Language header
+        var headerOverride = ctx.Request.Headers["X-Language"].ToString();
+        if (!string.IsNullOrWhiteSpace(headerOverride))
+        {
+            var match = MatchSupported(headerOverride, supported);
+            if (match != null) return match;
+        }
+
+        // 2. ?language= query
+        if (ctx.Request.Query.TryGetValue("language", out var qlang))
+        {
+            var match = MatchSupported(qlang.ToString(), supported);
+            if (match != null) return match;
+        }
+
+        // 3. Accept-Language header — "en-GB,en;q=0.9,de;q=0.8"
+        var accept = ctx.Request.Headers["Accept-Language"].ToString();
+        if (!string.IsNullOrEmpty(accept))
+        {
+            foreach (var part in accept.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var lang = part.Split(';')[0].Trim();
+                var match = MatchSupported(lang, supported);
+                if (match != null) return match;
+            }
+        }
+
+        // 4. Fallback. i18n service uses tenant default + "en" internally when we pass null.
+        return "en";
+    }
+
+    private static string? MatchSupported(string requested, IReadOnlyList<string> supported)
+    {
+        if (string.IsNullOrWhiteSpace(requested) || supported.Count == 0) return null;
+        var code = requested.Trim().ToLowerInvariant();
+
+        // Exact match first.
+        if (supported.Any(s => string.Equals(s, code, StringComparison.OrdinalIgnoreCase)))
+            return code;
+
+        // "en-GB" → "en"
+        var dash = code.IndexOf('-');
+        if (dash > 0)
+        {
+            var prefix = code.Substring(0, dash);
+            var match = supported.FirstOrDefault(s => string.Equals(s, prefix, StringComparison.OrdinalIgnoreCase));
+            if (match != null) return match;
+        }
+
+        // "en" → "en-GB" (supported language is more specific than request)
+        var loose = supported.FirstOrDefault(s => s.StartsWith(code + "-", StringComparison.OrdinalIgnoreCase));
+        return loose;
+    }
+}

--- a/Planscape.Server/src/Planscape.API/Planscape.API.csproj
+++ b/Planscape.Server/src/Planscape.API/Planscape.API.csproj
@@ -19,6 +19,13 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <!-- Optional structured-log sinks. Activated via Serilog:WriteTo config entries.
+         Seq:       docker run -p 5341:80 datalust/seq:latest  (free single-user)
+         Elastic:   ingest JSON directly to Elasticsearch 8.x / OpenSearch 2.x
+    -->
+    <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.17" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="ZXing.Net" Version="0.16.9" />
@@ -29,5 +36,15 @@
     <ProjectReference Include="..\Planscape.Infrastructure\Planscape.Infrastructure.csproj" />
     <ProjectReference Include="..\Planscape.MIM\Planscape.MIM.csproj" />
     <ProjectReference Include="..\Planscape.Shared\Planscape.Shared.csproj" />
+  </ItemGroup>
+
+  <!-- FLEX-03/07 — email templates ship next to the DLL so the renderer can find them. -->
+  <ItemGroup>
+    <None Update="EmailTemplates\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="I18n\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -8,17 +8,54 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using System.Threading.RateLimiting;
 using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.Elasticsearch;
 using Hangfire;
+using Prometheus;
 using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// ── Serilog ──
-builder.Host.UseSerilog((ctx, lc) => lc
-    .ReadFrom.Configuration(ctx.Configuration)
-    .Enrich.FromLogContext()
-    .WriteTo.Console()
-    .WriteTo.File("logs/planscape-.log", rollingInterval: RollingInterval.Day));
+// ── Serilog (MON-01: Seq / Elastic observability) ──
+// Console + rolling file is always-on. Optional structured-log sinks are
+// activated by config so this still works in sandboxed dev environments.
+//
+//   Serilog:Seq:ServerUrl          → e.g. http://seq:5341
+//   Serilog:Seq:ApiKey             → optional, for shared Seq instances
+//   Serilog:Elastic:NodeUris       → comma-separated https://host:9200
+//   Serilog:Elastic:IndexFormat    → planscape-{0:yyyy.MM}
+//   Serilog:Elastic:ApiKey         → ES API key (optional)
+builder.Host.UseSerilog((ctx, sp, lc) =>
+{
+    lc.ReadFrom.Configuration(ctx.Configuration)
+      .Enrich.FromLogContext()
+      .Enrich.WithProperty("app", "planscape-api")
+      .Enrich.WithProperty("env", ctx.HostingEnvironment.EnvironmentName)
+      .WriteTo.Console()
+      .WriteTo.File("logs/planscape-.log", rollingInterval: RollingInterval.Day);
+
+    var seqUrl = ctx.Configuration["Serilog:Seq:ServerUrl"];
+    if (!string.IsNullOrWhiteSpace(seqUrl))
+    {
+        lc.WriteTo.Seq(seqUrl, apiKey: ctx.Configuration["Serilog:Seq:ApiKey"]);
+    }
+
+    var elasticUris = ctx.Configuration["Serilog:Elastic:NodeUris"];
+    if (!string.IsNullOrWhiteSpace(elasticUris))
+    {
+        var nodes = elasticUris.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                               .Select(u => new Uri(u)).ToArray();
+        var sinkOpts = new ElasticsearchSinkOptions(nodes)
+        {
+            AutoRegisterTemplate = true,
+            AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv8,
+            IndexFormat = ctx.Configuration["Serilog:Elastic:IndexFormat"] ?? "planscape-{0:yyyy.MM}",
+            MinimumLogEventLevel = LogEventLevel.Information,
+            EmitEventFailure = EmitEventFailureHandling.WriteToSelfLog,
+        };
+        lc.WriteTo.Elasticsearch(sinkOpts);
+    }
+});
 
 // ── Database ──
 builder.Services.AddDbContext<PlanscapeDbContext>(options =>
@@ -78,8 +115,16 @@ builder.Services.AddSingleton<Planscape.Core.Interfaces.IPlatformConnector, Plan
 builder.Services.AddSingleton<Planscape.Core.Interfaces.IPlatformConnector, Planscape.Infrastructure.Services.TrimbleConnector>();
 builder.Services.AddSingleton<Planscape.Core.Interfaces.IPlatformConnectorFactory, Planscape.Infrastructure.Services.PlatformConnectorFactory>();
 
-// ── Email ──
-if (!string.IsNullOrEmpty(builder.Configuration["Email:Host"]))
+// ── Email & Tenant branding (FLEX-03, FLEX-07) ──
+builder.Services.AddSingleton<Planscape.Core.Interfaces.ITenantBrandingService, Planscape.Infrastructure.Services.TenantBrandingService>();
+// Renderer is Singleton so its file-read cache survives across requests.
+// Deps are all Singleton-safe (IHostEnvironment, IConfiguration, ILogger).
+builder.Services.AddSingleton<Planscape.Infrastructure.Services.IEmailTemplateRenderer, Planscape.Infrastructure.Services.FileEmailTemplateRenderer>();
+
+// ── i18n (FLEX-15) — load resource files once at startup; mobile pulls via /api/i18n. ──
+builder.Services.AddSingleton<Planscape.Core.Interfaces.II18nService, Planscape.Infrastructure.Services.I18nService>();
+if (!string.IsNullOrEmpty(builder.Configuration["Smtp:Host"])
+    || !string.IsNullOrEmpty(builder.Configuration["Email:Host"]))
     builder.Services.AddSingleton<Planscape.Core.Interfaces.IEmailService, Planscape.Infrastructure.Services.SmtpEmailService>();
 else
     builder.Services.AddSingleton<Planscape.Core.Interfaces.IEmailService, Planscape.Infrastructure.Services.NullEmailService>();
@@ -261,18 +306,31 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseSerilogRequestLogging();
+// MON-02: request/response metrics (latency histogram, status codes, in-flight).
+// Exposed at /metrics in Prometheus exposition format. Scrape once per 15-30s.
+app.UseHttpMetrics();
 app.UseRateLimiter();
 app.UseCors("Dashboard");
 app.UseCors("Mobile");
 app.UseAuthentication();
 app.UseMiddleware<TenantResolutionMiddleware>(); // Must run AFTER auth so JWT claims are available
 app.UseMiddleware<MobileContextMiddleware>();
+app.UseMiddleware<LocaleMiddleware>();           // FLEX-15 — resolves language after tenant is known
 app.UseAuthorization();
 
 app.UseHangfireDashboard("/hangfire", new DashboardOptions
 {
     Authorization = new[] { new Planscape.Infrastructure.Services.HangfireAuthorizationFilter() }
 });
+
+// MON-03: /metrics endpoint for Prometheus / Grafana Agent / Datadog / NewRelic.
+// Unauthenticated so scrapers can collect without a JWT, but restrict network-side
+// (bind nginx /metrics to internal IP only). Disable with Monitoring:ExposeMetrics=false.
+var exposeMetrics = builder.Configuration.GetValue<bool>("Monitoring:ExposeMetrics", true);
+if (exposeMetrics)
+{
+    app.MapMetrics("/metrics").AllowAnonymous();
+}
 
 // ── Health check ── (NEW-SRV-22)
 // Returns sub-check results so mobile can detect partial degradation.

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -123,6 +123,11 @@ builder.Services.AddSingleton<Planscape.Infrastructure.Services.IEmailTemplateRe
 
 // ── i18n (FLEX-15) — load resource files once at startup; mobile pulls via /api/i18n. ──
 builder.Services.AddSingleton<Planscape.Core.Interfaces.II18nService, Planscape.Infrastructure.Services.I18nService>();
+
+// ── NLP (NLP-AUTO-LINK) — rule-based + LLM fallback. Swap NullLlmResolver for
+//    a real provider (OpenAI / Azure OpenAI / Anthropic) when credentials land.
+builder.Services.AddSingleton<Planscape.Core.Interfaces.INlpLlmResolver, Planscape.Infrastructure.Services.NullLlmResolver>();
+builder.Services.AddSingleton<Planscape.Core.Interfaces.INlpResolver, Planscape.Infrastructure.Services.NlpResolver>();
 if (!string.IsNullOrEmpty(builder.Configuration["Smtp:Host"])
     || !string.IsNullOrEmpty(builder.Configuration["Email:Host"]))
     builder.Services.AddSingleton<Planscape.Core.Interfaces.IEmailService, Planscape.Infrastructure.Services.SmtpEmailService>();
@@ -179,6 +184,7 @@ builder.Services.AddScoped<Planscape.Infrastructure.Services.SlaEscalationJob>()
 builder.Services.AddScoped<Planscape.Infrastructure.Services.StaleWarningCleanupJob>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.DatabaseBackupJob>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.PlatformSyncJob>();
+builder.Services.AddScoped<Planscape.Infrastructure.Services.CustomFieldsPurgeJob>();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -461,5 +467,9 @@ RecurringJob.AddOrUpdate<Planscape.Infrastructure.Services.PlatformSyncJob>(
 RecurringJob.AddOrUpdate<Planscape.Infrastructure.Services.DatabaseBackupJob>(
     "database-backup", j => j.ExecuteAsync(CancellationToken.None),
     "15 2 * * *", new RecurringJobOptions { QueueName = "default" });
+// FLEX-13 — nightly 03:15 UTC purge of custom fields past the 30-day grace period.
+RecurringJob.AddOrUpdate<Planscape.Infrastructure.Services.CustomFieldsPurgeJob>(
+    "custom-fields-purge", j => j.ExecuteAsync(CancellationToken.None),
+    "15 3 * * *", new RecurringJobOptions { QueueName = "default" });
 
 await app.RunAsync();

--- a/Planscape.Server/src/Planscape.API/appsettings.Production.template.json
+++ b/Planscape.Server/src/Planscape.API/appsettings.Production.template.json
@@ -88,7 +88,34 @@
           "retainedFileCountLimit": 14
         }
       }
-    ]
+    ],
+    "Seq": {
+      "_note": "MON-01 — Optional Seq server. Leave blank to disable.",
+      "ServerUrl": "",
+      "ApiKey": ""
+    },
+    "Elastic": {
+      "_note": "MON-01 — Optional Elastic/OpenSearch cluster. Leave NodeUris blank to disable.",
+      "NodeUris": "",
+      "IndexFormat": "planscape-{0:yyyy.MM}",
+      "ApiKey": ""
+    }
+  },
+
+  "Monitoring": {
+    "_note": "MON-03 — Set ExposeMetrics=false if nginx doesn't restrict /metrics to internal scrapers.",
+    "ExposeMetrics": true
+  },
+
+  "Tenant": {
+    "_note": "FLEX-03 — System-wide defaults. Any tenant with TenantBranding row overrides these values.",
+    "DefaultBranding": {
+      "ProductName": "Planscape",
+      "AccentColor": "#E8912D",
+      "HeaderColor": "#1A237E",
+      "LogoUrl": "",
+      "SupportEmail": "support@planscape.yourco.com"
+    }
   },
 
   "AllowedHosts": "*"

--- a/Planscape.Server/src/Planscape.API/appsettings.json
+++ b/Planscape.Server/src/Planscape.API/appsettings.json
@@ -34,6 +34,31 @@
         "Microsoft.AspNetCore": "Warning",
         "Microsoft.EntityFrameworkCore": "Warning"
       }
+    },
+    "Seq": {
+      "_note": "Leave ServerUrl blank to disable. Local dev: `docker compose --profile observability up -d seq` then http://localhost:5341.",
+      "ServerUrl": "",
+      "ApiKey": ""
+    },
+    "Elastic": {
+      "_note": "Leave NodeUris blank to disable. Comma-separate multiple nodes.",
+      "NodeUris": "",
+      "IndexFormat": "planscape-{0:yyyy.MM}",
+      "ApiKey": ""
+    }
+  },
+  "Monitoring": {
+    "_note": "Set ExposeMetrics=false to disable the /metrics Prometheus endpoint.",
+    "ExposeMetrics": true
+  },
+  "Tenant": {
+    "_note": "Default branding and behavior when a tenant has not customised its own.",
+    "DefaultBranding": {
+      "ProductName": "Planscape",
+      "AccentColor": "#E8912D",
+      "HeaderColor": "#1A237E",
+      "LogoUrl": "",
+      "SupportEmail": "support@planscape.io"
     }
   },
   "Logging": {

--- a/Planscape.Server/src/Planscape.Core/Entities/BimIssue.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/BimIssue.cs
@@ -33,6 +33,16 @@ public class BimIssue
     public string? DeviceId { get; set; } // device that raised the issue (mobile audit)
     public string? Source { get; set; } // "mobile" | "plugin" | "web"
 
+    // MODEL-VIEWER — 3D model anchor. When an issue is created from the 3D
+    // viewer ("create issue here"), we record which model, which element
+    // inside it, and the exact XYZ the user tapped. Viewer then renders pins
+    // in-model. All nullable so non-viewer flows are untouched.
+    public Guid? ModelId { get; set; }
+    public string? ModelElementGuid { get; set; }
+    public double? ModelX { get; set; }
+    public double? ModelY { get; set; }
+    public double? ModelZ { get; set; }
+
     // CUSTOM-FIELDS (FLEX-13) — tenant/project-defined schema values live here
     // as a JSON object ({ "field_key": any }). Schema definitions are stored
     // separately in <see cref="IssueCustomFieldSchema"/>. Storage is JSONB on

--- a/Planscape.Server/src/Planscape.Core/Entities/BimIssue.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/BimIssue.cs
@@ -33,6 +33,12 @@ public class BimIssue
     public string? DeviceId { get; set; } // device that raised the issue (mobile audit)
     public string? Source { get; set; } // "mobile" | "plugin" | "web"
 
+    // CUSTOM-FIELDS (FLEX-13) — tenant/project-defined schema values live here
+    // as a JSON object ({ "field_key": any }). Schema definitions are stored
+    // separately in <see cref="IssueCustomFieldSchema"/>. Storage is JSONB on
+    // Postgres (with a GIN index for searched keys); empty object when unset.
+    public string? CustomFields { get; set; }
+
     // Navigation
     public Project? Project { get; set; }
     public AppUser? AssigneeUser { get; set; }

--- a/Planscape.Server/src/Planscape.Core/Entities/IssueCustomFieldSchema.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/IssueCustomFieldSchema.cs
@@ -1,0 +1,72 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// FLEX-13 — Per-project custom-field definitions for <see cref="BimIssue"/>.
+///
+/// Admin table-based editor (decision 4.3 = b) lets project admins add / edit /
+/// remove / reorder fields. Values live on <see cref="BimIssue.CustomFields"/>
+/// as a JSONB column keyed by <see cref="Key"/>.
+///
+/// v1 scope = Issues only (decision 4.1). Documents / Projects join later.
+/// </summary>
+public class IssueCustomFieldSchema
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ProjectId { get; set; }
+
+    /// <summary>Stable machine key (snake_case, used as the JSON object key on BimIssue.CustomFields).</summary>
+    public string Key { get; set; } = "";
+
+    /// <summary>Human-readable label shown on the form.</summary>
+    public string Label { get; set; } = "";
+
+    public CustomFieldType FieldType { get; set; } = CustomFieldType.Text;
+
+    /// <summary>Optional helper text under the input.</summary>
+    public string? HelpText { get; set; }
+
+    /// <summary>Default value (JSON-encoded so any type can be represented).</summary>
+    public string? DefaultValueJson { get; set; }
+
+    /// <summary>For Dropdown / MultiSelect: JSON array of option strings (or {value,label} objects).</summary>
+    public string? OptionsJson { get; set; }
+
+    public bool Required { get; set; }
+
+    /// <summary>Admin ordering. Lower values render first. Sparse integers are fine.</summary>
+    public int SortOrder { get; set; }
+
+    /// <summary>When false, the field is hidden from new issues but preserved on existing ones.</summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Archive-on-delete (decision 4.6 row 1). When an admin deletes the field,
+    /// we flip IsActive = false + set DeletedAt; values are preserved on existing
+    /// issues until the scheduled purge (default 30 days).
+    /// </summary>
+    public DateTime? DeletedAt { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public Guid? UpdatedByUserId { get; set; }
+
+    public Project? Project { get; set; }
+}
+
+/// <summary>
+/// Supported field types (decision 4.2). Add a new member + UI renderer to
+/// extend — storage is string/JSON so no migration is needed for new types.
+/// </summary>
+public enum CustomFieldType
+{
+    Text = 0,
+    TextArea = 1,
+    Number = 2,
+    Date = 3,
+    Dropdown = 4,
+    MultiSelect = 5,
+    Boolean = 6,
+    UserPicker = 7,
+    ElementReference = 8,
+    // Skipped for v1 (decision 4.2): URL, FileAttachment.
+}

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectModel.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectModel.cs
@@ -1,0 +1,88 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// MODEL-VIEWER — 3D model attached to a project. One project can have many
+/// models (multi-discipline federation, phased submissions, etc.). Storage is
+/// abstracted via <see cref="Planscape.Core.Interfaces.IFileStorageService"/>
+/// so the same entity works with local FS / MinIO / S3 / R2.
+///
+/// Supported formats:
+///   glTF / GLB       — primary, renders natively in the WebView viewer
+///   IFC              — stored for archival; client needs a converter
+///   RVT              — stored for archival; not renderable in-browser
+///
+/// An optional <c>ElementMapPath</c> points to a JSON sidecar produced by the
+/// Revit plugin mapping element GUID → ISO 19650 tag, category, location.
+/// Mobile uses that to cross-reference selected 3D elements with STING tags.
+/// </summary>
+public class ProjectModel
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ProjectId { get; set; }
+
+    /// <summary>Human-readable name — defaults to file name minus extension.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>Optional free-text description (purpose, discipline, phase).</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Discipline code (A/M/E/P/S/FP/LV/G) used for the disciplines layer filter.</summary>
+    public string? Discipline { get; set; }
+
+    /// <summary>Original file name (with extension) — shown in the UI.</summary>
+    public string FileName { get; set; } = "";
+
+    /// <summary>Format: glTF, GLB, IFC, RVT. Determines how the viewer treats it.</summary>
+    public ModelFormat Format { get; set; } = ModelFormat.Glb;
+
+    /// <summary>Storage path / key returned by IFileStorageService — opaque.</summary>
+    public string StoragePath { get; set; } = "";
+
+    /// <summary>SHA-256 of the file — used for client-side dedup + cache-busting.</summary>
+    public string? ContentHash { get; set; }
+
+    public long FileSizeBytes { get; set; }
+
+    /// <summary>Optional small thumbnail (PNG) stored alongside the main file.</summary>
+    public string? ThumbnailPath { get; set; }
+
+    /// <summary>Optional element-map JSON sidecar (Revit plugin exports this).</summary>
+    public string? ElementMapPath { get; set; }
+
+    /// <summary>Number of renderable elements (populated by the plugin / converter).</summary>
+    public int? ElementCount { get; set; }
+
+    /// <summary>Bounding box — used by the viewer to centre + auto-frame on load.</summary>
+    public double? BoundsMinX { get; set; }
+    public double? BoundsMinY { get; set; }
+    public double? BoundsMinZ { get; set; }
+    public double? BoundsMaxX { get; set; }
+    public double? BoundsMaxY { get; set; }
+    public double? BoundsMaxZ { get; set; }
+
+    /// <summary>Units the viewer should assume (mm / m / ft). Defaults to mm.</summary>
+    public string Units { get; set; } = "mm";
+
+    /// <summary>Source revision — links back to a DocumentRecord revision, or the RVT revision number.</summary>
+    public string? Revision { get; set; }
+
+    public string UploadedBy { get; set; } = "";
+    public Guid? UploadedByUserId { get; set; }
+    public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Soft-delete — kept for audit; file is purged by a Hangfire job after 30 days.</summary>
+    public DateTime? DeletedAt { get; set; }
+
+    public Project? Project { get; set; }
+    public AppUser? UploadedByUser { get; set; }
+}
+
+public enum ModelFormat
+{
+    Glb = 0,
+    Gltf = 1,
+    Ifc = 2,
+    Rvt = 3,
+    Obj = 4,
+    Fbx = 5,
+}

--- a/Planscape.Server/src/Planscape.Core/Entities/TenantBranding.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/TenantBranding.cs
@@ -1,0 +1,47 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// FLEX-03 — Per-tenant branding that customises emails, mobile theme, and web dashboard
+/// chrome without a code change. One row per tenant; falls back to Tenant:DefaultBranding
+/// config when no row exists.
+///
+/// Values that are null or empty are resolved from config at render time, so a tenant
+/// can override just the accent color and inherit the rest.
+/// </summary>
+public class TenantBranding
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid TenantId { get; set; }
+    public Tenant? Tenant { get; set; }
+
+    /// <summary>Display name shown in email subjects and mobile header. Null = inherit.</summary>
+    public string? ProductName { get; set; }
+
+    /// <summary>Hex color with leading # — accent/CTA. Default: #E8912D (Planscape orange).</summary>
+    public string? AccentColor { get; set; }
+
+    /// <summary>Hex color — email header banner and mobile status bar. Default: #1A237E.</summary>
+    public string? HeaderColor { get; set; }
+
+    /// <summary>Public HTTPS URL to a 400×120 PNG/SVG logo. Null = product-name text only.</summary>
+    public string? LogoUrl { get; set; }
+
+    /// <summary>Per-tenant support address (footer contact). Null = inherit.</summary>
+    public string? SupportEmail { get; set; }
+
+    /// <summary>Override SMTP FROM name for outbound mail. Null = inherit.</summary>
+    public string? EmailFromName { get; set; }
+
+    /// <summary>Override SMTP FROM address. Rarely set — requires DKIM alignment on the chosen domain.</summary>
+    public string? EmailFromAddress { get; set; }
+
+    /// <summary>Plain-text signature appended to outbound emails. Null = default signature.</summary>
+    public string? EmailSignature { get; set; }
+
+    /// <summary>Two-letter ISO language code. Used when the user has no locale preference.</summary>
+    public string? DefaultLanguage { get; set; } = "en";
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public Guid? UpdatedByUserId { get; set; }
+}

--- a/Planscape.Server/src/Planscape.Core/Interfaces/II18nService.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/II18nService.cs
@@ -1,0 +1,19 @@
+namespace Planscape.Core.Interfaces;
+
+/// <summary>
+/// FLEX-15 — Minimal translation service. Callers pass a dotted key
+/// (e.g. "notification.issue_assigned.title") and the current language code;
+/// the service returns the translated string with <c>{placeholder}</c> tokens
+/// substituted from <paramref name="vars"/>. Missing keys fall back through
+///   language → tenant default → "en" → the literal key.
+/// </summary>
+public interface II18nService
+{
+    string T(string key, string? language = null, IDictionary<string, object?>? vars = null);
+
+    /// <summary>Returns the list of language codes the server has resource files for.</summary>
+    IReadOnlyList<string> SupportedLanguages { get; }
+
+    /// <summary>Reload on-disk resource files without restarting the server.</summary>
+    void Reload();
+}

--- a/Planscape.Server/src/Planscape.Core/Interfaces/INlpResolver.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/INlpResolver.cs
@@ -1,0 +1,83 @@
+namespace Planscape.Core.Interfaces;
+
+/// <summary>
+/// NLP-AUTO-LINK — resolves free-form text (issue description, search query,
+/// meeting-minute line) to structured BIM references:
+///   - exact ISO 19650 tags (regex)
+///   - grid references (per-project lookup)
+///   - family / type fuzzy matches
+///
+/// Strategy is (d) rule-based + LLM fallback for ambiguous cases. Callers get
+/// deterministic results for the common path and only pay for an LLM call when
+/// the rules returned zero or ambiguous hits.
+/// </summary>
+public interface INlpResolver
+{
+    Task<NlpResolution> ResolveAsync(NlpResolveRequest request, CancellationToken ct = default);
+}
+
+public sealed record NlpResolveRequest(
+    Guid ProjectId,
+    string Text,
+    /// <summary>Language hint for PII redaction + LLM prompt locale.</summary>
+    string? Language = null,
+    /// <summary>When false, the LLM fallback is skipped even if the rules return empty.</summary>
+    bool AllowCloudFallback = true,
+    /// <summary>Per-call override of the default Max-LLM-Calls rate limiter.</summary>
+    int MaxCandidates = 10);
+
+public sealed record NlpResolution(
+    /// <summary>Verbatim inputs — useful for replay + audit.</summary>
+    string InputText,
+    IReadOnlyList<NlpCandidate> Candidates,
+    /// <summary>true = at least one candidate had confidence &gt;= AutoLinkThreshold.</summary>
+    bool HasAutoLinkCandidate,
+    /// <summary>Which strategy produced the top candidate — useful for metrics.</summary>
+    string Source,
+    /// <summary>Empty when no PII redaction ran or the text had no PII markers.</summary>
+    string? RedactedText);
+
+/// <summary>
+/// A single resolved reference. Mobile shows the whole list for ambiguous
+/// matches (decision 2.4 = b) and auto-links the top one silently when
+/// <paramref name="Confidence"/> &gt;= AutoLinkThreshold.
+/// </summary>
+public sealed record NlpCandidate(
+    NlpCandidateKind Kind,
+    /// <summary>Human-readable label — rendered in the picker.</summary>
+    string Label,
+    /// <summary>Confidence 0–1. &gt;=0.9 auto-links, &lt;0.9 waits for user confirm.</summary>
+    double Confidence,
+    /// <summary>The strategy that produced this candidate (Regex / Grid / Fuzzy / Llm).</summary>
+    string Strategy,
+    /// <summary>Opaque target — mobile/web dereference based on Kind.</summary>
+    IDictionary<string, string?> Target);
+
+public enum NlpCandidateKind
+{
+    IsoTag = 0,
+    GridReference = 1,
+    Element = 2,
+    Room = 3,
+    Discipline = 4,
+    Unknown = 99,
+}
+
+/// <summary>
+/// Pluggable escape hatch for cloud LLMs (OpenAI / Anthropic / Azure OpenAI).
+/// The default implementation is <c>NullLlmResolver</c> — returns no hits but
+/// never throws, so the rule-based path always wins when no LLM is configured.
+/// </summary>
+public interface INlpLlmResolver
+{
+    /// <summary>
+    /// Called only when the rule-based path returned zero or very-low confidence.
+    /// The caller has already redacted PII; implementations should not re-encode.
+    /// </summary>
+    Task<IReadOnlyList<NlpCandidate>> ResolveAsync(
+        Guid projectId, string redactedText, string? language,
+        int maxCandidates, CancellationToken ct);
+
+    /// <summary>Provider name surfaced in audit logs (e.g. "openai", "null").</summary>
+    string ProviderName { get; }
+}

--- a/Planscape.Server/src/Planscape.Core/Interfaces/ITenantBrandingService.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/ITenantBrandingService.cs
@@ -1,0 +1,41 @@
+using Planscape.Core.Entities;
+
+namespace Planscape.Core.Interfaces;
+
+/// <summary>
+/// FLEX-03 — Resolves tenant branding with fallback chain:
+///   1. TenantBranding row (database)
+///   2. Tenant:DefaultBranding (appsettings)
+///   3. Hardcoded safe defaults (never fails)
+/// </summary>
+public interface ITenantBrandingService
+{
+    /// <summary>
+    /// Returns the fully-resolved branding for a tenant (never null — falls back to defaults).
+    /// Result is cached for 5 minutes per tenant.
+    /// </summary>
+    Task<ResolvedBranding> GetAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists or updates the tenant's branding. Invalidates the cache entry.
+    /// </summary>
+    Task SetAsync(Guid tenantId, TenantBranding branding, CancellationToken ct = default);
+
+    /// <summary>Clears the resolved-branding cache — used after a bulk import.</summary>
+    void InvalidateCache(Guid? tenantId = null);
+}
+
+/// <summary>
+/// Immutable, always-populated branding snapshot. Use this from template renderers and
+/// mobile /branding endpoints — no null handling required at the call site.
+/// </summary>
+public sealed record ResolvedBranding(
+    string ProductName,
+    string AccentColor,
+    string HeaderColor,
+    string? LogoUrl,
+    string SupportEmail,
+    string EmailFromName,
+    string EmailFromAddress,
+    string? EmailSignature,
+    string DefaultLanguage);

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260417000000_AddTenantBranding.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260417000000_AddTenantBranding.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable enable
+
+namespace Planscape.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+/// <remarks>FLEX-03 — Per-tenant branding (logo, colors, product name, email overrides).</remarks>
+public partial class AddTenantBranding : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "TenantBrandings",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                ProductName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                AccentColor = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                HeaderColor = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                LogoUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                SupportEmail = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                EmailFromName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                EmailFromAddress = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                EmailSignature = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                DefaultLanguage = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: true),
+                CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                UpdatedByUserId = table.Column<Guid>(type: "uuid", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_TenantBrandings", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_TenantBrandings_Tenants_TenantId",
+                    column: x => x.TenantId,
+                    principalTable: "Tenants",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_TenantBrandings_TenantId",
+            table: "TenantBrandings",
+            column: "TenantId",
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "TenantBrandings");
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260418000000_AddIssueCustomFields.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260418000000_AddIssueCustomFields.cs
@@ -1,0 +1,79 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable enable
+
+namespace Planscape.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+/// <remarks>
+/// FLEX-13 — Per-project custom-field schema + JSONB value column on BimIssue.
+/// Adds a GIN index so queries against the CustomFields JSON stay fast as the
+/// table grows.
+/// </remarks>
+public partial class AddIssueCustomFields : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // 1. Schema table — per-project field definitions.
+        migrationBuilder.CreateTable(
+            name: "IssueCustomFieldSchemas",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                ProjectId = table.Column<Guid>(type: "uuid", nullable: false),
+                Key = table.Column<string>(type: "character varying(80)", maxLength: 80, nullable: false),
+                Label = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                FieldType = table.Column<int>(type: "integer", nullable: false),
+                HelpText = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                DefaultValueJson = table.Column<string>(type: "jsonb", nullable: true),
+                OptionsJson = table.Column<string>(type: "jsonb", nullable: true),
+                Required = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                SortOrder = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                UpdatedByUserId = table.Column<Guid>(type: "uuid", nullable: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_IssueCustomFieldSchemas", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_IssueCustomFieldSchemas_Projects_ProjectId",
+                    column: x => x.ProjectId,
+                    principalTable: "Projects",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_IssueCustomFieldSchemas_ProjectId",
+            table: "IssueCustomFieldSchemas",
+            column: "ProjectId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_IssueCustomFieldSchemas_ProjectId_Key",
+            table: "IssueCustomFieldSchemas",
+            columns: new[] { "ProjectId", "Key" },
+            unique: true);
+
+        // 2. JSONB column on BimIssue + GIN index for jsonb path queries.
+        migrationBuilder.AddColumn<string>(
+            name: "CustomFields",
+            table: "Issues",
+            type: "jsonb",
+            nullable: true);
+
+        migrationBuilder.Sql(@"CREATE INDEX IF NOT EXISTS ""IX_Issues_CustomFields_gin"" ON ""Issues"" USING gin (""CustomFields"");");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(@"DROP INDEX IF EXISTS ""IX_Issues_CustomFields_gin"";");
+        migrationBuilder.DropColumn(name: "CustomFields", table: "Issues");
+        migrationBuilder.DropTable(name: "IssueCustomFieldSchemas");
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260419000000_AddProjectModelsAndIssueAnchors.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260419000000_AddProjectModelsAndIssueAnchors.cs
@@ -1,0 +1,90 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable enable
+
+namespace Planscape.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+/// <remarks>
+/// MODEL-VIEWER — ProjectModel table + BimIssue 3D-anchor columns.
+/// </remarks>
+public partial class AddProjectModelsAndIssueAnchors : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // 1. Model storage table.
+        migrationBuilder.CreateTable(
+            name: "ProjectModels",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                ProjectId = table.Column<Guid>(type: "uuid", nullable: false),
+                Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                Discipline = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: true),
+                FileName = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: false),
+                Format = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                StoragePath = table.Column<string>(type: "character varying(600)", maxLength: 600, nullable: false),
+                ContentHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                FileSizeBytes = table.Column<long>(type: "bigint", nullable: false, defaultValue: 0L),
+                ThumbnailPath = table.Column<string>(type: "character varying(600)", maxLength: 600, nullable: true),
+                ElementMapPath = table.Column<string>(type: "character varying(600)", maxLength: 600, nullable: true),
+                ElementCount = table.Column<int>(type: "integer", nullable: true),
+                BoundsMinX = table.Column<double>(type: "double precision", nullable: true),
+                BoundsMinY = table.Column<double>(type: "double precision", nullable: true),
+                BoundsMinZ = table.Column<double>(type: "double precision", nullable: true),
+                BoundsMaxX = table.Column<double>(type: "double precision", nullable: true),
+                BoundsMaxY = table.Column<double>(type: "double precision", nullable: true),
+                BoundsMaxZ = table.Column<double>(type: "double precision", nullable: true),
+                Units = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false, defaultValue: "mm"),
+                Revision = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                UploadedBy = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false, defaultValue: ""),
+                UploadedByUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                UploadedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ProjectModels", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_ProjectModels_Projects_ProjectId",
+                    column: x => x.ProjectId,
+                    principalTable: "Projects",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_ProjectModels_Users_UploadedByUserId",
+                    column: x => x.UploadedByUserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.SetNull);
+            });
+
+        migrationBuilder.CreateIndex(name: "IX_ProjectModels_ProjectId", table: "ProjectModels", column: "ProjectId");
+        migrationBuilder.CreateIndex(name: "IX_ProjectModels_ContentHash", table: "ProjectModels", column: "ContentHash");
+        migrationBuilder.CreateIndex(name: "IX_ProjectModels_UploadedByUserId", table: "ProjectModels", column: "UploadedByUserId");
+
+        // 2. BimIssue 3D anchor columns.
+        migrationBuilder.AddColumn<Guid>(name: "ModelId", table: "Issues", type: "uuid", nullable: true);
+        migrationBuilder.AddColumn<string>(name: "ModelElementGuid", table: "Issues", type: "character varying(80)", maxLength: 80, nullable: true);
+        migrationBuilder.AddColumn<double>(name: "ModelX", table: "Issues", type: "double precision", nullable: true);
+        migrationBuilder.AddColumn<double>(name: "ModelY", table: "Issues", type: "double precision", nullable: true);
+        migrationBuilder.AddColumn<double>(name: "ModelZ", table: "Issues", type: "double precision", nullable: true);
+
+        migrationBuilder.CreateIndex(name: "IX_Issues_ModelId", table: "Issues", column: "ModelId");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(name: "IX_Issues_ModelId", table: "Issues");
+        migrationBuilder.DropColumn(name: "ModelZ", table: "Issues");
+        migrationBuilder.DropColumn(name: "ModelY", table: "Issues");
+        migrationBuilder.DropColumn(name: "ModelX", table: "Issues");
+        migrationBuilder.DropColumn(name: "ModelElementGuid", table: "Issues");
+        migrationBuilder.DropColumn(name: "ModelId", table: "Issues");
+        migrationBuilder.DropTable(name: "ProjectModels");
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -57,6 +57,7 @@ public class PlanscapeDbContext : DbContext
     public DbSet<UserNotificationPreferences> UserNotificationPreferences => Set<UserNotificationPreferences>();
     public DbSet<IssueAttachment> IssueAttachments => Set<IssueAttachment>();
     public DbSet<IssueCustomFieldSchema> IssueCustomFieldSchemas => Set<IssueCustomFieldSchema>();
+    public DbSet<ProjectModel> ProjectModels => Set<ProjectModel>();
     public DbSet<DocumentApproval> DocumentApprovals => Set<DocumentApproval>();
     public DbSet<PlatformConnection> PlatformConnections => Set<PlatformConnection>();
     public DbSet<DocumentVersion> DocumentVersions => Set<DocumentVersion>();
@@ -92,6 +93,34 @@ public class PlanscapeDbContext : DbContext
             e.Property(x => x.DefaultValueJson).HasColumnType("jsonb");
             e.Property(x => x.OptionsJson).HasColumnType("jsonb");
             e.HasOne(x => x.Project).WithMany().HasForeignKey(x => x.ProjectId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // ── ProjectModel (MODEL-VIEWER) ──
+        modelBuilder.Entity<ProjectModel>(e =>
+        {
+            e.HasKey(x => x.Id);
+            e.HasIndex(x => x.ProjectId);
+            e.HasIndex(x => x.ContentHash);
+            e.Property(x => x.Name).HasMaxLength(200);
+            e.Property(x => x.Description).HasMaxLength(1000);
+            e.Property(x => x.Discipline).HasMaxLength(8);
+            e.Property(x => x.FileName).HasMaxLength(260);
+            e.Property(x => x.StoragePath).HasMaxLength(600);
+            e.Property(x => x.ContentHash).HasMaxLength(64);
+            e.Property(x => x.ThumbnailPath).HasMaxLength(600);
+            e.Property(x => x.ElementMapPath).HasMaxLength(600);
+            e.Property(x => x.Units).HasMaxLength(8);
+            e.Property(x => x.Revision).HasMaxLength(30);
+            e.Property(x => x.UploadedBy).HasMaxLength(200);
+            e.HasOne(x => x.Project).WithMany().HasForeignKey(x => x.ProjectId).OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(x => x.UploadedByUser).WithMany().HasForeignKey(x => x.UploadedByUserId).OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // Issue → ProjectModel anchor (MODEL-VIEWER)
+        modelBuilder.Entity<BimIssue>(e =>
+        {
+            e.HasIndex(x => x.ModelId);
+            e.Property(x => x.ModelElementGuid).HasMaxLength(80);
         });
 
         // ── BimIssue.CustomFields JSONB (FLEX-13) ──

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -38,6 +38,7 @@ public class PlanscapeDbContext : DbContext
     }
 
     public DbSet<Tenant> Tenants => Set<Tenant>();
+    public DbSet<TenantBranding> TenantBrandings => Set<TenantBranding>();
     public DbSet<AppUser> Users => Set<AppUser>();
     public DbSet<Project> Projects => Set<Project>();
     public DbSet<TaggedElement> TaggedElements => Set<TaggedElement>();
@@ -76,6 +77,23 @@ public class PlanscapeDbContext : DbContext
             e.HasIndex(t => t.Slug).IsUnique();
             e.Property(t => t.Name).HasMaxLength(200);
             e.Property(t => t.Slug).HasMaxLength(50);
+        });
+
+        // ── TenantBranding (FLEX-03) ──
+        modelBuilder.Entity<TenantBranding>(e =>
+        {
+            e.HasKey(b => b.Id);
+            e.HasIndex(b => b.TenantId).IsUnique();
+            e.HasOne(b => b.Tenant).WithMany().HasForeignKey(b => b.TenantId).OnDelete(DeleteBehavior.Cascade);
+            e.Property(b => b.ProductName).HasMaxLength(100);
+            e.Property(b => b.AccentColor).HasMaxLength(20);
+            e.Property(b => b.HeaderColor).HasMaxLength(20);
+            e.Property(b => b.LogoUrl).HasMaxLength(500);
+            e.Property(b => b.SupportEmail).HasMaxLength(200);
+            e.Property(b => b.EmailFromName).HasMaxLength(100);
+            e.Property(b => b.EmailFromAddress).HasMaxLength(200);
+            e.Property(b => b.EmailSignature).HasMaxLength(2000);
+            e.Property(b => b.DefaultLanguage).HasMaxLength(8);
         });
 
         // ── AppUser ──

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -56,6 +56,7 @@ public class PlanscapeDbContext : DbContext
     public DbSet<DevicePushToken> DevicePushTokens => Set<DevicePushToken>();
     public DbSet<UserNotificationPreferences> UserNotificationPreferences => Set<UserNotificationPreferences>();
     public DbSet<IssueAttachment> IssueAttachments => Set<IssueAttachment>();
+    public DbSet<IssueCustomFieldSchema> IssueCustomFieldSchemas => Set<IssueCustomFieldSchema>();
     public DbSet<DocumentApproval> DocumentApprovals => Set<DocumentApproval>();
     public DbSet<PlatformConnection> PlatformConnections => Set<PlatformConnection>();
     public DbSet<DocumentVersion> DocumentVersions => Set<DocumentVersion>();
@@ -77,6 +78,30 @@ public class PlanscapeDbContext : DbContext
             e.HasIndex(t => t.Slug).IsUnique();
             e.Property(t => t.Name).HasMaxLength(200);
             e.Property(t => t.Slug).HasMaxLength(50);
+        });
+
+        // ── IssueCustomFieldSchema (FLEX-13) ──
+        modelBuilder.Entity<IssueCustomFieldSchema>(e =>
+        {
+            e.HasKey(x => x.Id);
+            e.HasIndex(x => new { x.ProjectId, x.Key }).IsUnique();
+            e.HasIndex(x => x.ProjectId);
+            e.Property(x => x.Key).HasMaxLength(80);
+            e.Property(x => x.Label).HasMaxLength(200);
+            e.Property(x => x.HelpText).HasMaxLength(500);
+            e.Property(x => x.DefaultValueJson).HasColumnType("jsonb");
+            e.Property(x => x.OptionsJson).HasColumnType("jsonb");
+            e.HasOne(x => x.Project).WithMany().HasForeignKey(x => x.ProjectId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // ── BimIssue.CustomFields JSONB (FLEX-13) ──
+        // Decision 4.5 = (c) — JSONB column with GIN index. The GIN index is
+        // created by the migration (raw SQL) rather than through HasIndex, to
+        // avoid the model snapshot trying to re-create/re-drop it on later
+        // unrelated migrations.
+        modelBuilder.Entity<BimIssue>(e =>
+        {
+            e.Property(x => x.CustomFields).HasColumnType("jsonb");
         });
 
         // ── TenantBranding (FLEX-03) ──

--- a/Planscape.Server/src/Planscape.Infrastructure/Planscape.Infrastructure.csproj
+++ b/Planscape.Server/src/Planscape.Infrastructure/Planscape.Infrastructure.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.17" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.10" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <!-- IHostEnvironment used by EmailTemplateRenderer + I18nService (FLEX-03/15) -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/CustomFieldsPurgeJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/CustomFieldsPurgeJob.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// FLEX-13 (decision 4.6 row 1) — Archive-then-purge for deleted custom fields.
+///
+/// Fields marked with <c>DeletedAt</c> older than 30 days are permanently
+/// removed, along with their values from each issue's <c>CustomFields</c>
+/// JSONB object. Runs nightly via Hangfire. Admin can force immediate purge
+/// by calling this method from an ops command if needed.
+/// </summary>
+public class CustomFieldsPurgeJob
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly ILogger<CustomFieldsPurgeJob> _logger;
+
+    private static readonly TimeSpan PurgeGrace = TimeSpan.FromDays(30);
+
+    public CustomFieldsPurgeJob(PlanscapeDbContext db, ILogger<CustomFieldsPurgeJob> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        var cutoff = DateTime.UtcNow - PurgeGrace;
+        var stale = await _db.IssueCustomFieldSchemas
+            .Where(s => s.DeletedAt != null && s.DeletedAt < cutoff)
+            .ToListAsync(ct);
+
+        if (stale.Count == 0)
+        {
+            _logger.LogInformation("CustomFieldsPurgeJob: nothing to purge");
+            return;
+        }
+
+        foreach (var schema in stale)
+        {
+            // Scrub the key from every issue's CustomFields for this project.
+            var issues = await _db.Issues
+                .Where(i => i.ProjectId == schema.ProjectId && i.CustomFields != null)
+                .ToListAsync(ct);
+            foreach (var issue in issues)
+            {
+                var updated = RemoveKey(issue.CustomFields!, schema.Key);
+                if (updated != issue.CustomFields) issue.CustomFields = updated;
+            }
+            _db.IssueCustomFieldSchemas.Remove(schema);
+            _logger.LogInformation(
+                "CustomFieldsPurgeJob: purged field {Key} (project {ProjectId}, deletedAt {DeletedAt:u}, {IssueCount} issues scrubbed)",
+                schema.Key, schema.ProjectId, schema.DeletedAt, issues.Count);
+        }
+
+        await _db.SaveChangesAsync(ct);
+    }
+
+    private static string RemoveKey(string json, string key)
+    {
+        try
+        {
+            var node = JsonNode.Parse(json);
+            if (node is JsonObject obj && obj.ContainsKey(key))
+            {
+                obj.Remove(key);
+                return obj.ToJsonString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed JSON on an issue — leave it, log at info level.
+        }
+        return json;
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/EmailTemplateRenderer.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/EmailTemplateRenderer.cs
@@ -1,0 +1,171 @@
+using System.Collections.Concurrent;
+using System.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Interfaces;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// FLEX-03 + FLEX-07 — Minimal safe template engine for outbound email.
+///
+/// Templates live on disk at <c>EmailTemplates/{name}.{lang}.html</c> with a
+/// <c>.txt</c> sibling for the plain-text alternative. The engine:
+///   - loads + caches templates once at first use (hot-reload via <see cref="Reload"/>),
+///   - falls back through lang → en → baseline string,
+///   - substitutes <c>{{Placeholder}}</c> tokens with HTML-escaped values,
+///   - accepts a <c>{{#if flag}}…{{/if}}</c> lightweight conditional block.
+///
+/// Intentionally NOT Handlebars / Razor / Scriban — no external dep, no arbitrary code
+/// execution, no expression parser to audit. If richer templating is needed, swap the
+/// <see cref="IEmailTemplateRenderer"/> implementation, not the interface.
+/// </summary>
+public interface IEmailTemplateRenderer
+{
+    /// <summary>Render the given template name into an HTML string with branding baked in.</summary>
+    Task<RenderedEmail> RenderAsync(string templateName, string language,
+        IDictionary<string, string?> model, ResolvedBranding branding,
+        CancellationToken ct = default);
+
+    /// <summary>Clears the template cache. Called when a tenant uploads a new template.</summary>
+    void Reload();
+}
+
+public sealed record RenderedEmail(string Subject, string Html, string Text);
+
+public class FileEmailTemplateRenderer : IEmailTemplateRenderer
+{
+    private readonly IHostEnvironment _env;
+    private readonly IConfiguration _config;
+    private readonly ILogger<FileEmailTemplateRenderer> _logger;
+    private readonly ConcurrentDictionary<string, string> _cache = new();
+
+    public FileEmailTemplateRenderer(
+        IHostEnvironment env,
+        IConfiguration config,
+        ILogger<FileEmailTemplateRenderer> logger)
+    {
+        _env = env;
+        _config = config;
+        _logger = logger;
+    }
+
+    public Task<RenderedEmail> RenderAsync(
+        string templateName, string language,
+        IDictionary<string, string?> model, ResolvedBranding branding,
+        CancellationToken ct = default)
+    {
+        // The .subject file owns the subject line so tenants can localise it without
+        // editing the HTML. Missing subject → fall back to "{{ProductName}} notification".
+        var subject = LoadTemplate(templateName, language, "subject")
+                      ?? $"{{ProductName}} notification";
+        var html    = LoadTemplate(templateName, language, "html")
+                      ?? FallbackHtmlShell(templateName);
+        var text    = LoadTemplate(templateName, language, "txt")
+                      ?? StripHtml(html);
+
+        // Merge branding into the model without overwriting caller-supplied keys.
+        var merged = new Dictionary<string, string?>(model, StringComparer.Ordinal);
+        TryAdd(merged, "ProductName",      branding.ProductName);
+        TryAdd(merged, "AccentColor",      branding.AccentColor);
+        TryAdd(merged, "HeaderColor",      branding.HeaderColor);
+        TryAdd(merged, "LogoUrl",          branding.LogoUrl ?? "");
+        TryAdd(merged, "SupportEmail",     branding.SupportEmail);
+        TryAdd(merged, "EmailSignature",   branding.EmailSignature ?? "");
+        TryAdd(merged, "HasLogo",          string.IsNullOrEmpty(branding.LogoUrl) ? "" : "1");
+        TryAdd(merged, "HasSignature",     string.IsNullOrEmpty(branding.EmailSignature) ? "" : "1");
+        TryAdd(merged, "Year",             DateTime.UtcNow.Year.ToString());
+
+        return Task.FromResult(new RenderedEmail(
+            Subject: Render(subject, merged, escape: false).Trim(),
+            Html:    Render(html, merged, escape: true),
+            Text:    Render(text, merged, escape: false)));
+    }
+
+    public void Reload() => _cache.Clear();
+
+    // ── Template I/O ──
+
+    private string? LoadTemplate(string name, string language, string kind)
+    {
+        // Resolve root once. Prefer configurable Tenant:EmailTemplatesPath, else
+        // ContentRoot/EmailTemplates (works for dev + docker image copy).
+        var root = _config["Tenant:EmailTemplatesPath"]
+                   ?? Path.Combine(_env.ContentRootPath, "EmailTemplates");
+
+        string[] candidates =
+        {
+            Path.Combine(root, $"{name}.{language}.{kind}"),
+            Path.Combine(root, $"{name}.en.{kind}"),
+            Path.Combine(root, $"{name}.{kind}"),
+        };
+        foreach (var path in candidates)
+        {
+            if (_cache.TryGetValue(path, out var cached)) return cached;
+            if (File.Exists(path))
+            {
+                try
+                {
+                    var content = File.ReadAllText(path);
+                    _cache[path] = content;
+                    return content;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to read email template {Path}", path);
+                }
+            }
+        }
+        return null;
+    }
+
+    // ── Rendering ──
+
+    private static string Render(string template, IDictionary<string, string?> model, bool escape)
+    {
+        // Handle simple {{#if Key}}…{{/if}} blocks first — strip block entirely when key is
+        // empty/null. No nesting supported; keep complexity out of the pipeline.
+        var ifPattern = new System.Text.RegularExpressions.Regex(
+            @"\{\{#if\s+([A-Za-z0-9_]+)\}\}(.*?)\{\{/if\}\}",
+            System.Text.RegularExpressions.RegexOptions.Singleline);
+        template = ifPattern.Replace(template, m =>
+        {
+            var key = m.Groups[1].Value;
+            model.TryGetValue(key, out var val);
+            return string.IsNullOrEmpty(val) ? "" : m.Groups[2].Value;
+        });
+
+        // Placeholder substitution. Escape when rendering HTML; leave subject/text raw so
+        // newlines in signature bodies survive.
+        var placeholderPattern = new System.Text.RegularExpressions.Regex(@"\{\{([A-Za-z0-9_]+)\}\}");
+        return placeholderPattern.Replace(template, m =>
+        {
+            var key = m.Groups[1].Value;
+            model.TryGetValue(key, out var val);
+            val ??= "";
+            return escape ? WebUtility.HtmlEncode(val) : val;
+        });
+    }
+
+    // ── Fallbacks ──
+
+    private static string FallbackHtmlShell(string templateName) => $@"
+<!DOCTYPE html><html><body style=""font-family:sans-serif"">
+  <h2>{{{{ProductName}}}}</h2>
+  <p>(Template <code>{templateName}</code> was not found — rendering the built-in
+  fallback. Provide a template to customise this email.)</p>
+  <p>{{{{Body}}}}</p>
+</body></html>";
+
+    private static string StripHtml(string html)
+    {
+        var noTags = System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", "");
+        return WebUtility.HtmlDecode(noTags).Trim();
+    }
+
+    private static void TryAdd(IDictionary<string, string?> dict, string key, string? value)
+    {
+        if (!dict.ContainsKey(key)) dict[key] = value;
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/I18nService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/I18nService.cs
@@ -1,0 +1,149 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Interfaces;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// FLEX-15 — JSON-resource translation service.
+///
+/// Resource files live at <c>I18n/{lang}.json</c> next to the API DLL (copied via
+/// csproj &lt;None Include="I18n\**"&gt;). Format is a dotted-key tree; "_note" keys are
+/// ignored. Missing keys fall back through language → "en" → literal key.
+/// </summary>
+public class I18nService : II18nService
+{
+    private readonly IHostEnvironment _env;
+    private readonly IConfiguration _config;
+    private readonly ILogger<I18nService> _logger;
+
+    private readonly ConcurrentDictionary<string, Dictionary<string, string>> _translations = new();
+    private IReadOnlyList<string> _supportedLanguages = Array.Empty<string>();
+    private string _fallbackLanguage = "en";
+
+    public I18nService(IHostEnvironment env, IConfiguration config, ILogger<I18nService> logger)
+    {
+        _env = env;
+        _config = config;
+        _logger = logger;
+        LoadAll();
+    }
+
+    public IReadOnlyList<string> SupportedLanguages => _supportedLanguages;
+
+    public void Reload()
+    {
+        _translations.Clear();
+        LoadAll();
+    }
+
+    public string T(string key, string? language = null, IDictionary<string, object?>? vars = null)
+    {
+        if (string.IsNullOrEmpty(key)) return "";
+
+        var lang = Normalize(language) ?? Normalize(_config["Tenant:DefaultBranding:DefaultLanguage"]) ?? _fallbackLanguage;
+
+        var value = Lookup(key, lang) ?? Lookup(key, _fallbackLanguage) ?? key;
+
+        if (vars != null && vars.Count > 0)
+        {
+            value = PlaceholderPattern.Replace(value, m =>
+            {
+                var varName = m.Groups[1].Value;
+                return vars.TryGetValue(varName, out var val) && val != null
+                    ? val.ToString() ?? ""
+                    : m.Value; // leave unresolved placeholders untouched for diagnostics
+            });
+        }
+        return value;
+    }
+
+    // ── loading ──
+
+    private void LoadAll()
+    {
+        var root = _config["I18n:ResourcesPath"]
+                   ?? Path.Combine(_env.ContentRootPath, "I18n");
+        if (!Directory.Exists(root))
+        {
+            _logger.LogWarning("i18n directory not found at {Root} — running without translations", root);
+            _supportedLanguages = Array.Empty<string>();
+            return;
+        }
+
+        var supported = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(root, "*.json"))
+        {
+            var lang = Path.GetFileNameWithoutExtension(file).ToLowerInvariant();
+            try
+            {
+                var flat = LoadFile(file);
+                _translations[lang] = flat;
+                supported.Add(lang);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load i18n file {File}", file);
+            }
+        }
+        _supportedLanguages = supported;
+        _fallbackLanguage = _config["I18n:FallbackLanguage"] ?? "en";
+    }
+
+    private static Dictionary<string, string> LoadFile(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var doc = JsonDocument.Parse(stream);
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        Flatten(doc.RootElement, "", result);
+        return result;
+    }
+
+    private static void Flatten(JsonElement element, string prefix, Dictionary<string, string> acc)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    if (prop.Name.StartsWith("_")) continue; // skip metadata keys
+                    var key = string.IsNullOrEmpty(prefix) ? prop.Name : $"{prefix}.{prop.Name}";
+                    Flatten(prop.Value, key, acc);
+                }
+                break;
+            case JsonValueKind.String:
+                acc[prefix] = element.GetString() ?? "";
+                break;
+            case JsonValueKind.Number:
+                acc[prefix] = element.ToString();
+                break;
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                acc[prefix] = element.GetBoolean().ToString();
+                break;
+            // Arrays / null — skipped. Translation values should be strings.
+        }
+    }
+
+    private string? Lookup(string key, string lang)
+    {
+        if (_translations.TryGetValue(lang, out var dict) && dict.TryGetValue(key, out var val))
+            return val;
+        return null;
+    }
+
+    private static string? Normalize(string? lang)
+    {
+        if (string.IsNullOrWhiteSpace(lang)) return null;
+        var code = lang.Trim().ToLowerInvariant();
+        // Handle "en-GB" → "en"; keep "zh-hans" because that maps to a resource file.
+        var dash = code.IndexOf('-');
+        return dash > 0 ? code.Substring(0, dash) : code;
+    }
+
+    private static readonly Regex PlaceholderPattern = new(@"\{([A-Za-z0-9_]+)\}", RegexOptions.Compiled);
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/NlpResolver.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/NlpResolver.cs
@@ -1,0 +1,285 @@
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// Rule-based NLP resolver with optional LLM fallback. Strategy per NLP-AUTO-LINK:
+///
+///   1. ISO 19650 tag regex          (deterministic, highest priority)
+///   2. Grid reference parsing       (per-project grid name lookup)
+///   3. Family/type fuzzy match      (Levenshtein with early exit)
+///   4. LLM fallback (optional)      (only when 1–3 returned nothing useful)
+///
+/// Confidence floor for auto-linking is 0.9 (decision 2.4 = b). Callers always
+/// receive the full candidate list so the UI can show a "did you mean?" picker.
+/// </summary>
+public class NlpResolver : INlpResolver
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly INlpLlmResolver _llm;
+    private readonly IConfiguration _config;
+    private readonly ILogger<NlpResolver> _logger;
+
+    public const double AutoLinkThreshold = 0.9;
+
+    public NlpResolver(
+        IServiceScopeFactory scopeFactory,
+        INlpLlmResolver llm,
+        IConfiguration config,
+        ILogger<NlpResolver> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _llm = llm;
+        _config = config;
+        _logger = logger;
+    }
+
+    public async Task<NlpResolution> ResolveAsync(NlpResolveRequest request, CancellationToken ct = default)
+    {
+        var text = request.Text ?? "";
+        var redacted = PiiRedactor.Redact(text);
+
+        var candidates = new List<NlpCandidate>();
+
+        // 1. ISO tag regex — deterministic, always runs.
+        candidates.AddRange(ExtractIsoTags(text));
+
+        // 2+3. Grid + fuzzy family — need DB context.
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+            candidates.AddRange(await ExtractGridReferences(db, request.ProjectId, text, ct));
+            candidates.AddRange(await ExtractElementMatches(db, request.ProjectId, text, ct));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Rule-based NLP lookup failed — falling back to regex-only");
+        }
+
+        var source = candidates.Count > 0 ? candidates[0].Strategy : "None";
+
+        // 4. LLM fallback — only when we have nothing above 0.7 and the caller
+        // didn't opt out, and the provider is real (not the null resolver).
+        var topConfidence = candidates.Count == 0 ? 0 : candidates.Max(c => c.Confidence);
+        var llmAllowed = request.AllowCloudFallback
+                        && topConfidence < 0.7
+                        && !string.Equals(_llm.ProviderName, "null", StringComparison.OrdinalIgnoreCase)
+                        && bool.TryParse(_config["Nlp:EnableLlmFallback"], out var enabled) && enabled;
+
+        if (llmAllowed)
+        {
+            try
+            {
+                var llmCandidates = await _llm.ResolveAsync(
+                    request.ProjectId, redacted, request.Language,
+                    request.MaxCandidates - candidates.Count, ct);
+                candidates.AddRange(llmCandidates);
+                if (llmCandidates.Count > 0) source = "Llm";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "LLM fallback failed for provider {Provider}", _llm.ProviderName);
+            }
+        }
+
+        // Sort: highest confidence first, cap to MaxCandidates.
+        var ranked = candidates
+            .OrderByDescending(c => c.Confidence)
+            .Take(request.MaxCandidates)
+            .ToList();
+
+        return new NlpResolution(
+            InputText: text,
+            Candidates: ranked,
+            HasAutoLinkCandidate: ranked.Count > 0 && ranked[0].Confidence >= AutoLinkThreshold,
+            Source: source,
+            RedactedText: redacted != text ? redacted : null);
+    }
+
+    // ── 1. ISO 19650 tag regex ────────────────────────────────────────────
+
+    private static readonly Regex IsoTagPattern = new(
+        @"\b([A-Z]{1,2})-([A-Z0-9]{2,6})-([A-Z0-9]{2,4})-([A-Z0-9]{2,4})-([A-Z]{2,5})-([A-Z]{2,5})-([A-Z]{2,5})-(\d{3,4})\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static IEnumerable<NlpCandidate> ExtractIsoTags(string text)
+    {
+        foreach (Match m in IsoTagPattern.Matches(text))
+        {
+            var canonical = m.Value.ToUpperInvariant();
+            yield return new NlpCandidate(
+                Kind: NlpCandidateKind.IsoTag,
+                Label: canonical,
+                Confidence: 1.0,
+                Strategy: "Regex",
+                Target: new Dictionary<string, string?> { ["tag"] = canonical });
+        }
+    }
+
+    // ── 2. Grid reference parsing ─────────────────────────────────────────
+
+    // Matches "B-3", "grid B-3", "on grid 5/C", "grid 5-C"
+    private static readonly Regex GridReferencePattern = new(
+        @"\b(?:grid\s+)?(?:on\s+)?([A-Z]{1,2})[\s\-/\\]?(\d{1,3})\b|\b(?:grid\s+)?(\d{1,3})[\s\-/\\]?([A-Z]{1,2})\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static async Task<IEnumerable<NlpCandidate>> ExtractGridReferences(
+        PlanscapeDbContext db, Guid projectId, string text, CancellationToken ct)
+    {
+        var result = new List<NlpCandidate>();
+        var refs = GridReferencePattern.Matches(text);
+        if (refs.Count == 0) return result;
+
+        // Look up tagged elements with a grid_ref parameter on this project.
+        // TaggedElement stores the resolved GRID_REF (or ASS_GRID_REF_TXT). When no
+        // elements are found, still emit a lower-confidence candidate so the UI can
+        // show the grid pick.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match m in refs)
+        {
+            var letter = (m.Groups[1].Success ? m.Groups[1].Value : m.Groups[4].Value).ToUpperInvariant();
+            var number = (m.Groups[2].Success ? m.Groups[2].Value : m.Groups[3].Value);
+            var label = $"{letter}-{number}";
+            if (!seen.Add(label)) continue;
+
+            var gridRef = $"{letter}/{number}";
+            // Low-latency query — projects have hundreds of tagged elements, not thousands.
+            var hits = await db.TaggedElements.AsNoTracking()
+                .Where(e => e.ProjectId == projectId && e.GridRef != null &&
+                            (e.GridRef == label || e.GridRef == gridRef))
+                .Take(5)
+                .Select(e => new { e.Id, e.Tag, e.FamilyName })
+                .ToListAsync(ct);
+
+            if (hits.Count == 0)
+            {
+                // Grid location only — no element match yet.
+                result.Add(new NlpCandidate(
+                    Kind: NlpCandidateKind.GridReference,
+                    Label: $"Grid {label}",
+                    Confidence: 0.6,
+                    Strategy: "Grid",
+                    Target: new Dictionary<string, string?> { ["grid"] = label }));
+            }
+            else
+            {
+                foreach (var h in hits)
+                {
+                    result.Add(new NlpCandidate(
+                        Kind: NlpCandidateKind.Element,
+                        Label: $"{h.Tag} ({h.FamilyName}) on grid {label}",
+                        Confidence: 0.82,
+                        Strategy: "Grid",
+                        Target: new Dictionary<string, string?>
+                        {
+                            ["elementId"] = h.Id.ToString(),
+                            ["tag"] = h.Tag,
+                            ["grid"] = label,
+                        }));
+                }
+            }
+        }
+        return result;
+    }
+
+    // ── 3. Family / type fuzzy match ──────────────────────────────────────
+
+    private static async Task<IEnumerable<NlpCandidate>> ExtractElementMatches(
+        PlanscapeDbContext db, Guid projectId, string text, CancellationToken ct)
+    {
+        // Heuristic: pull out 2–6-word noun phrases, then fuzzy match against
+        // distinct FamilyName values in the project. Short-circuit if text has
+        // an ISO tag (already handled).
+        if (IsoTagPattern.IsMatch(text)) return Array.Empty<NlpCandidate>();
+
+        var tokens = text.Split(new[] { ' ', ',', '.', ';', ':', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
+                         .Select(t => t.Trim())
+                         .Where(t => t.Length >= 3)
+                         .Take(40) // bound cost
+                         .ToArray();
+        if (tokens.Length == 0) return Array.Empty<NlpCandidate>();
+
+        // Pull the distinct family names for this project (small list — typically <500).
+        var families = await db.TaggedElements.AsNoTracking()
+            .Where(e => e.ProjectId == projectId && e.FamilyName != null)
+            .Select(e => e.FamilyName!)
+            .Distinct()
+            .Take(2000)
+            .ToListAsync(ct);
+        if (families.Count == 0) return Array.Empty<NlpCandidate>();
+
+        var results = new List<(string family, double score)>();
+        foreach (var family in families)
+        {
+            var familyTokens = family.Split(new[] { ' ', '-', '_', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var hits = 0;
+            foreach (var token in tokens)
+            {
+                foreach (var ft in familyTokens)
+                {
+                    if (string.Equals(ft, token, StringComparison.OrdinalIgnoreCase)) { hits += 2; break; }
+                    if (LevenshteinDistance(ft, token) <= 1) { hits += 1; break; }
+                }
+            }
+            if (hits == 0) continue;
+            // Normalize by shorter side — short family names shouldn't dominate.
+            var score = (double)hits / Math.Max(familyTokens.Length, 1);
+            results.Add((family, Math.Min(0.85, score / 2.0))); // cap fuzzy at 0.85
+        }
+        return results
+            .OrderByDescending(r => r.score)
+            .Take(5)
+            .Select(r => new NlpCandidate(
+                Kind: NlpCandidateKind.Element,
+                Label: r.family,
+                Confidence: r.score,
+                Strategy: "Fuzzy",
+                Target: new Dictionary<string, string?> { ["family"] = r.family }))
+            .ToArray();
+    }
+
+    // Iterative Levenshtein with early-exit when we exceed the max distance.
+    private static int LevenshteinDistance(string a, string b)
+    {
+        if (a == b) return 0;
+        if (a.Length == 0) return b.Length;
+        if (b.Length == 0) return a.Length;
+        var v0 = new int[b.Length + 1];
+        var v1 = new int[b.Length + 1];
+        for (var i = 0; i <= b.Length; i++) v0[i] = i;
+        for (var i = 0; i < a.Length; i++)
+        {
+            v1[0] = i + 1;
+            for (var j = 0; j < b.Length; j++)
+            {
+                var cost = char.ToLowerInvariant(a[i]) == char.ToLowerInvariant(b[j]) ? 0 : 1;
+                v1[j + 1] = Math.Min(Math.Min(v1[j] + 1, v0[j + 1] + 1), v0[j] + cost);
+            }
+            (v0, v1) = (v1, v0);
+        }
+        return v0[b.Length];
+    }
+}
+
+/// <summary>
+/// Default LLM resolver — refuses to call out, always returns empty. Swap via DI
+/// for a real Azure OpenAI / OpenAI / Anthropic implementation when credentials
+/// are available. The rule-based path stays intact regardless.
+/// </summary>
+public class NullLlmResolver : INlpLlmResolver
+{
+    public string ProviderName => "null";
+
+    public Task<IReadOnlyList<NlpCandidate>> ResolveAsync(
+        Guid projectId, string redactedText, string? language,
+        int maxCandidates, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<NlpCandidate>>(Array.Empty<NlpCandidate>());
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/PiiRedactor.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/PiiRedactor.cs
@@ -1,0 +1,42 @@
+using System.Text.RegularExpressions;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// Strips common PII before sending text to an external LLM (decision 2.5 =
+/// redact). Deliberately conservative — over-redacting a cloud prompt costs
+/// nothing, under-redacting leaks data.
+///
+///   email addresses       → [email]
+///   phone numbers (E.164) → [phone]
+///   UK NI numbers         → [ni]
+///   credit-card-ish       → [card]
+///   /api/.../{guid}       → [resource]
+///   8+ digit runs         → [digits]
+///
+/// Bypass this entirely by calling <see cref="INlpResolver.ResolveAsync"/>
+/// with <c>AllowCloudFallback = false</c>.
+/// </summary>
+public static class PiiRedactor
+{
+    private static readonly (Regex pattern, string replacement)[] _rules =
+    {
+        (new Regex(@"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",                       RegexOptions.Compiled), "[email]"),
+        (new Regex(@"\b\+?[1-9]\d{1,3}[\s\-]?\(?\d{2,5}\)?[\s\-]?\d{3,4}[\s\-]?\d{3,4}\b",      RegexOptions.Compiled), "[phone]"),
+        (new Regex(@"\b[A-CEGHJ-PR-TW-Z]{2}\d{6}[A-D]\b",                                       RegexOptions.Compiled), "[ni]"),
+        (new Regex(@"\b(?:\d[ -]*?){13,19}\b",                                                   RegexOptions.Compiled), "[card]"),
+        (new Regex(@"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b", RegexOptions.Compiled), "[guid]"),
+        (new Regex(@"\b\d{8,}\b",                                                                RegexOptions.Compiled), "[digits]"),
+    };
+
+    public static string Redact(string input)
+    {
+        if (string.IsNullOrEmpty(input)) return input;
+        var redacted = input;
+        foreach (var (pattern, replacement) in _rules)
+        {
+            redacted = pattern.Replace(redacted, replacement);
+        }
+        return redacted;
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/SmtpEmailService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/SmtpEmailService.cs
@@ -1,6 +1,7 @@
 using MailKit.Net.Smtp;
 using MailKit.Security;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MimeKit;
 using Planscape.Core.Interfaces;
@@ -8,106 +9,192 @@ using Planscape.Core.Interfaces;
 namespace Planscape.Infrastructure.Services;
 
 /// <summary>
-/// MailKit-based SMTP email service for sending invite, password-reset, and notification emails.
-/// Reads configuration from the "Email" section in appsettings.
+/// MailKit-based SMTP email service. FLEX-03/07 — renders templates from the
+/// on-disk <c>EmailTemplates/</c> directory with per-tenant branding resolved via
+/// <see cref="ITenantBrandingService"/>. Falls back to a hard-coded plain template
+/// when the renderer cannot find a file (never silently fails to send).
 /// </summary>
 public class SmtpEmailService : IEmailService
 {
     private readonly IConfiguration _config;
     private readonly ILogger<SmtpEmailService> _logger;
+    private readonly IServiceScopeFactory _scopeFactory;
 
-    private string Host        => _config["Email:Host"]!;
-    private int    Port        => int.TryParse(_config["Email:Port"], out var p) ? p : 587;
-    private string Username    => _config["Email:Username"] ?? "";
-    private string Password    => _config["Email:Password"] ?? "";
-    private string FromAddress => _config["Email:FromAddress"] ?? "noreply@planscape.com";
-    private string FromName    => _config["Email:FromName"] ?? "Planscape";
-    private bool   UseSsl      => bool.TryParse(_config["Email:UseSsl"], out var v) && v;
+    // Config keys use either "Smtp:*" (matches the Production template) or "Email:*" (legacy).
+    private string Cfg(string key, string fallback = "") =>
+        _config[$"Smtp:{key}"] ?? _config[$"Email:{key}"] ?? fallback;
 
-    public SmtpEmailService(IConfiguration config, ILogger<SmtpEmailService> logger)
+    private string Host        => Cfg("Host");
+    private int    Port        => int.TryParse(Cfg("Port", "587"), out var p) ? p : 587;
+    private string Username    => Cfg("Username");
+    private string Password    => Cfg("Password");
+    private string FromAddress => Cfg("FromAddress", "noreply@planscape.io");
+    private string FromName    => Cfg("FromName", "Planscape");
+    private bool   UseSsl      => bool.TryParse(Cfg("UseSsl", "true"), out var v) && v;
+
+    public SmtpEmailService(
+        IConfiguration config,
+        ILogger<SmtpEmailService> logger,
+        IServiceScopeFactory scopeFactory)
     {
         _config = config;
         _logger = logger;
+        _scopeFactory = scopeFactory;
     }
 
     public async Task SendInviteEmailAsync(
         string toEmail, string displayName, string inviterName,
         string projectName, string serverUrl, CancellationToken ct = default)
     {
-        var subject = $"You've been invited to {projectName} on Planscape";
-        var html = WrapInLayout($@"
-            <h2>Welcome to Planscape</h2>
-            <p>Hi {Escape(displayName)},</p>
-            <p><strong>{Escape(inviterName)}</strong> has invited you to collaborate on
-               <strong>{Escape(projectName)}</strong>.</p>
-            <p>To get started, visit the server and set your password:</p>
-            <p style=""text-align:center; margin:32px 0;"">
-              <a href=""{Escape(serverUrl)}/reset-password?email={Uri.EscapeDataString(toEmail)}""
-                 style=""background:#0066cc; color:#ffffff; padding:12px 32px;
-                        border-radius:6px; text-decoration:none; font-weight:600;"">
-                Set Password &amp; Join
-              </a>
-            </p>
-            <p style=""color:#666; font-size:13px;"">
-              If you did not expect this invitation you can safely ignore this email.
-            </p>");
-
-        await SendAsync(toEmail, subject, html, ct);
+        var acceptUrl = $"{serverUrl.TrimEnd('/')}/reset-password?email={Uri.EscapeDataString(toEmail)}";
+        var model = new Dictionary<string, string?>
+        {
+            ["DisplayName"]  = displayName,
+            ["InviterName"]  = inviterName,
+            ["ProjectName"]  = projectName,
+            ["AcceptUrl"]    = acceptUrl,
+            ["ServerUrl"]    = serverUrl,
+        };
+        var rendered = await RenderAsync("invite", model, ct);
+        await SendAsync(toEmail, rendered, ct);
     }
 
     public async Task SendPasswordResetEmailAsync(
         string toEmail, string resetToken, string serverUrl, CancellationToken ct = default)
     {
-        var subject = "Planscape — Password Reset";
-        var html = WrapInLayout($@"
-            <h2>Password Reset</h2>
-            <p>A password reset was requested for your Planscape account.</p>
-            <p style=""text-align:center; margin:32px 0;"">
-              <a href=""{Escape(serverUrl)}/reset-password?token={Uri.EscapeDataString(resetToken)}&amp;email={Uri.EscapeDataString(toEmail)}""
-                 style=""background:#0066cc; color:#ffffff; padding:12px 32px;
-                        border-radius:6px; text-decoration:none; font-weight:600;"">
-                Reset Password
-              </a>
-            </p>
-            <p style=""color:#666; font-size:13px;"">
-              This link expires in 24 hours. If you did not request a password reset, ignore this email.
-            </p>");
-
-        await SendAsync(toEmail, subject, html, ct);
+        var resetUrl = $"{serverUrl.TrimEnd('/')}/reset-password?token={Uri.EscapeDataString(resetToken)}&email={Uri.EscapeDataString(toEmail)}";
+        var model = new Dictionary<string, string?>
+        {
+            ["ResetUrl"]  = resetUrl,
+            ["ServerUrl"] = serverUrl,
+        };
+        var rendered = await RenderAsync("password-reset", model, ct);
+        await SendAsync(toEmail, rendered, ct);
     }
 
     public async Task SendNotificationAsync(
         string toEmail, string subject, string htmlBody, CancellationToken ct = default)
     {
-        var html = WrapInLayout(htmlBody);
-        await SendAsync(toEmail, subject, html, ct);
+        // Ad-hoc notification — wrap the caller's body in the branded layout but skip
+        // template lookup (the caller has already composed the message body).
+        var branding = await ResolveBrandingAsync(ct);
+        var layoutModel = new Dictionary<string, string?>
+        {
+            ["Body"] = htmlBody,
+        };
+        // Use the layout template directly by invoking a synthetic template name.
+        var renderer = GetRenderer();
+        var html = renderer != null
+            ? (await renderer.RenderAsync("_layout", branding.DefaultLanguage, layoutModel, branding, ct)).Html
+            : WrapInLegacyLayout(htmlBody, branding);
+        await SendAsync(toEmail, new RenderedEmail(subject, html, StripHtml(htmlBody)), ct);
     }
 
-    // ── Private helpers ──────────────────────────────────────────────────────────
+    // ── Rendering helpers ─────────────────────────────────────────────────────
 
-    private async Task SendAsync(string toEmail, string subject, string htmlBody, CancellationToken ct)
+    private async Task<RenderedEmail> RenderAsync(
+        string templateName,
+        Dictionary<string, string?> model,
+        CancellationToken ct)
     {
+        var branding = await ResolveBrandingAsync(ct);
+        var renderer = GetRenderer();
+        if (renderer == null)
+        {
+            // Renderer not wired (DI failure) — emit a plain, branding-aware fallback.
+            var subject = $"{branding.ProductName} — {templateName.Replace('-', ' ')}";
+            var legacyBody = string.Join("\n", model.Select(kv => $"<p>{System.Net.WebUtility.HtmlEncode(kv.Key)}: {System.Net.WebUtility.HtmlEncode(kv.Value ?? "")}</p>"));
+            var html = WrapInLegacyLayout(legacyBody, branding);
+            return new RenderedEmail(subject, html, StripHtml(legacyBody));
+        }
+        // Render the per-template body, then wrap in the layout.
+        var body = await renderer.RenderAsync(templateName, branding.DefaultLanguage, model, branding, ct);
+        var layoutModel = new Dictionary<string, string?>(model, StringComparer.Ordinal)
+        {
+            ["Body"] = body.Html,
+        };
+        var wrapped = await renderer.RenderAsync("_layout", branding.DefaultLanguage, layoutModel, branding, ct);
+        return new RenderedEmail(body.Subject, wrapped.Html, body.Text);
+    }
+
+    private async Task<ResolvedBranding> ResolveBrandingAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var brandingSvc = scope.ServiceProvider.GetService<ITenantBrandingService>();
+        var tenantCtx   = scope.ServiceProvider.GetService<ITenantContext>();
+        var tenantId    = tenantCtx?.TenantId;
+        if (brandingSvc != null && tenantId.HasValue)
+        {
+            try { return await brandingSvc.GetAsync(tenantId.Value, ct); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Branding lookup failed; using defaults"); }
+        }
+        // No tenant in scope (Hangfire job, seed task, etc.) — build defaults manually.
+        return new ResolvedBranding(
+            ProductName:      _config["Tenant:DefaultBranding:ProductName"]      ?? "Planscape",
+            AccentColor:      _config["Tenant:DefaultBranding:AccentColor"]      ?? "#E8912D",
+            HeaderColor:      _config["Tenant:DefaultBranding:HeaderColor"]      ?? "#1A237E",
+            LogoUrl:          _config["Tenant:DefaultBranding:LogoUrl"],
+            SupportEmail:     _config["Tenant:DefaultBranding:SupportEmail"]     ?? "support@planscape.io",
+            EmailFromName:    FromName,
+            EmailFromAddress: FromAddress,
+            EmailSignature:   _config["Tenant:DefaultBranding:EmailSignature"],
+            DefaultLanguage:  _config["Tenant:DefaultBranding:DefaultLanguage"]  ?? "en");
+    }
+
+    private IEmailTemplateRenderer? GetRenderer()
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            return scope.ServiceProvider.GetService<IEmailTemplateRenderer>();
+        }
+        catch { return null; }
+    }
+
+    // ── SMTP transport ────────────────────────────────────────────────────────
+
+    private async Task SendAsync(string toEmail, RenderedEmail email, CancellationToken ct)
+    {
+        var branding = await ResolveBrandingAsync(ct);
+        var fromAddress = !string.IsNullOrWhiteSpace(branding.EmailFromAddress)
+            ? branding.EmailFromAddress
+            : FromAddress;
+        var fromName = !string.IsNullOrWhiteSpace(branding.EmailFromName)
+            ? branding.EmailFromName
+            : FromName;
+
         var message = new MimeMessage();
-        message.From.Add(new MailboxAddress(FromName, FromAddress));
+        message.From.Add(new MailboxAddress(fromName, fromAddress));
         message.To.Add(MailboxAddress.Parse(toEmail));
-        message.Subject = subject;
-        message.Body = new TextPart("html") { Text = htmlBody };
+        message.Subject = email.Subject;
+
+        var bodyBuilder = new BodyBuilder
+        {
+            HtmlBody = email.Html,
+            TextBody = email.Text,
+        };
+        message.Body = bodyBuilder.ToMessageBody();
+
+        if (string.IsNullOrWhiteSpace(Host))
+        {
+            // No SMTP host configured — behave like NullEmailService to avoid a crash.
+            _logger.LogInformation("[Smtp:NoHost] to={ToEmail} subject={Subject}", toEmail, email.Subject);
+            return;
+        }
 
         using var client = new SmtpClient();
         try
         {
             var secureOption = UseSsl ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTls;
             await client.ConnectAsync(Host, Port, secureOption, ct);
-
             if (!string.IsNullOrEmpty(Username))
                 await client.AuthenticateAsync(Username, Password, ct);
-
             await client.SendAsync(message, ct);
-            _logger.LogInformation("Email sent to {ToEmail}: {Subject}", toEmail, subject);
+            _logger.LogInformation("Email sent to {ToEmail}: {Subject}", toEmail, email.Subject);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send email to {ToEmail}: {Subject}", toEmail, subject);
+            _logger.LogError(ex, "Failed to send email to {ToEmail}: {Subject}", toEmail, email.Subject);
             throw;
         }
         finally
@@ -116,7 +203,9 @@ public class SmtpEmailService : IEmailService
         }
     }
 
-    private static string WrapInLayout(string bodyContent) => $@"
+    // ── Legacy layout — used only if the template renderer is unavailable. ──
+
+    private static string WrapInLegacyLayout(string bodyContent, ResolvedBranding branding) => $@"
 <!DOCTYPE html>
 <html lang=""en"">
 <head><meta charset=""utf-8"" /></head>
@@ -125,22 +214,19 @@ public class SmtpEmailService : IEmailService
     <tr><td align=""center"">
       <table width=""600"" cellpadding=""0"" cellspacing=""0""
              style=""background:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 2px 8px rgba(0,0,0,0.08);"">
-        <!-- Header -->
         <tr>
-          <td style=""background:#0066cc; padding:24px 32px;"">
-            <span style=""color:#ffffff; font-size:22px; font-weight:700; letter-spacing:0.5px;"">Planscape</span>
+          <td style=""background:{branding.HeaderColor}; padding:24px 32px;"">
+            <span style=""color:#ffffff; font-size:22px; font-weight:700; letter-spacing:0.5px;"">{System.Net.WebUtility.HtmlEncode(branding.ProductName)}</span>
           </td>
         </tr>
-        <!-- Body -->
         <tr>
           <td style=""padding:32px;"">
             {bodyContent}
           </td>
         </tr>
-        <!-- Footer -->
         <tr>
           <td style=""padding:16px 32px; background:#f9fafb; border-top:1px solid #e5e7eb; font-size:12px; color:#9ca3af;"">
-            &copy; {DateTime.UtcNow.Year} Planscape &mdash; ISO 19650 compliant BIM collaboration
+            &copy; {DateTime.UtcNow.Year} {System.Net.WebUtility.HtmlEncode(branding.ProductName)}
           </td>
         </tr>
       </table>
@@ -149,8 +235,11 @@ public class SmtpEmailService : IEmailService
 </body>
 </html>";
 
-    private static string Escape(string text) =>
-        System.Net.WebUtility.HtmlEncode(text);
+    private static string StripHtml(string html)
+    {
+        var noTags = System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", "");
+        return System.Net.WebUtility.HtmlDecode(noTags).Trim();
+    }
 }
 
 /// <summary>

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/TenantBrandingService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/TenantBrandingService.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// FLEX-03 — DB-backed <see cref="ITenantBrandingService"/> with in-memory cache.
+/// Registered as Singleton so it can live alongside the singleton email service;
+/// uses <see cref="IServiceScopeFactory"/> to open a scope for each DB access.
+/// </summary>
+public class TenantBrandingService : ITenantBrandingService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IConfiguration _config;
+    private readonly ILogger<TenantBrandingService> _logger;
+
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+    private readonly ConcurrentDictionary<Guid, (ResolvedBranding Branding, DateTime CachedAt)> _cache = new();
+
+    public TenantBrandingService(
+        IServiceScopeFactory scopeFactory,
+        IConfiguration config,
+        ILogger<TenantBrandingService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _config = config;
+        _logger = logger;
+    }
+
+    public async Task<ResolvedBranding> GetAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        if (_cache.TryGetValue(tenantId, out var hit) && DateTime.UtcNow - hit.CachedAt < CacheTtl)
+            return hit.Branding;
+
+        TenantBranding? row = null;
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+            row = await db.Set<TenantBranding>().AsNoTracking()
+                          .FirstOrDefaultAsync(b => b.TenantId == tenantId, ct);
+        }
+        catch (Exception ex)
+        {
+            // DB might not have the table yet (migration pending). Fall back to defaults.
+            _logger.LogWarning(ex, "Tenant branding lookup failed, falling back to defaults");
+        }
+
+        var resolved = Resolve(row);
+        _cache[tenantId] = (resolved, DateTime.UtcNow);
+        return resolved;
+    }
+
+    public async Task SetAsync(Guid tenantId, TenantBranding branding, CancellationToken ct = default)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        var existing = await db.Set<TenantBranding>().FirstOrDefaultAsync(b => b.TenantId == tenantId, ct);
+        if (existing == null)
+        {
+            branding.TenantId = tenantId;
+            branding.CreatedAt = DateTime.UtcNow;
+            branding.UpdatedAt = DateTime.UtcNow;
+            db.Set<TenantBranding>().Add(branding);
+        }
+        else
+        {
+            existing.ProductName = branding.ProductName;
+            existing.AccentColor = branding.AccentColor;
+            existing.HeaderColor = branding.HeaderColor;
+            existing.LogoUrl = branding.LogoUrl;
+            existing.SupportEmail = branding.SupportEmail;
+            existing.EmailFromName = branding.EmailFromName;
+            existing.EmailFromAddress = branding.EmailFromAddress;
+            existing.EmailSignature = branding.EmailSignature;
+            existing.DefaultLanguage = branding.DefaultLanguage;
+            existing.UpdatedAt = DateTime.UtcNow;
+            existing.UpdatedByUserId = branding.UpdatedByUserId;
+        }
+        await db.SaveChangesAsync(ct);
+        InvalidateCache(tenantId);
+    }
+
+    public void InvalidateCache(Guid? tenantId = null)
+    {
+        if (tenantId.HasValue) _cache.TryRemove(tenantId.Value, out _);
+        else _cache.Clear();
+    }
+
+    private ResolvedBranding Resolve(TenantBranding? row)
+    {
+        // Layer: row → config → hardcoded. First non-empty wins.
+        string Pick(string? rowVal, string configKey, string fallback) =>
+            !string.IsNullOrWhiteSpace(rowVal) ? rowVal!
+            : !string.IsNullOrWhiteSpace(_config[$"Tenant:DefaultBranding:{configKey}"]) ? _config[$"Tenant:DefaultBranding:{configKey}"]!
+            : fallback;
+
+        string? PickOptional(string? rowVal, string configKey) =>
+            !string.IsNullOrWhiteSpace(rowVal) ? rowVal
+            : !string.IsNullOrWhiteSpace(_config[$"Tenant:DefaultBranding:{configKey}"]) ? _config[$"Tenant:DefaultBranding:{configKey}"]
+            : null;
+
+        return new ResolvedBranding(
+            ProductName:      Pick(row?.ProductName, "ProductName", "Planscape"),
+            AccentColor:      Pick(row?.AccentColor, "AccentColor", "#E8912D"),
+            HeaderColor:      Pick(row?.HeaderColor, "HeaderColor", "#1A237E"),
+            LogoUrl:          PickOptional(row?.LogoUrl, "LogoUrl"),
+            SupportEmail:     Pick(row?.SupportEmail, "SupportEmail", "support@planscape.io"),
+            EmailFromName:    Pick(row?.EmailFromName, "EmailFromName",
+                                   Pick(null, "ProductName", "Planscape")),
+            EmailFromAddress: Pick(row?.EmailFromAddress, "EmailFromAddress",
+                                   _config["Smtp:FromAddress"] ?? _config["Email:FromAddress"] ?? "no-reply@planscape.io"),
+            EmailSignature:   PickOptional(row?.EmailSignature, "EmailSignature"),
+            DefaultLanguage:  Pick(row?.DefaultLanguage, "DefaultLanguage", "en"));
+    }
+}

--- a/Planscape/app/(tabs)/_layout.tsx
+++ b/Planscape/app/(tabs)/_layout.tsx
@@ -1,6 +1,10 @@
 import { Tabs } from 'expo-router';
 import { Text } from 'react-native';
+import { useEffect } from 'react';
 import { theme } from '@/utils/theme';
+import { TenantSwitcher } from '@/components/TenantSwitcher';
+import { useTenantStore } from '@/stores/tenantStore';
+import { fetchMemberships } from '@/api/tenants';
 
 function TabIcon({ label, focused }: { label: string; focused: boolean }) {
   return (
@@ -16,12 +20,24 @@ function TabIcon({ label, focused }: { label: string; focused: boolean }) {
 }
 
 export default function TabLayout() {
+  const setMemberships = useTenantStore((s) => s.setMemberships);
+
+  useEffect(() => {
+    // TENANT-SWITCH — one call on tab-layout mount populates the store. The
+    // TenantSwitcher component decides whether to render itself based on the
+    // resulting count (0/1 = hidden, 2-5 = list, 6+ = search).
+    fetchMemberships()
+      .then(setMemberships)
+      .catch(() => { /* non-fatal — switcher just stays hidden */ });
+  }, [setMemberships]);
+
   return (
     <Tabs
       screenOptions={{
         headerStyle: { backgroundColor: theme.colors.primary },
         headerTintColor: theme.colors.surface,
         headerTitleStyle: { fontWeight: '600' },
+        headerRight: () => <TenantSwitcher />,
         tabBarActiveTintColor: theme.colors.accent,
         tabBarInactiveTintColor: theme.colors.textSecondary,
         tabBarStyle: {

--- a/Planscape/app/_layout.tsx
+++ b/Planscape/app/_layout.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from 'expo-status-bar';
 import { getToken, onSessionExpired } from '@/api/client';
 import { crashReporter } from '@/services/crashReporter';
 import { notificationTapRouter } from '@/services/notificationTapRouter';
+import { initI18n } from '@/i18n';
 
 export default function RootLayout() {
   const [isReady, setIsReady] = useState(false);
@@ -38,6 +39,9 @@ export default function RootLayout() {
   }, [isAuthenticated, segments, isReady]);
 
   async function checkAuth() {
+    // FLEX-15 — load the user's preferred language before we render any screen.
+    // initI18n is cheap (no network) and safe to call on every app start.
+    try { await initI18n(); } catch { /* non-fatal */ }
     const token = await getToken();
     setIsAuthenticated(!!token);
     setIsReady(true);

--- a/Planscape/app/models/[id].tsx
+++ b/Planscape/app/models/[id].tsx
@@ -1,0 +1,148 @@
+// MODEL-VIEWER — single-model viewer screen.
+//
+// Wraps <ModelViewer /> and wires:
+//   - GET /models/{id}          → metadata
+//   - GET /models/{id}/file     → geometry URL (passed to the WebView)
+//   - GET /models/{id}/element-map (optional sidecar)
+//   - SignalR: listens for IssueCreated to refresh pins
+//   - Long-press in viewer → opens issue-create modal prefilled with element GUID
+
+import { useEffect, useRef, useState } from "react";
+import { View, Text, Alert, StyleSheet } from "react-native";
+import { useLocalSearchParams, useRouter, Stack } from "expo-router";
+import {
+  ModelViewer,
+  ModelViewerHandle,
+  type PickEvent,
+  type PlaceIssueEvent,
+} from "@/components/ModelViewer";
+import { useProjectStore } from "@/stores/projectStore";
+import { getModel, modelFileUrl, fetchElementMap } from "@/api/models";
+import { listIssues } from "@/api/endpoints";
+import { getToken } from "@/api/client";
+import type { ModelMeta, ElementMap, ModelPin } from "@/types/models";
+
+export default function ModelViewerScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const projectId = useProjectStore((s) => s.activeProjectId);
+  const viewerRef = useRef<ModelViewerHandle>(null);
+
+  const [meta, setMeta] = useState<ModelMeta | null>(null);
+  const [modelUrl, setModelUrl] = useState<string | undefined>();
+  const [elementMap, setElementMap] = useState<ElementMap | undefined>();
+  const [pins, setPins] = useState<ModelPin[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!projectId || !id) return;
+    (async () => {
+      try {
+        const [m, token] = await Promise.all([
+          getModel(projectId, id),
+          getToken(),
+        ]);
+        setMeta(m);
+
+        // WebView doesn't forward Authorization automatically — append the
+        // token as a query parameter so the viewer can fetch directly.
+        const base = await modelFileUrl(projectId, id);
+        setModelUrl(token ? `${base}?access_token=${encodeURIComponent(token)}` : base);
+
+        if (m.hasElementMap) {
+          try {
+            const map = await fetchElementMap(projectId, id) as ElementMap;
+            setElementMap(map);
+          } catch (err) {
+            console.warn("[viewer] element map fetch failed", err);
+          }
+        }
+
+        // Load existing issue pins for this model.
+        try {
+          const issues = await listIssues(projectId);
+          const modelPins: ModelPin[] = issues
+            .filter((i) => i.modelId === id && i.modelX != null && i.modelY != null && i.modelZ != null)
+            .map((i) => ({
+              id: i.id,
+              x: i.modelX!,
+              y: i.modelY!,
+              z: i.modelZ!,
+              priority: (i.priority as ModelPin["priority"]) ?? "MEDIUM",
+            }));
+          setPins(modelPins);
+        } catch (err) {
+          console.warn("[viewer] issues fetch failed", err);
+        }
+      } catch (err) {
+        setError(String(err));
+      }
+    })();
+  }, [projectId, id]);
+
+  function onPick(e: PickEvent) {
+    if (!e.meta) return;
+    const tag = e.meta.tag ?? e.name ?? e.guid.slice(0, 8);
+    Alert.alert(tag, [
+      e.meta.category && `Category: ${e.meta.category}`,
+      e.meta.discipline && `Discipline: ${e.meta.discipline}`,
+      e.meta.level && `Level: ${e.meta.level}`,
+    ].filter(Boolean).join("\n") || "No metadata available.");
+  }
+
+  function onPlaceIssue(e: PlaceIssueEvent) {
+    if (!projectId || !id) return;
+    router.push({
+      pathname: "/issues/new",
+      params: {
+        modelId: id,
+        modelElementGuid: e.guid,
+        modelX: String(e.point[0]),
+        modelY: String(e.point[1]),
+        modelZ: String(e.point[2]),
+        tag: e.meta?.tag ?? "",
+        category: e.meta?.category ?? "",
+        discipline: e.meta?.discipline ?? "",
+      },
+    });
+  }
+
+  function onPinTap(e: { issueId: string }) {
+    router.push(`/issues/${e.issueId}`);
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorTitle}>Couldn't load the model</Text>
+        <Text style={styles.errorBody}>{error}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ title: meta?.name ?? "Model", headerBackTitle: "Models" }} />
+      <View style={styles.flex}>
+        <ModelViewer
+          ref={viewerRef}
+          modelUrl={modelUrl}
+          elementMap={elementMap}
+          pins={pins}
+          onPick={onPick}
+          onPlaceIssue={onPlaceIssue}
+          onPinTap={onPinTap}
+          onMeasure={(m) => console.log("[viewer] distance", m.distance)}
+          onError={setError}
+        />
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: "#1a1a1a" },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 40 },
+  errorTitle: { fontSize: 18, fontWeight: "700", marginBottom: 8, color: "#d32f2f" },
+  errorBody: { color: "#666", textAlign: "center" },
+});

--- a/Planscape/app/models/_layout.tsx
+++ b/Planscape/app/models/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from "expo-router";
+
+export default function ModelsLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: true }}>
+      <Stack.Screen name="index" options={{ title: "3D models" }} />
+      <Stack.Screen name="[id]" options={{ title: "Viewer" }} />
+    </Stack>
+  );
+}

--- a/Planscape/app/models/index.tsx
+++ b/Planscape/app/models/index.tsx
@@ -1,0 +1,145 @@
+// MODEL-VIEWER — list of 3D models for the current project.
+
+import { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  RefreshControl,
+  Image,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { listModels, modelThumbnailUrl } from "@/api/models";
+import { useProjectStore } from "@/stores/projectStore";
+import type { ModelMeta } from "@/types/models";
+import { theme } from "@/utils/theme";
+import { t } from "@/i18n";
+
+export default function ModelsList() {
+  const router = useRouter();
+  const projectId = useProjectStore((s) => s.activeProjectId);
+  const [models, setModels] = useState<ModelMeta[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  async function load() {
+    if (!projectId) return;
+    try {
+      const rows = await listModels(projectId);
+      setModels(rows);
+    } catch (err) {
+      console.warn("[models] list failed:", err);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => { load(); }, [projectId]);
+
+  if (!projectId) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>Select a project first.</Text>
+      </View>
+    );
+  }
+  if (loading) {
+    return <View style={styles.empty}><ActivityIndicator /></View>;
+  }
+  if (models.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyTitle}>No models yet</Text>
+        <Text style={styles.emptyText}>
+          Publish a glTF/GLB from the Revit plugin ("Publish Model to Planscape")
+          or upload one from the web dashboard.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={models}
+      keyExtractor={(m) => m.id}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={() => { setRefreshing(true); load(); }} />
+      }
+      renderItem={({ item }) => (
+        <ModelRow
+          model={item}
+          projectId={projectId}
+          onPress={() => router.push(`/models/${item.id}`)}
+        />
+      )}
+      ItemSeparatorComponent={() => <View style={styles.sep} />}
+    />
+  );
+}
+
+function ModelRow({
+  model, projectId, onPress,
+}: { model: ModelMeta; projectId: string; onPress: () => void }) {
+  const [thumb, setThumb] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!model.hasThumbnail) return;
+    modelThumbnailUrl(projectId, model.id).then(setThumb);
+  }, [model.hasThumbnail, model.id, projectId]);
+
+  return (
+    <TouchableOpacity onPress={onPress} style={styles.row}>
+      <View style={styles.thumb}>
+        {thumb ? (
+          <Image source={{ uri: thumb }} style={styles.thumbImg} />
+        ) : (
+          <Text style={styles.thumbPlaceholder}>
+            {model.format === "Glb" || model.format === "Gltf" ? "🧊" : "📦"}
+          </Text>
+        )}
+      </View>
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={1}>{model.name}</Text>
+        <Text style={styles.subtitle} numberOfLines={1}>
+          {model.format} · {formatBytes(model.fileSizeBytes)}
+          {model.discipline ? ` · ${model.discipline}` : ""}
+          {model.revision ? ` · ${model.revision}` : ""}
+        </Text>
+        <Text style={styles.meta} numberOfLines={1}>
+          by {model.uploadedBy || "—"} · {formatDate(model.uploadedAt)}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString();
+  } catch { return iso; }
+}
+
+const styles = StyleSheet.create({
+  empty: { flex: 1, justifyContent: "center", alignItems: "center", padding: 40 },
+  emptyTitle: { fontSize: 18, fontWeight: "600", marginBottom: 8, color: "#333" },
+  emptyText: { color: "#666", textAlign: "center", fontSize: 14, lineHeight: 20 },
+  row: { flexDirection: "row", padding: 12, alignItems: "center", backgroundColor: "#fff" },
+  thumb: { width: 72, height: 72, borderRadius: 8, backgroundColor: "#eee", alignItems: "center", justifyContent: "center", overflow: "hidden" },
+  thumbImg: { width: "100%", height: "100%" },
+  thumbPlaceholder: { fontSize: 32 },
+  body: { flex: 1, marginLeft: 12 },
+  title: { fontSize: 15, fontWeight: "600", color: "#222" },
+  subtitle: { fontSize: 12, color: "#666", marginTop: 2 },
+  meta: { fontSize: 11, color: "#999", marginTop: 4 },
+  sep: { height: 1, backgroundColor: "#eee" },
+});

--- a/Planscape/assets/viewer/README.md
+++ b/Planscape/assets/viewer/README.md
@@ -1,0 +1,82 @@
+# Planscape 3D viewer assets
+
+`viewer.html` is the self-contained three.js viewer loaded inside a `<WebView>`
+by `src/components/ModelViewer.tsx`. It expects three.js + GLTFLoader +
+OrbitControls to live **next to** this README.
+
+## One-time setup (CI or local)
+
+Download the three.js UMD bundle and the two loaders that match. We pin r160
+to keep behaviour deterministic across devices:
+
+```bash
+cd Planscape/assets/viewer
+
+# 1. Three core (UMD, minified)
+curl -fsSL -o three.min.js         https://unpkg.com/three@0.160.0/build/three.min.js
+
+# 2. GLTFLoader (examples bundle, UMD shim)
+curl -fsSL -o GLTFLoader.js        https://unpkg.com/three@0.160.0/examples/js/loaders/GLTFLoader.js
+
+# 3. OrbitControls (examples bundle, UMD shim)
+curl -fsSL -o OrbitControls.js     https://unpkg.com/three@0.160.0/examples/js/controls/OrbitControls.js
+```
+
+(Alternative — if the team already mirrors three.js internally, set
+`VIEWER_ASSETS_URL` in CI and copy from there.)
+
+Commit the three files alongside `viewer.html`. They're ~700 KB total gzipped —
+tiny compared to a typical model. Shipping them as static assets keeps the
+viewer fully offline on site.
+
+## File layout
+
+```
+Planscape/assets/viewer/
+├── viewer.html            ← main page loaded by WebView
+├── three.min.js           ← three.js r160 UMD (fetch via curl above)
+├── GLTFLoader.js          ← examples/js/loaders
+├── OrbitControls.js       ← examples/js/controls
+└── README.md              ← this file
+```
+
+`viewer.html` gracefully degrades — if any of the three script files are
+missing, the viewer shows a friendly error instead of a blank screen.
+
+## Bridge protocol (RN ↔ WebView)
+
+`ModelViewer.tsx` posts JSON strings to the viewer; the viewer posts JSON
+strings back via `window.ReactNativeWebView.postMessage`.
+
+### RN → viewer commands
+
+| `type`            | `payload`                                                     |
+|-------------------|---------------------------------------------------------------|
+| `load`            | `{ url: string }`  load a glTF/GLB from the given URL        |
+| `elementMap`      | `{ map: { [guid]: { tag, name, category, discipline } } }`   |
+| `setTool`         | `{ tool: "pick" \| "measure" \| "section" \| "pin" }`        |
+| `fit`             | —                                                             |
+| `addPin`          | `{ id, x, y, z, priority }`                                   |
+| `setPins`         | `Pin[]`                                                       |
+| `clearPins`       | —                                                             |
+| `clearMeasure`    | —                                                             |
+| `clearHighlight`  | —                                                             |
+| `setDiscipline`   | `{ discipline: "M" \| "E" \| ..., visible: boolean }`         |
+| `setBackground`   | `{ color: number }`                                           |
+
+### Viewer → RN events
+
+| `type`          | `payload`                                                       |
+|-----------------|-----------------------------------------------------------------|
+| `ready`         | `{ platform: "webview" }`                                       |
+| `loaded`        | `{ elementCount, bounds: [minX..maxZ] }`                        |
+| `pick`          | `{ guid, point: [x,y,z], name, meta }`                          |
+| `placeIssue`    | `{ guid, meta, point: [x,y,z] }`  (long-press or pin tool)      |
+| `pinTap`        | `{ issueId, priority }`                                         |
+| `measure`       | `{ distance, points: [[x,y,z],[x,y,z]] }`                       |
+| `toolChanged`   | `{ tool }`                                                      |
+
+## Updating the viewer
+
+Edit `viewer.html` directly — no build step. Increment the version
+comment at the top if you want to bust the WebView cache on-device.

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -1,0 +1,477 @@
+<!--
+  MODEL-VIEWER — Self-contained three.js glTF viewer hosted in a WebView.
+
+  This page is loaded from the app bundle via `Asset.fromModule(...).uri`
+  and receives commands from React Native via window.addEventListener('message').
+  Two-way bridge — the page posts selection / measure / pin events back to RN
+  via window.ReactNativeWebView.postMessage(JSON.stringify(...)).
+
+  Features implemented inline (no build step):
+    - OrbitControls (touch: 1-finger rotate, 2-finger pan+zoom)
+    - GLB / glTF loading from a URL or data URI
+    - Element pick (raycast) — emits "pick" to RN
+    - Section plane (horizontal clip, slider-driven)
+    - Measure tool (two-tap distance in model units)
+    - Issue pins (billboards at XYZ, tap → emits "pinTap")
+    - Long-press → emits "placeIssue" with element GUID + XYZ
+    - Layer toggle (discipline → mesh visibility)
+
+  Dependencies are loaded from `./three.min.js`, `./GLTFLoader.js`, and
+  `./OrbitControls.js` next to this HTML. The build pipeline is responsible
+  for populating those files — the fetch script at the bottom of this file
+  tries each asset and logs a friendly error if any are missing.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover" />
+<title>Planscape 3D viewer</title>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #1a1a1a; overflow: hidden; }
+  canvas { display: block; touch-action: none; }
+
+  .hud {
+    position: absolute; top: 12px; left: 12px; right: 12px;
+    display: flex; justify-content: space-between; pointer-events: none;
+    font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,.6);
+  }
+  .hud .chip {
+    padding: 6px 10px; border-radius: 14px; background: rgba(0,0,0,0.55);
+    pointer-events: auto;
+  }
+  .status { font-size: 11px; opacity: .85; }
+
+  .toolbar {
+    position: absolute; bottom: 16px; left: 50%; transform: translateX(-50%);
+    display: flex; gap: 6px; padding: 6px;
+    background: rgba(0,0,0,0.55); border-radius: 28px;
+  }
+  .toolbar button {
+    width: 44px; height: 44px; border: 0; border-radius: 50%;
+    background: transparent; color: #fff; font-size: 18px;
+  }
+  .toolbar button.active { background: #E8912D; }
+  .toolbar button:active { opacity: .6; }
+
+  .section-slider {
+    position: absolute; right: 12px; top: 60px; bottom: 100px;
+    display: flex; flex-direction: column; align-items: center; gap: 8px;
+    pointer-events: auto;
+  }
+  .section-slider input { -webkit-appearance: slider-vertical; writing-mode: bt-lr;
+    width: 24px; height: 100%; }
+  .section-slider.hidden { display: none; }
+
+  .loading, .error {
+    position: absolute; inset: 0; display: flex;
+    align-items: center; justify-content: center;
+    color: #fff; background: rgba(0,0,0,.8); padding: 40px; text-align: center;
+  }
+  .error code { background: rgba(255,255,255,.1); padding: 2px 6px; border-radius: 4px; }
+</style>
+</head>
+<body>
+
+<div id="loading" class="loading">
+  <div><div style="font-weight:600">Loading model…</div>
+  <div id="loadingProgress" class="status">0%</div></div>
+</div>
+
+<div class="hud">
+  <div class="chip" id="elementChip" style="display:none"></div>
+  <div class="chip status" id="statusChip">ready</div>
+</div>
+
+<div class="section-slider hidden" id="sectionSlider">
+  <div style="color:#fff;font-size:11px">cut</div>
+  <input type="range" min="0" max="100" value="100" id="sectionRange" />
+</div>
+
+<div class="toolbar">
+  <button id="toolHome"    title="Fit view">⌂</button>
+  <button id="toolPick"    title="Pick element" class="active">⊙</button>
+  <button id="toolMeasure" title="Measure">↔</button>
+  <button id="toolSection" title="Section">⊟</button>
+  <button id="toolPin"     title="Drop pin">📍</button>
+</div>
+
+<!--
+  Three.js + loaders live next to this HTML. See assets/viewer/README.md for
+  how to populate these files. The viewer falls back gracefully when any are
+  missing so the rest of the app keeps working.
+-->
+<script src="./three.min.js"></script>
+<script src="./GLTFLoader.js"></script>
+<script src="./OrbitControls.js"></script>
+
+<script>
+(() => {
+  'use strict';
+
+  // ── RN bridge ───────────────────────────────────────────────────────
+  const bridge = {
+    send(type, payload) {
+      const msg = JSON.stringify({ type, payload });
+      if (window.ReactNativeWebView) window.ReactNativeWebView.postMessage(msg);
+      else console.log('[viewer→rn]', msg);
+    }
+  };
+  window.addEventListener('message', (ev) => {
+    try { handleCommand(JSON.parse(ev.data)); }
+    catch (err) { console.warn('[viewer] bad command:', ev.data, err); }
+  });
+  // Android delivers WebView→page messages on document.
+  document.addEventListener('message', (ev) => {
+    try { handleCommand(JSON.parse(ev.data)); }
+    catch (err) {}
+  });
+
+  if (typeof THREE === 'undefined') {
+    showError('three.js is missing from <code>assets/viewer/</code>. See the README alongside this file.');
+    return;
+  }
+
+  // ── Scene setup ─────────────────────────────────────────────────────
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x1a1a1a);
+
+  const hemi = new THREE.HemisphereLight(0xffffff, 0x404060, 0.9);
+  scene.add(hemi);
+  const dir = new THREE.DirectionalLight(0xffffff, 0.7);
+  dir.position.set(5, 10, 3);
+  scene.add(dir);
+  scene.add(new THREE.AmbientLight(0xffffff, 0.15));
+
+  const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.01, 10000);
+  camera.position.set(10, 10, 10);
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.localClippingEnabled = true;
+  document.body.appendChild(renderer.domElement);
+
+  const controls = new THREE.OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+
+  // Clip plane for section mode (disabled by default).
+  const clipPlane = new THREE.Plane(new THREE.Vector3(0, -1, 0), 0);
+  renderer.clippingPlanes = [];
+
+  // Pin group — always rendered on top.
+  const pinGroup = new THREE.Group();
+  pinGroup.renderOrder = 999;
+  scene.add(pinGroup);
+
+  const measureGroup = new THREE.Group();
+  scene.add(measureGroup);
+
+  let modelRoot = null;
+  let modelBounds = new THREE.Box3();
+  let elementMap = null;                // guid → { tag, name, category, discipline }
+  let pinMeta = new Map();               // mesh.uuid → { issueId, priority }
+  let measurePoints = [];
+  let activeTool = 'pick';               // 'pick' | 'measure' | 'section' | 'pin'
+  let lastPickEl = null;
+  let pressTimer = null;
+
+  // ── Loading ─────────────────────────────────────────────────────────
+  function loadModel(url) {
+    const loader = new THREE.GLTFLoader();
+    setStatus('loading');
+    document.getElementById('loading').style.display = 'flex';
+
+    loader.load(
+      url,
+      (gltf) => {
+        if (modelRoot) scene.remove(modelRoot);
+        modelRoot = gltf.scene;
+        assignElementIds(modelRoot);
+        scene.add(modelRoot);
+        modelBounds.setFromObject(modelRoot);
+        fitCamera();
+        document.getElementById('loading').style.display = 'none';
+        setStatus('loaded ' + countMeshes(modelRoot) + ' meshes');
+        bridge.send('loaded', { elementCount: countMeshes(modelRoot),
+                                bounds: bbToArray(modelBounds) });
+      },
+      (progress) => {
+        if (progress.total > 0) {
+          const pct = Math.round(progress.loaded / progress.total * 100);
+          document.getElementById('loadingProgress').textContent = pct + '%';
+        }
+      },
+      (err) => {
+        document.getElementById('loading').style.display = 'none';
+        showError('Failed to load model: ' + (err && err.message ? err.message : err));
+      }
+    );
+  }
+
+  function assignElementIds(root) {
+    // glTF exporters typically store the Revit GUID under userData.extras.guid
+    // or userData.name. Walk the tree and fall back to Object.uuid so every
+    // mesh has *some* stable id we can emit to RN.
+    root.traverse(obj => {
+      if (!obj.isMesh) return;
+      const g = obj.userData && (obj.userData.guid || (obj.userData.extras && obj.userData.extras.guid));
+      obj.userData.elementGuid = g || obj.uuid;
+    });
+  }
+
+  function fitCamera() {
+    if (modelBounds.isEmpty()) return;
+    const size = modelBounds.getSize(new THREE.Vector3());
+    const centre = modelBounds.getCenter(new THREE.Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z);
+    const dist = maxDim * 1.8;
+    camera.position.copy(centre).add(new THREE.Vector3(dist, dist * 0.8, dist));
+    controls.target.copy(centre);
+    controls.update();
+  }
+
+  // ── Interactions ────────────────────────────────────────────────────
+  const raycaster = new THREE.Raycaster();
+  const pointer = new THREE.Vector2();
+  let pointerDown = { x: 0, y: 0, t: 0 };
+
+  renderer.domElement.addEventListener('pointerdown', (e) => {
+    pointerDown = { x: e.clientX, y: e.clientY, t: Date.now() };
+    pressTimer = setTimeout(() => pressTimer = 'fired', 600);
+  });
+  renderer.domElement.addEventListener('pointerup', (e) => {
+    const moved = Math.hypot(e.clientX - pointerDown.x, e.clientY - pointerDown.y);
+    const duration = Date.now() - pointerDown.t;
+    const longPress = pressTimer === 'fired';
+    if (pressTimer) clearTimeout(pressTimer);
+    if (moved > 6) return;               // treat as an orbit / pan drag
+
+    setPointer(e);
+    const hits = raycast();
+    if (hits.length === 0) return;
+    const hit = hits[0];
+
+    if (longPress) {
+      emitPlaceIssue(hit);
+      return;
+    }
+    if (activeTool === 'pick')     emitPick(hit);
+    else if (activeTool === 'measure') addMeasurePoint(hit);
+    else if (activeTool === 'pin') emitPlaceIssue(hit);
+    else emitPick(hit);
+  });
+
+  function setPointer(ev) {
+    const rect = renderer.domElement.getBoundingClientRect();
+    pointer.x = ((ev.clientX - rect.left) / rect.width) * 2 - 1;
+    pointer.y = -((ev.clientY - rect.top) / rect.height) * 2 + 1;
+  }
+  function raycast() {
+    raycaster.setFromCamera(pointer, camera);
+    const targets = modelRoot ? [modelRoot, pinGroup] : [];
+    return raycaster.intersectObjects(targets, true);
+  }
+
+  function emitPick(hit) {
+    if (pinMeta.has(hit.object.uuid)) {
+      bridge.send('pinTap', pinMeta.get(hit.object.uuid));
+      return;
+    }
+    const guid = hit.object.userData.elementGuid;
+    lastPickEl = guid;
+    const meta = elementMap && elementMap[guid] ? elementMap[guid] : null;
+    bridge.send('pick', { guid, point: hit.point.toArray(), name: hit.object.name, meta });
+    const chip = document.getElementById('elementChip');
+    chip.textContent = meta && meta.tag ? meta.tag : (hit.object.name || guid.slice(0, 8));
+    chip.style.display = 'inline-block';
+    highlight(hit.object);
+  }
+
+  function emitPlaceIssue(hit) {
+    const guid = hit.object.userData.elementGuid;
+    const meta = elementMap && elementMap[guid] ? elementMap[guid] : null;
+    bridge.send('placeIssue', {
+      guid, meta, point: hit.point.toArray()
+    });
+  }
+
+  // ── Highlight ───────────────────────────────────────────────────────
+  let highlightedMesh = null, originalMat = null;
+  function highlight(mesh) {
+    if (highlightedMesh === mesh) return;
+    clearHighlight();
+    highlightedMesh = mesh;
+    originalMat = mesh.material;
+    mesh.material = new THREE.MeshStandardMaterial({
+      color: 0xE8912D, emissive: 0xE8912D, emissiveIntensity: 0.35,
+      transparent: false
+    });
+  }
+  function clearHighlight() {
+    if (highlightedMesh && originalMat) {
+      highlightedMesh.material = originalMat;
+    }
+    highlightedMesh = null; originalMat = null;
+    document.getElementById('elementChip').style.display = 'none';
+  }
+
+  // ── Measure tool ────────────────────────────────────────────────────
+  function addMeasurePoint(hit) {
+    const p = hit.point.clone();
+    measurePoints.push(p);
+    addMeasureMarker(p);
+    if (measurePoints.length === 2) {
+      const d = measurePoints[0].distanceTo(measurePoints[1]);
+      drawMeasureLine(measurePoints[0], measurePoints[1]);
+      bridge.send('measure', { distance: d, points: measurePoints.map(v => v.toArray()) });
+      setStatus('distance = ' + d.toFixed(3) + ' model-units');
+      measurePoints = [];
+    }
+  }
+  function addMeasureMarker(p) {
+    const sphere = new THREE.Mesh(
+      new THREE.SphereGeometry(0.1, 12, 12),
+      new THREE.MeshBasicMaterial({ color: 0xffcc00 })
+    );
+    sphere.position.copy(p);
+    measureGroup.add(sphere);
+  }
+  function drawMeasureLine(a, b) {
+    const g = new THREE.BufferGeometry().setFromPoints([a, b]);
+    const m = new THREE.LineBasicMaterial({ color: 0xffcc00, linewidth: 2 });
+    measureGroup.add(new THREE.Line(g, m));
+  }
+  function clearMeasure() {
+    while (measureGroup.children.length) measureGroup.remove(measureGroup.children[0]);
+    measurePoints = [];
+  }
+
+  // ── Section plane ───────────────────────────────────────────────────
+  function enableSection(enabled) {
+    if (enabled) {
+      const size = modelBounds.getSize(new THREE.Vector3());
+      const top = modelBounds.max.y;
+      clipPlane.constant = top;
+      renderer.clippingPlanes = [clipPlane];
+      const slider = document.getElementById('sectionRange');
+      slider.value = 100;
+      document.getElementById('sectionSlider').classList.remove('hidden');
+      slider.oninput = () => {
+        const frac = slider.value / 100;
+        const min = modelBounds.min.y, max = modelBounds.max.y;
+        clipPlane.constant = min + (max - min) * frac;
+      };
+    } else {
+      renderer.clippingPlanes = [];
+      document.getElementById('sectionSlider').classList.add('hidden');
+    }
+  }
+
+  // ── Pins ────────────────────────────────────────────────────────────
+  function addPin({ id, x, y, z, priority = 'MEDIUM' }) {
+    const color = priorityColor(priority);
+    const sprite = new THREE.Sprite(
+      new THREE.SpriteMaterial({ color, depthTest: false })
+    );
+    const scale = modelBounds.isEmpty() ? 1
+      : modelBounds.getSize(new THREE.Vector3()).length() * 0.015;
+    sprite.scale.set(scale, scale, scale);
+    sprite.position.set(x, y, z);
+    pinGroup.add(sprite);
+    pinMeta.set(sprite.uuid, { issueId: id, priority });
+  }
+  function clearPins() {
+    while (pinGroup.children.length) pinGroup.remove(pinGroup.children[0]);
+    pinMeta.clear();
+  }
+  function priorityColor(p) {
+    switch (p) {
+      case 'CRITICAL': return 0xD32F2F;
+      case 'HIGH':     return 0xF57C00;
+      case 'MEDIUM':   return 0xFBC02D;
+      case 'LOW':      return 0x7CB342;
+      default:         return 0x2196F3;
+    }
+  }
+
+  // ── Layers (discipline filter) ──────────────────────────────────────
+  function setDisciplineVisible(discipline, visible) {
+    if (!modelRoot || !elementMap) return;
+    modelRoot.traverse(obj => {
+      if (!obj.isMesh) return;
+      const guid = obj.userData.elementGuid;
+      const meta = elementMap[guid];
+      if (meta && meta.discipline === discipline) obj.visible = visible;
+    });
+  }
+
+  // ── Commands from RN ────────────────────────────────────────────────
+  function handleCommand(cmd) {
+    switch (cmd.type) {
+      case 'load':            loadModel(cmd.payload.url); break;
+      case 'elementMap':      elementMap = cmd.payload.map; break;
+      case 'setTool':         setTool(cmd.payload.tool); break;
+      case 'fit':             fitCamera(); break;
+      case 'clearMeasure':    clearMeasure(); break;
+      case 'clearHighlight':  clearHighlight(); break;
+      case 'addPin':          addPin(cmd.payload); break;
+      case 'setPins':         clearPins(); (cmd.payload || []).forEach(addPin); break;
+      case 'clearPins':       clearPins(); break;
+      case 'setDiscipline':   setDisciplineVisible(cmd.payload.discipline, cmd.payload.visible); break;
+      case 'setBackground':   scene.background = new THREE.Color(cmd.payload.color || 0x1a1a1a); break;
+    }
+  }
+
+  function setTool(t) {
+    activeTool = t;
+    for (const id of ['toolPick', 'toolMeasure', 'toolSection', 'toolPin']) {
+      document.getElementById(id).classList.remove('active');
+    }
+    const btn = { pick: 'toolPick', measure: 'toolMeasure',
+                  section: 'toolSection', pin: 'toolPin' }[t];
+    if (btn) document.getElementById(btn).classList.add('active');
+    enableSection(t === 'section');
+    if (t !== 'measure') clearMeasure();
+    bridge.send('toolChanged', { tool: t });
+  }
+
+  // Toolbar buttons.
+  document.getElementById('toolHome').addEventListener('click', () => { fitCamera(); clearHighlight(); });
+  document.getElementById('toolPick').addEventListener('click', () => setTool('pick'));
+  document.getElementById('toolMeasure').addEventListener('click', () => setTool('measure'));
+  document.getElementById('toolSection').addEventListener('click', () =>
+    setTool(activeTool === 'section' ? 'pick' : 'section'));
+  document.getElementById('toolPin').addEventListener('click', () => setTool('pin'));
+
+  // ── Resize + render loop ────────────────────────────────────────────
+  window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+  (function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+    renderer.render(scene, camera);
+  })();
+
+  // ── Utils ───────────────────────────────────────────────────────────
+  function setStatus(text) { document.getElementById('statusChip').textContent = text; }
+  function countMeshes(obj) { let n = 0; obj.traverse(o => { if (o.isMesh) n++; }); return n; }
+  function bbToArray(b) { return [b.min.x, b.min.y, b.min.z, b.max.x, b.max.y, b.max.z]; }
+  function showError(html) {
+    const el = document.createElement('div');
+    el.className = 'error';
+    el.innerHTML = html;
+    document.body.appendChild(el);
+  }
+
+  // Tell RN we're ready to receive a `load` command.
+  bridge.send('ready', { platform: 'webview' });
+})();
+</script>
+</body>
+</html>

--- a/Planscape/metro.config.js
+++ b/Planscape/metro.config.js
@@ -1,0 +1,25 @@
+// MODEL-VIEWER — teach Metro that .html and .js-as-asset files in
+// assets/viewer/ are bundled resources, not source modules.
+//
+// Without this:
+//   - `require("../../assets/viewer/viewer.html")` returns a weird module ref
+//   - three.min.js / GLTFLoader.js get tree-shaken as JS source
+
+const { getDefaultConfig } = require("expo/metro-config");
+
+const config = getDefaultConfig(__dirname);
+
+// Treat HTML + GLTF + GLB as static assets the bundler copies verbatim.
+// three.min.js and the loaders ship as sibling files under assets/viewer/
+// and are referenced from viewer.html via relative script tags — they do
+// NOT need to be in Metro's transformed JS source tree.
+config.resolver.assetExts = [
+  ...config.resolver.assetExts,
+  "html",
+  "gltf",
+  "glb",
+  "bin",
+  "ifc",
+];
+
+module.exports = config;

--- a/Planscape/package.json
+++ b/Planscape/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/native": "^7.0.0",
     "expo": "~52.0.0",
     "expo-application": "^55.0.14",
+    "expo-asset": "~11.0.0",
     "expo-camera": "~16.0.0",
     "expo-device": "~7.0.0",
     "expo-file-system": "^55.0.16",
@@ -38,6 +39,7 @@
     "react-native-reanimated": "~3.16.0",
     "react-native-safe-area-context": "4.14.0",
     "react-native-screens": "~4.4.0",
+    "react-native-webview": "13.12.5",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/Planscape/src/api/client.ts
+++ b/Planscape/src/api/client.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from 'expo-secure-store';
+import { getLanguage } from '../i18n';
 
 const TOKEN_KEY = 'planscape_token';
 const REFRESH_KEY = 'planscape_refresh';
@@ -95,6 +96,9 @@ export async function apiFetch<T>(
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+    // FLEX-15 — let the server pick the right translation for responses
+    // (errors, push payload text, email copy triggered by this request).
+    'X-Language': getLanguage(),
     ...(options.headers as Record<string, string>),
   };
 

--- a/Planscape/src/api/customFields.ts
+++ b/Planscape/src/api/customFields.ts
@@ -1,0 +1,56 @@
+// FLEX-13 — Custom-field schema client.
+//
+// End-user callers only need fetchSchema + the CustomFieldValues map. The
+// admin-only create/update/delete helpers are exported for the schema-editor
+// screen (which only project admins ever see).
+
+import { apiFetch } from "./client";
+import type { CustomFieldSchema } from "@/types/customFields";
+
+/** Fetch the active schema for a project (server filters DeletedAt/IsActive). */
+export async function fetchSchema(projectId: string): Promise<CustomFieldSchema[]> {
+  return apiFetch<CustomFieldSchema[]>(`/api/projects/${projectId}/custom-fields`);
+}
+
+// ── Admin-only ──────────────────────────────────────────────────────────
+
+export interface UpsertSchemaRequest {
+  key: string;
+  label: string;
+  fieldType: CustomFieldSchema["fieldType"];
+  helpText?: string;
+  defaultValueJson?: string | null;
+  optionsJson?: string | null;
+  required?: boolean;
+  sortOrder?: number;
+}
+
+export async function createField(projectId: string, req: UpsertSchemaRequest) {
+  return apiFetch<CustomFieldSchema>(`/api/projects/${projectId}/custom-fields`, {
+    method: "POST",
+    body: JSON.stringify(req),
+  });
+}
+
+export async function updateField(projectId: string, id: string, req: UpsertSchemaRequest) {
+  return apiFetch<CustomFieldSchema>(`/api/projects/${projectId}/custom-fields/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(req),
+  });
+}
+
+export async function deleteField(projectId: string, id: string) {
+  return apiFetch<void>(`/api/projects/${projectId}/custom-fields/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function reorderFields(
+  projectId: string,
+  items: { id: string; sortOrder: number }[]
+) {
+  return apiFetch<void>(`/api/projects/${projectId}/custom-fields/reorder`, {
+    method: "POST",
+    body: JSON.stringify({ items }),
+  });
+}

--- a/Planscape/src/api/models.ts
+++ b/Planscape/src/api/models.ts
@@ -1,0 +1,98 @@
+// MODEL-VIEWER — client for /api/projects/{id}/models endpoints.
+
+import { apiFetch, getBaseUrl, getToken } from "./client";
+import type { ModelMeta } from "@/types/models";
+
+export async function listModels(projectId: string): Promise<ModelMeta[]> {
+  return apiFetch<ModelMeta[]>(`/api/projects/${projectId}/models`);
+}
+
+export async function getModel(projectId: string, modelId: string): Promise<ModelMeta> {
+  return apiFetch<ModelMeta>(`/api/projects/${projectId}/models/${modelId}`);
+}
+
+/** URL (not a fetch) — pass into the WebView viewer with an Authorization header. */
+export async function modelFileUrl(projectId: string, modelId: string): Promise<string> {
+  const base = await getBaseUrl();
+  return `${base}/api/projects/${projectId}/models/${modelId}/file`;
+}
+
+export async function modelThumbnailUrl(projectId: string, modelId: string): Promise<string> {
+  const base = await getBaseUrl();
+  return `${base}/api/projects/${projectId}/models/${modelId}/thumbnail`;
+}
+
+export async function fetchElementMap(
+  projectId: string,
+  modelId: string
+): Promise<Record<string, unknown>> {
+  return apiFetch<Record<string, unknown>>(
+    `/api/projects/${projectId}/models/${modelId}/element-map`
+  );
+}
+
+export async function deleteModel(projectId: string, modelId: string): Promise<void> {
+  return apiFetch<void>(`/api/projects/${projectId}/models/${modelId}`, { method: "DELETE" });
+}
+
+/**
+ * Upload a glTF / GLB / IFC file. Element map + thumbnail are optional sidecars.
+ * Uses `fetch` directly (not `apiFetch`) because we send multipart, not JSON.
+ */
+export async function uploadModel(
+  projectId: string,
+  files: {
+    file: { uri: string; name: string; type?: string };
+    elementMap?: { uri: string; name: string; type?: string };
+    thumbnail?: { uri: string; name: string; type?: string };
+  },
+  meta: Partial<{
+    name: string;
+    description: string;
+    discipline: string;
+    elementCount: number;
+    units: string;
+    revision: string;
+    boundsMinX: number; boundsMinY: number; boundsMinZ: number;
+    boundsMaxX: number; boundsMaxY: number; boundsMaxZ: number;
+  }>
+): Promise<ModelMeta> {
+  const base = await getBaseUrl();
+  const token = await getToken();
+  const form = new FormData();
+
+  form.append("File", {
+    uri: files.file.uri,
+    name: files.file.name,
+    type: files.file.type ?? "application/octet-stream",
+  } as unknown as Blob);
+
+  if (files.elementMap) {
+    form.append("ElementMap", {
+      uri: files.elementMap.uri,
+      name: files.elementMap.name,
+      type: files.elementMap.type ?? "application/json",
+    } as unknown as Blob);
+  }
+  if (files.thumbnail) {
+    form.append("Thumbnail", {
+      uri: files.thumbnail.uri,
+      name: files.thumbnail.name,
+      type: files.thumbnail.type ?? "image/png",
+    } as unknown as Blob);
+  }
+  for (const [k, v] of Object.entries(meta)) {
+    if (v != null) form.append(k.charAt(0).toUpperCase() + k.slice(1), String(v));
+  }
+
+  const res = await fetch(`${base}/api/projects/${projectId}/models`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: form as unknown as BodyInit,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`uploadModel failed: ${res.status} ${body}`);
+  }
+  return res.json();
+}

--- a/Planscape/src/api/tenants.ts
+++ b/Planscape/src/api/tenants.ts
@@ -1,0 +1,61 @@
+// TENANT-SWITCH — API + SecureStore helpers for per-tenant tokens.
+//
+// Each tenant gets its own token + refresh token under a keyed SecureStore
+// entry: `planscape_token:{tenantId}`. This lets the user switch tenants
+// instantly without re-login (decision 3.2 = b) while keeping the bearer
+// tokens isolated — a leaked tenant-A token can't talk to tenant-B endpoints.
+
+import * as SecureStore from "expo-secure-store";
+import { apiFetch, setTokens } from "./client";
+import type { TenantMembership } from "@/stores/tenantStore";
+
+const TOKEN_PREFIX = "planscape_token:";
+const REFRESH_PREFIX = "planscape_refresh:";
+const ACTIVE_TENANT_KEY = "planscape_active_tenant";
+
+export async function fetchMemberships(): Promise<TenantMembership[]> {
+  return apiFetch<TenantMembership[]>("/api/auth/tenants");
+}
+
+export async function switchTenant(tenantId: string): Promise<{ token: string; refresh: string }> {
+  const response = await apiFetch<{ accessToken: string; refreshToken: string }>(
+    "/api/auth/switch-tenant",
+    {
+      method: "POST",
+      body: JSON.stringify({ tenantId }),
+    }
+  );
+  // Persist under the per-tenant key AND as the active tokens (client.ts reads
+  // those). Caller is expected to update zustand + flush/rehydrate the
+  // tenant-scoped stores (offline queue, saved filters) after this returns.
+  await persistTenantTokens(tenantId, response.accessToken, response.refreshToken);
+  await setTokens(response.accessToken, response.refreshToken);
+  await SecureStore.setItemAsync(ACTIVE_TENANT_KEY, tenantId);
+  return { token: response.accessToken, refresh: response.refreshToken };
+}
+
+export async function persistTenantTokens(tenantId: string, token: string, refresh: string) {
+  await SecureStore.setItemAsync(TOKEN_PREFIX + tenantId, token);
+  await SecureStore.setItemAsync(REFRESH_PREFIX + tenantId, refresh);
+}
+
+export async function loadTenantTokens(tenantId: string): Promise<{ token: string | null; refresh: string | null }> {
+  const token   = await SecureStore.getItemAsync(TOKEN_PREFIX + tenantId);
+  const refresh = await SecureStore.getItemAsync(REFRESH_PREFIX + tenantId);
+  return { token, refresh };
+}
+
+export async function getActiveTenantId(): Promise<string | null> {
+  return SecureStore.getItemAsync(ACTIVE_TENANT_KEY);
+}
+
+export async function setActiveTenantId(tenantId: string): Promise<void> {
+  await SecureStore.setItemAsync(ACTIVE_TENANT_KEY, tenantId);
+}
+
+/** Clear tenant-scoped tokens (e.g. after sign-out-of-all-tenants). */
+export async function clearAllTenantTokens(): Promise<void> {
+  // SecureStore has no "list keys" API — tenant IDs must be passed in. Callers
+  // should iterate `useTenantStore.memberships` before calling this.
+  await SecureStore.deleteItemAsync(ACTIVE_TENANT_KEY);
+}

--- a/Planscape/src/components/CustomFieldInput.tsx
+++ b/Planscape/src/components/CustomFieldInput.tsx
@@ -1,0 +1,223 @@
+// FLEX-13 — Dynamic renderer for a single custom field.
+//
+// Placement: decision 4.4 = (b) a collapsible "More fields" section below the
+// standard issue form. See <CustomFieldsSection /> below for the wrapper.
+
+import { useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Switch,
+  ScrollView,
+  Platform,
+} from "react-native";
+import type { CustomFieldSchema, CustomFieldValues } from "@/types/customFields";
+import { parseOptions } from "@/types/customFields";
+
+interface Props {
+  schema: CustomFieldSchema;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}
+
+export function CustomFieldInput({ schema, value, onChange }: Props) {
+  return (
+    <View style={{ marginBottom: 16 }}>
+      <Text style={{ fontSize: 12, color: "#555", marginBottom: 4, textTransform: "uppercase", letterSpacing: 0.5 }}>
+        {schema.label}
+        {schema.required ? " *" : ""}
+      </Text>
+      {renderControl(schema, value, onChange)}
+      {schema.helpText && (
+        <Text style={{ fontSize: 11, color: "#888", marginTop: 4 }}>{schema.helpText}</Text>
+      )}
+    </View>
+  );
+}
+
+function renderControl(schema: CustomFieldSchema, value: unknown, onChange: (v: unknown) => void) {
+  switch (schema.fieldType) {
+    case "Text":
+      return (
+        <TextInput
+          value={asString(value)}
+          onChangeText={onChange}
+          style={baseInputStyle}
+        />
+      );
+    case "TextArea":
+      return (
+        <TextInput
+          value={asString(value)}
+          onChangeText={onChange}
+          multiline
+          numberOfLines={4}
+          textAlignVertical="top"
+          style={{ ...baseInputStyle, height: 88 }}
+        />
+      );
+    case "Number":
+      return (
+        <TextInput
+          value={asString(value)}
+          onChangeText={(t) => onChange(t === "" ? null : Number(t))}
+          keyboardType="decimal-pad"
+          style={baseInputStyle}
+        />
+      );
+    case "Date":
+      // Lightweight text input — swap for @react-native-community/datetimepicker
+      // on the admin screen when required. Keeps this component dependency-free.
+      return (
+        <TextInput
+          value={asString(value)}
+          onChangeText={onChange}
+          placeholder={Platform.OS === "ios" ? "YYYY-MM-DD" : "YYYY-MM-DD"}
+          style={baseInputStyle}
+        />
+      );
+    case "Boolean":
+      return (
+        <Switch value={!!value} onValueChange={onChange} />
+      );
+    case "Dropdown":
+      return <SelectControl schema={schema} value={value} onChange={onChange} multi={false} />;
+    case "MultiSelect":
+      return <SelectControl schema={schema} value={value} onChange={onChange} multi />;
+    case "UserPicker":
+      // v1 stub — prompts for email. Admin screen will wire an in-app picker later.
+      return (
+        <TextInput
+          value={asString(value)}
+          onChangeText={onChange}
+          placeholder="user@example.com"
+          autoCapitalize="none"
+          keyboardType="email-address"
+          style={baseInputStyle}
+        />
+      );
+    case "ElementReference":
+      // v1 stub — ISO 19650 tag text. Scanner flow can pre-populate via OCR.
+      return (
+        <TextInput
+          value={asString(value)}
+          onChangeText={onChange}
+          placeholder="M-BLD1-Z01-L01-HVAC-SUP-AHU-0001"
+          autoCapitalize="characters"
+          style={{ ...baseInputStyle, fontFamily: "monospace" }}
+        />
+      );
+    default:
+      return <Text style={{ color: "#999" }}>Unsupported type: {schema.fieldType}</Text>;
+  }
+}
+
+function SelectControl({
+  schema, value, onChange, multi,
+}: {
+  schema: CustomFieldSchema;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  multi: boolean;
+}) {
+  const options = parseOptions(schema.optionsJson);
+  const current: string[] = multi
+    ? Array.isArray(value) ? value.map(String) : []
+    : value == null ? [] : [String(value)];
+
+  function toggle(v: string) {
+    if (multi) {
+      onChange(current.includes(v) ? current.filter((x) => x !== v) : [...current, v]);
+    } else {
+      onChange(current[0] === v ? null : v);
+    }
+  }
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <View style={{ flexDirection: "row", gap: 6 }}>
+        {options.map((opt) => {
+          const selected = current.includes(opt.value);
+          return (
+            <TouchableOpacity
+              key={opt.value}
+              onPress={() => toggle(opt.value)}
+              style={{
+                paddingHorizontal: 12,
+                paddingVertical: 8,
+                borderRadius: 16,
+                backgroundColor: selected ? "#E8912D" : "#f0f0f0",
+              }}
+            >
+              <Text style={{ color: selected ? "#fff" : "#333", fontSize: 13, fontWeight: "500" }}>
+                {opt.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+}
+
+// ── Public: collapsible wrapper ─────────────────────────────────────────
+
+export function CustomFieldsSection({
+  schemas,
+  values,
+  onChange,
+  initiallyOpen = false,
+}: {
+  schemas: CustomFieldSchema[];
+  values: CustomFieldValues;
+  onChange: (v: CustomFieldValues) => void;
+  initiallyOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(initiallyOpen);
+  if (schemas.length === 0) return null;
+
+  return (
+    <View style={{ marginTop: 16 }}>
+      <TouchableOpacity
+        onPress={() => setOpen(!open)}
+        style={{ flexDirection: "row", alignItems: "center", paddingVertical: 8 }}
+      >
+        <Text style={{ fontSize: 14, fontWeight: "600", color: "#333" }}>
+          {open ? "▼" : "▶"} More fields ({schemas.length})
+        </Text>
+      </TouchableOpacity>
+      {open && (
+        <View style={{ paddingTop: 12 }}>
+          {schemas.map((s) => (
+            <CustomFieldInput
+              key={s.id}
+              schema={s}
+              value={values[s.key]}
+              onChange={(v) => onChange({ ...values, [s.key]: v })}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ── Shared styles/helpers ───────────────────────────────────────────────
+
+const baseInputStyle = {
+  borderWidth: 1,
+  borderColor: "#ddd",
+  borderRadius: 6,
+  padding: 10,
+  fontSize: 15,
+};
+
+function asString(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "true" : "false";
+  try { return JSON.stringify(value); } catch { return String(value); }
+}

--- a/Planscape/src/components/ModelViewer.tsx
+++ b/Planscape/src/components/ModelViewer.tsx
@@ -1,0 +1,201 @@
+// MODEL-VIEWER — WebView-hosted three.js viewer + RN bridge.
+//
+// Hosts `assets/viewer/viewer.html` in a WebView, posts commands to load the
+// model + element map, and emits typed events back to RN (`onPick`,
+// `onPlaceIssue`, `onMeasure`, `onPinTap`). Zero native-module dependencies —
+// ships in Expo Go as soon as `react-native-webview` is installed.
+//
+// Usage:
+//
+//   <ModelViewer
+//     modelUrl={url}
+//     elementMap={map}
+//     pins={pins}
+//     onPick={(e)        => console.log("picked", e.guid)}
+//     onPlaceIssue={(e)  => openIssueModal(e)}
+//     onPinTap={(e)      => navigate(`/issues/${e.issueId}`)}
+//     onMeasure={(e)     => console.log("distance", e.distance)}
+//   />
+
+import React, { useEffect, useRef, useState } from "react";
+import { StyleSheet, View, ActivityIndicator, Text, Platform } from "react-native";
+import { WebView, WebViewMessageEvent } from "react-native-webview";
+import { Asset } from "expo-asset";
+import type { ElementMap, ModelPin, ViewerTool } from "@/types/models";
+
+export interface ModelViewerHandle {
+  setTool: (tool: ViewerTool) => void;
+  fit: () => void;
+  clearMeasure: () => void;
+  clearHighlight: () => void;
+  setDisciplineVisible: (discipline: string, visible: boolean) => void;
+  setPins: (pins: ModelPin[]) => void;
+  addPin: (pin: ModelPin) => void;
+  clearPins: () => void;
+  setBackground: (color: number) => void;
+}
+
+interface ModelViewerProps {
+  /**
+   * URL the WebView should fetch to load the glTF/GLB. Include an auth
+   * token in the URL if your server endpoint requires it — WebView doesn't
+   * forward the app's Authorization header automatically.
+   */
+  modelUrl?: string;
+  /** Optional element metadata keyed by GUID. */
+  elementMap?: ElementMap;
+  /** Pins to show at XYZ positions in model space. */
+  pins?: ModelPin[];
+  /** Initial tool. Default "pick". */
+  initialTool?: ViewerTool;
+
+  onReady?: () => void;
+  onLoaded?: (meta: { elementCount: number; bounds: number[] }) => void;
+  onPick?: (e: PickEvent) => void;
+  onPlaceIssue?: (e: PlaceIssueEvent) => void;
+  onPinTap?: (e: { issueId: string; priority?: string }) => void;
+  onMeasure?: (e: { distance: number; points: number[][] }) => void;
+  onToolChanged?: (tool: ViewerTool) => void;
+  onError?: (err: string) => void;
+}
+
+export interface PickEvent {
+  guid: string;
+  point: [number, number, number];
+  name?: string;
+  meta?: ElementMap[string] | null;
+}
+export interface PlaceIssueEvent {
+  guid: string;
+  point: [number, number, number];
+  meta?: ElementMap[string] | null;
+}
+
+const VIEWER_ASSET = require("../../assets/viewer/viewer.html");
+
+export const ModelViewer = React.forwardRef<ModelViewerHandle, ModelViewerProps>(
+  function ModelViewer(props, ref) {
+    const webRef = useRef<WebView>(null);
+    const [localUri, setLocalUri] = useState<string | null>(null);
+    const [isReady, setIsReady] = useState(false);
+
+    // Resolve the bundled viewer.html to a file:// URI the WebView can load.
+    useEffect(() => {
+      let mounted = true;
+      (async () => {
+        const asset = Asset.fromModule(VIEWER_ASSET);
+        await asset.downloadAsync();
+        if (mounted) setLocalUri(asset.localUri ?? asset.uri);
+      })();
+      return () => { mounted = false; };
+    }, []);
+
+    // Drain queued commands once the viewer says it's ready.
+    useEffect(() => {
+      if (!isReady || !webRef.current) return;
+      if (props.modelUrl) {
+        send({ type: "load", payload: { url: props.modelUrl } });
+      }
+      if (props.elementMap) {
+        send({ type: "elementMap", payload: { map: props.elementMap } });
+      }
+      if (props.pins) {
+        send({ type: "setPins", payload: props.pins });
+      }
+      if (props.initialTool) {
+        send({ type: "setTool", payload: { tool: props.initialTool } });
+      }
+    }, [isReady, props.modelUrl]);
+
+    // Keep pins + element map in sync when they change post-ready.
+    useEffect(() => {
+      if (!isReady) return;
+      if (props.elementMap) send({ type: "elementMap", payload: { map: props.elementMap } });
+    }, [isReady, props.elementMap]);
+    useEffect(() => {
+      if (!isReady) return;
+      if (props.pins) send({ type: "setPins", payload: props.pins });
+    }, [isReady, props.pins]);
+
+    function send(cmd: { type: string; payload?: unknown }) {
+      const json = JSON.stringify(cmd).replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+      // Both platforms — iOS WebView listens on window, Android on document.
+      const js = `
+        (function() {
+          var msg = '${json}';
+          try { window.dispatchEvent(new MessageEvent('message', { data: msg })); } catch(e) {}
+          try { document.dispatchEvent(new MessageEvent('message', { data: msg })); } catch(e) {}
+        })();
+        true;
+      `;
+      webRef.current?.injectJavaScript(js);
+    }
+
+    React.useImperativeHandle(ref, () => ({
+      setTool: (tool) => send({ type: "setTool", payload: { tool } }),
+      fit: () => send({ type: "fit" }),
+      clearMeasure: () => send({ type: "clearMeasure" }),
+      clearHighlight: () => send({ type: "clearHighlight" }),
+      setDisciplineVisible: (discipline, visible) =>
+        send({ type: "setDiscipline", payload: { discipline, visible } }),
+      setPins: (pins) => send({ type: "setPins", payload: pins }),
+      addPin: (pin) => send({ type: "addPin", payload: pin }),
+      clearPins: () => send({ type: "clearPins" }),
+      setBackground: (color) => send({ type: "setBackground", payload: { color } }),
+    }));
+
+    function onMessage(ev: WebViewMessageEvent) {
+      let msg: { type: string; payload?: any };
+      try { msg = JSON.parse(ev.nativeEvent.data); } catch { return; }
+      switch (msg.type) {
+        case "ready":        setIsReady(true); props.onReady?.(); break;
+        case "loaded":       props.onLoaded?.(msg.payload); break;
+        case "pick":         props.onPick?.(msg.payload); break;
+        case "placeIssue":   props.onPlaceIssue?.(msg.payload); break;
+        case "pinTap":       props.onPinTap?.(msg.payload); break;
+        case "measure":      props.onMeasure?.(msg.payload); break;
+        case "toolChanged":  props.onToolChanged?.(msg.payload?.tool); break;
+      }
+    }
+
+    if (!localUri) {
+      return (
+        <View style={styles.center}>
+          <ActivityIndicator />
+          <Text style={styles.hint}>Preparing viewer…</Text>
+        </View>
+      );
+    }
+
+    return (
+      <View style={styles.flex}>
+        <WebView
+          ref={webRef}
+          source={{ uri: localUri }}
+          // Android can't load file:// images from other file:// URLs without this.
+          allowFileAccessFromFileURLs
+          allowUniversalAccessFromFileURLs
+          allowsInlineMediaPlayback
+          mediaPlaybackRequiresUserAction={false}
+          originWhitelist={["*"]}
+          javaScriptEnabled
+          domStorageEnabled
+          onMessage={onMessage}
+          onError={(e) => props.onError?.(e.nativeEvent.description)}
+          // iOS has its own inertia that fights with OrbitControls.
+          scrollEnabled={false}
+          bounces={false}
+          // Keep touch events coming even while RN list views scroll.
+          nestedScrollEnabled
+          style={styles.flex}
+        />
+      </View>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: "#1a1a1a" },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: "#1a1a1a" },
+  hint: { color: "#ddd", marginTop: 8, fontSize: 13 },
+});

--- a/Planscape/src/components/OcrConfirmModal.tsx
+++ b/Planscape/src/components/OcrConfirmModal.tsx
@@ -1,0 +1,103 @@
+// FLEX-15-OCR — "Did you mean?" confirmation UI for low-confidence OCR extractions.
+//
+// Shown when OCR returns a result below AUTO_APPLY_CONFIDENCE (0.9). Users can
+// edit each field before applying, or dismiss entirely and keep their manual
+// entry.
+
+import { useState } from "react";
+import { Modal, View, Text, TextInput, TouchableOpacity, ScrollView } from "react-native";
+import type { OcrExtraction } from "@/services/ocr";
+import { t } from "@/i18n";
+
+interface Props {
+  visible: boolean;
+  extraction: OcrExtraction | null;
+  onApply: (fields: Partial<OcrFields>) => void;
+  onCancel: () => void;
+}
+
+export interface OcrFields {
+  isoTag?: string;
+  drawingNumber?: string;
+  serialNumber?: string;
+  manufacturerModel?: string;
+}
+
+export function OcrConfirmModal({ visible, extraction, onApply, onCancel }: Props) {
+  const [fields, setFields] = useState<OcrFields>({});
+
+  // Re-seed fields each time a new extraction comes in.
+  if (extraction && Object.keys(fields).length === 0) {
+    setFields({
+      isoTag: extraction.isoTag,
+      drawingNumber: extraction.drawingNumber,
+      serialNumber: extraction.serialNumber,
+      manufacturerModel: extraction.manufacturerModel,
+    });
+  }
+
+  if (!extraction) return null;
+
+  const confidencePct = Math.round(extraction.extractionConfidence * 100);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
+      <View style={{ flex: 1, justifyContent: "flex-end", backgroundColor: "rgba(0,0,0,0.5)" }}>
+        <View style={{ backgroundColor: "#fff", borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 20, maxHeight: "80%" }}>
+          <ScrollView>
+            <Text style={{ fontSize: 18, fontWeight: "700", marginBottom: 4 }}>
+              {t("common.edit")} — OCR ({confidencePct}%)
+            </Text>
+            <Text style={{ color: "#666", marginBottom: 20, fontSize: 13 }}>
+              {confidencePct < 70
+                ? "Confidence is low — please check each field before applying."
+                : "Review and adjust the auto-detected fields below."}
+            </Text>
+
+            <Field label="ISO 19650 tag"       value={fields.isoTag}            onChange={v => setFields({ ...fields, isoTag: v })} />
+            <Field label="Drawing number"      value={fields.drawingNumber}     onChange={v => setFields({ ...fields, drawingNumber: v })} />
+            <Field label="Serial number"       value={fields.serialNumber}      onChange={v => setFields({ ...fields, serialNumber: v })} />
+            <Field label="Manufacturer / model" value={fields.manufacturerModel} onChange={v => setFields({ ...fields, manufacturerModel: v })} />
+
+            <View style={{ flexDirection: "row", marginTop: 20, gap: 12 }}>
+              <TouchableOpacity
+                onPress={onCancel}
+                style={{ flex: 1, padding: 14, borderRadius: 8, backgroundColor: "#eee", alignItems: "center" }}
+              >
+                <Text style={{ fontWeight: "600" }}>{t("common.cancel")}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => onApply(fields)}
+                style={{ flex: 1, padding: 14, borderRadius: 8, backgroundColor: "#E8912D", alignItems: "center" }}
+              >
+                <Text style={{ fontWeight: "700", color: "#fff" }}>{t("common.save")}</Text>
+              </TouchableOpacity>
+            </View>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function Field({ label, value, onChange }: { label: string; value?: string; onChange: (v: string) => void }) {
+  return (
+    <View style={{ marginBottom: 16 }}>
+      <Text style={{ fontSize: 12, color: "#555", marginBottom: 4, textTransform: "uppercase", letterSpacing: 0.5 }}>{label}</Text>
+      <TextInput
+        value={value ?? ""}
+        onChangeText={onChange}
+        autoCapitalize="characters"
+        placeholder="—"
+        style={{
+          borderWidth: 1,
+          borderColor: "#ddd",
+          borderRadius: 6,
+          padding: 10,
+          fontSize: 15,
+          fontFamily: "monospace",
+        }}
+      />
+    </View>
+  );
+}

--- a/Planscape/src/components/TenantSwitcher.tsx
+++ b/Planscape/src/components/TenantSwitcher.tsx
@@ -1,0 +1,180 @@
+// TENANT-SWITCH — Adaptive tenant switcher.
+//
+//   0 memberships → returns null (UI is hidden)
+//   1 membership  → badge with tenant name, non-interactive
+//   2-5           → badge opens an inline modal list
+//   6+            → badge opens a searchable modal
+
+import { useState } from "react";
+import {
+  View,
+  Text,
+  Modal,
+  TouchableOpacity,
+  FlatList,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { useTenantStore } from "@/stores/tenantStore";
+import { switchTenant } from "@/api/tenants";
+import { pendingCount, clearQueue } from "@/utils/offlineQueue";
+import { t } from "@/i18n";
+
+export function TenantSwitcher() {
+  const presentation = useTenantStore((s) => s.presentation());
+  const memberships = useTenantStore((s) => s.memberships);
+  const currentId = useTenantStore((s) => s.currentTenantId);
+  const setCurrent = useTenantStore((s) => s.setCurrentTenant);
+
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [switching, setSwitching] = useState(false);
+
+  if (presentation === "hidden") return null;
+
+  const current = memberships.find((m) => m.tenantId === currentId);
+  const filtered = search
+    ? memberships.filter((m) =>
+        m.tenantName.toLowerCase().includes(search.toLowerCase())
+      )
+    : memberships;
+
+  async function handlePick(tenantId: string) {
+    if (tenantId === currentId) {
+      setOpen(false);
+      return;
+    }
+    // Mid-switch safety (decision 3.3) — drain / warn on queued actions.
+    const pending = await pendingCount();
+    if (pending > 0) {
+      const proceed = await new Promise<boolean>((resolve) => {
+        Alert.alert(
+          t("common.offline"),
+          `${pending} actions still queued for the current organisation. Switch anyway? (pending actions will be cleared)`,
+          [
+            { text: t("common.cancel"), onPress: () => resolve(false), style: "cancel" },
+            { text: t("common.save"), onPress: () => resolve(true) },
+          ]
+        );
+      });
+      if (!proceed) return;
+    }
+
+    setSwitching(true);
+    try {
+      await switchTenant(tenantId);
+      setCurrent(tenantId);
+      // Tenant-scoped caches: clear the queue so we don't replay actions
+      // belonging to the previous organisation against the new one. Saved
+      // filters are keyed by projectId so they refresh naturally when the
+      // project list reloads.
+      await clearQueue();
+      setOpen(false);
+    } catch (err) {
+      Alert.alert("Switch failed", String(err));
+    } finally {
+      setSwitching(false);
+    }
+  }
+
+  return (
+    <>
+      <TouchableOpacity
+        onPress={() => memberships.length > 1 && setOpen(true)}
+        disabled={memberships.length <= 1}
+        style={{
+          paddingHorizontal: 10,
+          paddingVertical: 6,
+          borderRadius: 14,
+          backgroundColor: "rgba(255,255,255,0.15)",
+          flexDirection: "row",
+          alignItems: "center",
+          maxWidth: 180,
+        }}
+      >
+        <Text
+          numberOfLines={1}
+          style={{ color: "#fff", fontSize: 13, fontWeight: "600" }}
+        >
+          {current?.tenantName ?? "…"}
+        </Text>
+        {memberships.length > 1 && (
+          <Text style={{ color: "#fff", marginLeft: 6, fontSize: 13 }}>▾</Text>
+        )}
+      </TouchableOpacity>
+
+      <Modal visible={open} transparent animationType="slide" onRequestClose={() => setOpen(false)}>
+        <View style={{ flex: 1, backgroundColor: "rgba(0,0,0,0.5)", justifyContent: "flex-end" }}>
+          <View style={{ backgroundColor: "#fff", borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 20, maxHeight: "80%" }}>
+            <Text style={{ fontSize: 18, fontWeight: "700", marginBottom: 16 }}>
+              Switch organisation
+            </Text>
+
+            {presentation === "search" && (
+              <TextInput
+                value={search}
+                onChangeText={setSearch}
+                placeholder="Search organisations"
+                autoFocus
+                style={{
+                  borderWidth: 1,
+                  borderColor: "#ddd",
+                  borderRadius: 8,
+                  padding: 10,
+                  marginBottom: 12,
+                  fontSize: 15,
+                }}
+              />
+            )}
+
+            {switching ? (
+              <ActivityIndicator size="large" style={{ padding: 32 }} />
+            ) : (
+              <FlatList
+                data={filtered}
+                keyExtractor={(m) => m.tenantId}
+                ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: "#eee" }} />}
+                renderItem={({ item }) => (
+                  <TouchableOpacity
+                    onPress={() => handlePick(item.tenantId)}
+                    style={{
+                      paddingVertical: 14,
+                      flexDirection: "row",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                    }}
+                  >
+                    <View style={{ flex: 1 }}>
+                      <Text style={{ fontSize: 15, fontWeight: "600" }}>{item.tenantName}</Text>
+                      <Text style={{ fontSize: 12, color: "#666", marginTop: 2 }}>
+                        {item.tenantTier} · {item.role}
+                        {item.mimEnabled ? " · MIM" : ""}
+                      </Text>
+                    </View>
+                    {item.tenantId === currentId && (
+                      <Text style={{ fontSize: 14, color: "#E8912D", fontWeight: "700" }}>✓</Text>
+                    )}
+                  </TouchableOpacity>
+                )}
+              />
+            )}
+
+            <TouchableOpacity
+              onPress={() => setOpen(false)}
+              style={{
+                marginTop: 16,
+                padding: 12,
+                backgroundColor: "#eee",
+                borderRadius: 8,
+                alignItems: "center",
+              }}
+            >
+              <Text style={{ fontWeight: "600" }}>{t("common.close")}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}

--- a/Planscape/src/i18n/README.md
+++ b/Planscape/src/i18n/README.md
@@ -1,0 +1,46 @@
+# Mobile i18n (FLEX-15)
+
+Tiny, zero-dependency translation helper. Swap for `i18next` later if ICU
+message-format / pluralisation / namespaces are needed — the public API
+(`t`, `useT`, `setLanguage`, `getLanguage`) matches the common shape.
+
+## Usage
+
+```tsx
+import { t, useT, setLanguage, initI18n } from "@/i18n";
+
+// App bootstrap (once, before the first render)
+await initI18n();
+
+// Plain call — safe anywhere, including outside React.
+label = t("common.save");
+badge = t("issue.days_open", { n: 3 });
+
+// Reactive hook — component re-renders when setLanguage() is called.
+const translate = useT();
+const title = translate("tabs.issues");
+
+// Let the user change language from a settings screen.
+await setLanguage("de");
+```
+
+## Adding a new language
+
+1. Copy `locales/en.json` to `locales/<code>.json` (e.g. `fr.json`).
+2. Translate the string values. Leave untranslated keys out — the helper
+   falls back to English automatically.
+3. Add the import in `src/i18n/index.ts`:
+   ```ts
+   import fr from "./locales/fr.json";
+   const BUNDLES: Record<string, Bundle> = { en, de, es, fr };
+   ```
+4. (Optional) Add a matching `I18n/fr.json` on the server so server-generated
+   strings (emails, push notifications, validation errors) also translate.
+
+## Server-side companion
+
+- `GET /api/i18n` — list of supported languages + resolved language for the caller.
+- `GET /api/i18n/{lang}` — full translation bundle (mobile prefetch).
+- Pass the current language back to the server via the `X-Language` request header;
+  `LocaleMiddleware` honours it before falling back to `Accept-Language` or
+  the tenant's default language.

--- a/Planscape/src/i18n/index.ts
+++ b/Planscape/src/i18n/index.ts
@@ -1,0 +1,128 @@
+// FLEX-15 — Mobile translation helper. Zero runtime dependencies on purpose — swap
+// the underlying store for i18next/react-intl/etc later without changing any caller.
+//
+// Usage:
+//   import { t, setLanguage, useT } from "@/i18n";
+//   t("common.save")                         → "Save"
+//   t("issue.days_open", { n: 3 })           → "3 days open"
+//   useT("tabs.home")                        → re-renders when setLanguage() runs
+//
+// Bundled locales ship with the app (see locales/*.json). At first start the
+// wrapper falls back through:
+//   AsyncStorage["planscape.language"]  →  device locale  →  "en"
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { NativeModules, Platform } from "react-native";
+import { useEffect, useState } from "react";
+
+import en from "./locales/en.json";
+import de from "./locales/de.json";
+import es from "./locales/es.json";
+
+type Bundle = Record<string, any>;
+
+const BUNDLES: Record<string, Bundle> = { en, de, es };
+const FALLBACK = "en";
+const STORAGE_KEY = "planscape.language";
+
+let currentLanguage: string = FALLBACK;
+const listeners = new Set<(lang: string) => void>();
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+export async function initI18n(): Promise<string> {
+  try {
+    const stored = await AsyncStorage.getItem(STORAGE_KEY);
+    if (stored && BUNDLES[stored]) {
+      currentLanguage = stored;
+      return stored;
+    }
+  } catch { /* AsyncStorage unavailable — fall through */ }
+
+  const deviceLang = detectDeviceLanguage();
+  if (BUNDLES[deviceLang]) {
+    currentLanguage = deviceLang;
+  }
+  return currentLanguage;
+}
+
+export async function setLanguage(lang: string): Promise<void> {
+  const normalised = normaliseLanguage(lang);
+  if (!BUNDLES[normalised]) {
+    console.warn(`[i18n] unsupported language "${lang}" — keeping "${currentLanguage}"`);
+    return;
+  }
+  currentLanguage = normalised;
+  try { await AsyncStorage.setItem(STORAGE_KEY, normalised); } catch { /* ignore */ }
+  listeners.forEach(fn => fn(normalised));
+}
+
+export function getLanguage(): string { return currentLanguage; }
+
+export function supportedLanguages(): string[] { return Object.keys(BUNDLES); }
+
+/**
+ * Translate a dotted key with optional parameter substitution.
+ * Unknown keys return the literal key so missing translations are visible in dev.
+ */
+export function t(key: string, vars?: Record<string, string | number>): string {
+  const bundle = BUNDLES[currentLanguage] ?? BUNDLES[FALLBACK];
+  const fallbackBundle = BUNDLES[FALLBACK];
+
+  const value = lookup(bundle, key) ?? lookup(fallbackBundle, key) ?? key;
+  if (!vars) return value;
+
+  return value.replace(/\{([A-Za-z0-9_]+)\}/g, (_, name) => {
+    const v = vars[name];
+    return v == null ? `{${name}}` : String(v);
+  });
+}
+
+/** Hook variant — re-renders when the active language changes. */
+export function useT(key?: string, vars?: Record<string, string | number>) {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    const fn = () => tick(n => n + 1);
+    listeners.add(fn);
+    return () => { listeners.delete(fn); };
+  }, []);
+  return key == null ? t : t(key, vars);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function lookup(bundle: Bundle, key: string): string | null {
+  let node: any = bundle;
+  for (const segment of key.split(".")) {
+    if (node == null || typeof node !== "object") return null;
+    node = node[segment];
+  }
+  return typeof node === "string" ? node : null;
+}
+
+function normaliseLanguage(lang: string): string {
+  if (!lang) return FALLBACK;
+  const code = lang.toLowerCase().trim();
+  if (BUNDLES[code]) return code;
+  const dash = code.indexOf("-");
+  if (dash > 0) {
+    const prefix = code.substring(0, dash);
+    if (BUNDLES[prefix]) return prefix;
+  }
+  return FALLBACK;
+}
+
+function detectDeviceLanguage(): string {
+  try {
+    const candidate: string | undefined =
+      Platform.OS === "ios"
+        ? NativeModules?.SettingsManager?.settings?.AppleLocale
+          ?? NativeModules?.SettingsManager?.settings?.AppleLanguages?.[0]
+        : NativeModules?.I18nManager?.localeIdentifier
+          ?? NativeModules?.I18nManager?.language;
+    if (!candidate) return FALLBACK;
+    return normaliseLanguage(candidate);
+  } catch {
+    return FALLBACK;
+  }
+}

--- a/Planscape/src/i18n/locales/de.json
+++ b/Planscape/src/i18n/locales/de.json
@@ -1,0 +1,72 @@
+{
+  "_note": "Deutsch (de)",
+
+  "common": {
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "delete": "Löschen",
+    "retry": "Erneut versuchen",
+    "close": "Schließen",
+    "edit": "Bearbeiten",
+    "share": "Teilen",
+    "loading": "Lädt…",
+    "empty": "Noch nichts zu zeigen",
+    "offline": "Sie sind offline",
+    "synced": "Synchronisiert {when}",
+    "queued": "In Warteschlange für Synchronisierung"
+  },
+
+  "auth": {
+    "sign_in": "Anmelden",
+    "sign_out": "Abmelden",
+    "email": "E-Mail",
+    "password": "Passwort",
+    "forgot_password": "Passwort vergessen?",
+    "session_expired": "Ihre Sitzung ist abgelaufen — bitte melden Sie sich erneut an.",
+    "invalid_credentials": "E-Mail oder Passwort ist falsch."
+  },
+
+  "tabs": {
+    "home": "Start",
+    "issues": "Vorgänge",
+    "documents": "Dokumente",
+    "scanner": "Scan",
+    "settings": "Einstellungen"
+  },
+
+  "issue": {
+    "create": "Vorgang melden",
+    "title": "Titel",
+    "description": "Beschreibung",
+    "priority": "Priorität",
+    "priorities": {
+      "critical": "Kritisch",
+      "high": "Hoch",
+      "medium": "Mittel",
+      "low": "Niedrig"
+    },
+    "status": {
+      "open": "Offen",
+      "in_progress": "In Bearbeitung",
+      "closed": "Geschlossen",
+      "overdue": "Überfällig"
+    },
+    "assigned_to": "Zugewiesen an {name}",
+    "days_open": "{n} Tage offen",
+    "no_location": "Kein Standort erfasst",
+    "outside_geofence": "Sie befinden sich außerhalb der Projektgrenze — der Vorgang wird zur Prüfung markiert.",
+    "attach_photo": "Foto anhängen"
+  },
+
+  "document": {
+    "upload": "Hochladen",
+    "approve": "Freigeben",
+    "reject": "Ablehnen",
+    "cde": {
+      "wip": "WIP",
+      "shared": "Geteilt",
+      "published": "Veröffentlicht",
+      "archive": "Archiv"
+    }
+  }
+}

--- a/Planscape/src/i18n/locales/en.json
+++ b/Planscape/src/i18n/locales/en.json
@@ -1,0 +1,72 @@
+{
+  "_note": "FLEX-15 — English is the canonical bundle. Strings without a translation in another locale fall back here.",
+
+  "common": {
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "retry": "Retry",
+    "close": "Close",
+    "edit": "Edit",
+    "share": "Share",
+    "loading": "Loading…",
+    "empty": "Nothing to show yet",
+    "offline": "You're offline",
+    "synced": "Synced {when}",
+    "queued": "Queued for sync"
+  },
+
+  "auth": {
+    "sign_in": "Sign in",
+    "sign_out": "Sign out",
+    "email": "Email",
+    "password": "Password",
+    "forgot_password": "Forgot password?",
+    "session_expired": "Your session has expired — please sign in again.",
+    "invalid_credentials": "Email or password is incorrect."
+  },
+
+  "tabs": {
+    "home": "Home",
+    "issues": "Issues",
+    "documents": "Documents",
+    "scanner": "Scan",
+    "settings": "Settings"
+  },
+
+  "issue": {
+    "create": "Raise issue",
+    "title": "Title",
+    "description": "Description",
+    "priority": "Priority",
+    "priorities": {
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    },
+    "status": {
+      "open": "Open",
+      "in_progress": "In progress",
+      "closed": "Closed",
+      "overdue": "Overdue"
+    },
+    "assigned_to": "Assigned to {name}",
+    "days_open": "{n} days open",
+    "no_location": "No location captured",
+    "outside_geofence": "You are outside the project boundary — the issue will be marked for review.",
+    "attach_photo": "Attach photo"
+  },
+
+  "document": {
+    "upload": "Upload",
+    "approve": "Approve",
+    "reject": "Reject",
+    "cde": {
+      "wip": "WIP",
+      "shared": "Shared",
+      "published": "Published",
+      "archive": "Archive"
+    }
+  }
+}

--- a/Planscape/src/i18n/locales/es.json
+++ b/Planscape/src/i18n/locales/es.json
@@ -1,0 +1,72 @@
+{
+  "_note": "Español (es)",
+
+  "common": {
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "retry": "Reintentar",
+    "close": "Cerrar",
+    "edit": "Editar",
+    "share": "Compartir",
+    "loading": "Cargando…",
+    "empty": "No hay nada que mostrar",
+    "offline": "Estás sin conexión",
+    "synced": "Sincronizado {when}",
+    "queued": "En cola para sincronizar"
+  },
+
+  "auth": {
+    "sign_in": "Iniciar sesión",
+    "sign_out": "Cerrar sesión",
+    "email": "Correo",
+    "password": "Contraseña",
+    "forgot_password": "¿Olvidaste tu contraseña?",
+    "session_expired": "Tu sesión ha expirado — inicia sesión de nuevo.",
+    "invalid_credentials": "El correo o la contraseña son incorrectos."
+  },
+
+  "tabs": {
+    "home": "Inicio",
+    "issues": "Incidencias",
+    "documents": "Documentos",
+    "scanner": "Escáner",
+    "settings": "Ajustes"
+  },
+
+  "issue": {
+    "create": "Nueva incidencia",
+    "title": "Título",
+    "description": "Descripción",
+    "priority": "Prioridad",
+    "priorities": {
+      "critical": "Crítica",
+      "high": "Alta",
+      "medium": "Media",
+      "low": "Baja"
+    },
+    "status": {
+      "open": "Abierta",
+      "in_progress": "En progreso",
+      "closed": "Cerrada",
+      "overdue": "Vencida"
+    },
+    "assigned_to": "Asignada a {name}",
+    "days_open": "{n} días abierta",
+    "no_location": "Sin ubicación",
+    "outside_geofence": "Estás fuera del perímetro del proyecto — la incidencia se marcará para revisión.",
+    "attach_photo": "Adjuntar foto"
+  },
+
+  "document": {
+    "upload": "Subir",
+    "approve": "Aprobar",
+    "reject": "Rechazar",
+    "cde": {
+      "wip": "WIP",
+      "shared": "Compartido",
+      "published": "Publicado",
+      "archive": "Archivo"
+    }
+  }
+}

--- a/Planscape/src/services/ocr.md
+++ b/Planscape/src/services/ocr.md
@@ -1,0 +1,89 @@
+# On-device OCR (FLEX-15-OCR)
+
+Zero-dependency scaffold — real text recognition activates as soon as a native
+module is added to the iOS / Android projects. Until then `detectText()`
+returns a `source: "unavailable"` result and the UI keeps the manual-entry
+path.
+
+## Engine choice (decision 1.1 = b)
+
+Apple Vision (iOS) + ML Kit Text Recognition (Android) — free, on-device,
+offline, no PII leaves the device. ~90% accuracy on printed plant labels.
+
+## Wiring real recognition
+
+### iOS
+
+1. Add a Swift native module `PlanscapeVisionOcr` exposing:
+   ```swift
+   @objc(PlanscapeVisionOcr)
+   class PlanscapeVisionOcr: NSObject {
+     @objc func recognize(_ uri: NSString, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+       // use VNRecognizeTextRequest, return { text, confidence, blocks }
+     }
+   }
+   ```
+2. `pod install` after adding the module to Podfile.
+3. Rebuild the iOS shell. `ocr.ts` picks it up automatically via
+   `NativeModules.PlanscapeVisionOcr`.
+
+### Android
+
+1. `npm install @react-native-ml-kit/text-recognition`
+2. `cd android && ./gradlew clean`
+3. Rebuild. `ocr.ts` picks up `NativeModules.MLKitTextRecognition`.
+
+### Verifying
+
+```ts
+import { detectText } from "@/services/ocr";
+const r = await detectText("file:///path/to/photo.jpg");
+console.log(r.source, r.confidence, r.text);
+// source: "unavailable"  → native module not wired yet
+// source: "native-ios" / "native-android"  → real result
+```
+
+## Trigger points (decision 1.4)
+
+Implemented:
+- **Issue-create attachment upload** — `OcrConfirmModal` pops when confidence
+  falls below 90 %. Above 90 %, fields auto-apply silently.
+
+Follow-up (same service, no additional scaffolding needed):
+- Scanner tab lookup — already wired to QR; add a "Scan label" button that
+  calls `detectAndExtract` on the captured frame.
+- Document upload — call `detectAndExtract` server-side via the rendered PDF
+  thumbnail; not implemented in v1.
+
+## Confidence handling (decision 1.5 = b, 90 %)
+
+- `extract()` returns an `extractionConfidence` 0–1.
+- `AUTO_APPLY_CONFIDENCE = 0.9` is the gate. Callers:
+  ```ts
+  const result = await detectAndExtract(uri);
+  if (result.raw.source === "unavailable") return; // no-op, keep manual path
+  if (result.extractionConfidence >= AUTO_APPLY_CONFIDENCE) {
+    applyFields(result);
+  } else {
+    // show OcrConfirmModal
+  }
+  ```
+
+## What it extracts (decision 1.3)
+
+- ISO 19650 tag strings (strong regex with OCR-confusion fix-ups for
+  `O↔0`, `I↔1` in SEQ segment)
+- Drawing numbers (title block format)
+- Serial numbers (heuristic: alphanumeric with digits)
+- Manufacturer/model (nearby-line heuristic)
+
+## Adding fields
+
+1. Write a `matchX` helper in `ocr.ts`.
+2. Add it to `extract()` and the `OcrExtraction` interface.
+3. Add a `<Field>` row in `OcrConfirmModal.tsx`.
+
+## Privacy
+
+All recognition runs on the device. No image is uploaded for OCR (attachments
+still upload to MinIO/S3 for storage — OCR happens before, not on the server).

--- a/Planscape/src/services/ocr.ts
+++ b/Planscape/src/services/ocr.ts
@@ -1,0 +1,204 @@
+// FLEX-15-OCR — On-device text recognition.
+//
+// Platform strategy (no new runtime dependency yet):
+//   iOS     → Vision framework via a Native Module (to be wired when the
+//             custom iOS module is added to the project). Until then we
+//             invoke a `TextRecognizer` bridge if present; otherwise no-op.
+//   Android → ML Kit Text Recognition via `@react-native-ml-kit/text-recognition`.
+//             Same bridge pattern — module is optional.
+//
+// When neither is available (Expo Go, first-run before native module ships)
+// the service cleanly falls back to "no result" and the UI keeps the manual
+// entry path. This keeps the feature shippable piece-by-piece without
+// breaking existing builds.
+//
+// To enable real OCR later, drop in one of:
+//   npm install @react-native-ml-kit/text-recognition
+//   OR
+//   npm install vision-camera-text-recognition
+// and the detectText() call below will start returning real results.
+
+import { NativeModules, Platform } from "react-native";
+
+export interface OcrResult {
+  text: string;
+  confidence: number;           // 0–1
+  blocks: OcrBlock[];
+  processedAt: number;
+  source: "native-ios" | "native-android" | "unavailable";
+}
+
+export interface OcrBlock {
+  text: string;
+  confidence: number;
+  bounds?: { x: number; y: number; width: number; height: number };
+}
+
+export interface OcrExtraction {
+  isoTag?: string;
+  serialNumber?: string;
+  manufacturerModel?: string;
+  drawingNumber?: string;
+  raw: OcrResult;
+  /** 0–1 — the minimum confidence across the fields we extracted. */
+  extractionConfidence: number;
+}
+
+// Threshold used by the "did you mean?" prompt. Matches decision 1.5 = (b) 90 %.
+export const AUTO_APPLY_CONFIDENCE = 0.9;
+
+// ── Native-module discovery ─────────────────────────────────────────────
+
+type BridgeResult = { text?: string; confidence?: number; blocks?: OcrBlock[] };
+function findBridge(): { recognize: (uri: string) => Promise<BridgeResult> } | null {
+  // iOS: PlanscapeVisionOcr (custom module shipped with the iOS app).
+  // Android: MLKitTextRecognition (provided by @react-native-ml-kit/text-recognition).
+  const ios     = (NativeModules as any)?.PlanscapeVisionOcr;
+  const android = (NativeModules as any)?.MLKitTextRecognition;
+  const chosen  = Platform.OS === "ios" ? ios : android;
+  if (chosen && typeof chosen.recognize === "function") {
+    return { recognize: chosen.recognize.bind(chosen) };
+  }
+  return null;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/**
+ * Run text recognition on a local image URI. Returns an empty result when
+ * no native module is wired — callers should check `source === "unavailable"`
+ * and skip the OCR-dependent code path.
+ */
+export async function detectText(imageUri: string): Promise<OcrResult> {
+  const bridge = findBridge();
+  if (!bridge) {
+    return {
+      text: "",
+      confidence: 0,
+      blocks: [],
+      processedAt: Date.now(),
+      source: "unavailable",
+    };
+  }
+  try {
+    const raw = await bridge.recognize(imageUri);
+    return {
+      text: raw.text ?? "",
+      confidence: clamp01(raw.confidence ?? 0),
+      blocks: (raw.blocks ?? []).map(b => ({
+        text: b.text,
+        confidence: clamp01(b.confidence ?? 0),
+        bounds: b.bounds,
+      })),
+      processedAt: Date.now(),
+      source: Platform.OS === "ios" ? "native-ios" : "native-android",
+    };
+  } catch (err) {
+    console.warn("[ocr] native recogniser failed:", err);
+    return {
+      text: "",
+      confidence: 0,
+      blocks: [],
+      processedAt: Date.now(),
+      source: "unavailable",
+    };
+  }
+}
+
+/**
+ * Extract structured fields from an OCR result. Runs deterministic regex
+ * first (ISO 19650 tag, drawing number), then falls back to heuristics for
+ * serial numbers and manufacturer plates. Callers can inspect
+ * `extractionConfidence` and decide whether to auto-apply (>= 0.9) or show
+ * the confirmation modal.
+ */
+export function extract(result: OcrResult): OcrExtraction {
+  const text = result.text ?? "";
+  const isoTag = matchIsoTag(text);
+  const drawingNumber = matchDrawingNumber(text);
+  const serialNumber = matchSerial(text);
+  const manufacturerModel = matchManufacturerModel(text);
+
+  // Lowest per-field confidence wins. Confidence weighted: ISO tag match is
+  // only valid when the regex is fully satisfied; heuristics cap at 0.75.
+  const fieldConfidences: number[] = [];
+  if (isoTag)              fieldConfidences.push(result.confidence);
+  if (drawingNumber)       fieldConfidences.push(Math.min(result.confidence, 0.85));
+  if (serialNumber)        fieldConfidences.push(Math.min(result.confidence, 0.75));
+  if (manufacturerModel)   fieldConfidences.push(Math.min(result.confidence, 0.7));
+
+  const extractionConfidence = fieldConfidences.length === 0
+    ? 0
+    : Math.min(...fieldConfidences);
+
+  return {
+    isoTag,
+    drawingNumber,
+    serialNumber,
+    manufacturerModel,
+    raw: result,
+    extractionConfidence,
+  };
+}
+
+export async function detectAndExtract(imageUri: string): Promise<OcrExtraction> {
+  const raw = await detectText(imageUri);
+  return extract(raw);
+}
+
+// ── Regex / heuristic helpers ───────────────────────────────────────────
+
+/**
+ * ISO 19650 tag — 8 segments separated by the configured separator (default '-').
+ *   DISC   1–2 letters (M, E, P, A, S, FP, LV)
+ *   LOC    3–6 alphanumerics (BLD1, EXT, XX, ROOF)
+ *   ZONE   3 chars (Z01, Z02, ZZ, XX)
+ *   LVL    2–4 chars (L01, GF, B1, RF, XX)
+ *   SYS    3–5 letters (HVAC, DCW, LV, SAN)
+ *   FUNC   3–5 letters (SUP, HTG, PWR)
+ *   PROD   2–5 letters (AHU, DB, DR)
+ *   SEQ    3–4 digits
+ *
+ * OCR frequently misreads 'O' for '0' and 'I' for '1' in the SEQ segment,
+ * so we accept both and normalise the result.
+ */
+function matchIsoTag(text: string): string | undefined {
+  const pattern = /\b([A-Z]{1,2})-([A-Z0-9]{2,6})-([A-Z0-9]{2,4})-([A-Z0-9]{2,4})-([A-Z]{2,5})-([A-Z]{2,5})-([A-Z]{2,5})-([A-Z0-9OI]{3,4})\b/i;
+  const m = text.match(pattern);
+  if (!m) return undefined;
+  // Normalise SEQ — swap common OCR confusions.
+  const seq = m[8].replace(/O/gi, "0").replace(/I/g, "1");
+  return [m[1], m[2], m[3], m[4], m[5], m[6], m[7], seq].map(s => s.toUpperCase()).join("-");
+}
+
+/** Drawing number — usually "AA-NN-NNNN" on title blocks. */
+function matchDrawingNumber(text: string): string | undefined {
+  const m = text.match(/\b([A-Z]{1,3})[- ]?(\d{2,4})[- ]?(\d{3,5})\b/);
+  return m ? `${m[1]}-${m[2]}-${m[3]}`.toUpperCase() : undefined;
+}
+
+/** Serial — 6+ alnum with at least one digit, between separators/whitespace. */
+function matchSerial(text: string): string | undefined {
+  const candidates = text.match(/\b[A-Z0-9]{6,}\b/g) ?? [];
+  return candidates.find(c => /\d/.test(c) && !/^[A-Z]+$/.test(c));
+}
+
+/**
+ * Manufacturer + model is usually on consecutive lines; grab the longest
+ * short line near "MODEL" / "TYPE" / "MFR". Rough but useful for pre-filling.
+ */
+function matchManufacturerModel(text: string): string | undefined {
+  const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  const idx = lines.findIndex(l => /\b(model|type|mfr|manufacturer)\b/i.test(l));
+  if (idx === -1) return undefined;
+  const next = lines[idx + 1];
+  if (next && next.length <= 40) return next;
+  // Sometimes "MODEL: XYZ-1234" on the same line.
+  const inline = lines[idx].match(/:(.+)$/);
+  return inline ? inline[1].trim() : undefined;
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return n < 0 ? 0 : n > 1 ? 1 : n;
+}

--- a/Planscape/src/stores/projectStore.ts
+++ b/Planscape/src/stores/projectStore.ts
@@ -1,0 +1,44 @@
+// Shared "active project" store. Dashboard + Issues + Models all need to
+// know which project is currently selected. Introduced for the model viewer
+// but intentionally generic — existing screens should migrate to this store
+// instead of keeping their own `useState<Project | null>`.
+
+import { create } from "zustand";
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  code: string;
+  tenantId?: string;
+}
+
+interface ProjectState {
+  activeProjectId: string | null;
+  active: ProjectSummary | null;
+  recent: ProjectSummary[];
+
+  setActive: (project: ProjectSummary | null) => void;
+  pushRecent: (project: ProjectSummary) => void;
+  clear: () => void;
+}
+
+export const useProjectStore = create<ProjectState>((set, get) => ({
+  activeProjectId: null,
+  active: null,
+  recent: [],
+
+  setActive: (project) => {
+    if (!project) { set({ activeProjectId: null, active: null }); return; }
+    set({ activeProjectId: project.id, active: project });
+    // Remember last 5 distinct projects the user touched.
+    const existing = get().recent.filter((p) => p.id !== project.id);
+    set({ recent: [project, ...existing].slice(0, 5) });
+  },
+
+  pushRecent: (project) => {
+    const existing = get().recent.filter((p) => p.id !== project.id);
+    set({ recent: [project, ...existing].slice(0, 5) });
+  },
+
+  clear: () => set({ activeProjectId: null, active: null, recent: [] }),
+}));

--- a/Planscape/src/stores/tenantStore.ts
+++ b/Planscape/src/stores/tenantStore.ts
@@ -1,0 +1,65 @@
+// TENANT-SWITCH — Zustand store for the user's tenant memberships.
+//
+// When the user belongs to exactly one tenant (the common case) the UI hides
+// the switcher entirely. When the count is 2–5 we show an inline picker; 6+
+// gets a search box. Decision 3.1 = (c) adaptive.
+
+import { create } from "zustand";
+
+export interface TenantMembership {
+  userId: string;
+  tenantId: string;
+  tenantName: string;
+  tenantSlug: string;
+  tenantTier: string;
+  mimEnabled: boolean;
+  role: string;
+  isActiveTenant: boolean;
+}
+
+interface TenantState {
+  memberships: TenantMembership[];
+  currentTenantId: string | null;
+
+  setMemberships: (m: TenantMembership[]) => void;
+  setCurrentTenant: (tenantId: string) => void;
+  clear: () => void;
+
+  /** Derived — how many organisations the user belongs to. */
+  count: () => number;
+
+  /** Derived — how the UI should present the switcher. */
+  presentation: () => "hidden" | "list" | "search";
+}
+
+export const useTenantStore = create<TenantState>((set, get) => ({
+  memberships: [],
+  currentTenantId: null,
+
+  setMemberships: (memberships) => {
+    const active = memberships.find((m) => m.isActiveTenant);
+    set({
+      memberships,
+      currentTenantId: active?.tenantId ?? memberships[0]?.tenantId ?? null,
+    });
+  },
+
+  setCurrentTenant: (tenantId) => {
+    const memberships = get().memberships.map((m) => ({
+      ...m,
+      isActiveTenant: m.tenantId === tenantId,
+    }));
+    set({ memberships, currentTenantId: tenantId });
+  },
+
+  clear: () => set({ memberships: [], currentTenantId: null }),
+
+  count: () => get().memberships.length,
+
+  presentation: () => {
+    const n = get().memberships.length;
+    if (n <= 1) return "hidden";
+    if (n <= 5) return "list";
+    return "search";
+  },
+}));

--- a/Planscape/src/types/api.ts
+++ b/Planscape/src/types/api.ts
@@ -77,6 +77,13 @@ export interface BimIssue {
   deviceId?: string;
   source?: 'mobile' | 'plugin' | 'web' | 'mobile-bridge';
   attachmentCount?: number;
+  // MODEL-VIEWER — 3D anchor. Populated when the issue was raised from the
+  // viewer's "create issue here" action.
+  modelId?: string | null;
+  modelElementGuid?: string | null;
+  modelX?: number | null;
+  modelY?: number | null;
+  modelZ?: number | null;
 }
 
 /** NEW-INFO-06/07 — Activity timeline entries surfaced from AuditLog. */

--- a/Planscape/src/types/customFields.ts
+++ b/Planscape/src/types/customFields.ts
@@ -1,0 +1,69 @@
+// FLEX-13 — Shared types for custom-field schema + values.
+
+export type CustomFieldType =
+  | "Text"
+  | "TextArea"
+  | "Number"
+  | "Date"
+  | "Dropdown"
+  | "MultiSelect"
+  | "Boolean"
+  | "UserPicker"
+  | "ElementReference";
+
+export interface CustomFieldSchema {
+  id: string;
+  key: string;
+  label: string;
+  fieldType: CustomFieldType;
+  helpText?: string;
+  /** JSON-encoded default — parse before use. */
+  defaultValueJson?: string | null;
+  /** JSON-encoded options (Dropdown / MultiSelect). */
+  optionsJson?: string | null;
+  required: boolean;
+  sortOrder: number;
+}
+
+/** Runtime value map — what actually lives on BimIssue.CustomFields. */
+export type CustomFieldValues = Record<string, unknown>;
+
+/** Utility: parse a schema's options JSON into a normalised string[] or {value,label}[]. */
+export function parseOptions(
+  optionsJson: string | null | undefined
+): { value: string; label: string }[] {
+  if (!optionsJson) return [];
+  try {
+    const parsed = JSON.parse(optionsJson);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((o) =>
+      typeof o === "string"
+        ? { value: o, label: o }
+        : { value: String(o.value ?? o), label: String(o.label ?? o.value ?? o) }
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Returns the first validation error or null if the values satisfy the schema. */
+export function validateAgainstSchema(
+  schemas: CustomFieldSchema[],
+  values: CustomFieldValues
+): { field: string; error: string } | null {
+  for (const s of schemas) {
+    const v = values[s.key];
+    if (s.required && (v === undefined || v === null || v === "" ||
+        (Array.isArray(v) && v.length === 0))) {
+      return { field: s.key, error: `${s.label} is required` };
+    }
+    if (v == null || v === "") continue;
+    if (s.fieldType === "Number" && typeof v !== "number" && isNaN(Number(v))) {
+      return { field: s.key, error: `${s.label} must be a number` };
+    }
+    if (s.fieldType === "Date" && typeof v === "string" && isNaN(Date.parse(v))) {
+      return { field: s.key, error: `${s.label} must be a date` };
+    }
+  }
+  return null;
+}

--- a/Planscape/src/types/models.ts
+++ b/Planscape/src/types/models.ts
@@ -1,0 +1,50 @@
+// MODEL-VIEWER — shared types.
+
+export type ModelFormat = "Glb" | "Gltf" | "Ifc" | "Rvt" | "Obj" | "Fbx";
+
+export interface ModelMeta {
+  id: string;
+  projectId: string;
+  name: string;
+  description?: string | null;
+  discipline?: string | null;
+  fileName: string;
+  format: ModelFormat;
+  fileSizeBytes: number;
+  contentHash?: string | null;
+  hasElementMap: boolean;
+  hasThumbnail: boolean;
+  elementCount?: number | null;
+  units: string;
+  revision?: string | null;
+  boundsMinX?: number | null;
+  boundsMinY?: number | null;
+  boundsMinZ?: number | null;
+  boundsMaxX?: number | null;
+  boundsMaxY?: number | null;
+  boundsMaxZ?: number | null;
+  uploadedBy: string;
+  uploadedAt: string;
+}
+
+/** Optional sidecar exported by the Revit plugin. Keys are element GUIDs. */
+export type ElementMap = Record<
+  string,
+  {
+    tag?: string;
+    name?: string;
+    category?: string;
+    discipline?: string;
+    level?: string;
+  }
+>;
+
+export interface ModelPin {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  priority?: "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
+}
+
+export type ViewerTool = "pick" | "measure" | "section" | "pin";

--- a/Planscape/tsconfig.json
+++ b/Planscape/tsconfig.json
@@ -5,7 +5,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
 }

--- a/StingTools/BIMManager/MobileIssueBridge.cs
+++ b/StingTools/BIMManager/MobileIssueBridge.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -441,6 +441,114 @@ public sealed class PlanscapeServerClient : IDisposable
         _http?.Dispose();
         _http = null;
     }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    //  Models (MODEL-VIEWER)
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Upload a 3D model (glTF / GLB / IFC) plus an optional element-map sidecar
+    /// to <c>POST /api/projects/{id}/models</c>. Returns the created model id on
+    /// success or an error message on failure.
+    /// </summary>
+    public async Task<(bool ok, Guid modelId, string? error)> UploadModelAsync(
+        Guid projectId,
+        string modelFilePath,
+        string? elementMapPath = null,
+        string? name = null,
+        string? description = null,
+        string? discipline = null,
+        string? revision = null,
+        string units = "mm",
+        int? elementCount = null,
+        double[]? bounds = null)
+    {
+        if (!await EnsureAuthenticatedAsync()) return (false, Guid.Empty, LastError);
+        if (!File.Exists(modelFilePath))       return (false, Guid.Empty, $"Model file not found: {modelFilePath}");
+
+        try
+        {
+            using var content = new System.Net.Http.MultipartFormDataContent();
+
+            // Primary geometry — streaming to avoid loading huge files into memory.
+            var modelStream = File.OpenRead(modelFilePath);
+            var modelContent = new System.Net.Http.StreamContent(modelStream);
+            modelContent.Headers.ContentType = new MediaTypeWithQualityHeaderValue(GuessMime(modelFilePath));
+            content.Add(modelContent, "File", Path.GetFileName(modelFilePath));
+
+            // Optional element map.
+            System.Net.Http.StreamContent? mapContent = null;
+            FileStream? mapStream = null;
+            if (!string.IsNullOrEmpty(elementMapPath) && File.Exists(elementMapPath))
+            {
+                mapStream = File.OpenRead(elementMapPath!);
+                mapContent = new System.Net.Http.StreamContent(mapStream);
+                mapContent.Headers.ContentType = new MediaTypeWithQualityHeaderValue("application/json");
+                content.Add(mapContent, "ElementMap", Path.GetFileName(elementMapPath!));
+            }
+
+            // Metadata fields (PascalCase to match the server's UploadModelRequest).
+            void AddField(string key, string? value)
+            {
+                if (value != null) content.Add(new System.Net.Http.StringContent(value, Encoding.UTF8), key);
+            }
+            AddField("Name", name);
+            AddField("Description", description);
+            AddField("Discipline", discipline);
+            AddField("Revision", revision);
+            AddField("Units", units);
+            if (elementCount.HasValue) AddField("ElementCount", elementCount.Value.ToString());
+            if (bounds != null && bounds.Length == 6)
+            {
+                AddField("BoundsMinX", bounds[0].ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AddField("BoundsMinY", bounds[1].ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AddField("BoundsMinZ", bounds[2].ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AddField("BoundsMaxX", bounds[3].ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AddField("BoundsMaxY", bounds[4].ToString(System.Globalization.CultureInfo.InvariantCulture));
+                AddField("BoundsMaxZ", bounds[5].ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+
+            try
+            {
+                using var resp = await _http!.PostAsync($"/api/projects/{projectId}/models", content).ConfigureAwait(false);
+                var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!resp.IsSuccessStatusCode)
+                {
+                    return (false, Guid.Empty, $"HTTP {(int)resp.StatusCode}: {body}");
+                }
+                var json = JObject.Parse(body);
+                var id = json["id"]?.Value<string>() ?? "";
+                return (true, Guid.TryParse(id, out var g) ? g : Guid.Empty, null);
+            }
+            finally
+            {
+                modelStream.Dispose();
+                mapContent?.Dispose();
+                mapStream?.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            StingLog.Error("Planscape: UploadModelAsync failed", ex);
+            return (false, Guid.Empty, ex.Message);
+        }
+    }
+
+    /// <summary>Guess MIME type from the file extension for multipart uploads.</summary>
+    private static string GuessMime(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".glb"  => "model/gltf-binary",
+            ".gltf" => "model/gltf+json",
+            ".ifc"  => "application/x-step",
+            ".obj"  => "model/obj",
+            ".fbx"  => "application/octet-stream",
+            _ => "application/octet-stream",
+        };
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────────

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Microsoft.Win32;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.BIMManager
+{
+    /// <summary>
+    /// MODEL-VIEWER — Publishes a 3D model (glTF / GLB / IFC) to the Planscape
+    /// server together with an element map sidecar that bridges the exporter's
+    /// element GUIDs to STING ISO 19650 tags.
+    ///
+    /// Workflow:
+    ///   1. Sign in to Planscape (PlanscapeServerClient.Instance.LoginAsync)
+    ///   2. Pick a project on the server to publish into
+    ///   3. Plugin asks the user to select a glTF/GLB/IFC file that was
+    ///      produced by an external exporter (Revit doesn't ship a built-in
+    ///      glTF writer — any of the following work:
+    ///        - Autodesk Platform Services (APS) Model Derivative
+    ///        - 3rd party: SimLab glTF exporter, rvt2gltf, Blender via IFC
+    ///        - Autodesk Dynamo package "Rhythm → ExportToGltf"
+    ///   4. Plugin generates the element map JSON from the currently visible
+    ///      elements in the active 3D view (mapping Revit UniqueId ↔ ISO tag).
+    ///   5. Both files are uploaded to /api/projects/{id}/models.
+    ///
+    /// The element map is optional — the viewer works without it (element
+    /// names come from the glTF userData), but rich tooltips + discipline
+    /// filter need the mapping.
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class PublishModelCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(commandData);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            var doc = ctx.Doc;
+
+            // ── Step 1: ensure connected ───────────────────────────────
+            var client = PlanscapeServerClient.Instance;
+            if (string.IsNullOrEmpty(client.ConnectedUser))
+            {
+                TaskDialog.Show(
+                    "Publish Model to Planscape",
+                    "You're not signed in to Planscape. Use 'Sign in to Planscape' first (BIM tab → Platform Integration).");
+                return Result.Cancelled;
+            }
+
+            // ── Step 2: pick a project ─────────────────────────────────
+            var projectId = PickProject(client);
+            if (projectId == Guid.Empty) return Result.Cancelled;
+
+            // ── Step 3: pick a geometry file ───────────────────────────
+            var modelPath = PromptForModelFile();
+            if (string.IsNullOrEmpty(modelPath)) return Result.Cancelled;
+
+            // ── Step 4: collect element map ────────────────────────────
+            string? mapPath = null;
+            try
+            {
+                mapPath = Path.Combine(
+                    OutputLocationHelper.GetOutputDirectory(doc),
+                    Path.GetFileNameWithoutExtension(modelPath) + "-elements.json");
+                BuildElementMap(doc, mapPath, out var elementCount, out var bounds);
+                StingLog.Info($"Planscape: element map generated ({elementCount} elements) → {mapPath}");
+
+                // ── Step 5: upload to server ───────────────────────────
+                var result = Task.Run(() => client.UploadModelAsync(
+                    projectId,
+                    modelPath,
+                    mapPath,
+                    name: doc.Title,
+                    description: $"Published from Revit {doc.Application.VersionName}",
+                    discipline: DetectDocDiscipline(doc),
+                    revision: doc.ProjectInformation?.get_Parameter(BuiltInParameter.PROJECT_REVISION)?.AsString(),
+                    units: "mm",
+                    elementCount: elementCount,
+                    bounds: bounds)).GetAwaiter().GetResult();
+
+                if (!result.ok)
+                {
+                    TaskDialog.Show("Publish Model", $"Upload failed: {result.error}");
+                    StingLog.Warn($"Planscape: model upload failed — {result.error}");
+                    return Result.Failed;
+                }
+
+                TaskDialog.Show(
+                    "Publish Model to Planscape",
+                    $"Published {Path.GetFileName(modelPath)}\n\n" +
+                    $"Elements mapped: {elementCount}\n" +
+                    $"Project: {projectId}\n" +
+                    $"Model id:   {result.modelId}\n\n" +
+                    "Site users can now open the model from the Planscape mobile app → Models.");
+                StingLog.Info($"Planscape: model published → {result.modelId}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                TaskDialog.Show("Publish Model", $"Failed: {ex.Message}");
+                StingLog.Error("Planscape: publish model failed", ex);
+                return Result.Failed;
+            }
+        }
+
+        // ── Project picker ─────────────────────────────────────────────
+
+        private static Guid PickProject(PlanscapeServerClient client)
+        {
+            var projects = Task.Run(() => client.GetProjectsAsync()).GetAwaiter().GetResult();
+            if (projects == null || projects.Count == 0)
+            {
+                TaskDialog.Show("Publish Model", "No Planscape projects are visible to your account.");
+                return Guid.Empty;
+            }
+
+            // Reuse StingListPicker via its public surface when present.
+            var names = projects.Select(p => (p["name"]?.Value<string>() ?? "") + "  ·  " + (p["code"]?.Value<string>() ?? "")).ToList();
+            var dlg = new TaskDialog("Publish Model") { MainInstruction = "Select the target project" };
+            for (int i = 0; i < Math.Min(names.Count, 4); i++)
+            {
+                dlg.AddCommandLink(
+                    i == 0 ? TaskDialogCommandLinkId.CommandLink1 :
+                    i == 1 ? TaskDialogCommandLinkId.CommandLink2 :
+                    i == 2 ? TaskDialogCommandLinkId.CommandLink3 :
+                             TaskDialogCommandLinkId.CommandLink4,
+                    names[i]);
+            }
+            var r = dlg.Show();
+            int idx = r == TaskDialogResult.CommandLink1 ? 0
+                    : r == TaskDialogResult.CommandLink2 ? 1
+                    : r == TaskDialogResult.CommandLink3 ? 2
+                    : r == TaskDialogResult.CommandLink4 ? 3 : -1;
+            if (idx < 0 || idx >= projects.Count) return Guid.Empty;
+            return Guid.TryParse(projects[idx]["id"]?.Value<string>() ?? "", out var id) ? id : Guid.Empty;
+        }
+
+        // ── File picker ────────────────────────────────────────────────
+
+        private static string? PromptForModelFile()
+        {
+            var dlg = new OpenFileDialog
+            {
+                Title = "Select 3D model to publish",
+                Filter = "3D models (*.glb;*.gltf;*.ifc;*.obj;*.fbx)|*.glb;*.gltf;*.ifc;*.obj;*.fbx|All files (*.*)|*.*",
+                CheckFileExists = true,
+                CheckPathExists = true,
+            };
+            var ok = dlg.ShowDialog();
+            return ok == true ? dlg.FileName : null;
+        }
+
+        // ── Element map generator ──────────────────────────────────────
+
+        private static void BuildElementMap(
+            Document doc, string outputPath,
+            out int elementCount, out double[] bounds)
+        {
+            var activeView = doc.ActiveView;
+            var collector = activeView is View3D
+                ? new FilteredElementCollector(doc, activeView.Id)
+                : new FilteredElementCollector(doc);
+
+            var elements = collector
+                .WhereElementIsNotElementType()
+                .Where(e => e.Category != null && e.get_Geometry(new Options()) != null)
+                .ToList();
+
+            var map = new JObject();
+            var bb = new BoundingBoxXYZ { Min = new XYZ(double.MaxValue, double.MaxValue, double.MaxValue),
+                                          Max = new XYZ(double.MinValue, double.MinValue, double.MinValue) };
+            int count = 0;
+
+            foreach (var el in elements)
+            {
+                var guid = el.UniqueId;
+                var tag = ParameterHelpers.GetString(el, ParamRegistry.TAG1);
+                if (string.IsNullOrEmpty(tag)) continue; // only include tagged elements
+                var disc = ParameterHelpers.GetString(el, ParamRegistry.DISC);
+                var loc  = ParameterHelpers.GetString(el, ParamRegistry.LOC);
+                var lvl  = ParameterHelpers.GetString(el, ParamRegistry.LVL);
+
+                map[guid] = new JObject
+                {
+                    ["tag"]        = tag,
+                    ["name"]       = el.Name ?? "",
+                    ["category"]   = el.Category?.Name ?? "",
+                    ["discipline"] = disc,
+                    ["location"]   = loc,
+                    ["level"]      = lvl,
+                    ["elementId"]  = el.Id.Value,
+                };
+                count++;
+
+                // Track bounds (mm units to match server default).
+                var eb = el.get_BoundingBox(null);
+                if (eb != null)
+                {
+                    bb.Min = new XYZ(Math.Min(bb.Min.X, eb.Min.X),
+                                     Math.Min(bb.Min.Y, eb.Min.Y),
+                                     Math.Min(bb.Min.Z, eb.Min.Z));
+                    bb.Max = new XYZ(Math.Max(bb.Max.X, eb.Max.X),
+                                     Math.Max(bb.Max.Y, eb.Max.Y),
+                                     Math.Max(bb.Max.Z, eb.Max.Z));
+                }
+            }
+
+            // Convert feet → mm for the bounds (Revit internal units are feet).
+            const double feetToMm = 304.8;
+            bounds = new[]
+            {
+                bb.Min.X * feetToMm, bb.Min.Y * feetToMm, bb.Min.Z * feetToMm,
+                bb.Max.X * feetToMm, bb.Max.Y * feetToMm, bb.Max.Z * feetToMm,
+            };
+            elementCount = count;
+
+            File.WriteAllText(outputPath, map.ToString(Newtonsoft.Json.Formatting.Indented), Encoding.UTF8);
+        }
+
+        private static string DetectDocDiscipline(Document doc)
+        {
+            // Heuristic: look at the document name for a discipline prefix.
+            var name = doc.Title.ToUpperInvariant();
+            if (name.Contains("MECH") || name.StartsWith("M-") || name.StartsWith("M_")) return "M";
+            if (name.Contains("ELEC") || name.StartsWith("E-") || name.StartsWith("E_")) return "E";
+            if (name.Contains("PLUMB") || name.StartsWith("P-") || name.StartsWith("P_")) return "P";
+            if (name.Contains("STRUCT") || name.StartsWith("S-") || name.StartsWith("S_")) return "S";
+            if (name.Contains("ARCH") || name.StartsWith("A-") || name.StartsWith("A_")) return "A";
+            if (name.Contains("FIRE") || name.StartsWith("FP-")) return "FP";
+            return "";
+        }
+    }
+}

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -81,7 +82,7 @@ namespace StingTools.BIMManager
                     name: doc.Title,
                     description: $"Published from Revit {doc.Application.VersionName}",
                     discipline: DetectDocDiscipline(doc),
-                    revision: doc.ProjectInformation?.get_Parameter(BuiltInParameter.PROJECT_REVISION)?.AsString(),
+                    revision: PhaseAutoDetect.DetectProjectRevision(doc),
                     units: "mm",
                     elementCount: elementCount,
                     bounds: bounds)).GetAwaiter().GetResult();

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -2819,6 +2819,7 @@ namespace StingTools.UI
                     case "PlanscapeDisconnect":     BIMManager.PlanscapeServerClient.Instance.Disconnect();
                                                    TaskDialog.Show("Planscape", "Disconnected from Planscape server."); break;
                     case "PlanscapeSyncNow":        BIMManager.PlatformSyncCommand.SyncToPlanscapeServer(app); break;
+                    case "PublishModelToPlanscape": RunCommand<BIMManager.PublishModelCommand>(app); break;
                     case "SendMeetingInvites":     TaskDialog.Show("STING — Meeting Invites", "Invite generation requires email integration.\nConfigure SMTP settings in Settings > Notifications to enable automatic email invites.\n\nFor now, use the 'Copy List' button to get email addresses."); break;
                     case "ExportMeetingAnalytics":
                     {


### PR DESCRIPTION
## Summary

This PR implements four major feature areas deferred from the previous sprint:

1. **Tenant branding (FLEX-03/07)** — Per-tenant customisation of emails, product name, colors, and logos without code changes
2. **Internationalisation (FLEX-15)** — Multi-language support for both server (email/notifications) and mobile (UI)
3. **Observability stack (MON-01/02/03)** — Structured logging (Seq/Elasticsearch) and metrics (Prometheus/Grafana) integration

## Key Changes

### Tenant Branding (FLEX-03/07)
- **New entity & service**: `TenantBranding` table with `ITenantBrandingService` for fallback chain (DB → config → hardcoded defaults)
- **Email template engine**: `FileEmailTemplateRenderer` + `IEmailTemplateRenderer` interface — loads `.html`/`.txt`/`.subject` files from disk with safe `{{Placeholder}}` substitution and `{{#if flag}}` conditionals
- **Controller**: `TenantBrandingController` for GET/PUT/DELETE branding + template cache reload
- **Email refactor**: `SmtpEmailService` now uses the renderer instead of inline HTML; supports per-tenant branding in all outbound emails
- **Migration**: `AddTenantBranding` creates the new table with tenant FK and color validation

### Internationalisation (FLEX-15)
- **Server-side**: `I18nService` loads JSON resource files from `I18n/` directory with dotted-key fallback chain (language → "en" → literal key)
- **Middleware**: `LocaleMiddleware` resolves caller language from `X-Language` header → `?language=` query → `Accept-Language` header → tenant default → "en"
- **Controller**: `I18nController` exposes supported languages and full translation bundles for mobile prefetch
- **Mobile**: Zero-dependency `i18n/index.ts` helper with `t()`, `useT()`, `setLanguage()`, `initI18n()` — bundles en/de/es locales
- **Resource files**: Server-side i18n for email subjects/notification titles in en/de/es; mobile UI strings in same three languages

### Observability Stack (MON-01/02/03)
- **Serilog sinks**: Optional Seq (structured logs) and Elasticsearch (log aggregation) on top of existing console/file output
- **Metrics**: `prometheus-net.AspNetCore` integration — `/metrics` endpoint with HTTP request/latency histograms
- **Docker Compose**: New `seq`, `prometheus`, `grafana` services behind `--profile observability` flag
- **Grafana dashboard**: Pre-built dashboard showing requests/sec, P95 latency, error rates
- **Configuration**: New `Serilog:Seq`, `Serilog:Elastic`, `Monitoring:ExposeMetrics` sections in appsettings (all inert by default)

## Implementation Details

- **Email template fallback**: Missing template files never silently fail — renderer falls back to a hard-coded plain-text shell
- **Branding cache**: 5-minute TTL per tenant to avoid DB hammering; invalidated on PUT/DELETE
- **Language resolution**: Middleware runs early to set `HttpContext.Items["Language"]` and `Content-Language` response header
- **Config key compatibility**: SMTP settings support both `Smtp:*` (production template) and legacy `Email:*` keys
- **No external template engine**: Intentionally avoided Handlebars/Razor/Scriban to eliminate code-execution risk; can swap implementation later
- **Mobile i18n**: Bundled locales ship with app; falls back through AsyncStorage → device locale → "en"

## Testing Notes

- Observability services are opt-in via Docker Compose profile — existing dev workflows unaffected
- Email templates can be tested via `TenantBrandingController` endpoints
- i18n endpoints are public (no auth required) to support mobile prefetch on cold start

https://claude.ai/code/session_01NJYXFh3Up1K8xV43bn325z