### PR TITLE
Implement Planscape delta-pull sync and debounce logic (INT-01/02/03)

### DIFF
--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -307,6 +307,30 @@ public sealed class PlanscapeServerClient : IDisposable
         catch (Exception ex) { LastError = ex.Message; return null; }
     }
 
+    /// <summary>
+    /// INT-03 delta pull — GET /api/tagsync/elements/{projectId}?lastSyncUtc=&lt;watermark&gt;.
+    /// When <paramref name="lastSyncUtc"/> is supplied, the server returns only elements
+    /// whose LastModifiedUtc (or SyncedAt fallback) is newer than the watermark. With
+    /// <c>null</c>, acts as a plain paginated list. Server-side per-device watermark
+    /// is tracked via the X-Device-Id header (defaults to "desktop" when absent).
+    /// </summary>
+    public async Task<JArray?> GetElementsDeltaAsync(Guid projectId, DateTime? lastSyncUtc,
+        int page = 1, int pageSize = 500)
+    {
+        if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+        try
+        {
+            var path = $"/api/tagsync/elements/{projectId}?page={page}&pageSize={pageSize}";
+            if (lastSyncUtc.HasValue)
+                path += $"&lastSyncUtc={Uri.EscapeDataString(lastSyncUtc.Value.ToUniversalTime().ToString("o"))}";
+            var resp = await GetAsync(path);
+            if (!resp.ok) { LastError = $"Delta pull failed ({resp.status}): {resp.body}"; return null; }
+            var json = JObject.Parse(resp.body);
+            return json["elements"] as JArray ?? new JArray();
+        }
+        catch (Exception ex) { LastError = ex.Message; StingLog.Warn($"GetElementsDeltaAsync: {ex.Message}"); return null; }
+    }
+
     // ────────────────────────────────────────────────────────────────────────────
     //  Issues
     // ────────────────────────────────────────────────────────────────────────────

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -2072,6 +2072,57 @@ namespace StingTools.BIMManager
                 return Guid.Empty;
             }
         }
+
+        /// <summary>
+        /// Resolve the wall-clock UTC last-modified timestamp for a single
+        /// tagged element, for use in the Planscape sync payload (INT-03).
+        ///
+        /// Priority chain:
+        ///   1. <c>ASS_TAG_MODIFIED_DT</c> — the STING audit trail stamp
+        ///      written by <c>TagPipelineHelper.RunFullPipeline</c> after
+        ///      every successful tag update (Phase 77 entry 748). This is
+        ///      the most precise "when did the tokens actually change"
+        ///      signal and is what the server cares about for true-delta
+        ///      detection on <c>GET /api/tagsync/elements/{projectId}</c>.
+        ///   2. <c>DateTime.UtcNow</c> — last-resort fallback so the server
+        ///      still sees a non-null timestamp for legacy elements that
+        ///      predate the audit-trail plumbing (the server's last-write-
+        ///      wins logic is tolerant of this and simply accepts the
+        ///      update with <c>Version += 1</c>).
+        /// </summary>
+        /// <remarks>
+        /// Revit itself does not expose a first-class per-element
+        /// "modified time" BuiltInParameter — the prompt's reference to
+        /// <c>BuiltInParameter.EDITED_TIME</c> is not a real enum value
+        /// (only <c>EDITED_BY</c> exists, and it returns a worksharing
+        /// username, not a timestamp). The STING audit stamp is therefore
+        /// the only reliable per-element signal we have.
+        /// </remarks>
+        private static DateTime ResolveElementLastModifiedUtc(Element el)
+        {
+            if (el == null) return DateTime.UtcNow;
+
+            // 1. STING audit stamp — the canonical "last token edit".
+            try
+            {
+                string stamp = ParameterHelpers.GetString(el, "ASS_TAG_MODIFIED_DT");
+                if (!string.IsNullOrWhiteSpace(stamp)
+                    && DateTime.TryParse(stamp,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        out var parsed))
+                {
+                    return parsed;
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ResolveElementLastModifiedUtc: ASS_TAG_MODIFIED_DT parse failed on {el.Id.Value}: {ex.Message}");
+            }
+
+            // 2. Fallback — so the server never sees null from current clients.
+            return DateTime.UtcNow;
+        }
     }
 
     #endregion
@@ -2207,57 +2258,6 @@ namespace StingTools.BIMManager
             }
 
             public string GetName() => "STING PluginSync Tick";
-        }
-
-        /// <summary>
-        /// Resolve the wall-clock UTC last-modified timestamp for a single
-        /// tagged element, for use in the Planscape sync payload (INT-03).
-        ///
-        /// Priority chain:
-        ///   1. <c>ASS_TAG_MODIFIED_DT</c> — the STING audit trail stamp
-        ///      written by <c>TagPipelineHelper.RunFullPipeline</c> after
-        ///      every successful tag update (Phase 77 entry 748). This is
-        ///      the most precise "when did the tokens actually change"
-        ///      signal and is what the server cares about for true-delta
-        ///      detection on <c>GET /api/tagsync/elements/{projectId}</c>.
-        ///   2. <c>DateTime.UtcNow</c> — last-resort fallback so the server
-        ///      still sees a non-null timestamp for legacy elements that
-        ///      predate the audit-trail plumbing (the server's last-write-
-        ///      wins logic is tolerant of this and simply accepts the
-        ///      update with <c>Version += 1</c>).
-        /// </summary>
-        /// <remarks>
-        /// Revit itself does not expose a first-class per-element
-        /// "modified time" BuiltInParameter — the prompt's reference to
-        /// <c>BuiltInParameter.EDITED_TIME</c> is not a real enum value
-        /// (only <c>EDITED_BY</c> exists, and it returns a worksharing
-        /// username, not a timestamp). The STING audit stamp is therefore
-        /// the only reliable per-element signal we have.
-        /// </remarks>
-        private static DateTime ResolveElementLastModifiedUtc(Element el)
-        {
-            if (el == null) return DateTime.UtcNow;
-
-            // 1. STING audit stamp — the canonical "last token edit".
-            try
-            {
-                string stamp = ParameterHelpers.GetString(el, "ASS_TAG_MODIFIED_DT");
-                if (!string.IsNullOrWhiteSpace(stamp)
-                    && DateTime.TryParse(stamp,
-                        CultureInfo.InvariantCulture,
-                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-                        out var parsed))
-                {
-                    return parsed;
-                }
-            }
-            catch (Exception ex)
-            {
-                StingLog.Warn($"ResolveElementLastModifiedUtc: ASS_TAG_MODIFIED_DT parse failed on {el.Id.Value}: {ex.Message}");
-            }
-
-            // 2. Fallback — so the server never sees null from current clients.
-            return DateTime.UtcNow;
         }
     }
 

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -1952,13 +1952,136 @@ namespace StingTools.BIMManager
             }
             catch (Exception ex) { StingLog.Warn($"Planscape sync timestamp update: {ex.Message}"); }
 
+            // GAP 1-A (INT-03) — Delta PULL from server after push completes.
+            // Picks up any edits other devices made since our last pull,
+            // keyed by the per-project `lastPullUtc` watermark in
+            // planscape_connection.json. Parameters are applied inside a
+            // short Revit Transaction; failed rows are skipped, not rolled back.
+            int pulledCount = 0, pullAppliedCount = 0;
+            try
+            {
+                DateTime? watermark = null;
+                string watermarkStr = null;
+                try
+                {
+                    var cfg = File.Exists(cfgPath)
+                        ? JObject.Parse(File.ReadAllText(cfgPath))
+                        : new JObject();
+                    watermarkStr = cfg["lastPullUtc"]?.Value<string>();
+                    if (!string.IsNullOrWhiteSpace(watermarkStr)
+                        && DateTime.TryParse(watermarkStr,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            System.Globalization.DateTimeStyles.AssumeUniversal
+                                | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                            out var parsed))
+                    {
+                        watermark = parsed;
+                    }
+                }
+                catch (Exception ex) { StingLog.Warn($"Planscape delta-pull: watermark read failed: {ex.Message}"); }
+
+                var remote = System.Threading.Tasks.Task.Run(
+                    () => client.GetElementsDeltaAsync(projectId, watermark)).GetAwaiter().GetResult();
+
+                if (remote != null && remote.Count > 0)
+                {
+                    pulledCount = remote.Count;
+
+                    // Index local tagged elements by UniqueId for O(1) match.
+                    // Same collection shape as BuildPluginSyncPayload — every non-type
+                    // element with a non-empty ASS_TAG_1 is a candidate for update.
+                    var localByUid = new Dictionary<string, Element>(StringComparer.Ordinal);
+                    try
+                    {
+                        foreach (Element el in new FilteredElementCollector(doc).WhereElementIsNotElementType())
+                        {
+                            if (string.IsNullOrEmpty(el.UniqueId)) continue;
+                            string t1 = ParameterHelpers.GetString(el, "ASS_TAG_1") ?? "";
+                            if (string.IsNullOrEmpty(t1)) continue;
+                            if (!localByUid.ContainsKey(el.UniqueId))
+                                localByUid[el.UniqueId] = el;
+                        }
+                    }
+                    catch (Exception ex) { StingLog.Warn($"Planscape delta-pull: local index build: {ex.Message}"); }
+
+                    using (var tx = new Transaction(doc, "STING Planscape Delta Pull"))
+                    {
+                        tx.Start();
+                        foreach (var row in remote.OfType<JObject>())
+                        {
+                            try
+                            {
+                                string uid = row["uniqueId"]?.Value<string>() ?? row["UniqueId"]?.Value<string>();
+                                if (string.IsNullOrEmpty(uid)) continue;
+                                if (!localByUid.TryGetValue(uid, out var el) || el == null) continue;
+
+                                // Apply server-side tokens. Null/empty values are skipped
+                                // so the server never blanks a field the user has locally.
+                                ApplyServerToken(el, "ASS_DISC",   row, "disc");
+                                ApplyServerToken(el, "ASS_LOC",    row, "loc");
+                                ApplyServerToken(el, "ASS_ZONE",   row, "zone");
+                                ApplyServerToken(el, "ASS_LVL",    row, "lvl");
+                                ApplyServerToken(el, "ASS_SYS",    row, "sys");
+                                ApplyServerToken(el, "ASS_FUNC",   row, "func");
+                                ApplyServerToken(el, "ASS_PROD",   row, "prod");
+                                ApplyServerToken(el, "ASS_SEQ",    row, "seq");
+                                ApplyServerToken(el, "ASS_TAG_1",  row, "tag1");
+                                ApplyServerToken(el, "ASS_TAG_7",  row, "tag7");
+                                ApplyServerToken(el, "ASS_STATUS", row, "status");
+                                ApplyServerToken(el, "ASS_REV",    row, "rev");
+                                pullAppliedCount++;
+                            }
+                            catch (Exception ex) { StingLog.Warn($"Planscape delta-pull row apply: {ex.Message}"); }
+                        }
+                        tx.Commit();
+                    }
+
+                    try { Core.ComplianceScan.InvalidateCache(); } catch { /* defensive */ }
+                }
+
+                // Persist watermark after pull. Use UtcNow so subsequent pulls
+                // retrieve everything created/modified during this session.
+                try
+                {
+                    var cfg = File.Exists(cfgPath)
+                        ? JObject.Parse(File.ReadAllText(cfgPath))
+                        : new JObject();
+                    cfg["lastPullUtc"] = DateTime.UtcNow.ToString("o");
+                    cfg["lastPullCount"] = pulledCount;
+                    File.WriteAllText(cfgPath, cfg.ToString(Formatting.Indented));
+                }
+                catch (Exception ex) { StingLog.Warn($"Planscape delta-pull watermark persist: {ex.Message}"); }
+
+                StingLog.Info($"Planscape delta-pull: {pulledCount} server elements returned, {pullAppliedCount} applied locally (watermark: {watermarkStr ?? "<none>"} → {DateTime.UtcNow:O})");
+            }
+            catch (Exception ex) { StingLog.Warn($"Planscape delta-pull failed (non-fatal): {ex.Message}"); }
+
             TaskDialog.Show("Planscape Sync — Complete",
                 $"Sync to Planscape server complete!\n\n" +
-                $"Elements sent:    {tagSync.Count:N0}\n" +
-                $"Drained payloads: {sResult.TagsCreated:N0}\n\n" +
+                $"Elements sent:     {tagSync.Count:N0}\n" +
+                $"Drained payloads:  {sResult.TagsCreated:N0}\n" +
+                $"Delta pulled:      {pulledCount:N0}\n" +
+                $"Delta applied:     {pullAppliedCount:N0}\n\n" +
                 $"Server: {client.ServerUrl}\n" +
                 $"User: {client.ConnectedUser}\n\n" +
                 $"Compliance metrics will arrive on the ComplianceHub.");
+        }
+
+        /// <summary>
+        /// GAP 1-A helper — applies a JSON-bearing token to a Revit element only
+        /// when the server value is non-empty. Read-only / missing parameters
+        /// are silently skipped (ParameterHelpers handles that throttling).
+        /// </summary>
+        private static void ApplyServerToken(Element el, string paramName, JObject row, string jsonKey)
+        {
+            try
+            {
+                string val = row[jsonKey]?.Value<string>();
+                if (val == null) val = row[char.ToUpper(jsonKey[0]) + jsonKey.Substring(1)]?.Value<string>();
+                if (string.IsNullOrEmpty(val)) return;
+                ParameterHelpers.SetString(el, paramName, val, overwrite: true);
+            }
+            catch (Exception ex) { StingLog.Warn($"ApplyServerToken({paramName}): {ex.Message}"); }
         }
 
         /// <summary>

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -259,6 +259,18 @@ namespace StingTools.Core
             }
         }
 
+        // GAP 1-B (INT-02) — debounce state for OnPlanscapeSyncAfterSTC.
+        // STC can fire multiple times in quick succession (user hitting
+        // Sync-to-Central twice, or worksharing-initiated re-syncs); we
+        // throttle to at most one full payload every DebounceSeconds per
+        // document path. The _pendingSyncDoc field tracks the document
+        // whose sync is being held so a subsequent same-doc STC during
+        // the window is a no-op, but a different doc's STC still fires.
+        private static readonly object _planscapeSyncLock = new object();
+        private static Document _pendingSyncDoc;
+        private static DateTime _lastPlanscapeSync = DateTime.MinValue;
+        private const int PlanscapeSyncDebounceSeconds = 60;
+
         /// <summary>INT-03: After a successful STC, trigger a Planscape server sync.
         /// Exits silently if the plugin isn't authenticated; otherwise delegates to the
         /// existing PlatformSyncCommand.SyncToPlanscapeServer() path which collects tags,
@@ -274,6 +286,23 @@ namespace StingTools.Core
 
                 Document doc = e.Document;
                 if (doc == null || !doc.IsValidObject || doc.IsFamilyDocument) return;
+
+                // GAP 1-B — 60s debounce. Multiple STCs in the same window collapse
+                // into a single sync. Doc-scoped so swapping documents still syncs.
+                lock (_planscapeSyncLock)
+                {
+                    var sincePrev = DateTime.UtcNow - _lastPlanscapeSync;
+                    bool sameDocPending = _pendingSyncDoc != null
+                        && _pendingSyncDoc.IsValidObject
+                        && string.Equals(_pendingSyncDoc.PathName, doc.PathName, StringComparison.OrdinalIgnoreCase);
+                    if (sameDocPending && sincePrev.TotalSeconds < PlanscapeSyncDebounceSeconds)
+                    {
+                        StingLog.Info($"Planscape STC sync debounced ({sincePrev.TotalSeconds:F0}s < {PlanscapeSyncDebounceSeconds}s) for {doc.Title}");
+                        return;
+                    }
+                    _pendingSyncDoc = doc;
+                    _lastPlanscapeSync = DateTime.UtcNow;
+                }
 
                 StingLog.Info("Planscape: auto-sync triggered by STC");
 
@@ -364,6 +393,69 @@ namespace StingTools.Core
                     });
                 }
                 catch (Exception pwEx) { StingLog.Warn($"FUT-19 pre-warm launch: {pwEx.Message}"); }
+
+                // GAP 1-C (INT-01) — Lazy-start SyncScheduler on document open.
+                // OnStartup only succeeds if credentials were in memory before any
+                // document was loaded. When the user connects AFTER plugin start and
+                // THEN opens the project document, OnStartup's check already missed.
+                // This hook retries: if the client is authenticated, the project is
+                // linked (planscape_connection.json present with a projectId), and
+                // the scheduler is still idle, start it now.
+                try
+                {
+                    if (Planscape.PluginSync.SyncScheduler.Instance == null)
+                    {
+                        var pClient = PlanscapeServerClient.Instance;
+                        bool connected = pClient != null && pClient.IsConnected
+                            && !string.IsNullOrEmpty(pClient.ServerUrl)
+                            && !string.IsNullOrEmpty(pClient.AuthToken);
+                        if (connected)
+                        {
+                            string docPath = e.Document?.PathName;
+                            string projectDir = !string.IsNullOrEmpty(docPath)
+                                ? System.IO.Path.GetDirectoryName(docPath)
+                                : null;
+                            string cfgPath = null;
+                            if (!string.IsNullOrEmpty(projectDir))
+                            {
+                                // Preferred: _bim_manager/planscape_connection.json
+                                string bimDir = System.IO.Path.Combine(projectDir, "_bim_manager");
+                                cfgPath = System.IO.Path.Combine(bimDir, "planscape_connection.json");
+                                if (!System.IO.File.Exists(cfgPath)) cfgPath = null;
+                            }
+                            bool hasProjectLink = false;
+                            if (cfgPath != null)
+                            {
+                                try
+                                {
+                                    var jc = Newtonsoft.Json.Linq.JObject.Parse(System.IO.File.ReadAllText(cfgPath));
+                                    string pid = jc["projectId"]?.Value<string>();
+                                    hasProjectLink = !string.IsNullOrWhiteSpace(pid)
+                                        && Guid.TryParse(pid, out var _g) && _g != Guid.Empty;
+                                }
+                                catch (Exception cfgReadEx) { StingLog.Warn($"GAP 1-C cfg read: {cfgReadEx.Message}"); }
+                            }
+                            if (hasProjectLink)
+                            {
+                                Planscape.PluginSync.SyncScheduler.Start(pClient.ServerUrl, pClient.AuthToken);
+                                StingTools.BIMManager.PluginSyncTickBridge.EnsureWired();
+                                StingLog.Info($"GAP 1-C: SyncScheduler lazy-started on DocumentOpened against {pClient.ServerUrl}");
+                                try
+                                {
+                                    if (Planscape.PluginSync.SyncScheduler.Instance != null)
+                                    {
+                                        Planscape.PluginSync.SyncScheduler.Instance.OnSyncComplete += _ =>
+                                        {
+                                            StingTools.UI.StingDockPanel.LastInstance?.RefreshSyncIndicator();
+                                        };
+                                    }
+                                }
+                                catch (Exception icEx) { StingLog.Warn($"GAP 1-C OnSyncComplete wire: {icEx.Message}"); }
+                            }
+                        }
+                    }
+                }
+                catch (Exception lzEx) { StingLog.Warn($"GAP 1-C SyncScheduler lazy-start: {lzEx.Message}"); }
 
                 // FIX-B10: Restore auto-tagger state from persisted config
                 try


### PR DESCRIPTION
## Summary
This PR implements three interconnected improvements to the Planscape synchronization workflow:
- **INT-03**: Delta-pull mechanism to retrieve server-side edits after push completes
- **INT-02**: Debounce logic to prevent excessive syncs during rapid Sync-to-Central operations
- **INT-01**: Lazy-start scheduler when user authenticates after plugin initialization

## Key Changes

### Delta-Pull Implementation (INT-03)
- Added `GetElementsDeltaAsync()` method to `PlanscapeServerClient` to fetch server elements modified since a watermark timestamp
- Implemented delta-pull logic in `SyncToPlanscapeServer()` that:
  - Reads the `lastPullUtc` watermark from `planscape_connection.json`
  - Fetches remote elements modified after that watermark
  - Indexes local tagged elements by UniqueId for O(1) matching
  - Applies server tokens (ASS_DISC, ASS_LOC, ASS_ZONE, etc.) to matching local elements within a transaction
  - Persists updated watermark and pull count for next sync cycle
- Added `ApplyServerToken()` helper to safely apply JSON values to element parameters, skipping null/empty values to prevent server from blanking local fields
- Moved `ResolveElementLastModifiedUtc()` method from inner class to main class for reuse
- Updated sync completion dialog to display delta-pull statistics

### Debounce Logic (INT-02)
- Added debounce state tracking in `StingToolsApp` with 60-second window
- Implemented `OnPlanscapeSyncAfterSTC()` debounce check that:
  - Collapses multiple rapid Sync-to-Central operations into a single payload
  - Tracks pending document by path to allow different documents to sync independently
  - Logs debounce events for diagnostics

### Lazy-Start Scheduler (INT-01)
- Added `OnDocumentOpened` hook to detect late authentication scenarios
- When document opens, checks if:
  - Planscape client is authenticated
  - Project has a valid `planscape_connection.json` with projectId
  - Scheduler hasn't already started
- Starts `SyncScheduler` and wires up UI refresh callbacks if conditions are met
- Gracefully handles missing/invalid config files

## Implementation Details
- All new code includes defensive exception handling with `StingLog.Warn()` to prevent sync failures from blocking document operations
- Delta-pull skips failed rows rather than rolling back entire transaction, improving resilience
- Watermark uses ISO 8601 format with UTC normalization for consistency
- Parameter application uses existing `ParameterHelpers` infrastructure with `overwrite: true` flag
- Debounce uses thread-safe locking to prevent race conditions in multi-threaded Revit environment

https://claude.ai/code/session_011VXb92d9kUonYTchqDgMsE