### PR TITLE
Add Tier 4-10 parameters and expand tag configuration schema

### DIFF
--- a/StingTools/Core/ParamRegistry.cs
+++ b/StingTools/Core/ParamRegistry.cs
@@ -2445,79 +2445,98 @@ namespace StingTools.Core
 
         #endregion
 
-        #region V6 parameters
+        #region V6 / Tier 4-10 parameters
+        //
+        // Parameters backing tag label tiers T4..T10 (schema v5.3 — see STING_TAG_CONFIG_v5_0_*.csv).
+        // All GUIDs follow the placeholder pattern `5753b5aa-000T-4000-8000-0000000000PP`
+        // where T is the tier (4..a hex) and PP is the per-tier row index. Pattern is valid hex
+        // so Guid.TryParse succeeds — essential for the families to bind via shared parameters.
+        // Each constant is also mirrored into PARAMETER_REGISTRY.json extended_params.tier_4_10
+        // so ParamRegistry.GetGuid() resolves correctly at runtime.
+        //
+        // NOTE: The earlier `v6-0001-...` pseudo-GUIDs were invalid hex and silently dropped out
+        // of _guidByName. This region replaces them with valid-hex placeholders. Real stable
+        // GUIDs will be assigned during family-library authoring (same policy as the v4 region).
 
-        // --- N-G12 install time (labour takeoff) ---
-        public const string CST_INSTALL_HRS              = "CST_INSTALL_HRS";
-        public const string CST_INSTALL_HRS_GUID         = "v6-0001-0000-0000-000000000001";
-
-        // --- N-G13 carbon stage breakdown (ISO 14064 / BS EN 15978) ---
-        public const string CBN_A1_A3_KG_CO2E            = "CBN_A1_A3_KG_CO2E";
-        public const string CBN_A1_A3_KG_CO2E_GUID       = "v6-0001-0000-0000-000000000002";
-        public const string CBN_A4_KG_CO2E               = "CBN_A4_KG_CO2E";
-        public const string CBN_A4_KG_CO2E_GUID          = "v6-0001-0000-0000-000000000003";
-        public const string CBN_A5_KG_CO2E               = "CBN_A5_KG_CO2E";
-        public const string CBN_A5_KG_CO2E_GUID          = "v6-0001-0000-0000-000000000004";
-        public const string CBN_B6_KG_CO2E_YR            = "CBN_B6_KG_CO2E_YR";
-        public const string CBN_B6_KG_CO2E_YR_GUID       = "v6-0001-0000-0000-000000000005";
-        public const string CBN_C1_KG_CO2E               = "CBN_C1_KG_CO2E";
-        public const string CBN_C1_KG_CO2E_GUID          = "v6-0001-0000-0000-000000000006";
-        public const string CBN_C2_KG_CO2E               = "CBN_C2_KG_CO2E";
-        public const string CBN_C2_KG_CO2E_GUID          = "v6-0001-0000-0000-000000000007";
-        public const string CBN_C3_C4_KG_CO2E            = "CBN_C3_C4_KG_CO2E";
-        public const string CBN_C3_C4_KG_CO2E_GUID       = "v6-0001-0000-0000-000000000008";
-
-        // --- N-G5 / N-G6 clash triage + resolution ---
-        public const string CLASH_TRIAGE_SEVERITY_NR     = "CLASH_TRIAGE_SEVERITY_NR";
-        public const string CLASH_TRIAGE_SEVERITY_NR_GUID = "v6-0001-0000-0000-000000000009";
-        public const string CLASH_TRIAGE_SCORE           = "CLASH_TRIAGE_SCORE";
-        public const string CLASH_TRIAGE_SCORE_GUID      = "v6-0001-0000-0000-00000000000a";
-        public const string CLASH_TRIAGE_CATEGORY_TXT    = "CLASH_TRIAGE_CATEGORY_TXT";
-        public const string CLASH_TRIAGE_CATEGORY_TXT_GUID = "v6-0001-0000-0000-00000000000b";
-        public const string CLASH_RESOLUTION_STATUS_TXT  = "CLASH_RESOLUTION_STATUS_TXT";
-        public const string CLASH_RESOLUTION_STATUS_TXT_GUID = "v6-0001-0000-0000-00000000000c";
-        public const string CLASH_RESOLUTION_ACTION_TXT  = "CLASH_RESOLUTION_ACTION_TXT";
-        public const string CLASH_RESOLUTION_ACTION_TXT_GUID = "v6-0001-0000-0000-00000000000d";
-
-        // --- N-G9 as-built reconciliation ---
-        public const string ASBUILT_DEVIATION_MM         = "ASBUILT_DEVIATION_MM";
-        public const string ASBUILT_DEVIATION_MM_GUID    = "v6-0001-0000-0000-00000000000e";
-        public const string ASBUILT_CAPTURE_DATE_TXT     = "ASBUILT_CAPTURE_DATE_TXT";
-        public const string ASBUILT_CAPTURE_DATE_TXT_GUID = "v6-0001-0000-0000-00000000000f";
-
-        // --- N-G8 ACC Issues round-trip ---
-        public const string ACC_ISSUE_ID_TXT             = "ACC_ISSUE_ID_TXT";
-        public const string ACC_ISSUE_ID_TXT_GUID        = "v6-0001-0000-0000-000000000010";
-        public const string ACC_SYNC_STATUS_TXT          = "ACC_SYNC_STATUS_TXT";
-        public const string ACC_SYNC_STATUS_TXT_GUID     = "v6-0001-0000-0000-000000000011";
-
-        // --- N-G14 IFC 4.3 PSet override ---
-        public const string IFC_PSET_OVERRIDE_TXT        = "IFC_PSET_OVERRIDE_TXT";
-        public const string IFC_PSET_OVERRIDE_TXT_GUID   = "v6-0001-0000-0000-000000000012";
-
-        // --- N-G4 model health metrics ---
-        public const string HEALTH_SCORE_LAST_NR         = "HEALTH_SCORE_LAST_NR";
-        public const string HEALTH_SCORE_LAST_NR_GUID    = "v6-0001-0000-0000-000000000013";
-        public const string HEALTH_SCORE_DATE_TXT        = "HEALTH_SCORE_DATE_TXT";
-        public const string HEALTH_SCORE_DATE_TXT_GUID   = "v6-0001-0000-0000-000000000014";
-
-        // --- N-G12 labour-hours engine (crew + rate override) ---
-        public const string CST_LABOUR_CREW_TXT          = "CST_LABOUR_CREW_TXT";
-        public const string CST_LABOUR_CREW_TXT_GUID     = "v6-0001-0000-0000-000000000015";
-        public const string CST_LABOUR_RATE_GBP          = "CST_LABOUR_RATE_GBP";
-        public const string CST_LABOUR_RATE_GBP_GUID     = "v6-0001-0000-0000-000000000016";
-
-        // --- N-G16 QR commissioning workflow (state + stamps) ---
+        // --- T4: Commissioning & handover (N-G16 QR workflow) ---
         public const string COMM_STATE_TXT               = "COMM_STATE_TXT";
-        public const string COMM_STATE_TXT_GUID          = "v6-0001-0000-0000-000000000017";
+        public const string COMM_STATE_TXT_GUID          = "5753b5aa-0004-4000-8000-000000000001";
         public const string COMM_DATE_TXT                = "COMM_DATE_TXT";
-        public const string COMM_DATE_TXT_GUID           = "v6-0001-0000-0000-000000000018";
+        public const string COMM_DATE_TXT_GUID           = "5753b5aa-0004-4000-8000-000000000002";
         public const string COMM_OPERATIVE_TXT           = "COMM_OPERATIVE_TXT";
-        public const string COMM_OPERATIVE_TXT_GUID      = "v6-0001-0000-0000-000000000019";
+        public const string COMM_OPERATIVE_TXT_GUID      = "5753b5aa-0004-4000-8000-000000000003";
         public const string COMM_WITNESS_TXT             = "COMM_WITNESS_TXT";
-        public const string COMM_WITNESS_TXT_GUID        = "v6-0001-0000-0000-00000000001a";
+        public const string COMM_WITNESS_TXT_GUID        = "5753b5aa-0004-4000-8000-000000000010";
         public const string COMM_NOTES_TXT               = "COMM_NOTES_TXT";
-        public const string COMM_NOTES_TXT_GUID          = "v6-0001-0000-0000-00000000001b";
+        public const string COMM_NOTES_TXT_GUID          = "5753b5aa-0004-4000-8000-000000000011";
+
+        // --- T5: Cost & procurement (N-G12 install/labour + UGX/USD quote) ---
+        public const string CST_UG_PRICE_UGX             = "CST_UG_PRICE_UGX";
+        public const string CST_UG_PRICE_UGX_GUID        = "5753b5aa-0005-4000-8000-000000000001";
+        public const string CST_INTL_PRICE_USD           = "CST_INTL_PRICE_USD";
+        public const string CST_INTL_PRICE_USD_GUID      = "5753b5aa-0005-4000-8000-000000000002";
+        public const string CST_QUOTE_REF_TXT            = "CST_QUOTE_REF_TXT";
+        public const string CST_QUOTE_REF_TXT_GUID       = "5753b5aa-0005-4000-8000-000000000003";
+        public const string CST_INSTALL_HRS              = "CST_INSTALL_HRS";
+        public const string CST_INSTALL_HRS_GUID         = "5753b5aa-0005-4000-8000-000000000010";
+        public const string CST_LABOUR_CREW_TXT          = "CST_LABOUR_CREW_TXT";
+        public const string CST_LABOUR_CREW_TXT_GUID     = "5753b5aa-0005-4000-8000-000000000011";
+        public const string CST_LABOUR_RATE_GBP          = "CST_LABOUR_RATE_GBP";
+        public const string CST_LABOUR_RATE_GBP_GUID     = "5753b5aa-0005-4000-8000-000000000012";
+
+        // --- T6: Carbon & sustainability (N-G13 — ISO 14064 / BS EN 15978) ---
+        public const string CBN_A1_A3_KG_CO2E            = "CBN_A1_A3_KG_CO2E";
+        public const string CBN_A1_A3_KG_CO2E_GUID       = "5753b5aa-0006-4000-8000-000000000001";
+        public const string CBN_A4_KG_CO2E               = "CBN_A4_KG_CO2E";
+        public const string CBN_A4_KG_CO2E_GUID          = "5753b5aa-0006-4000-8000-000000000002";
+        public const string CBN_B6_KG_CO2E_YR            = "CBN_B6_KG_CO2E_YR";
+        public const string CBN_B6_KG_CO2E_YR_GUID       = "5753b5aa-0006-4000-8000-000000000003";
+        public const string CBN_A5_KG_CO2E               = "CBN_A5_KG_CO2E";
+        public const string CBN_A5_KG_CO2E_GUID          = "5753b5aa-0006-4000-8000-000000000010";
+        public const string CBN_C1_KG_CO2E               = "CBN_C1_KG_CO2E";
+        public const string CBN_C1_KG_CO2E_GUID          = "5753b5aa-0006-4000-8000-000000000011";
+        public const string CBN_C2_KG_CO2E               = "CBN_C2_KG_CO2E";
+        public const string CBN_C2_KG_CO2E_GUID          = "5753b5aa-0006-4000-8000-000000000012";
+        public const string CBN_C3_C4_KG_CO2E            = "CBN_C3_C4_KG_CO2E";
+        public const string CBN_C3_C4_KG_CO2E_GUID       = "5753b5aa-0006-4000-8000-000000000013";
+
+        // --- T7: Fabrication & QC (BS EN ISO 6412 spool / QC inspector chain) ---
+        public const string ASS_SPOOL_NR_TXT             = "ASS_SPOOL_NR_TXT";
+        public const string ASS_SPOOL_NR_TXT_GUID        = "5753b5aa-0007-4000-8000-000000000001";
+        public const string ASS_FAB_STATUS_TXT           = "ASS_FAB_STATUS_TXT";
+        public const string ASS_FAB_STATUS_TXT_GUID      = "5753b5aa-0007-4000-8000-000000000002";
+        public const string ASS_QC_INSPECTOR_TXT         = "ASS_QC_INSPECTOR_TXT";
+        public const string ASS_QC_INSPECTOR_TXT_GUID    = "5753b5aa-0007-4000-8000-000000000003";
+
+        // --- T8: Clash triage + resolution (N-G5 / N-G6) ---
+        public const string CLASH_TRIAGE_SEVERITY_NR     = "CLASH_TRIAGE_SEVERITY_NR";
+        public const string CLASH_TRIAGE_SEVERITY_NR_GUID = "5753b5aa-0008-4000-8000-000000000001";
+        public const string CLASH_TRIAGE_CATEGORY_TXT    = "CLASH_TRIAGE_CATEGORY_TXT";
+        public const string CLASH_TRIAGE_CATEGORY_TXT_GUID = "5753b5aa-0008-4000-8000-000000000002";
+        public const string CLASH_RESOLUTION_STATUS_TXT  = "CLASH_RESOLUTION_STATUS_TXT";
+        public const string CLASH_RESOLUTION_STATUS_TXT_GUID = "5753b5aa-0008-4000-8000-000000000003";
+        public const string CLASH_TRIAGE_SCORE           = "CLASH_TRIAGE_SCORE";
+        public const string CLASH_TRIAGE_SCORE_GUID      = "5753b5aa-0008-4000-8000-000000000010";
+        public const string CLASH_RESOLUTION_ACTION_TXT  = "CLASH_RESOLUTION_ACTION_TXT";
+        public const string CLASH_RESOLUTION_ACTION_TXT_GUID = "5753b5aa-0008-4000-8000-000000000011";
+
+        // --- T9: As-built reconciliation & model health (N-G4 / N-G9) ---
+        public const string ASBUILT_DEVIATION_MM         = "ASBUILT_DEVIATION_MM";
+        public const string ASBUILT_DEVIATION_MM_GUID    = "5753b5aa-0009-4000-8000-000000000001";
+        public const string ASBUILT_CAPTURE_DATE_TXT     = "ASBUILT_CAPTURE_DATE_TXT";
+        public const string ASBUILT_CAPTURE_DATE_TXT_GUID = "5753b5aa-0009-4000-8000-000000000002";
+        public const string HEALTH_SCORE_LAST_NR         = "HEALTH_SCORE_LAST_NR";
+        public const string HEALTH_SCORE_LAST_NR_GUID    = "5753b5aa-0009-4000-8000-000000000003";
+        public const string HEALTH_SCORE_DATE_TXT        = "HEALTH_SCORE_DATE_TXT";
+        public const string HEALTH_SCORE_DATE_TXT_GUID   = "5753b5aa-0009-4000-8000-000000000010";
+
+        // --- T10: Compliance / audit trail (N-G8 ACC round-trip + N-G14 IFC PSet) ---
+        public const string IFC_PSET_OVERRIDE_TXT        = "IFC_PSET_OVERRIDE_TXT";
+        public const string IFC_PSET_OVERRIDE_TXT_GUID   = "5753b5aa-000a-4000-8000-000000000001";
+        public const string ACC_ISSUE_ID_TXT             = "ACC_ISSUE_ID_TXT";
+        public const string ACC_ISSUE_ID_TXT_GUID        = "5753b5aa-000a-4000-8000-000000000002";
+        public const string ACC_SYNC_STATUS_TXT          = "ACC_SYNC_STATUS_TXT";
+        public const string ACC_SYNC_STATUS_TXT_GUID     = "5753b5aa-000a-4000-8000-000000000003";
 
         #endregion
     }

--- a/StingTools/Data/LABEL_DEFINITIONS.json
+++ b/StingTools/Data/LABEL_DEFINITIONS.json
@@ -1,6 +1,6 @@
 {
-  "version": "5.8",
-  "description": "STING Seed Tag v5.7 — master label specification. Paragraph tiers expanded from 3 to 10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated. (v5.8: tier_4..tier_10 added for commissioning/cost/carbon/fab/clash/as-built/compliance per STING_TAG_CONFIG_v5_0_*.csv schema v5.3)",
+  "version": "5.9",
+  "description": "STING Seed Tag v5.9 — master label specification. Paragraph tiers 1..10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated. (v5.9: backfilled 12 CSV-only families and enriched 39 Revit-category entries with CSV-derived tier_1/2/3 rows. Total 138 categories covering 142 tag families. Naming note: Revit BuiltInCategory display names are plural — CSVs use singular family names — csv_family_alias field links the two.)",
   "presentation_modes": {
     "Compact": {
       "state_1": true,
@@ -2017,20 +2017,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
-        },
-        {
-          "param": "BLE_CEILING_SYSTEM_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Ceiling system"
-        },
-        {
-          "param": "BLE_CEILING_HEIGHT_MM",
-          "spaces": 1,
-          "break": true,
-          "suffix_override": " mm",
-          "note": "Ceiling height"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -2038,450 +2027,134 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_CEILING_SYSTEM_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Ceiling type/system"
-        },
-        {
-          "param": "BLE_CEILING_HEIGHT_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " mm",
-          "note": "Ceiling height"
-        },
-        {
-          "param": "BLE_CEILING_GRID_SZ_MM",
-          "spaces": 0,
-          "break": false,
-          "suffix_override": " mm grid",
-          "note": "Grid size"
-        },
-        {
-          "param": "BLE_CEILING_TILE_SIZE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Tile size"
-        },
-        {
-          "param": "BLE_CEILING_FINISH_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Finish: ",
-          "note": "Ceiling finish"
-        },
-        {
-          "param": "FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | FRR: ",
-          "suffix_override": " min",
-          "note": "Fire resistance"
-        },
-        {
-          "param": "BLE_CEILING_ACOUSTIC_NRC_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "NRC: ",
-          "note": "Acoustic rating"
-        },
-        {
-          "param": "MNT_HGT_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "BLE_ELE_AREA_SQ_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Area: ",
-          "suffix_override": " m²",
-          "note": "Ceiling area"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_CEIL_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_CEILING_TYPE_CLASSIFICATION_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_CEILING_HEIGHT_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "PER_FIRE_RATING_HR",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "break": true,
+          "suffix_override": "hr",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_SOUND_TRANSMISSION_CLASS_RATING_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "STC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_CEILING_NOISE_REDUCTION_COEFFICIENT_NRC_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "NRC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_INTERIOR_FINISH_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Fin:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_CEIL_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_CEILING_MAT_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_CEILING_GRID_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Grid:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_SUST_EMBODIED_CARBON_KG",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "kgCO₂/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -2751,7 +2424,8 @@
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Ceiling"
     },
     "Doors": {
       "family_name": "STING - Door Tag",
@@ -2762,20 +2436,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
-        },
-        {
-          "param": "BLE_DOOR_WIDTH_MM",
-          "spaces": 0,
-          "break": false,
-          "suffix_override": ""
-        },
-        {
-          "param": "BLE_DOOR_HEIGHT_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " x ",
-          "suffix_override": " mm"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -2783,487 +2446,163 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_DOOR_OPERATION_TYPE_SWING_SLIDE_FOLD_ROLL_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Operation type"
-        },
-        {
-          "param": "BLE_DOOR_MAT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Door material"
-        },
-        {
-          "param": "BLE_DOOR_WIDTH_MM",
-          "spaces": 0,
-          "break": false,
-          "suffix_override": ""
-        },
-        {
-          "param": "BLE_DOOR_HEIGHT_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " x ",
-          "suffix_override": " mm",
-          "note": "Size"
-        },
-        {
-          "param": "FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | FRR: ",
-          "suffix_override": " min",
-          "note": "Fire resistance"
-        },
-        {
-          "param": "BLE_DOOR_HARDWARE_SPECIFICATION_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Hardware: ",
-          "note": "Hardware"
-        },
-        {
-          "param": "BLE_DOOR_FRAME_MAT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Frame: ",
-          "note": "Frame material"
-        },
-        {
-          "param": "BLE_DOOR_GLAZING_TYPE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Glazing: ",
-          "note": "Glazing type"
-        },
-        {
-          "param": "BLE_DOOR_ACOUSTIC_STC_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | STC: ",
-          "suffix_override": " dB",
-          "note": "Acoustic rating"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: "
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | "
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        },
-        {
-          "param": "BLE_DOOR_TYPE_TXT",
-          "spaces": 1,
-          "break": false,
-          "note": "Door type classification"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_DOOR_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_DOOR_FRR",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_DOOR_FRR, \"\")"
-        },
-        {
-          "param": "WARN_BLE_DOOR_ACOUSTIC",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_DOOR_ACOUSTIC, \"\")"
-        },
-        {
-          "param": "WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_DOOR_WIDTH_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "break": true,
+          "prefix_override": "W:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_DOOR_HEIGHT_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "prefix_override": "× H:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "BLE_DOOR_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_DOOR_OPERATION_TYPE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Op:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_FIRE_RATING_HR",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "hr",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_SOUND_TRANSMISSION_CLASS_RATING_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "STC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_DOOR_WIDTH_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Clear:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_DOOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_DOOR_MAT_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_DOOR_HARDWARE_SPECIFICATION_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "HW:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_DOOR_GLAZING_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Glazed:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_DOOR_THRESHOLD_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Thresh:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_DOOR_CLOSER_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Closer:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -3533,7 +2872,8 @@
           "standard": "Building Regs Part M / BS 8300",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_DOOR_HEIGHT_MM, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Door"
     },
     "Floors": {
       "family_name": "STING - Floor Tag",
@@ -3544,13 +2884,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
-        },
-        {
-          "param": "BLE_FLR_TYPE_CLASSIFICATION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Floor type"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -3558,482 +2894,170 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_FLR_TYPE_CLASSIFICATION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Floor type classification"
-        },
-        {
-          "param": "BLE_FLR_THICKNESS_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " mm",
-          "note": "Thickness"
-        },
-        {
-          "param": "BLE_FLR_FINISH_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Finish: ",
-          "note": "Floor finish"
-        },
-        {
-          "param": "BLE_FLR_LD_CAP_KPA",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Load: ",
-          "suffix_override": " kPa",
-          "note": "Load capacity"
-        },
-        {
-          "param": "PER_THERM_U_VALUE_W_M2K",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "U=",
-          "suffix_override": " W/m²K",
-          "note": "Thermal transmittance"
-        },
-        {
-          "param": "PER_THERM_R_VALUE_M2K_W",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | R=",
-          "suffix_override": " m²K/W",
-          "note": "Thermal resistance"
-        },
-        {
-          "param": "FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "FRR: ",
-          "suffix_override": " min",
-          "note": "Fire resistance"
-        },
-        {
-          "param": "BLE_WALL_SOUND_TRANSMISSION_CLASS_RATING_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | STC: ",
-          "suffix_override": " dB",
-          "note": "Acoustic rating"
-        },
-        {
-          "param": "PER_SUST_RECYCLED_CONTENT_PCT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Recycled: ",
-          "suffix_override": "%",
-          "note": "Sustainability"
-        },
-        {
-          "param": "PER_SUST_CARBON_FOOTPRINT_KG",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | CO₂: ",
-          "suffix_override": " kg",
-          "note": "Embodied carbon"
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_FLOOR_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS, \"\")"
-        },
-        {
-          "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
-        },
-        {
-          "param": "WARN_BLE_FLR_LD_CAP_KPA",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_FLR_LD_CAP_KPA, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_FLR_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_FLR_THICKNESS_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "BLE_FLR_AREA_SQ_M",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_THERM_U_VALUE_W_M2K",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "W/m²K",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_FIRE_RATING_HR",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "hr",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_INTERIOR_FINISH_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Fin:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_FLOOR_SLIP_RESISTANCE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Slip:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_FLOOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_FLR_FINISH_MAT_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_FLOOR_LOAD_KN_M2",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Load:",
+          "suffix_override": "kN/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_SOUND_TRANSMISSION_CLASS_RATING_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "STC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_FLR_STRUCTURAL_SYSTEM_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Const:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_FLOOR_WATERPROOF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| WP:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_SUST_EMBODIED_CARBON_KG",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "kgCO₂/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -4330,7 +3354,8 @@
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Floor"
     },
     "Furniture": {
       "family_name": "STING - Furniture Tag",
@@ -6389,7 +5414,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -6397,434 +5424,101 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_RAMP_SLOPE_PCT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Slope: ",
-          "note": "Ramp slope"
-        },
-        {
-          "param": "BLE_RAMP_WIDTH_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Width: ",
-          "suffix_override": " mm",
-          "note": "Ramp width"
-        },
-        {
-          "param": "BLE_RAMP_LENGTH_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Length: ",
-          "suffix_override": " mm",
-          "note": "Ramp length"
-        },
-        {
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Handrail: ",
-          "note": "Handrail type"
-        },
-        {
-          "param": "BLE_RAMP_SURFACE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Surface: ",
-          "note": "Surface finish"
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_RAMP_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_BLE_RAMP_SLOPE_PCT_RAMPS",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAMP_SLOPE_PCT_RAMPS, \"\")"
-        },
-        {
-          "param": "WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_RAMP_SLOPE_PCT",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "break": true,
+          "prefix_override": "Slope:",
+          "suffix_override": "%",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_RAMP_WIDTH_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "prefix_override": "W:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "BLE_RAMP_LENGTH_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "L:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_RAMP_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_RAMP_LANDING_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Landing:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_RAMP_HANDRAIL_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Handrail:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -7076,7 +5770,8 @@
           "standard": "BS 8300:2018 / ADA / Uganda Building Code",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Ramp"
     },
     "Roofs": {
       "family_name": "STING - Roof Tag",
@@ -7087,21 +5782,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
-        },
-        {
-          "param": "BLE_ROOF_TYPE_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Roof type"
-        },
-        {
-          "param": "BLE_ROOF_SLOPE_DEG",
-          "spaces": 1,
-          "break": true,
-          "prefix_override": "Slope: ",
-          "suffix_override": "°",
-          "note": "Roof slope"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -7109,495 +5792,152 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_ROOF_TYPE_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Roof type"
-        },
-        {
-          "param": "BLE_ROOF_COVERING_MAT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Covering material"
-        },
-        {
-          "param": "BLE_ROOF_SLOPE_DEG",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Slope: ",
-          "suffix_override": "°",
-          "note": "Slope"
-        },
-        {
-          "param": "BLE_ROOF_THICKNESS_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " mm",
-          "note": "Thickness"
-        },
-        {
-          "param": "PER_THERM_U_VALUE_W_M2K",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "U=",
-          "suffix_override": " W/m²K",
-          "note": "Thermal transmittance"
-        },
-        {
-          "param": "PER_THERM_R_VALUE_M2K_W",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | R=",
-          "suffix_override": " m²K/W",
-          "note": "Thermal resistance"
-        },
-        {
-          "param": "FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "FRR: ",
-          "suffix_override": " min",
-          "note": "Fire resistance"
-        },
-        {
-          "param": "BLE_ROOF_DRAINAGE_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Drainage: ",
-          "note": "Drainage type"
-        },
-        {
-          "param": "PER_SUST_RECYCLED_CONTENT_PCT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Recycled: ",
-          "suffix_override": "%",
-          "note": "Sustainability"
-        },
-        {
-          "param": "PER_SUST_CARBON_FOOTPRINT_KG",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | CO₂: ",
-          "suffix_override": " kg",
-          "note": "Embodied carbon"
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        },
-        {
-          "param": "BLE_ROOF_AREA_SQ_M",
-          "spaces": 1,
-          "suffix": "m²",
-          "break": false,
-          "note": "Roof area"
-        },
-        {
-          "param": "BLE_ROOF_THICKNESS_MM",
-          "spaces": 1,
-          "suffix": "mm",
-          "break": false,
-          "note": "Roof build-up thickness"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_ROOF_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS, \"\")"
-        },
-        {
-          "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
-        },
-        {
-          "param": "WARN_BLE_ROOF_SLOPE",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_ROOF_SLOPE, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_ROOF_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_ROOF_THICKNESS_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "PER_THERM_U_VALUE_W_M2K",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "W/m²K",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_FIRE_RATING_HR",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "hr",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_ROOF_SLOPE_DEG",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Slope:",
+          "suffix_override": "°",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_ROOF_AREA_SQ_M",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_ROOF_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_ROOF_COVERING_MAT_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_ROOF_PLM_DRN_SYSTEM_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Drain:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_CONDENSATION_RISK_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Cond:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_SUST_EMBODIED_CARBON_KG",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "kgCO₂/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_ROOF_WATERPROOFING_SYSTEM_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "WP:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -7867,7 +6207,8 @@
           "standard": "BREEAM Mat 01 / LEED MR Credit",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_RECYCLABILITY_LOW, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Roof"
     },
     "Rooms": {
       "family_name": "STING - Room Tag",
@@ -7877,7 +6218,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -7885,441 +6228,147 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Room name"
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_ROOM_AREA_SQ_M",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " m²",
-          "note": "Room area"
+          "prefix_override": "Area:",
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_LVL_COD_TXT",
+          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Level: ",
-          "note": "Level code"
+          "prefix_override": "Dept:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_LOC_TXT",
+          "param": "BLE_ROOM_OCCUPANCY_NR",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Loc: ",
-          "note": "Location"
+          "prefix_override": "| Occ:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ZONE_TXT",
+          "param": "BLE_HEADROOM_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "Zone: ",
-          "note": "Zone"
+          "break": true,
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_ROOM_VENTILATION_RATE_LPS",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Vent:",
+          "suffix_override": "L/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_DESIGN_LTG_LVL_LUX_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Lux:",
+          "suffix_override": "lx",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_ROOM_VOLUME_CU_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Vol: ",
-          "suffix_override": " m³",
-          "note": "Room volume"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ARCH_TAG_7_PARA_ROOM_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_ASS_ROOM_AREA_MIN",
+          "param": "BLE_FLR_FINISH_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Floor Fin:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_FINISH_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_ROOM_AREA_MIN, \"\")"
+          "prefix_override": "| Wall Fin:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_ASS_ROOM_VENTILATION",
+          "param": "BLE_CEILING_FINISH_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_ROOM_VENTILATION, \"\")"
+          "prefix_override": "| Ceil Fin:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "BLE_ROOM_FIRE_ESCAPE_CAPACITY_NR",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Esc Cap:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -8617,7 +6666,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESSIBLE_WC, \"\")"
         }
       ],
-      "paragraph_template": "This is {room_name} (Room {room_number}) with a floor area of {area} m² and volume of {volume} m³, located on level {level} in the {zone} zone within the {department} department. The room has a ceiling height of {height} mm with {finishes} finishes. Design lighting level: {lux} lux. Ventilation rate: {ventilation} L/s per person. Acoustic requirement: {noise} dB background noise maximum. Fire escape travel distance: {travel} m. Occupancy load: {occupancy} persons. Grid reference: {grid}. Phase: {phase}. Workset: {workset}. Compliant with {standard}."
+      "paragraph_template": "This is {room_name} (Room {room_number}) with a floor area of {area} m² and volume of {volume} m³, located on level {level} in the {zone} zone within the {department} department. The room has a ceiling height of {height} mm with {finishes} finishes. Design lighting level: {lux} lux. Ventilation rate: {ventilation} L/s per person. Acoustic requirement: {noise} dB background noise maximum. Fire escape travel distance: {travel} m. Occupancy load: {occupancy} persons. Grid reference: {grid}. Phase: {phase}. Workset: {workset}. Compliant with {standard}.",
+      "csv_family_alias": "Room"
     },
     "Site": {
       "family_name": "STING - Site Tag",
@@ -9301,7 +7351,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -9309,451 +7361,129 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_STAIR_RISE_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Rise: ",
-          "suffix_override": " mm",
-          "note": "Riser height"
-        },
-        {
-          "param": "BLE_STAIR_GOING_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Going: ",
-          "suffix_override": " mm",
-          "note": "Going/tread"
-        },
-        {
-          "param": "BLE_STAIR_WIDTH_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Width: ",
-          "suffix_override": " mm",
-          "note": "Stair width"
-        },
-        {
-          "param": "BLE_STAIR_NR_RISERS_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Risers: ",
-          "note": "Number of risers"
-        },
-        {
-          "param": "BLE_STAIR_HANDRAIL_MAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Handrail: ",
-          "note": "Handrail type"
-        },
-        {
-          "param": "FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | FRR: ",
-          "suffix_override": " min",
-          "note": "Fire resistance"
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_STAIR_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_BLE_STAIR_RISE",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_RISE, \"\")"
-        },
-        {
-          "param": "WARN_BLE_STAIR_GOING",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_GOING, \"\")"
-        },
-        {
-          "param": "WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_STAIR_WIDTH_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "break": true,
+          "prefix_override": "W:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_STAIR_RISE_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "prefix_override": "R:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "BLE_STAIR_GOING_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| G:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_FIRE_RATING_HR",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "hr",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_STAIR_HEADROOM_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Hd:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_STAIR_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_STAIR_HANDRAIL_MAT_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Handrail:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_STAIR_NOSING_TYPE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Nosing:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_STAIR_TREAD_FINISH_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -10041,7 +7771,8 @@
           "standard": "Building Regs Part B / BS 9999 Table 3",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_TRAVEL_DIST_M, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Stair"
     },
     "Walls": {
       "family_name": "STING - Wall Tag",
@@ -10052,21 +7783,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
-        },
-        {
-          "param": "BLE_WALL_FUNCTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Wall function"
-        },
-        {
-          "param": "BLE_WALL_THICKNESS_MM",
-          "spaces": 1,
-          "break": true,
-          "prefix_override": "[",
-          "suffix_override": " mm]",
-          "note": "Thickness in brackets"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -10074,562 +7793,197 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_WALL_FUNCTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Wall function"
-        },
-        {
-          "param": "BLE_WALL_TYPE_CLASSIFICATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Classification"
-        },
-        {
-          "param": "BLE_WALL_PRIMARY_WALL_MAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Primary material"
-        },
-        {
-          "param": "BLE_WALL_CST_METHOD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Construction method"
-        },
-        {
-          "param": "BLE_WALL_THICKNESS_MM",
-          "spaces": 0,
-          "break": false,
-          "suffix_override": " mm",
-          "note": "Thickness"
-        },
-        {
-          "param": "BLE_WALL_HEIGHT_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " x ",
-          "suffix_override": " mm",
-          "note": "Height"
-        },
-        {
-          "param": "PER_THERM_U_VALUE_W_M2K",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "U=",
-          "suffix_override": " W/m²K",
-          "note": "Thermal transmittance"
-        },
-        {
-          "param": "PER_THERM_R_VALUE_M2K_W",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " | R=",
-          "suffix_override": " m²K/W",
-          "note": "Thermal resistance"
-        },
-        {
-          "param": "PER_THERM_CONDENSATION_RISK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Condensation risk"
-        },
-        {
-          "param": "FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "FRR: ",
-          "suffix_override": " min",
-          "note": "Fire resistance"
-        },
-        {
-          "param": "BLE_WALL_SOUND_TRANSMISSION_CLASS_RATING_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | STC: ",
-          "suffix_override": " dB",
-          "note": "Acoustic rating"
-        },
-        {
-          "param": "BLE_WALL_INTERIOR_FINISH_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Int: ",
-          "note": "Internal finish"
-        },
-        {
-          "param": "BLE_WALL_EXTERIOR_FINISH_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " | Ext: ",
-          "note": "External finish"
-        },
-        {
-          "param": "BLE_WALL_MOISTURE_BARRIER_INCLUDED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Moisture: ",
-          "note": "Moisture barrier"
-        },
-        {
-          "param": "PER_SUST_RECYCLED_CONTENT_PCT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Recycled: ",
-          "suffix_override": "%",
-          "note": "Sustainability"
-        },
-        {
-          "param": "PER_SUST_CARBON_FOOTPRINT_KG",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | CO₂: ",
-          "suffix_override": " kg",
-          "note": "Embodied carbon"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "BLE_WALL_LENGTH_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Length: ",
-          "suffix_override": " mm",
-          "note": "Wall length"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        },
-        {
-          "param": "BLE_WALL_CORE_MATERIAL_TXT",
-          "spaces": 1,
-          "break": false,
-          "note": "Wall core material"
-        },
-        {
-          "param": "BLE_WALL_INSULATION_TXT",
-          "spaces": 1,
-          "break": false,
-          "note": "Wall insulation type"
-        },
-        {
-          "param": "BLE_WALL_WATERPROOF_TXT",
-          "spaces": 1,
-          "break": false,
-          "note": "Wall waterproofing system"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_WALL_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS, \"\")"
-        },
-        {
-          "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
-        },
-        {
-          "param": "WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_WALL_TYPE_CLASSIFICATION_TXT",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "break": true,
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_WALL_THICKNESS_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "BLE_ELE_AREA_SQ_M",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_THERM_U_VALUE_W_M2K",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "W/m²K",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_FIRE_RATING_HR",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "hr",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_SOUND_TRANSMISSION_CLASS_RATING_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "STC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_EXTERIOR_FINISH_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Fin:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_CST_METHOD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Const:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_WALL_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_PRIMARY_WALL_MAT_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_CORE_MATERIAL_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Core:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_INSULATION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Insul:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_CONDENSATION_RISK_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Cond Risk:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_SUST_EMBODIED_CARBON_KG",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "kgCO₂/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_WATERPROOF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "WP:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_DELIVERY_LEAD_TIME_DAYS",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
+          "prefix_override": "Lead:",
+          "suffix_override": "days",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_MARK_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "prefix_override": "| Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -10935,7 +8289,8 @@
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Wall"
     },
     "Windows": {
       "family_name": "STING - Window Tag",
@@ -10946,20 +8301,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
-        },
-        {
-          "param": "BLE_WINDOW_WIDTH_MM",
-          "spaces": 0,
-          "break": false,
-          "suffix_override": ""
-        },
-        {
-          "param": "BLE_WINDOW_HEIGHT_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " x ",
-          "suffix_override": " mm"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -10967,462 +8311,146 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_WINDOW_WIDTH_MM",
-          "spaces": 0,
-          "break": false,
-          "suffix_override": ""
-        },
-        {
-          "param": "BLE_WINDOW_HEIGHT_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " x ",
-          "suffix_override": " mm",
-          "note": "Size"
-        },
-        {
-          "param": "BLE_WINDOW_FRAME_MAT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Frame: ",
-          "note": "Frame material"
-        },
-        {
-          "param": "BLE_WINDOW_GLAZING_TYPE_SINGLE_DOUBLE_TRIPLE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Glazing: ",
-          "note": "Glazing type"
-        },
-        {
-          "param": "BLE_WINDOW_U_VALUE_W_M_2K_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | U=",
-          "suffix_override": " W/m²K",
-          "note": "U-value"
-        },
-        {
-          "param": "BLE_WINDOW_SHGC_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "SHGC: ",
-          "note": "Solar heat gain"
-        },
-        {
-          "param": "BLE_WINDOW_VLT_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | VLT: ",
-          "note": "Visible light transmission"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: "
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "BLE_WINDOW_SILL_HEIGHT_FROM_FLR_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Sill: ",
-          "suffix_override": " mm AFF",
-          "note": "Sill height from floor"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "ARCH_TAG_7_PARA_WIN_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_BLE_WINDOW_U_VALUE",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_WINDOW_U_VALUE, \"\")"
-        },
-        {
-          "param": "WARN_BLE_WINDOW_SHGC",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_WINDOW_SHGC, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "BLE_WINDOW_WIDTH_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "break": true,
+          "prefix_override": "W:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "BLE_WINDOW_HEIGHT_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "prefix_override": "× H:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "BLE_WINDOW_TYPE_CLASSIFICATION_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WINDOW_OPERATION_TYPE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Op:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_THERM_U_VALUE_W_M2K",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "W/m²K",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WINDOW_SOLAR_HEAT_GAIN_COEFFICIENT_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "g:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ARCH_TAG_7_PARA_WIN_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WINDOW_FRAME_MAT_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Frame:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WINDOW_GLAZING_TYPE_SINGLE_DOUBLE_TRIPLE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Glaze:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WINDOW_AREA_SQ_M",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Vent:",
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WALL_SOUND_TRANSMISSION_CLASS_RATING_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "STC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -11674,7 +8702,8 @@
           "standard": "Building Regs Part L / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_WINDOW_SHGC, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Window"
     },
     "Structural Rebar": {
       "family_name": "STING - Structural Rebar Tag",
@@ -12373,7 +9402,10 @@
         {
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
-          "break": true
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -12381,417 +9413,100 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "BLE_RAILING_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_RAILING_TYPE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_RAILING_MATERIAL_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
+          "param": "ARCH_TAG_7_PARA_RAILING_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_TAG_7_PARA_RAILINGS_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph"
-        },
-        {
-          "param": "WARN_BLE_RAIL_HEIGHT_MM",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_HEIGHT_MM, \"\")"
-        },
-        {
-          "param": "WARN_BLE_RAIL_LOAD_KN_M",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_LOAD_KN_M, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "BLE_RAILING_INFILL_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "prefix_override": "Infill:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "BLE_RAILING_BALUSTER_SPACING_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "| Bal:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -13043,7 +9758,8 @@
           "standard": "Building Regs Part K / BS 6180:2011",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_LOAD_KN_M, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Railing"
     },
     "Areas": {
       "family_name": "STING - Areas Tag",
@@ -14374,7 +11090,10 @@
         {
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
-          "break": true
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -14382,417 +11101,100 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "BLE_PANEL_WIDTH_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "W:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_PANEL_HEIGHT_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "× H:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_THERM_U_VALUE_W_M2K",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "W/m²K",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_WINDOW_SOLAR_HEAT_GAIN_COEFFICIENT_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "g:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
+          "param": "ARCH_TAG_7_PARA_CURTAIN_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_TAG_7_PARA_CURTAIN_PANELS_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph"
-        },
-        {
-          "param": "WARN_BLE_CW_PANEL_U_VALUE",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_CW_PANEL_U_VALUE, \"\")"
-        },
-        {
-          "param": "WARN_BLE_CW_PANEL_SHGC",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_CW_PANEL_SHGC, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "BLE_PANEL_GLASS_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Glass:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -15044,7 +11446,8 @@
           "standard": "Building Regs Part L / CWCT TN 42",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_CW_PANEL_SHGC, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Curtain Panel"
     },
     "Curtain Wall Mullions": {
       "family_name": "STING - Curtain Wall Mullions Tag",
@@ -15054,7 +11457,10 @@
         {
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
-          "break": true
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -15062,403 +11468,119 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "BLE_MULLION_DEPTH_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "D:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_MULLION_MATERIAL_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_MULLION_FINISH_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Fin:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "BLE_PANEL_GLASS_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
+          "prefix_override": "Glass:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
+          "param": "BLE_PANEL_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
+          "prefix_override": "PH:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
+          "param": "BLE_PANEL_WIDTH_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "PW:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
+          "param": "ARCH_TAG_7_PARA_MULLION_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_TAG_7_PARA_CURTAIN_MULLIONS_TXT",
+          "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "suffix_override": "W/m²K",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -15701,7 +11823,8 @@
           "standard": "BS EN 1992/1993/1994 / Eurocode 2-4",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STRUCT_LD_CAP, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Curtain Wall Mullion"
     },
     "Columns": {
       "family_name": "STING - Columns Tag",
@@ -34937,7 +31060,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -34945,455 +31070,210 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "BLE_STRUCT_COLUMN_SZ_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Column size"
-        },
-        {
-          "param": "BLE_STRUCT_MAT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Material"
-        },
-        {
-          "param": "BLE_STRUCT_CONCRETE_GRADE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grade: ",
-          "note": "Concrete grade"
-        },
-        {
-          "param": "BLE_STRUCT_REINFORCEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rebar: ",
-          "note": "Reinforcement"
-        },
-        {
-          "param": "BLE_STRUCT_LD_CAP_KN_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Capacity: ",
-          "suffix_override": " kN",
-          "note": "Load capacity"
-        },
-        {
-          "param": "STR_FIRE_PROTECTION_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | FP: ",
-          "note": "Fire protection"
-        },
-        {
-          "param": "BLE_STRUCT_EXPOSURE_CLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Exposure: ",
-          "note": "Exposure class"
-        },
-        {
-          "param": "BLE_STRUCT_COVER_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cover: ",
-          "suffix_override": " mm",
-          "note": "Concrete cover"
-        },
-        {
-          "param": "RGL_STD_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "BLE_STRUCT_ELE_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Struct Type: ",
-          "note": "Structural element type"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        }
-      ],
-      "tier_3": [
-        {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
-          "param": "STR_TAG_7_PARA_COL_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
-        },
-        {
-          "param": "WARN_BLE_STRUCT_LD_CAP",
-          "spaces": 0,
-          "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STRUCT_LD_CAP, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "STR_COL_SECTION_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "prefix_override": "Sec:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
+          "param": "STR_COL_SIZE_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
+          "break": true,
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_VOLUME_COD_TXT",
+          "param": "STR_COL_MATERIAL_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_STRUCT_STEEL_GRADE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Gr:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_COL_HEIGHT_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_LOAD_AXIAL_KN",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Load:",
+          "suffix_override": "kN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_FIRE_RATING_HR",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "hr",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "STR_TAG_7_PARA_COL_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_COL_GRID_REF_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Grid:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_COL_SPLICE_DETAIL_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Splice:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_FIRE_PROTECTION_TYPE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "FP:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_COL_BASE_PLATE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| BP:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_S_REI_WEIGHT_KG",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "kg",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_COL_MOMENT_CAPACITY_KNM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Mom:",
+          "suffix_override": "kNm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_SUST_EMBODIED_CARBON_KG",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "kgCO₂/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_DELIVERY_LEAD_TIME_DAYS",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
+          "prefix_override": "Lead:",
+          "suffix_override": "days",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_MARK_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
+          "prefix_override": "| Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_COMMENTS_TXT",
+          "param": "RGL_QA_COMMISSIONING_REQ_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "prefix_override": "Comm:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -35654,7 +31534,8 @@
           "standard": "BS EN 1992-1-1 §5.8 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_COL_ECCENTRICITY, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Structural Column"
     },
     "Structural Foundations": {
       "family_name": "STING - Structural Foundation Tag",
@@ -35665,7 +31546,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -35673,456 +31556,211 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Foundation type"
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_STRUCT_MAT_TXT",
+          "param": "STR_FDN_TYPE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_FDN_SIZE_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Material"
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_STRUCT_CONCRETE_GRADE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grade: ",
-          "note": "Concrete grade"
-        },
-        {
-          "param": "BLE_STRUCT_REINFORCEMENT_TXT",
+          "param": "STR_FDN_DEPTH_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Rebar: ",
-          "note": "Reinforcement"
+          "prefix_override": "D:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_STRUCT_LD_CAP_KN_NR",
+          "param": "STR_FDN_MATERIAL_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Capacity: ",
-          "suffix_override": " kN",
-          "note": "Load capacity"
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_STRUCT_DEPTH_MM",
+          "param": "BLE_STRUCT_STEEL_GRADE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Depth: ",
-          "suffix_override": " mm",
-          "note": "Foundation depth"
+          "prefix_override": "| Gr:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "BLE_STRUCT_COVER_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Cover: ",
-          "suffix_override": " mm",
-          "note": "Concrete cover"
-        },
-        {
-          "param": "BLE_STRUCT_EXPOSURE_CLASS_TXT",
+          "param": "STR_FDN_BEARING_KN_M2",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Exposure: ",
-          "note": "Exposure class"
-        },
-        {
-          "param": "BLE_STRUCT_WATERPROOFING_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "WP: ",
-          "note": "Waterproofing"
+          "prefix_override": "Bearing:",
+          "suffix_override": "kN/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "STR_TAG_7_PARA_FDN_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_BLE_STRUCT_FDN_BEARING",
+          "param": "STR_FDN_REBAR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Rebar:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_FDN_COVER_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STRUCT_FDN_BEARING, \"\")"
+          "prefix_override": "| Cover:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "STR_FDN_WATERPROOF_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "prefix_override": "WP:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "STR_FDN_EXPOSURE_CLASS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "prefix_override": "| Exp:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
+          "param": "CST_S_REI_WEIGHT_KG",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
+          "suffix_override": "kg",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
+          "param": "STR_FDN_SETTLEMENT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
+          "prefix_override": "Settl:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "STR_FDN_PILE_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
+          "prefix_override": "Pile:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
+          "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "suffix_override": "kgCO₂/m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_DELIVERY_LEAD_TIME_DAYS",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
+          "prefix_override": "Lead:",
+          "suffix_override": "days",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_MARK_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
+          "prefix_override": "| Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_COMMENTS_TXT",
+          "param": "RGL_QA_COMMISSIONING_REQ_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "prefix_override": "| Comm:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -36374,7 +32012,8 @@
           "standard": "BS EN 1997-1 / Eurocode 7",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_FDN_DEPTH_MM, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Structural Foundation"
     },
     "Structural Framing": {
       "family_name": "STING - Structural Framing Tag",
@@ -49508,7 +45147,10 @@
         {
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
-          "break": true
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -49516,410 +45158,146 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
+          "param": "STR_CONN_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "note": "Manufacturer"
+          "prefix_override": "Type:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "STR_CONN_CAPACITY_KN",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "Cap:",
+          "suffix_override": "kN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_CONN_BOLT_SIZE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Bolt:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
+          "param": "STR_TAG_7_PARA_CONN_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "STR_TAG_7_PARA_STR_CONNECTIONS_TXT",
+          "param": "STR_CONN_WELD_TYPE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Weld:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_CONN_PLATE_THICKNESS_MM",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph"
+          "prefix_override": "| Plt:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_STR_CONN_CAPACITY_KN",
+          "param": "STR_CONN_ROTATION_CAPACITY_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Rot:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_FIRE_PROTECTION_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_CONN_CAPACITY_KN, \"\")"
+          "prefix_override": "FP:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "CST_S_REI_WEIGHT_KG",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
+          "suffix_override": "kg",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_STATUS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_DELIVERY_LEAD_TIME_DAYS",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
+          "prefix_override": "Lead:",
+          "suffix_override": "days",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_MARK_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "prefix_override": "| Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -50162,7 +45540,8 @@
           "standard": "BS EN 1993-1-8 / Eurocode 3",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_CONN_CAPACITY_KN, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Structural Connection"
     },
     "Structural Stiffeners": {
       "family_name": "STING - Structural Stiffeners Tag",
@@ -51494,7 +46873,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -51502,444 +46883,109 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_DCT_FLW_CFM",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | Flow: ",
-          "suffix_override": " CFM",
-          "note": "Airflow"
+          "break": false,
+          "prefix_override": "Flow:",
+          "suffix_override": "CFM",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_VEL_MPS",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "Vel: ",
-          "suffix_override": " m/s",
-          "note": "Face velocity"
-        },
-        {
-          "param": "HVC_DCT_SOUNDLVL_DB",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | NC: ",
-          "suffix_override": " dB",
-          "note": "Sound level"
-        },
-        {
-          "param": "HVC_THROW_M",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Throw: ",
-          "suffix_override": " m",
-          "note": "Throw distance"
+          "prefix_override": "|",
+          "suffix_override": "m/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "MNT_HGT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "HVC_TAG_7_PARA_AT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_HVC_DCT_SOUNDLVL_DB",
+          "param": "HVC_DCT_TERMINAL_TYPE_SD_RG_EG_VAV_TXT",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "V",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DCT_TERMINAL_SZ_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_DCT_SOUNDLVL_DB, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "param": "HVC_TERMINAL_MAT_TXT",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "HVC_TERMINAL_FINISH_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -52182,7 +47228,8 @@
           "standard": "CIBSE Guide B5 / BS 8233:2014",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_DCT_SOUNDLVL_DB, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Air Terminal"
     },
     "Duct Accessories": {
       "family_name": "STING - Duct Accessory Tag",
@@ -52193,7 +47240,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -52201,419 +47250,54 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "HVC_DCT_FLW_CFM",
+          "param": "HVC_DCT_PROPERTY_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Flow: ",
-          "suffix_override": " CFM",
-          "note": "Airflow"
-        },
-        {
-          "param": "HVC_PIPE_PRESSURE_KPA",
-          "spaces": 0,
-          "break": false,
-          "suffix_override": " kPa",
-          "note": "Pressure drop"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "HVC_TAG_7_PARA_DCTACC_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -52857,7 +47541,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_MEP_DUCT_ACC_PRESSURE_DROP, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Duct Accessory"
     },
     "Duct Fittings": {
       "family_name": "STING - Duct Fitting Tag",
@@ -52868,7 +47553,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -52876,412 +47563,53 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_DCT_PROPERTY_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Size"
-        },
-        {
-          "param": "HVC_DCT_FLW_CFM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Flow: ",
-          "suffix_override": " CFM",
-          "note": "Airflow"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "HVC_TAG_7_PARA_DCTACC_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "HVC_DUCT_CLASS_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -53525,7 +47853,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_MEP_DUCT_FITTING_LOSS, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Duct Fitting"
     },
     "Ducts": {
       "family_name": "STING - Duct Tag",
@@ -53536,13 +47865,19 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         },
         {
           "param": "HVC_DCT_PROPERTY_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Duct size"
+          "break": true,
+          "prefix_override": "[",
+          "suffix_override": "]",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -53550,472 +47885,236 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "HVC_DCT_PROPERTY_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Duct size/shape"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_DCT_FLW_CFM",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | Flow: ",
-          "suffix_override": " CFM",
-          "note": "Airflow"
+          "break": false,
+          "prefix_override": "Flow:",
+          "suffix_override": "CFM",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_VEL_MPS",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Vel: ",
-          "suffix_override": " m/s",
-          "note": "Velocity"
+          "prefix_override": "|",
+          "suffix_override": "m/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_PIPE_PRESSURE_KPA",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " kPa",
-          "note": "Pressure"
-        },
-        {
-          "param": "SYS_INSULATION_TYPE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Insul: ",
-          "note": "Insulation type"
+          "prefix_override": "|",
+          "suffix_override": "kPa",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_DCT_MAT_TXT",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | Mat: ",
-          "note": "Duct material"
-        },
-        {
-          "param": "FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN",
-          "spaces": 0,
           "break": false,
-          "prefix_override": "FRR: ",
-          "suffix_override": " min",
-          "note": "Fire resistance"
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "MEP_TIE_POINT_ID_TXT",
+          "param": "HVC_INSULATION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point identifier"
+          "prefix_override": "| Insul:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "HVC_DCT_SHOP_DRAWING_REQ_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "HVC_AIRFLOW_LPS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Airflow: ",
-          "suffix_override": " L/s",
-          "note": "Airflow"
-        },
-        {
-          "param": "HVC_PRESSURE_DROP_PA",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ΔP: ",
-          "suffix_override": " Pa",
-          "note": "Pressure drop"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
-        },
-        {
-          "param": "HVC_DCT_SZ_TXT",
-          "spaces": 1,
-          "break": false,
-          "note": "Duct size designation"
+          "prefix_override": "Shop:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "HVC_TAG_7_PARA_DUCT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_HVC_VEL_MPS_DUCTS",
+          "param": "HVC_DUCT_CLASS_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_VEL_MPS_DUCTS, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "HVC_DUCT_LINING_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DUCT_AREA_SQ_M",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DUCT_FLOWRATE_M3H",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "m³/h",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DCT_TAG_01_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DCT_TAG_02_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DCT_TAG_03_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_PIPE_LENGTH_M",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_AIR_CHANGES_PER_HR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "A",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DCT_FAB_METHOD_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "prefix_override": "Fab:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "HVC_DCT_SEAM_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "prefix_override": "| Seam:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
+          "param": "HVC_DCT_SUPPORTS_SPACING_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
+          "prefix_override": "Supt:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_KEYNOTE_TXT",
+          "param": "HVC_DCT_HANGER_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
+          "prefix_override": "| Hanger:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGIN_TXT",
+          "param": "CST_CALC_LENGTH_M",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
+          "prefix_override": "Length:",
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_REV_TXT",
+          "param": "CST_CALC_AREA_M2",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
+          "prefix_override": "| Area:",
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "prefix_override": "Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -54268,7 +48367,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_DUCT_LEAKAGE_CLASS, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Duct"
     },
     "Flex Ducts": {
       "family_name": "STING - Flex Duct Tag",
@@ -54279,7 +48379,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -54287,420 +48389,74 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "HVC_DCT_PROPERTY_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Size"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "HVC_DCT_FLW_CFM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Flow: ",
-          "suffix_override": " CFM",
-          "note": "Airflow"
-        },
-        {
-          "param": "HVC_VEL_MPS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Vel: ",
-          "suffix_override": " m/s",
-          "note": "Velocity"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point"
+          "prefix_override": "Flow:",
+          "suffix_override": "CFM",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "HVC_DCT_SZ_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
+          "prefix_override": "Size:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
+          "param": "INS_MATERIAL_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Ins:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "HVC_TAG_7_PARA_FLEXDUCT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_HVC_VEL_MPS_FLEX_DUCTS",
-          "spaces": 0,
+          "param": "HVC_DUCT_FLOWRATE_M3H",
+          "spaces": 1,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_VEL_MPS_FLEX_DUCTS, \"\")"
+          "suffix_override": "m³/h",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -54953,7 +48709,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_DUCT_LEAKAGE_CLASS, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Flex Duct"
     },
     "Mechanical Equipment": {
       "family_name": "STING - Mechanical Equipment Tag",
@@ -55717,7 +49474,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -55725,421 +49484,64 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PPE_SZ_MM",
           "spaces": 0,
           "break": false,
           "prefix_override": "DN",
-          "note": "Size"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PPE_MAT_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Mat: ",
-          "note": "Material"
-        },
-        {
-          "param": "PLM_PPE_FLW_LPS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Flow: ",
-          "suffix_override": " L/s",
-          "note": "Flow rate"
-        },
-        {
-          "param": "PLM_VEL_MPS",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Vel: ",
-          "suffix_override": " m/s",
-          "note": "Velocity"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "TP: ",
-          "note": "MEP tie-point"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "PLM_TAG_7_PARA_PIPE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "PLM_PPE_LENGTH_M",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -56383,7 +49785,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_VEL_MPS_PIPES, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Flex Pipe"
     },
     "Pipe Accessories": {
       "family_name": "STING - Pipe Accessory Tag",
@@ -56394,7 +49797,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -56402,418 +49807,55 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PPE_SZ_MM",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | DN",
-          "note": "Size"
-        },
-        {
-          "param": "PLM_PSR_KPA",
-          "spaces": 0,
           "break": false,
-          "suffix_override": " kPa",
-          "note": "Pressure"
+          "prefix_override": "DN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "MEP_TIE_POINT_ID_TXT",
+          "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "PLM_TAG_7_PARA_PIPEACC_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -57057,7 +50099,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PIPE_ACC_RATING, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Pipe Accessory"
     },
     "Pipe Fittings": {
       "family_name": "STING - Pipe Fitting Tag",
@@ -57068,7 +50111,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -57076,411 +50121,64 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PPE_SZ_MM",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | DN",
-          "note": "Size"
+          "break": false,
+          "prefix_override": "DN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PPE_MAT_TXT",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "Mat: ",
-          "note": "Material"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "PLM_TAG_7_PARA_PIPEACC_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "PLM_PPE_PSR_RATING_BAR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "suffix_override": "bar",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -57724,7 +50422,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PIPE_FITTING_LOSS, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Pipe Fitting"
     },
     "Pipes": {
       "family_name": "STING - Pipe Tag",
@@ -57735,14 +50434,18 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         },
         {
           "param": "PLM_PPE_SZ_MM",
           "spaces": 0,
-          "break": false,
+          "break": true,
           "prefix_override": "DN",
-          "note": "Pipe size"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -57750,480 +50453,225 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "PLM_PPE_SZ_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "DN",
-          "note": "Pipe size"
-        },
-        {
-          "param": "PLM_PPE_MAT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Mat: ",
-          "note": "Material"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PPE_FLW_LPS",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Flow: ",
-          "suffix_override": " L/s",
-          "note": "Flow rate"
+          "prefix_override": "Flow:",
+          "suffix_override": "L/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_VEL_MPS",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | Vel: ",
-          "suffix_override": " m/s",
-          "note": "Velocity"
+          "break": false,
+          "prefix_override": "|",
+          "suffix_override": "m/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PSR_KPA",
           "spaces": 0,
-          "break": false,
-          "suffix_override": " kPa",
-          "note": "Pressure"
-        },
-        {
-          "param": "SYS_INSULATION_TYPE_TXT",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | Insul: ",
-          "note": "Insulation"
+          "prefix_override": "|",
+          "suffix_override": "kPa",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "PLM_PIPE_GRADIENT_PCT",
+          "param": "PLM_PPE_MAT_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Grad: ",
-          "suffix_override": "%",
-          "note": "Gradient"
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "MEP_TIE_POINT_ID_TXT",
+          "param": "PLM_INSULATION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point"
+          "prefix_override": "| Insul:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "PLM_PPE_SHOP_DRAWING_REQ_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "PLM_FLOW_RATE_LPS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Flow: ",
-          "suffix_override": " L/s",
-          "note": "Flow rate"
-        },
-        {
-          "param": "PLM_PPE_LENGTH_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Length: ",
-          "suffix_override": " m",
-          "note": "Pipe length"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Shop:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "PLM_TAG_7_PARA_PIPE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_PLM_PPE_FLW_LPS_PIPES__HOT_WATE",
+          "param": "PLM_PPE_JOINT_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PPE_FLW_LPS_PIPES__HOT_WATE, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_PLM_VEL_MPS_PIPES",
+          "param": "PLM_PPE_PSR_RATING_BAR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "bar",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_INS_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_VEL_MPS_PIPES, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_PLM_PIPE_GRADIENT",
+          "param": "PLM_PPE_INS_THK_MM",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_LENGTH_M",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_EQP_TAG_01_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_PIPE_GRADIENT, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "PLM_EQP_TAG_02_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_VLV_END_CONNECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_VLV_PSR_CLASS_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_FAB_METHOD_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "prefix_override": "Fab:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "PLM_PPE_WELD_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "prefix_override": "| Weld:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
+          "param": "PLM_PPE_SUPPORTS_SPACING_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Supt:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_HANGER_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
+          "prefix_override": "Hanger:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_KEYNOTE_TXT",
+          "param": "CST_CALC_LENGTH_M",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
+          "prefix_override": "| Length:",
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGIN_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
+          "prefix_override": "Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -58494,7 +50942,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_VENT_PIPE, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Pipe"
     },
     "Plumbing Fixtures": {
       "family_name": "STING - Plumbing Fixture Tag",
@@ -58505,7 +50954,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -58513,440 +50964,179 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_DESCRIPTION_TXT",
+          "param": "PLM_PPE_SZ_MM",
           "spaces": 0,
           "break": false,
-          "note": "Description / type name"
+          "prefix_override": "DN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "PLM_PPE_FLW_LPS",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Flow: ",
-          "suffix_override": " L/s",
-          "note": "Flow rate"
-        },
-        {
-          "param": "PLM_FIXTURE_LOAD_UNIT_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "FLU: ",
-          "note": "Fixture loading unit"
-        },
-        {
-          "param": "PLM_CONN_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Conn: ",
-          "note": "Connection type"
-        },
-        {
-          "param": "PLM_TRAP_TYPE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Trap: ",
-          "note": "Trap type"
+          "prefix_override": "|",
+          "suffix_override": "L/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_MANUFACTURER_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "prefix_override": "Mfr:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_MODEL_NR_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "RGL_NWSC_APPROVAL_REQ_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "NWSC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "PLM_TAG_7_PARA_FIXTURE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_PLM_FIXTURE_FLOW",
+          "param": "PLM_VLV_ACTUATION_TYPE_TXT",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "A",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_VLV_BODY_MAT_TXT",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "V",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_VLV_CV_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "V",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_ACC_CONNECTION_SZ_NR",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_FIXTURE_FLOW, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "PLM_VNT_SZ_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_EXPECTED_LIFE_YEARS_YRS",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PER_SUST_WTR_RATING_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_NWSC_CERT_NR",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "prefix_override": "Cert:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "PER_SUST_WATER_RATING_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "prefix_override": "| Water:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
+          "prefix_override": "Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_KEYNOTE_TXT",
+          "param": "CST_DELIVERY_LEAD_TIME_DAYS",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
+          "prefix_override": "| Lead:",
+          "suffix_override": "days",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -59216,7 +51406,8 @@
           "standard": "BS 8300:2018 / ADA / Uganda Building Code",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESSIBLE_WC, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Plumbing Fixture"
     },
     "Fire Alarm Devices": {
       "family_name": "STING - Fire Alarm Device Tag",
@@ -59227,7 +51418,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -59235,433 +51428,150 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "FLS_SFTY_DEV_TYPE_TXT",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Device type"
+          "break": false,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "FLS_SFTY_DEV_ZONE_TXT",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "Zone: ",
-          "note": "Fire zone"
-        },
-        {
-          "param": "FLS_SFTY_LOOP_NR_TXT",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | Loop: ",
-          "note": "Loop number"
-        },
-        {
-          "param": "FLS_SFTY_ADDR_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Addr: ",
-          "note": "Address"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "MNT_HGT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "RGL_KCCA_APPROVAL_REQ_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "KCCA:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "FLS_TAG_7_PARA_FA_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR",
+          "param": "FLS_SFTY_DEV_LOOP_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "FLS_SFTY_DEV_ADDRESS_TXT",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "A",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_SFTY_DEV_DETECTOR_SENSITIVITY_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_ALARM_CIRCUIT_COUNT_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "A",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_DETECTOR_COUNT_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_DETECTION_COST_UGX",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_QA_TST_REPORT_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_KCCA_CERT_NR",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "prefix_override": "Cert:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "RGL_QA_COMMISSIONING_REQ_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "prefix_override": "| Comm:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -59913,7 +51823,8 @@
           "standard": "BS 5839-1:2017 / BS EN 54",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_SMOKE_DETECTOR_SPACING, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Fire Alarm Device"
     },
     "Sprinklers": {
       "family_name": "STING - Sprinkler Tag",
@@ -59924,7 +51835,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -59932,441 +51845,168 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
-        },
-        {
-          "param": "FLS_SFTY_DEV_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Sprinkler type"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "FLS_SFTY_COVERAGE_AREA_SQ_M",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Coverage: ",
-          "suffix_override": " m²",
-          "note": "Coverage area"
+          "prefix_override": "Coverage:",
+          "suffix_override": "m²",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "FLS_SFTY_K_FACTOR_NR",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | K=",
-          "note": "K-factor"
-        },
-        {
-          "param": "FLS_SFTY_DEV_ZONE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Zone: ",
-          "note": "Fire zone"
+          "prefix_override": "| K=",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "MNT_HGT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "RGL_KCCA_APPROVAL_REQ_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "KCCA:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "FLS_TAG_7_PARA_SPR_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR",
+          "param": "FLS_SFTY_TEMP_RATING_C",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR, \"\")"
+          "suffix_override": "°C",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_FLS_SFTY_SPACING",
+          "param": "FLS_PROT_SPRINKLER_HED_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_SFTY_SPACING, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
+          "param": "FLS_SFTY_FLW_RATE_LPM_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_DEV_TAG_01_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_DEV_TAG_02_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_DETECTION_COST_UGX",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_DETECTOR_COUNT_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "FLS_SFTY_HEADS_OPERATING_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_KCCA_CERT_NR",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
+          "prefix_override": "Cert:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "RGL_QA_COMMISSIONING_REQ_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "prefix_override": "| Comm:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
+          "prefix_override": "Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -60618,7 +52258,8 @@
           "standard": "BS 9251:2021 / BS EN 12845",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_SFTY_SPACING, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Sprinkler"
     },
     "Cable Tray Fittings": {
       "family_name": "STING - Cable Tray Fitting Tag",
@@ -60629,7 +52270,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -60637,405 +52280,53 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ELC_CTR_WIDTH_MM",
+          "param": "ELC_CTR_MAT_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | W: ",
-          "suffix_override": " mm",
-          "note": "Width"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "TP: ",
-          "note": "MEP tie-point"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ELC_TAG_7_PARA_TRAY_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -61279,7 +52570,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Cable Tray Fitting"
     },
     "Cable Trays": {
       "family_name": "STING - Cable Tray Tag",
@@ -61290,7 +52582,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -61298,427 +52592,137 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
-        },
-        {
-          "param": "ELC_CTR_WIDTH_MM",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | W: ",
-          "suffix_override": " mm",
-          "note": "Width"
-        },
-        {
-          "param": "ELC_CTR_HEIGHT_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "H: ",
-          "suffix_override": " mm",
-          "note": "Height"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_CTR_MAT_TXT",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | Mat: ",
-          "note": "Material"
+          "break": false,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "MEP_TIE_POINT_ID_TXT",
+          "param": "MNT_HGT_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "TP: ",
-          "note": "MEP tie-point"
+          "break": true,
+          "prefix_override": "| Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
+          "param": "ELC_CBT_SHOP_DRAWING_REQ_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
+          "prefix_override": "Shop:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
+          "param": "ELC_CTR_SZ_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Size:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ELC_TAG_7_PARA_TRAY_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_ELC_CTR_FILL_RATIO",
+          "param": "ELC_CTR_WIDTH_MM",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CTR_FILL_PCT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
           "suffix_override": "%",
-          "note": "Recyclability"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "PER_EXPECTED_LIFE_YEARS",
+          "param": "ELC_CTR_TAG_01_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CBT_FAB_TYPE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
+          "prefix_override": "Fab:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "PER_REPLACEMENT_COST_UGX",
+          "param": "ELC_CBT_SUPPORT_SPACING_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
+          "prefix_override": "| Supt:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
+          "param": "CST_CALC_LENGTH_M",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
+          "prefix_override": "Length:",
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
+          "prefix_override": "| Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -61962,7 +52966,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Cable Tray"
     },
     "Conduit Fittings": {
       "family_name": "STING - Conduit Fitting Tag",
@@ -61973,7 +52978,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -61981,404 +52988,55 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_CDT_SZ_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | DN",
-          "note": "Size"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "TP: ",
-          "note": "MEP tie-point"
+          "prefix_override": "Conduit:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ELC_TAG_7_PARA_CONDUIT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -62622,7 +53280,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_FILL_RATIO, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Conduit Fitting"
     },
     "Conduits": {
       "family_name": "STING - Conduit Tag",
@@ -62633,14 +53292,19 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         },
         {
           "param": "ELC_CDT_SZ_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "DN",
-          "note": "Conduit size"
+          "break": true,
+          "prefix_override": "Conduit:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -62648,447 +53312,179 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ELC_CDT_SZ_MM",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "DN",
-          "note": "Conduit size"
-        },
-        {
-          "param": "ELC_CDT_MAT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Mat: ",
-          "note": "Material"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_CKT_NR",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Ckt: ",
-          "note": "Circuit"
+          "prefix_override": "Ckt:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ELC_CBL_SOURCE_FROM_TXT",
+          "param": "ELC_CDT_MAT_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | From: ",
-          "note": "Source"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ELC_CBL_DESTINATION_TO_TXT",
+          "param": "ELC_CBL_SOURCE_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "To: ",
-          "note": "Destination"
+          "prefix_override": "From:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CBL_DEST_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "→",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_CBL_INSTALL_METHOD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Method: ",
-          "note": "Install method"
-        },
-        {
-          "param": "ELC_CBL_NUM_CABLES_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Cables: ",
-          "note": "Number of cables"
-        },
-        {
-          "param": "MEP_TIE_POINT_ID_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | TP: ",
-          "note": "MEP tie-point"
+          "prefix_override": "Install:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ELC_TAG_7_PARA_CONDUIT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_ELC_CDT_FILL_RATIO",
+          "param": "ELC_CDT_INSTALL_METHOD_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_FILL_RATIO, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "ELC_CDT_CBL_FILL_PCT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
           "suffix_override": "%",
-          "note": "Recyclability"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "PER_EXPECTED_LIFE_YEARS",
+          "param": "ELC_CDT_TAG_01_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CDT_TAG_02_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CBL_NUM_OF_CORES_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CKT_PHASE_COUNT_NR",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CDT_FAB_METHOD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Fab:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CDT_BEND_RADIUS_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
+          "prefix_override": "Bend R:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "PER_REPLACEMENT_COST_UGX",
+          "param": "ELC_CDT_SUPPORT_SPACING_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
+          "prefix_override": "| Supt:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
+          "param": "CST_CALC_LENGTH_M",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
+          "prefix_override": "Length:",
+          "suffix_override": "m",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
+          "param": "CST_LOCAL_MAT_BOOL",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
+          "prefix_override": "| Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -63332,7 +53728,8 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_FILL_RATIO, \"\")"
         }
       ],
-      "has_tie_point": true
+      "has_tie_point": true,
+      "csv_family_alias": "Conduit"
     },
     "Electrical Equipment": {
       "family_name": "STING - Electrical Equipment Tag",
@@ -64187,7 +54584,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -64195,455 +54594,95 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_PWR_KW",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " kW",
-          "note": "Power rating"
+          "break": false,
+          "prefix_override": "Power:",
+          "suffix_override": "kW",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_VLT_PRIMARY_RATING_V",
           "spaces": 0,
-          "break": false,
-          "suffix_override": " V",
-          "note": "Voltage"
-        },
-        {
-          "param": "ELC_CKT_CUR_A",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " A",
-          "note": "Current"
+          "prefix_override": "|",
+          "suffix_override": "V",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_CKT_NR",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Ckt: ",
-          "note": "Circuit number"
+          "prefix_override": "Ckt:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ELC_IP_RATING_TXT",
+          "param": "ELC_PNL_DESIGNATION_NAME_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | IP: ",
-          "note": "IP rating"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "MNT_HGT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_VOLTAGE_V",
-          "spaces": 1,
-          "suffix": "V",
-          "break": false,
-          "note": "Device voltage"
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "V:",
+          "suffix_override": "V",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ELC_TAG_7_PARA_CIRCUIT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI, \"\")"
-        },
-        {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -64904,7 +54943,8 @@
           "standard": "BS EN 60529 / IEC 60529",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_IP_RATING, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Electrical Fixture"
     },
     "Lighting Devices": {
       "family_name": "STING - Lighting Device Tag",
@@ -64915,7 +54955,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -64923,441 +54965,73 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
-        },
-        {
-          "param": "ELC_PWR_KW",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " kW",
-          "note": "Power"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_CKT_NR",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Ckt: ",
-          "note": "Circuit"
+          "prefix_override": "Ckt:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ELC_IP_RATING_TXT",
+          "param": "ELC_PNL_DESIGNATION_NAME_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | IP: ",
-          "note": "IP rating"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "MNT_HGT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "LTG_FIX_EFFICACY_LM_W",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Efficacy: ",
-          "suffix_override": " lm/W",
-          "note": "Lamp efficacy"
-        },
-        {
-          "param": "LTG_FIX_LAMP_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Lamp: ",
-          "note": "Lamp type"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ELC_TAG_7_PARA_CIRCUIT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "LTG_CTRL_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -65600,7 +55274,8 @@
           "standard": "CIBSE SLL LG7 / BS EN 12464-1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_LTG_ILLUMINANCE, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Lighting Device"
     },
     "Lighting Fixtures": {
       "family_name": "STING - Lighting Fixture Tag",
@@ -65611,13 +55286,17 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         },
         {
           "param": "LTG_FIX_TYPE_CLASSIFICATION_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Fixture type"
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -65625,491 +55304,189 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "LTG_FIX_TYPE_CLASSIFICATION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Fixture type"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "LTG_FIX_LMP_WATTAGE_W",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " W",
-          "note": "Wattage"
+          "break": false,
+          "suffix_override": "W",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "CST_FIX_LUMEN_OUTPUT_LM",
           "spaces": 0,
           "break": false,
-          "suffix_override": " lm",
-          "note": "Luminous flux"
-        },
-        {
-          "param": "LTG_EFFICACY_LM_W",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "suffix_override": " lm/W",
-          "note": "Efficacy"
+          "prefix_override": "|",
+          "suffix_override": "lm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "LTG_CLR_TEMP_K",
           "spaces": 0,
-          "break": false,
-          "suffix_override": " K",
-          "note": "Colour temperature"
+          "break": true,
+          "prefix_override": "|",
+          "suffix_override": "K",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "LTG_CRI_NR",
+          "param": "LTG_EFFICACY_LM_W",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | CRI: ",
-          "note": "Colour rendering index"
+          "break": false,
+          "prefix_override": "Eff:",
+          "suffix_override": "lm/W",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ELC_CKT_NR",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "Ckt: ",
-          "note": "Circuit"
-        },
-        {
-          "param": "ELC_IP_RATING_TXT",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | IP: ",
-          "note": "IP rating"
-        },
-        {
-          "param": "LTG_DIMMABLE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Dim: ",
-          "note": "Dimmable"
-        },
-        {
-          "param": "LTG_EMERGENCY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Emerg: ",
-          "note": "Emergency"
+          "prefix_override": "| Ckt:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_MANUFACTURER_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "prefix_override": "Mfr:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_MODEL_NR_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "MNT_HGT_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "LTG_FIX_EFFICACY_LM_W",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Efficacy: ",
-          "suffix_override": " lm/W",
-          "note": "Lamp efficacy"
-        },
-        {
-          "param": "LTG_FIX_LAMP_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Lamp: ",
-          "note": "Lamp type"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ELC_TAG_7_PARA_CIRCUIT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "WARN_LTG_ILLUMINANCE",
+          "param": "LTG_FIX_TAG_01_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
-          "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_LTG_ILLUMINANCE, \"\")"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "LTG_FIX_TAG_02_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
+          "param": "LTG_EMRG_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
+          "param": "LTG_CLR_RENDERING_INDEX_NR",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
+          "prefix_override": "CRI:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "LTG_CKT_NR_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
+          "prefix_override": "Ckt:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
+          "param": "LTG_CTRL_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "prefix_override": "Ctrl:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "param": "LTG_DESIGN_ILLUMINANCE_LUX",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "lux",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
+          "param": "ASS_EXPECTED_LIFE_YEARS_YRS",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
+          "param": "PER_SUST_ENERGY_RATING_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -66361,7 +55738,8 @@
           "standard": "BS EN 60529 / IEC 60529",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_IP_RATING, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Lighting Fixture"
     },
     "Communication Devices": {
       "family_name": "STING - Communication Device Tag",
@@ -66372,7 +55750,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -66380,426 +55760,121 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "COM_C_PROTOCOL_TXT",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Protocol"
+          "break": false,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "COM_C_NETWORK_ADDRESS_TXT",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "IP: ",
-          "note": "Network address"
-        },
-        {
-          "param": "COM_C_PANEL_TXT",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | Panel: ",
-          "note": "BMS panel"
-        },
-        {
-          "param": "ELC_CKT_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Ckt: ",
-          "note": "Circuit"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "MNT_HGT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "COM_TAG_7_PARA_BMS_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "COM_DEV_TAG_01_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
+          "param": "COM_C_DEV_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
+          "param": "COM_C_MEASUREMENT_RANGE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "param": "COM_C_PWR_SUPPLY_V",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "V",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_MODEL_NR_TXT",
+          "param": "COM_BMS_RANGE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
+          "param": "COM_C_DEV_BACNET_INSTANCE_INT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
+          "param": "COM_C_DEV_CONTROLLER_NAME_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -67042,7 +56117,8 @@
           "standard": "BS EN 50600 / ISO/IEC 11801",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_COM_DEVICE_COVERAGE, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Communication Device"
     },
     "Data Devices": {
       "family_name": "STING - Data Device Tag",
@@ -67053,7 +56129,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -67061,419 +56139,63 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ICT_OUTLET_TYPE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Outlet type"
-        },
-        {
-          "param": "ICT_CAT_RATING_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Cat: ",
-          "note": "Category rating"
-        },
-        {
-          "param": "COM_C_NETWORK_ADDRESS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | IP: ",
-          "note": "Network address"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "MNT_HGT_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
+          "break": true,
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ICT_TAG_7_PARA_DATA_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "ICT_DEV_TAG_01_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -67716,7 +56438,8 @@
           "standard": "BS EN 50600 / ISO/IEC 11801",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_COM_DEVICE_COVERAGE, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Data Device"
     },
     "Nurse Call Devices": {
       "family_name": "STING - Nurse Call Device Tag",
@@ -67727,7 +56450,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -67735,418 +56460,56 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "NCL_ZONE_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Zone: ",
-          "note": "Nurse call zone"
-        },
-        {
-          "param": "NCL_DEV_TYPE_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Device type"
-        },
-        {
-          "param": "ELC_CKT_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Ckt: ",
-          "note": "Circuit"
+          "prefix_override": "Zone:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "MNT_HGT_MM",
           "spaces": 0,
-          "break": false,
-          "prefix_override": "Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
+          "break": true,
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "NCL_TAG_7_PARA_NURSECALL_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -68389,7 +56752,8 @@
           "standard": "BS EN 50600 / ISO/IEC 11801",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_COM_DEVICE_COVERAGE, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Nurse Call Device"
     },
     "Security Devices": {
       "family_name": "STING - Security Device Tag",
@@ -68400,7 +56764,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -68408,425 +56774,65 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "SEC_DEV_ZONE_TXT",
           "spaces": 0,
-          "break": true,
-          "prefix_override": " | Zone: ",
-          "note": "Security zone"
-        },
-        {
-          "param": "SEC_DEV_TYPE_TXT",
-          "spaces": 0,
           "break": false,
-          "note": "Device type"
+          "prefix_override": "Zone:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "SEC_DEV_COVERAGE_TXT",
+          "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Coverage: ",
-          "note": "Coverage"
-        },
-        {
-          "param": "ELC_CKT_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Ckt: ",
-          "note": "Circuit"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "MNT_HGT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Ht: ",
-          "suffix_override": " mm",
-          "note": "Mount height"
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "SEC_TAG_7_PARA_SECURITY_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
-        },
-        {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
-        },
-        {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
-        },
-        {
-          "param": "ASS_DESCRIPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
-        },
-        {
-          "param": "ASS_PROJECT_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
-        },
-        {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -69069,7 +57075,8 @@
           "standard": "BS EN 50600 / ISO/IEC 11801",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_COM_DEVICE_COVERAGE, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Security Device"
     },
     "Telephone Devices": {
       "family_name": "STING - Telephone Devices Tag",
@@ -69754,7 +57761,9 @@
           "param": "ASS_TAG_1_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Full 8-segment tag"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
         }
       ],
       "tier_2": [
@@ -69762,435 +57771,150 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
           "spaces": 0,
-          "break": false,
-          "note": "Description / type name"
-        },
-        {
-          "param": "ASS_FUNC_TXT",
-          "spaces": 0,
           "break": true,
-          "prefix_override": " | Func: ",
-          "note": "Function code"
-        },
-        {
-          "param": "ELC_PWR_KW",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Elec: ",
-          "suffix_override": " kW",
-          "note": "Power"
-        },
-        {
-          "param": "ASS_WEIGHT_KG_NR",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Wt: ",
-          "suffix_override": " kg",
-          "note": "Weight"
-        },
-        {
-          "param": "ASS_CST_UNIT_PRICE_UGX_NR",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Cost: ",
-          "suffix_override": " UGX",
-          "note": "Cost"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_MANUFACTURER_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
+          "prefix_override": "Mfr:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_MODEL_NR_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Model number"
+          "prefix_override": "|",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "MNT_HGT_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Ht:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "RGL_STD_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Std: ",
-          "note": "Compliance standard"
-        },
-        {
-          "param": "ASS_TYPE_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Type: ",
-          "note": "Type/symbol name"
-        },
-        {
-          "param": "ASS_FAMILY_NAME_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Family: ",
-          "note": "Family name"
-        },
-        {
-          "param": "ASS_ROOM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Room: ",
-          "note": "Room name"
-        },
-        {
-          "param": "ASS_ROOM_NUM_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "Room number"
-        },
-        {
-          "param": "ASS_DEPARTMENT_ASSIGNMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Dept: ",
-          "note": "Department"
-        },
-        {
-          "param": "ASS_WORKSET_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Workset: ",
-          "note": "Workset name"
-        },
-        {
-          "param": "ASS_PHASE_CREATED_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Phase: ",
-          "note": "Phase created"
-        },
-        {
-          "param": "ASS_HOST_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Host: ",
-          "note": "Host element"
-        },
-        {
-          "param": "MEP_SYSTEM_NAME_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "System: ",
-          "note": "MEP system name"
-        },
-        {
-          "param": "MEP_SYSTEM_ABBREVIATION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " (",
-          "suffix_override": ")",
-          "note": "System abbreviation"
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_3": [
         {
-          "param": "ASS_TAG_2_TXT",
-          "spaces": 0,
-          "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
-        },
-        {
           "param": "ASS_TAG_7_PARA_EQUIPMENT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_UNIFORMAT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Uniformat: ",
-          "note": "Uniformat code"
-        },
-        {
-          "param": "ASS_UNIFORMAT_DESC_TXT",
+          "param": "ASS_CAT_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
-          "note": "Uniformat description"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_OMNICLASS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "OmniClass: ",
-          "note": "OmniClass code"
-        },
-        {
-          "param": "ASS_KEYNOTE_TXT",
+          "param": "ASS_SERIAL_NR_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Keynote: ",
-          "note": "Keynote"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGIN_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Origin: ",
-          "note": "Origin (NEW/EXISTING/DEMOLISHED)"
-        },
-        {
-          "param": "ASS_REV_TXT",
+          "param": "ASS_CST_QUANTITY_NR",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | Rev: ",
-          "note": "Revision code"
-        },
-        {
-          "param": "ASS_MANUFACTURER_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mfr: ",
-          "note": "Manufacturer"
-        },
-        {
-          "param": "ASS_MODEL_NR_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Model: ",
-          "note": "Model number"
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
           "param": "ASS_CST_UNIT_PRICE_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_EXPECTED_LIFE_YEARS_YRS",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_LOCAL_MAT_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_IMPORT_REQUIRED_BOOL",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Unit Cost: UGX ",
-          "note": "Unit cost"
+          "prefix_override": "Import:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_DESCRIPTION_TXT",
+          "param": "PER_SUST_EPD_REF_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " | ",
-          "note": "Element description"
+          "prefix_override": "| EPD:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_PROJECT_COD_TXT",
+          "param": "RGL_QA_STD_COMPLY_TXT",
           "spaces": 0,
           "break": false,
-          "prefix_override": "ISO: ",
-          "note": "ISO 19650 project code"
+          "prefix_override": "Standard:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         },
         {
-          "param": "ASS_ORIGINATOR_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 originator"
-        },
-        {
-          "param": "ASS_VOLUME_COD_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "-",
-          "note": "ISO 19650 volume code"
-        },
-        {
-          "param": "ASS_STATUS_TXT",
-          "spaces": 0,
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
           "break": true,
-          "prefix_override": "-",
-          "note": "ISO 19650 status code"
-        },
-        {
-          "param": "ASS_ID_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Mark: ",
-          "note": "Element mark/ID"
-        },
-        {
-          "param": "ASS_TYPE_MARK_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Type Mark: ",
-          "note": "Type mark"
-        },
-        {
-          "param": "ASS_TYPE_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Comments: ",
-          "note": "Type comments"
-        },
-        {
-          "param": "PRJ_GRID_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Grid: ",
-          "note": "Grid reference"
-        },
-        {
-          "param": "PRJ_COMMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Note: ",
-          "note": "Project comments"
-        },
-        {
-          "param": "MNT_TYPE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Maintenance: ",
-          "note": "Maintenance type"
-        },
-        {
-          "param": "PER_EMBODIED_ENERGY_MJ",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Embodied: ",
-          "suffix_override": " MJ",
-          "note": "Embodied energy"
-        },
-        {
-          "param": "PER_RECYCLABILITY_PCT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Recycle: ",
-          "suffix_override": "%",
-          "note": "Recyclability"
-        },
-        {
-          "param": "PER_EXPECTED_LIFE_YEARS",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Life: ",
-          "suffix_override": " yrs",
-          "note": "Expected service life"
-        },
-        {
-          "param": "PER_REPLACEMENT_COST_UGX",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Replace: UGX ",
-          "note": "Replacement cost"
-        },
-        {
-          "param": "RGL_BUILDING_CODE_REF_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Code: ",
-          "note": "Building code reference"
-        },
-        {
-          "param": "RGL_ACCESSIBILITY_STATUS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Access: ",
-          "note": "Accessibility status"
-        },
-        {
-          "param": "MNT_FREQUENCY_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Maint: ",
-          "note": "Maintenance frequency"
-        },
-        {
-          "param": "MNT_WARRANTY_EXPIRY_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Warranty: ",
-          "note": "Warranty expiry"
-        },
-        {
-          "param": "MNT_ACCESS_REQUIREMENTS_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Access Req: ",
-          "note": "Maintenance access requirements"
-        },
-        {
-          "param": "COM_COMMISSION_STATUS_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Commission: ",
-          "note": "Commissioning status"
-        },
-        {
-          "param": "COM_TEST_CERT_REF_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Cert: ",
-          "note": "Test certificate"
-        },
-        {
-          "param": "ASS_ASSEMBLY_CODE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Assy: ",
-          "note": "Assembly code"
-        },
-        {
-          "param": "ASS_ASSEMBLY_DESC_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " — ",
-          "note": "Assembly description"
-        },
-        {
-          "param": "STR_STRUCTURAL_USAGE_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Usage: ",
-          "note": "Structural usage"
-        },
-        {
-          "param": "STR_MATERIAL_GRADE_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Grade: ",
-          "note": "Material grade"
-        },
-        {
-          "param": "MEP_UPSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": false,
-          "prefix_override": "Upstream: ",
-          "note": "Upstream element"
-        },
-        {
-          "param": "MEP_DOWNSTREAM_ELEMENT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": " | Downstream: ",
-          "note": "Downstream element"
-        },
-        {
-          "param": "RGL_ENVIRONMENTAL_CERT_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Env Cert: ",
-          "note": "Environmental certification"
-        },
-        {
-          "param": "ASS_DESIGN_OPTION_TXT",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Design Option: ",
-          "note": "Design option"
-        },
-        {
-          "param": "ASS_ELEVATION_M",
-          "spaces": 0,
-          "break": true,
-          "prefix_override": "Elevation: ",
-          "suffix_override": " m",
-          "note": "Element elevation"
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
         }
       ],
       "tier_4": [
@@ -70433,7 +58157,8 @@
           "standard": "Project-specific requirement",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_GENERIC_CLEARANCE_MM, \"\")"
         }
-      ]
+      ],
+      "csv_family_alias": "Generic Model"
     },
     "Specialty Equipment": {
       "family_name": "STING - Specialty Equipment Tag",
@@ -86995,6 +74720,3928 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_FIXTURE_FLOW, \"\")"
         }
       ]
+    },
+    "Architectural Sheet": {
+      "family_name": "STING - Architectural Sheet Tag",
+      "paragraph_container": "SHT_TAG_7_TXT",
+      "tier_1": [
+        {
+          "param": "SHT_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "SHT_DISC_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Disc:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_FORM_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Form:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_LEVEL_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Level:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NUMBER_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "No:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NAME_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Name:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "SHT_TAG_7_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_ARCH.csv"
+    },
+    "Tie-In Point Tag (Pipe — Plumbing & Hydraulic)": {
+      "family_name": "STING - Tie-In Point Tag (Pipe — Plumbing & Hydraulic)",
+      "paragraph_container": "PLM_TAG_7_PARA_TIEIN_TXT",
+      "tier_1": [
+        {
+          "param": "ASS_TIEIN_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        },
+        {
+          "param": "PLM_PPE_SZ_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "DN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TIEIN_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "[",
+          "suffix_override": "]",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_FLOW_DIR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Dir:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_FLW_LPS",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Flow:",
+          "suffix_override": "L/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PSR_KPA",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "|",
+          "suffix_override": "kPa",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_ELEV_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Elev:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "PLM_TAG_7_PARA_TIEIN_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_PHASE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Phase:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_BY_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "By:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_IFC_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_MAT_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_PSR_RATING_BAR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "bar",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_CONNECTED_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Resolved:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "Tie-In Point Tag (Duct — HVAC)": {
+      "family_name": "STING - Tie-In Point Tag (Duct — HVAC)",
+      "paragraph_container": "HVC_TAG_7_PARA_TIEIN_TXT",
+      "tier_1": [
+        {
+          "param": "ASS_TIEIN_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        },
+        {
+          "param": "HVC_DCT_SZ_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TIEIN_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "[",
+          "suffix_override": "]",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_FLOW_DIR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Dir:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DCT_FLW_CFM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Flow:",
+          "suffix_override": "CFM",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_VEL_MPS",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "|",
+          "suffix_override": "m/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_ELEV_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Elev:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DCT_MAT_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "HVC_TAG_7_PARA_TIEIN_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_PHASE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Phase:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_BY_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "By:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_IFC_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "HVC_DUCT_CLASS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Class:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_CONNECTED_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Resolved:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "Tie-In Point Tag (Conduit — Electrical LV/ELV)": {
+      "family_name": "STING - Tie-In Point Tag (Conduit — Electrical LV/ELV)",
+      "paragraph_container": "ELC_TAG_7_PARA_TIEIN_TXT",
+      "tier_1": [
+        {
+          "param": "ASS_TIEIN_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        },
+        {
+          "param": "ELC_CDT_SZ_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "∅",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TIEIN_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "[",
+          "suffix_override": "]",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CDT_MAT_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_ELEV_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Elev:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ELC_TAG_7_PARA_TIEIN_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_PHASE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Phase:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_BY_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "By:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_IFC_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CDT_CBL_FILL_PCT",
+          "spaces": 1,
+          "break": true,
+          "prefix_override": "Fill:",
+          "suffix_override": "%",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_CONNECTED_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Resolved:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "Tie-In Point Tag (Cable Tray — Electrical)": {
+      "family_name": "STING - Tie-In Point Tag (Cable Tray — Electrical)",
+      "paragraph_container": "ELC_TAG_7_PARA_TIEIN_TXT",
+      "tier_1": [
+        {
+          "param": "ASS_TIEIN_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        },
+        {
+          "param": "ELC_CTR_SZ_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TIEIN_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "[",
+          "suffix_override": "]",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CTR_MAT_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ELC_CTR_FILL_PCT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fill:",
+          "suffix_override": "%",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_ELEV_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Elev:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "ELC_TAG_7_PARA_TIEIN_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_PHASE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Phase:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_BY_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "By:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_IFC_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_CONNECTED_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Resolved:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)": {
+      "family_name": "STING - Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)",
+      "paragraph_container": "FLS_TAG_7_PARA_TIEIN_TXT",
+      "tier_1": [
+        {
+          "param": "ASS_TIEIN_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        },
+        {
+          "param": "PLM_PPE_SZ_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "DN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TIEIN_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "[",
+          "suffix_override": "]",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_FLW_LPS",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Flow:",
+          "suffix_override": "L/s",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PSR_KPA",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "|",
+          "suffix_override": "kPa",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_ELEV_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Elev:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "FLS_TAG_7_PARA_TIEIN_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_PHASE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Phase:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_BY_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "By:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_IFC_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_PSR_RATING_BAR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "bar",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_CONNECTED_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Resolved:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)": {
+      "family_name": "STING - Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)",
+      "paragraph_container": "PLM_TAG_7_PARA_TIEIN_TXT",
+      "tier_1": [
+        {
+          "param": "ASS_TIEIN_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        },
+        {
+          "param": "PLM_PPE_SZ_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "DN",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TIEIN_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "[",
+          "suffix_override": "]",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PSR_KPA",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Press:",
+          "suffix_override": "kPa",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_FLOW_DIR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Dir:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_ELEV_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Elev:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_MAT_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "PLM_TAG_7_PARA_TIEIN_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_PHASE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Phase:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_BY_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "By:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_IFC_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "PLM_PPE_PSR_RATING_BAR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "bar",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_TIEIN_CONNECTED_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Resolved:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "MEP Sheet": {
+      "family_name": "STING - MEP Sheet Tag",
+      "paragraph_container": "SHT_TAG_7_TXT",
+      "tier_1": [
+        {
+          "param": "SHT_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "SHT_DISC_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Disc:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_FORM_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Form:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_LEVEL_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Level:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NUMBER_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "No:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NAME_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Name:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "SHT_TAG_7_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "MEP Sleeve": {
+      "family_name": "STING - MEP Sleeve Tag",
+      "tier_1": [
+        {
+          "param": "ASS_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TAG_2_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_SZ_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Ø",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_FIRE_RATING_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_SERVICE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Service:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "SLV_MAT_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Material:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_SEAL_TYPE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Seal:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_WALL_TYPE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Host:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_FIRESTOP_PRODUCT_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Firestop:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_TESTED_TO_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Tested:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SLV_INSPECTION_DATE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Inspected:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
+    },
+    "Brace / Truss": {
+      "family_name": "STING - Brace / Truss Tag",
+      "paragraph_container": "STR_TAG_7_PARA_BRACE_TXT",
+      "tier_1": [
+        {
+          "param": "ASS_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "ASS_TAG_2_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_DESCRIPTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_BRACE_SECTION_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sec:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_BRACE_MATERIAL_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Mat:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "BLE_STRUCT_STEEL_GRADE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Gr:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_BRACE_LENGTH_MM",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "L:",
+          "suffix_override": "mm",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "RGL_STD_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Std:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "STR_TAG_7_PARA_BRACE_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "STR_BRACE_CONNECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Conn:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_S_REI_WEIGHT_KG",
+          "spaces": 0,
+          "break": true,
+          "suffix_override": "kg",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_CST_TOTAL_UGX_NR",
+          "spaces": 1,
+          "break": true,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_DELIVERY_LEAD_TIME_DAYS",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Lead:",
+          "suffix_override": "days",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_LOCAL_MAT_BOOL",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| Local:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_STR.csv"
+    },
+    "Structural Sheet": {
+      "family_name": "STING - Structural Sheet Tag",
+      "paragraph_container": "SHT_TAG_7_TXT",
+      "tier_1": [
+        {
+          "param": "SHT_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "SHT_DISC_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Disc:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_FORM_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Form:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_LEVEL_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Level:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NUMBER_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "No:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NAME_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Name:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "SHT_TAG_7_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_STR.csv"
+    },
+    "Sheet Document": {
+      "family_name": "STING - Sheet Document Tag",
+      "paragraph_container": "SHT_TAG_7_TXT",
+      "tier_1": [
+        {
+          "param": "SHT_TAG_1_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.5"
+        }
+      ],
+      "tier_2": [
+        {
+          "param": "SHT_DISC_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Disc:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_FORM_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Form:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_LEVEL_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Level:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_ORIGINATOR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Orig:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_REV_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Rev:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NUMBER_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "No:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        },
+        {
+          "param": "SHT_NAME_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Name:",
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_3": [
+        {
+          "param": "SHT_TAG_7_TXT",
+          "spaces": 0,
+          "break": true,
+          "style": "NOM",
+          "color": "BLACK",
+          "size": "2.0"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": "UGX",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": "USD",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": "kgCO₂e",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": "kgCO₂e/yr",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": "mm",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "source_csv": "STING_TAG_CONFIG_v5_0_GEN.csv"
     }
   },
   "tag7_heading_style": {

--- a/StingTools/Data/LABEL_DEFINITIONS.json
+++ b/StingTools/Data/LABEL_DEFINITIONS.json
@@ -1,6 +1,6 @@
 {
-  "version": "5.7",
-  "description": "STING Seed Tag v5.7 — master label specification. Paragraph tiers expanded from 3 to 10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated.",
+  "version": "5.8",
+  "description": "STING Seed Tag v5.7 — master label specification. Paragraph tiers expanded from 3 to 10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated. (v5.8: tier_4..tier_10 added for commissioning/cost/carbon/fab/clash/as-built/compliance per STING_TAG_CONFIG_v5_0_*.csv schema v5.3)",
   "presentation_modes": {
     "Compact": {
       "state_1": true,
@@ -1233,6 +1233,97 @@
       "label": "Warning: Weld Throat"
     }
   },
+  "tier_style_defaults": {
+    "description": "Per-tier default style inherited by label rows when an entry omits style/color/size. Mirrors the STING_TAG_CONFIG_v5_0_*.csv schema v5.3 preamble. TagFamilyCreatorCommand and ApplyTagStyleCommand read these when generating / switching label rows.",
+    "tier_1": {
+      "style": "NOM",
+      "color": "BLACK",
+      "size": "2.5"
+    },
+    "tier_2": {
+      "style": "NOM",
+      "color": "BLACK",
+      "size": "2.0"
+    },
+    "tier_3": {
+      "style": "NOM",
+      "color": "BLACK",
+      "size": "2.0"
+    },
+    "tier_4": {
+      "style": "BOLD",
+      "color": "BLUE",
+      "size": "2.0"
+    },
+    "tier_5": {
+      "style": "NOM",
+      "color": "PURPLE",
+      "size": "2.0"
+    },
+    "tier_6": {
+      "style": "ITALIC",
+      "color": "GREEN",
+      "size": "2.0"
+    },
+    "tier_7": {
+      "style": "BOLD",
+      "color": "ORANGE",
+      "size": "2.0"
+    },
+    "tier_8": {
+      "style": "BOLD",
+      "color": "RED",
+      "size": "2.0"
+    },
+    "tier_9": {
+      "style": "ITALIC",
+      "color": "GREY",
+      "size": "2.0"
+    },
+    "tier_10": {
+      "style": "NOM",
+      "color": "GREY",
+      "size": "2.0"
+    },
+    "tag7_sections": {
+      "ASS_TAG_7A_TXT": {
+        "style": "BOLD",
+        "color": "BLUE",
+        "size": "2.5",
+        "note": "Identity Header"
+      },
+      "ASS_TAG_7B_TXT": {
+        "style": "ITALIC",
+        "color": "GREEN",
+        "size": "2.0",
+        "note": "System & Function"
+      },
+      "ASS_TAG_7C_TXT": {
+        "style": "NOM",
+        "color": "ORANGE",
+        "size": "2.0",
+        "note": "Spatial Context"
+      },
+      "ASS_TAG_7D_TXT": {
+        "style": "NOM",
+        "color": "RED",
+        "size": "2.0",
+        "note": "Lifecycle & Status"
+      },
+      "ASS_TAG_7E_TXT": {
+        "style": "BOLD",
+        "color": "PURPLE",
+        "size": "2.0",
+        "note": "Technical Specs"
+      },
+      "ASS_TAG_7F_TXT": {
+        "style": "ITALIC",
+        "color": "GREY",
+        "size": "2.0",
+        "note": "Classification"
+      }
+    }
+  },
   "category_labels": {
     "Casework": {
       "family_name": "STING - Casework Tag",
@@ -1663,6 +1754,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -2161,6 +2482,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -2715,6 +3266,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_DOOR_FRR",
@@ -3255,6 +4036,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS",
@@ -3752,6 +4763,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_FURNITURE_CLEARANCE_MM",
@@ -4214,6 +5455,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_FURNITURE_CLEARANCE_MM",
@@ -4656,6 +6127,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -5124,6 +6825,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -5669,6 +7600,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS",
@@ -6159,6 +8320,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -6659,6 +9050,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_SITE_BEARING_CAP_KPA",
@@ -7133,6 +9754,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -7781,6 +10632,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS",
@@ -8344,6 +11425,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_WINDOW_U_VALUE",
@@ -8792,6 +12103,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -9253,6 +12794,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_RAIL_HEIGHT_MM",
@@ -9689,6 +13460,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ASS_ROOM_AREA_MIN",
@@ -10121,6 +14122,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -10564,6 +14795,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_CW_PANEL_U_VALUE",
@@ -11000,6 +15461,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -11434,6 +16125,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_COLUMN_SLENDERNESS",
@@ -11859,6 +16780,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -12288,6 +17439,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_GENERIC_CLEARANCE_MM",
@@ -12715,6 +18096,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_ENTOURAGE_SCALE",
@@ -13140,6 +18751,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -13585,6 +19426,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_FLR_LD_CAP_KPA",
@@ -14012,6 +20083,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
@@ -14437,6 +20738,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -14873,6 +21404,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_FDN_BEARING",
@@ -15298,6 +22059,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -15727,6 +22718,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_GENERIC_CLEARANCE_MM",
@@ -16154,6 +23375,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_GENERIC_CLEARANCE_MM",
@@ -16579,6 +24030,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -17015,6 +24696,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ROAD_GRADIENT_PCT",
@@ -17440,6 +25351,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -17885,6 +26026,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_SITE_BEARING_CAP_KPA",
@@ -18317,6 +26688,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -18755,6 +27356,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ASS_ROOM_VENTILATION",
@@ -19180,6 +28011,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -19609,6 +28670,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
@@ -20034,6 +29325,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -20477,6 +29998,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_RAIL_HEIGHT_MM",
@@ -20911,6 +30662,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -21349,6 +31330,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
@@ -21774,6 +31985,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -22215,6 +32656,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -22678,6 +33349,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -23119,6 +34020,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_RAIL_HEIGHT_MM",
@@ -23553,6 +34684,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -24033,6 +35394,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -24534,6 +36125,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_FDN_BEARING",
@@ -25024,6 +36845,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -25476,6 +37527,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_STR_FABRIC_SPEC",
@@ -25901,6 +38182,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -26330,6 +38841,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -26755,6 +39496,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -27184,6 +40155,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -27609,6 +40810,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -28038,6 +41469,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -28463,6 +42124,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -28892,6 +42783,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -29317,6 +43438,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -29746,6 +44097,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -30173,6 +44754,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
@@ -30554,6 +45365,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -30946,6 +45987,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_STR_WLD_THROAT_MM",
@@ -31336,6 +46607,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -31772,6 +47273,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_STR_RBR_COVER_MM",
@@ -32204,6 +47935,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -32640,6 +48601,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_STR_BLT_PROOF_LOAD_KN",
@@ -33065,6 +49256,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -33501,6 +49922,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_STR_CONN_CAPACITY_KN",
@@ -33926,6 +50577,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -34360,6 +51241,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -34831,6 +51942,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_HVC_DCT_SOUNDLVL_DB",
@@ -35275,6 +52616,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_MEP_DUCT_ACC_PRESSURE_DROP",
@@ -35711,6 +53282,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -36217,6 +54018,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_HVC_VEL_MPS_DUCTS",
@@ -36670,6 +54701,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -37187,6 +55448,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI",
@@ -37651,6 +56142,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PLM_VEL_MPS_PIPES",
@@ -38095,6 +56816,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PLM_PIPE_ACC_RATING",
@@ -38530,6 +57481,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -39045,6 +58226,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PLM_VEL_MPS_PIPES",
@@ -39538,6 +58949,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PLM_FIXTURE_FLOW",
@@ -40023,6 +59664,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_FLS_PROT_COVERAGE",
@@ -40498,6 +60369,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR",
@@ -40935,6 +61036,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -41390,6 +61721,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ELC_CTR_FILL_RATIO",
@@ -41818,6 +62379,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -42298,6 +63089,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -42870,6 +63891,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI",
@@ -43395,6 +64646,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI",
@@ -43877,6 +65358,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -44401,6 +66112,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_LTG_ILLUMINANCE",
@@ -44861,6 +66802,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_COM_DEVICE_COVERAGE",
@@ -45305,6 +67476,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_COM_DEVICE_COVERAGE",
@@ -45746,6 +68147,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -46198,6 +68829,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_COM_DEVICE_COVERAGE",
@@ -46640,6 +69501,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -47102,6 +70193,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_GENERIC_CLEARANCE_MM",
@@ -47562,6 +70883,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI",
@@ -48002,6 +71553,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_INS_THICKNESS_MM",
@@ -48434,6 +72215,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -48876,6 +72887,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_INS_THICKNESS_MM",
@@ -49308,6 +73549,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -49764,6 +74235,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI",
@@ -50191,6 +74892,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI",
@@ -50616,6 +75547,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -51052,6 +76213,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_FLS_PROT_COVERAGE",
@@ -51477,6 +76868,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -51906,6 +77527,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_HVC_VEL_MPS_DUCTS",
@@ -52331,6 +78182,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -52780,6 +78861,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_FAB_HANGER_LOAD_KN",
@@ -53205,6 +79516,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -53634,6 +80175,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
@@ -54059,6 +80830,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -54488,6 +81489,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_PLM_VEL_MPS_PIPES",
@@ -54913,6 +82144,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -55342,6 +82803,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_COM_DEVICE_COVERAGE",
@@ -55769,6 +83460,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_BLE_GENERIC_CLEARANCE_MM",
@@ -56194,6 +84115,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -56632,6 +84783,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_SITE_BEARING_CAP_KPA",
@@ -57057,6 +85438,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [
@@ -57486,6 +86097,236 @@
           "note": "Element elevation"
         }
       ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
       "warnings": [
         {
           "param": "WARN_SITE_BEARING_CAP_KPA",
@@ -57911,6 +86752,236 @@
           "prefix_override": "Elevation: ",
           "suffix_override": " m",
           "note": "Element elevation"
+        }
+      ],
+      "tier_4": [
+        {
+          "param": "COMM_STATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Comm:",
+          "note": "T4 Commissioning state (Draft/Pre-C/Witness/Final)",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T4 Commissioning stamp date",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        },
+        {
+          "param": "COMM_OPERATIVE_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "by ",
+          "note": "T4 Commissioning operative signature",
+          "style": "BOLD",
+          "color": "BLUE",
+          "size": "2.0"
+        }
+      ],
+      "tier_5": [
+        {
+          "param": "CST_UG_PRICE_UGX",
+          "spaces": 0,
+          "break": false,
+          "suffix_override": " UGX",
+          "note": "T5 Local price (UGX ex-works)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_INTL_PRICE_USD",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "/ ",
+          "suffix_override": " USD",
+          "note": "T5 International price (USD CIF/DAP)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        },
+        {
+          "param": "CST_QUOTE_REF_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Quote:",
+          "note": "T5 Supplier quote / PO ref",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
+        }
+      ],
+      "tier_6": [
+        {
+          "param": "CBN_A1_A3_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "A1-A3:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Product-stage embodied carbon (BS EN 15978)",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_A4_KG_CO2E",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "| A4:",
+          "suffix_override": " kgCO₂e",
+          "note": "T6 Transport-stage carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        },
+        {
+          "param": "CBN_B6_KG_CO2E_YR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "| B6:",
+          "suffix_override": " kgCO₂e/yr",
+          "note": "T6 Operational energy carbon",
+          "style": "ITALIC",
+          "color": "GREEN",
+          "size": "2.0"
+        }
+      ],
+      "tier_7": [
+        {
+          "param": "ASS_SPOOL_NR_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Spool:",
+          "note": "T7 Fabrication spool number (ISO 6412)",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_FAB_STATUS_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Fab:",
+          "note": "T7 Fabrication status",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        },
+        {
+          "param": "ASS_QC_INSPECTOR_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "QC:",
+          "note": "T7 QC inspector signature",
+          "style": "BOLD",
+          "color": "ORANGE",
+          "size": "2.0"
+        }
+      ],
+      "tier_8": [
+        {
+          "param": "CLASH_TRIAGE_SEVERITY_NR",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Sev:",
+          "suffix_override": "/5",
+          "note": "T8 Clash triage severity 0-5",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_TRIAGE_CATEGORY_TXT",
+          "spaces": 0,
+          "break": false,
+          "note": "T8 Clash category (Hard/Soft/Tolerance/Workflow)",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        },
+        {
+          "param": "CLASH_RESOLUTION_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Res:",
+          "note": "T8 Clash resolution status",
+          "style": "BOLD",
+          "color": "RED",
+          "size": "2.0"
+        }
+      ],
+      "tier_9": [
+        {
+          "param": "ASBUILT_DEVIATION_MM",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "Δ:",
+          "suffix_override": " mm",
+          "note": "T9 As-built deviation vs design",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ASBUILT_CAPTURE_DATE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "on ",
+          "note": "T9 Reality-capture snapshot date",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "HEALTH_SCORE_LAST_NR",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Health:",
+          "suffix_override": "/100",
+          "note": "T9 Last computed model health score",
+          "style": "ITALIC",
+          "color": "GREY",
+          "size": "2.0"
+        }
+      ],
+      "tier_10": [
+        {
+          "param": "IFC_PSET_OVERRIDE_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "IFC:",
+          "note": "T10 IFC 4.3 PSet / property override",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_ISSUE_ID_TXT",
+          "spaces": 0,
+          "break": false,
+          "prefix_override": "ACC:",
+          "note": "T10 ACC Issue ID round-trip reference",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
+        },
+        {
+          "param": "ACC_SYNC_STATUS_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "Sync:",
+          "note": "T10 ACC sync status (Pending/Synced/Conflict/Failed)",
+          "style": "NOM",
+          "color": "GREY",
+          "size": "2.0"
         }
       ],
       "warnings": [

--- a/StingTools/Data/PARAMETER_REGISTRY.json
+++ b/StingTools/Data/PARAMETER_REGISTRY.json
@@ -1,6 +1,6 @@
 {
   "version": "5.6",
-  "description": "STING Tools master parameter registry v5.6 \u2014 single source of truth for all parameter names, GUIDs, containers, bindings, and warning thresholds",
+  "description": "STING Tools master parameter registry v5.6 — single source of truth for all parameter names, GUIDs, containers, bindings, and warning thresholds",
   "tag_format": {
     "separator": "-",
     "num_pad": 4,
@@ -1289,7 +1289,7 @@
     {
       "param_name": "TAG_BOX_COLOR_R_INT",
       "guid": "d5a1b2c3-5001-4e05-a1c1-500000000001",
-      "description": "Tag bounding box fill color \u2014 Red channel (0-255)",
+      "description": "Tag bounding box fill color — Red channel (0-255)",
       "binding": "universal",
       "param_type": "INTEGER",
       "required": false
@@ -1297,7 +1297,7 @@
     {
       "param_name": "TAG_BOX_COLOR_G_INT",
       "guid": "d5a1b2c3-5002-4e05-a1c1-500000000002",
-      "description": "Tag bounding box fill color \u2014 Green channel (0-255)",
+      "description": "Tag bounding box fill color — Green channel (0-255)",
       "binding": "universal",
       "param_type": "INTEGER",
       "required": false
@@ -1305,7 +1305,7 @@
     {
       "param_name": "TAG_BOX_COLOR_B_INT",
       "guid": "d5a1b2c3-5003-4e05-a1c1-500000000003",
-      "description": "Tag bounding box fill color \u2014 Blue channel (0-255)",
+      "description": "Tag bounding box fill color — Blue channel (0-255)",
       "binding": "universal",
       "param_type": "INTEGER",
       "required": false
@@ -1328,7 +1328,7 @@
     {
       "param_name": "TAG_LEADER_COLOR_R_INT",
       "guid": "d5a1b2c3-5006-4e05-a1c1-500000000006",
-      "description": "Tag leader line color \u2014 Red channel (0-255)",
+      "description": "Tag leader line color — Red channel (0-255)",
       "binding": "universal",
       "param_type": "INTEGER",
       "required": false
@@ -1336,7 +1336,7 @@
     {
       "param_name": "TAG_LEADER_COLOR_G_INT",
       "guid": "d5a1b2c3-5007-4e05-a1c1-500000000007",
-      "description": "Tag leader line color \u2014 Green channel (0-255)",
+      "description": "Tag leader line color — Green channel (0-255)",
       "binding": "universal",
       "param_type": "INTEGER",
       "required": false
@@ -1344,7 +1344,7 @@
     {
       "param_name": "TAG_LEADER_COLOR_B_INT",
       "guid": "d5a1b2c3-5008-4e05-a1c1-500000000008",
-      "description": "Tag leader line color \u2014 Blue channel (0-255)",
+      "description": "Tag leader line color — Blue channel (0-255)",
       "binding": "universal",
       "param_type": "INTEGER",
       "required": false
@@ -2010,7 +2010,7 @@
           "separator": " | ",
           "prefix": "",
           "suffix": "",
-          "description": "Comprehensive descriptive narrative \u2014 AI-assembled asset profile with embedded markup tokens for rich rendering"
+          "description": "Comprehensive descriptive narrative — AI-assembled asset profile with embedded markup tokens for rich rendering"
         },
         {
           "param_name": "ASS_TAG_7A_TXT",
@@ -2019,7 +2019,7 @@
           "separator": " | ",
           "prefix": "",
           "suffix": "",
-          "description": "TAG7 Section A: Identity Header \u2014 asset name, product, manufacturer, model (styled as BOLD in tag families)"
+          "description": "TAG7 Section A: Identity Header — asset name, product, manufacturer, model (styled as BOLD in tag families)"
         },
         {
           "param_name": "ASS_TAG_7B_TXT",
@@ -2028,7 +2028,7 @@
           "separator": " | ",
           "prefix": "",
           "suffix": "",
-          "description": "TAG7 Section B: System & Function Context \u2014 full system/function descriptions (styled as ITALIC in tag families)"
+          "description": "TAG7 Section B: System & Function Context — full system/function descriptions (styled as ITALIC in tag families)"
         },
         {
           "param_name": "ASS_TAG_7C_TXT",
@@ -2037,7 +2037,7 @@
           "separator": " | ",
           "prefix": "",
           "suffix": "",
-          "description": "TAG7 Section C: Spatial Context \u2014 room, department, grid reference"
+          "description": "TAG7 Section C: Spatial Context — room, department, grid reference"
         },
         {
           "param_name": "ASS_TAG_7D_TXT",
@@ -2046,7 +2046,7 @@
           "separator": " | ",
           "prefix": "",
           "suffix": "",
-          "description": "TAG7 Section D: Lifecycle & Status \u2014 status, revision, origin, maintenance"
+          "description": "TAG7 Section D: Lifecycle & Status — status, revision, origin, maintenance"
         },
         {
           "param_name": "ASS_TAG_7E_TXT",
@@ -2055,7 +2055,7 @@
           "separator": " | ",
           "prefix": "",
           "suffix": "",
-          "description": "TAG7 Section E: Technical Specifications \u2014 discipline-specific MEP/BLE performance data"
+          "description": "TAG7 Section E: Technical Specifications — discipline-specific MEP/BLE performance data"
         },
         {
           "param_name": "ASS_TAG_7F_TXT",
@@ -2064,7 +2064,7 @@
           "separator": " | ",
           "prefix": "",
           "suffix": "",
-          "description": "TAG7 Section F: Classification & Reference \u2014 Uniformat, OmniClass, keynote, cost, ISO tag"
+          "description": "TAG7 Section F: Classification & Reference — Uniformat, OmniClass, keynote, cost, ISO tag"
         }
       ]
     },
@@ -2834,12 +2834,12 @@
       {
         "key": "ROOM_AREA",
         "param_name": "ASS_ROOM_AREA_SQ_M",
-        "description": "Room area (m\u00b2)"
+        "description": "Room area (m²)"
       },
       {
         "key": "ROOM_VOLUME",
         "param_name": "ASS_ROOM_VOLUME_CU_M",
-        "description": "Room volume (m\u00b3)"
+        "description": "Room volume (m³)"
       },
       {
         "key": "DEPT",
@@ -2965,7 +2965,7 @@
       {
         "key": "ELE_AREA",
         "param_name": "BLE_ELE_AREA_SQ_M",
-        "description": "Element area (m\u00b2)"
+        "description": "Element area (m²)"
       },
       {
         "key": "CEILING_HEIGHT",
@@ -5733,6 +5733,338 @@
         "param_name": "SLV_INSPECTION_DATE_TXT",
         "description": "Last inspection date"
       }
+    ],
+    "tier_4_10": [
+      {
+        "key": "COMM_STATE",
+        "param_name": "COMM_STATE_TXT",
+        "guid": "5753b5aa-0004-4000-8000-000000000001",
+        "description": "Commissioning state (Draft / Pre-C / Witness / Final)",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T4"
+      },
+      {
+        "key": "COMM_DATE",
+        "param_name": "COMM_DATE_TXT",
+        "guid": "5753b5aa-0004-4000-8000-000000000002",
+        "description": "Commissioning date (ISO 8601) — when state was last stamped",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T4"
+      },
+      {
+        "key": "COMM_OPERATIVE",
+        "param_name": "COMM_OPERATIVE_TXT",
+        "guid": "5753b5aa-0004-4000-8000-000000000003",
+        "description": "Commissioning operative — name / ID of engineer who stamped the asset",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T4"
+      },
+      {
+        "key": "CST_UG_PRICE",
+        "param_name": "CST_UG_PRICE_UGX",
+        "guid": "5753b5aa-0005-4000-8000-000000000001",
+        "description": "Uganda local price (UGX) — quoted supplier price ex-works",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T5"
+      },
+      {
+        "key": "CST_INTL_PRICE",
+        "param_name": "CST_INTL_PRICE_USD",
+        "guid": "5753b5aa-0005-4000-8000-000000000002",
+        "description": "International price (USD) — CIF/DAP quote for imported goods",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T5"
+      },
+      {
+        "key": "CST_QUOTE_REF",
+        "param_name": "CST_QUOTE_REF_TXT",
+        "guid": "5753b5aa-0005-4000-8000-000000000003",
+        "description": "Quote reference — supplier quote/PO number",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T5"
+      },
+      {
+        "key": "CBN_A1_A3",
+        "param_name": "CBN_A1_A3_KG_CO2E",
+        "guid": "5753b5aa-0006-4000-8000-000000000001",
+        "description": "Product stage carbon A1-A3 (kgCO2e) — cradle-to-gate embodied",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T6"
+      },
+      {
+        "key": "CBN_A4",
+        "param_name": "CBN_A4_KG_CO2E",
+        "guid": "5753b5aa-0006-4000-8000-000000000002",
+        "description": "Transport stage carbon A4 (kgCO2e) — factory-to-site haulage",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T6"
+      },
+      {
+        "key": "CBN_B6",
+        "param_name": "CBN_B6_KG_CO2E_YR",
+        "guid": "5753b5aa-0006-4000-8000-000000000003",
+        "description": "Operational energy carbon B6 (kgCO2e/yr) — annual in-use emissions",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T6"
+      },
+      {
+        "key": "ASS_SPOOL_NR",
+        "param_name": "ASS_SPOOL_NR_TXT",
+        "guid": "5753b5aa-0007-4000-8000-000000000001",
+        "description": "Fabrication spool number — BS EN ISO 6412 isometric reference",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T7"
+      },
+      {
+        "key": "ASS_FAB_STATUS",
+        "param_name": "ASS_FAB_STATUS_TXT",
+        "guid": "5753b5aa-0007-4000-8000-000000000002",
+        "description": "Fabrication status (Designed / Spool released / Fabricated / Delivered / Installed)",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T7"
+      },
+      {
+        "key": "ASS_QC_INSPECTOR",
+        "param_name": "ASS_QC_INSPECTOR_TXT",
+        "guid": "5753b5aa-0007-4000-8000-000000000003",
+        "description": "QC inspector — name / ID of signing engineer",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T7"
+      },
+      {
+        "key": "CLASH_TRIAGE_SEV",
+        "param_name": "CLASH_TRIAGE_SEVERITY_NR",
+        "guid": "5753b5aa-0008-4000-8000-000000000001",
+        "description": "Clash triage severity (0-5) — higher = more blocking",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T8"
+      },
+      {
+        "key": "CLASH_TRIAGE_CAT",
+        "param_name": "CLASH_TRIAGE_CATEGORY_TXT",
+        "guid": "5753b5aa-0008-4000-8000-000000000002",
+        "description": "Clash triage category (Hard / Soft / Tolerance / Workflow)",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T8"
+      },
+      {
+        "key": "CLASH_RES_STATUS",
+        "param_name": "CLASH_RESOLUTION_STATUS_TXT",
+        "guid": "5753b5aa-0008-4000-8000-000000000003",
+        "description": "Clash resolution status (Open / Under Review / Resolved / Accepted)",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T8"
+      },
+      {
+        "key": "ASBUILT_DEV",
+        "param_name": "ASBUILT_DEVIATION_MM",
+        "guid": "5753b5aa-0009-4000-8000-000000000001",
+        "description": "As-built deviation (mm) — delta vs design position from reality capture",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T9"
+      },
+      {
+        "key": "ASBUILT_DATE",
+        "param_name": "ASBUILT_CAPTURE_DATE_TXT",
+        "guid": "5753b5aa-0009-4000-8000-000000000002",
+        "description": "As-built capture date (ISO 8601) — when reality-capture snapshot was taken",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T9"
+      },
+      {
+        "key": "HEALTH_SCORE",
+        "param_name": "HEALTH_SCORE_LAST_NR",
+        "guid": "5753b5aa-0009-4000-8000-000000000003",
+        "description": "Model health score (0-100) — last computed compliance / data quality rating",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T9"
+      },
+      {
+        "key": "IFC_PSET_OVERRIDE",
+        "param_name": "IFC_PSET_OVERRIDE_TXT",
+        "guid": "5753b5aa-000a-4000-8000-000000000001",
+        "description": "IFC PSet override — custom IFC property set / value mapping for export",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T10"
+      },
+      {
+        "key": "ACC_ISSUE_ID",
+        "param_name": "ACC_ISSUE_ID_TXT",
+        "guid": "5753b5aa-000a-4000-8000-000000000002",
+        "description": "ACC Issue ID — Autodesk Construction Cloud Issue round-trip reference",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T10"
+      },
+      {
+        "key": "ACC_SYNC_STATUS",
+        "param_name": "ACC_SYNC_STATUS_TXT",
+        "guid": "5753b5aa-000a-4000-8000-000000000003",
+        "description": "ACC sync status (Pending / Synced / Conflict / Failed)",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T10"
+      },
+      {
+        "key": "COMM_WITNESS",
+        "param_name": "COMM_WITNESS_TXT",
+        "guid": "5753b5aa-0004-4000-8000-000000000010",
+        "description": "Commissioning witness — name / ID of client/third-party observer",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T4"
+      },
+      {
+        "key": "COMM_NOTES",
+        "param_name": "COMM_NOTES_TXT",
+        "guid": "5753b5aa-0004-4000-8000-000000000011",
+        "description": "Commissioning free-text notes (defects, overrides, escalations)",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T4"
+      },
+      {
+        "key": "CST_INSTALL_HRS",
+        "param_name": "CST_INSTALL_HRS",
+        "guid": "5753b5aa-0005-4000-8000-000000000010",
+        "description": "Installation labour hours (N-G12) — estimated man-hours for install",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T5"
+      },
+      {
+        "key": "CST_LABOUR_CREW",
+        "param_name": "CST_LABOUR_CREW_TXT",
+        "guid": "5753b5aa-0005-4000-8000-000000000011",
+        "description": "Labour crew identifier — crew code assigned to install",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T5"
+      },
+      {
+        "key": "CST_LABOUR_RATE_GBP",
+        "param_name": "CST_LABOUR_RATE_GBP",
+        "guid": "5753b5aa-0005-4000-8000-000000000012",
+        "description": "Labour rate (GBP/hr) — override for cost roll-up",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T5"
+      },
+      {
+        "key": "CBN_A5",
+        "param_name": "CBN_A5_KG_CO2E",
+        "guid": "5753b5aa-0006-4000-8000-000000000010",
+        "description": "Construction stage carbon A5 (kgCO2e) — site installation emissions",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T6"
+      },
+      {
+        "key": "CBN_C1",
+        "param_name": "CBN_C1_KG_CO2E",
+        "guid": "5753b5aa-0006-4000-8000-000000000011",
+        "description": "End-of-life carbon C1 (kgCO2e) — demolition energy",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T6"
+      },
+      {
+        "key": "CBN_C2",
+        "param_name": "CBN_C2_KG_CO2E",
+        "guid": "5753b5aa-0006-4000-8000-000000000012",
+        "description": "End-of-life carbon C2 (kgCO2e) — transport to waste processing",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T6"
+      },
+      {
+        "key": "CBN_C3_C4",
+        "param_name": "CBN_C3_C4_KG_CO2E",
+        "guid": "5753b5aa-0006-4000-8000-000000000013",
+        "description": "End-of-life carbon C3-C4 (kgCO2e) — waste processing + disposal",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T6"
+      },
+      {
+        "key": "CLASH_TRIAGE_SCORE",
+        "param_name": "CLASH_TRIAGE_SCORE",
+        "guid": "5753b5aa-0008-4000-8000-000000000010",
+        "description": "Clash triage composite score (0-100) — weighted severity x business impact",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T8"
+      },
+      {
+        "key": "CLASH_RES_ACTION",
+        "param_name": "CLASH_RESOLUTION_ACTION_TXT",
+        "guid": "5753b5aa-0008-4000-8000-000000000011",
+        "description": "Clash resolution action — remediation action taken or planned",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T8"
+      },
+      {
+        "key": "HEALTH_SCORE_DATE",
+        "param_name": "HEALTH_SCORE_DATE_TXT",
+        "guid": "5753b5aa-0009-4000-8000-000000000010",
+        "description": "Model health score capture date (ISO 8601)",
+        "categories": [
+          "ALL"
+        ],
+        "tier": "T9"
+      }
     ]
   },
   "category_enum_map": {
@@ -6095,7 +6427,7 @@
       "guid": "2e3596c7-f913-5c86-9c2b-547f6375ca3c",
       "description": "Room minimum area compliance",
       "threshold": "7.0",
-      "unit": "m\u00b2",
+      "unit": "m²",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6185,7 +6517,7 @@
       "guid": "cc3fc151-264e-5c9e-88fe-add4e5c4e52f",
       "description": "U-value thermal transmittance check",
       "threshold": "0.30",
-      "unit": "W/m\u00b2K",
+      "unit": "W/m²K",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6375,7 +6707,7 @@
       "guid": "18e66013-b783-5748-9389-06897dd57a86",
       "description": "Vertical circulation structural load check",
       "threshold": "5.0",
-      "unit": "kN/m\u00b2",
+      "unit": "kN/m²",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6405,7 +6737,7 @@
       "guid": "43c8ea79-cafd-5da0-9e6f-e228b85efb39",
       "description": "U-value thermal transmittance check",
       "threshold": "0.30",
-      "unit": "W/m\u00b2K",
+      "unit": "W/m²K",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6545,7 +6877,7 @@
       "guid": "573be7bf-3821-5434-b6f6-783e1c83ef87",
       "description": "Fire safety device coverage limit",
       "threshold": "12.0",
-      "unit": "m\u00b2",
+      "unit": "m²",
       "severity": "CRITICAL",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6555,7 +6887,7 @@
       "guid": "f8855ea2-6eee-5cd7-a0c7-fdcd787ced84",
       "description": "Sprinkler coverage area limit",
       "threshold": "12.0",
-      "unit": "m\u00b2",
+      "unit": "m²",
       "severity": "CRITICAL",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6685,7 +7017,7 @@
       "guid": "4b0595c4-908f-58fc-821c-b1cacc438418",
       "description": "Space lighting power density limit",
       "threshold": "10",
-      "unit": "W/m\u00b2",
+      "unit": "W/m²",
       "severity": "MEDIUM",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6745,7 +7077,7 @@
       "guid": "88990dc2-2aca-5179-8407-6511d3e36248",
       "description": "Embodied carbon footprint limit per unit",
       "threshold": "500",
-      "unit": "kgCO\u2082e/m\u00b2",
+      "unit": "kgCO₂e/m²",
       "severity": "MEDIUM",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6755,7 +7087,7 @@
       "guid": "5de3531a-bb17-52f6-a946-97320b6fdc89",
       "description": "Floor U-value thermal transmittance limit",
       "threshold": "0.30",
-      "unit": "W/m\u00b2K",
+      "unit": "W/m²K",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6765,7 +7097,7 @@
       "guid": "04fbb073-cde7-55dd-b056-f67d22e26437",
       "description": "Roof U-value thermal transmittance limit",
       "threshold": "0.30",
-      "unit": "W/m\u00b2K",
+      "unit": "W/m²K",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6775,7 +7107,7 @@
       "guid": "f6b023a0-c2eb-59f8-8fd7-d05f64aa6f7b",
       "description": "Wall U-value thermal transmittance limit",
       "threshold": "0.30",
-      "unit": "W/m\u00b2K",
+      "unit": "W/m²K",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"
@@ -6785,7 +7117,7 @@
       "guid": "698beeb9-f4f0-5c0c-a998-dbe92cb657b0",
       "description": "VOC emissions limit for indoor air quality",
       "threshold": "250",
-      "unit": "\u00b5g/m\u00b3",
+      "unit": "µg/m³",
       "severity": "HIGH",
       "param_type": "TEXT",
       "binding": "universal"

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,FAMILIES=142,ADDS=tier_1_to_10_rows+style_parameter_catalog_150_params,SYNC=LABEL_DEFINITIONS.json_v5.9(138_categories)+PARAMETER_REGISTRY.json_extended_params.tier_4_10(33_entries)
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)
@@ -49,6 +49,182 @@
 #   Scale / depth cache            TAG_SCALE_TIER_AUTO_BOOL / TAG_DEPTH_TIER_INT
 #   Warnings                       TAG_WARN_VISIBLE_BOOL / TAG_WARN_SEVERITY_FILTER_TXT
 #
+
+═══════════════════════════════════════════════════════════════════════════════
+TAG STYLE PARAMETER CATALOG (v5.3) — Type parameters injected into every family
+═══════════════════════════════════════════════════════════════════════════════
+# Source: StingTools/Core/ParamRegistry.cs — injected by TagFamilyCreatorCommand.StyleParams
+# Copy-paste this list when authoring a STING seed tag family by hand. Every
+# parameter below is bound as a TYPE parameter on the tag family. ApplyTagStyleCommand
+# (visibility BOOLs) and SetBoxColor / SetLeaderColor (RGB ints) flip them at runtime.
+#
+# Group breakdown (150 parameters per family):
+#   128  TAG_{size}{style}_{color}_BOOL   — text style switch matrix (4 × 4 × 8)
+#    10  TAG_PARA_STATE_N_BOOL            — paragraph-depth gates (N=1..10)
+#     1  TAG_WARN_VISIBLE_BOOL            — threshold warning toggle
+#     1  TAG_WARN_SEVERITY_FILTER_TXT     — warning severity filter
+#     3  TAG_BOX_COLOR_{R/G/B}_INT        — tag box colour RGB
+#     1  TAG_BOX_VISIBLE_BOOL             — tag box visibility
+#     1  TAG_BOX_STYLE_TXT                — tag box style (SOLID | DASHED | NONE | ROUND)
+#     3  TAG_LEADER_COLOR_{R/G/B}_INT     — leader colour RGB
+#     1  TAG_SCALE_TIER_AUTO_BOOL         — auto-scale tier cache
+#     1  TAG_DEPTH_TIER_INT               — current depth tier (cache)
+
+#,Group,Parameter,Datatype,Default,Category,Role,Description
+1,TextStyle,TAG_2NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLACK
+2,TextStyle,TAG_2NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLUE
+3,TextStyle,TAG_2NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREEN
+4,TextStyle,TAG_2NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM RED
+5,TextStyle,TAG_2NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM ORANGE
+6,TextStyle,TAG_2NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM PURPLE
+7,TextStyle,TAG_2NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREY
+8,TextStyle,TAG_2NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM WHITE
+9,TextStyle,TAG_2BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLACK
+10,TextStyle,TAG_2BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLUE
+11,TextStyle,TAG_2BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREEN
+12,TextStyle,TAG_2BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD RED
+13,TextStyle,TAG_2BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD ORANGE
+14,TextStyle,TAG_2BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD PURPLE
+15,TextStyle,TAG_2BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREY
+16,TextStyle,TAG_2BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD WHITE
+17,TextStyle,TAG_2ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLACK
+18,TextStyle,TAG_2ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLUE
+19,TextStyle,TAG_2ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREEN
+20,TextStyle,TAG_2ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC RED
+21,TextStyle,TAG_2ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC ORANGE
+22,TextStyle,TAG_2ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC PURPLE
+23,TextStyle,TAG_2ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREY
+24,TextStyle,TAG_2ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC WHITE
+25,TextStyle,TAG_2BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLACK
+26,TextStyle,TAG_2BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLUE
+27,TextStyle,TAG_2BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREEN
+28,TextStyle,TAG_2BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC RED
+29,TextStyle,TAG_2BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC ORANGE
+30,TextStyle,TAG_2BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC PURPLE
+31,TextStyle,TAG_2BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREY
+32,TextStyle,TAG_2BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC WHITE
+33,TextStyle,TAG_2.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLACK
+34,TextStyle,TAG_2.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLUE
+35,TextStyle,TAG_2.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREEN
+36,TextStyle,TAG_2.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM RED
+37,TextStyle,TAG_2.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM ORANGE
+38,TextStyle,TAG_2.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM PURPLE
+39,TextStyle,TAG_2.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREY
+40,TextStyle,TAG_2.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM WHITE
+41,TextStyle,TAG_2.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLACK
+42,TextStyle,TAG_2.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLUE
+43,TextStyle,TAG_2.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREEN
+44,TextStyle,TAG_2.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD RED
+45,TextStyle,TAG_2.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD ORANGE
+46,TextStyle,TAG_2.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD PURPLE
+47,TextStyle,TAG_2.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREY
+48,TextStyle,TAG_2.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD WHITE
+49,TextStyle,TAG_2.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLACK
+50,TextStyle,TAG_2.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLUE
+51,TextStyle,TAG_2.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREEN
+52,TextStyle,TAG_2.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC RED
+53,TextStyle,TAG_2.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC ORANGE
+54,TextStyle,TAG_2.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC PURPLE
+55,TextStyle,TAG_2.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREY
+56,TextStyle,TAG_2.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC WHITE
+57,TextStyle,TAG_2.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLACK
+58,TextStyle,TAG_2.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLUE
+59,TextStyle,TAG_2.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREEN
+60,TextStyle,TAG_2.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC RED
+61,TextStyle,TAG_2.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC ORANGE
+62,TextStyle,TAG_2.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC PURPLE
+63,TextStyle,TAG_2.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREY
+64,TextStyle,TAG_2.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC WHITE
+65,TextStyle,TAG_3NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLACK
+66,TextStyle,TAG_3NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLUE
+67,TextStyle,TAG_3NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREEN
+68,TextStyle,TAG_3NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM RED
+69,TextStyle,TAG_3NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM ORANGE
+70,TextStyle,TAG_3NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM PURPLE
+71,TextStyle,TAG_3NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREY
+72,TextStyle,TAG_3NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM WHITE
+73,TextStyle,TAG_3BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLACK
+74,TextStyle,TAG_3BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLUE
+75,TextStyle,TAG_3BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREEN
+76,TextStyle,TAG_3BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD RED
+77,TextStyle,TAG_3BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD ORANGE
+78,TextStyle,TAG_3BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD PURPLE
+79,TextStyle,TAG_3BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREY
+80,TextStyle,TAG_3BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD WHITE
+81,TextStyle,TAG_3ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLACK
+82,TextStyle,TAG_3ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLUE
+83,TextStyle,TAG_3ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREEN
+84,TextStyle,TAG_3ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC RED
+85,TextStyle,TAG_3ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC ORANGE
+86,TextStyle,TAG_3ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC PURPLE
+87,TextStyle,TAG_3ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREY
+88,TextStyle,TAG_3ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC WHITE
+89,TextStyle,TAG_3BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLACK
+90,TextStyle,TAG_3BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLUE
+91,TextStyle,TAG_3BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREEN
+92,TextStyle,TAG_3BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC RED
+93,TextStyle,TAG_3BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC ORANGE
+94,TextStyle,TAG_3BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC PURPLE
+95,TextStyle,TAG_3BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREY
+96,TextStyle,TAG_3BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC WHITE
+97,TextStyle,TAG_3.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLACK
+98,TextStyle,TAG_3.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLUE
+99,TextStyle,TAG_3.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREEN
+100,TextStyle,TAG_3.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM RED
+101,TextStyle,TAG_3.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM ORANGE
+102,TextStyle,TAG_3.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM PURPLE
+103,TextStyle,TAG_3.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREY
+104,TextStyle,TAG_3.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM WHITE
+105,TextStyle,TAG_3.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLACK
+106,TextStyle,TAG_3.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLUE
+107,TextStyle,TAG_3.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREEN
+108,TextStyle,TAG_3.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD RED
+109,TextStyle,TAG_3.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD ORANGE
+110,TextStyle,TAG_3.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD PURPLE
+111,TextStyle,TAG_3.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREY
+112,TextStyle,TAG_3.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD WHITE
+113,TextStyle,TAG_3.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLACK
+114,TextStyle,TAG_3.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLUE
+115,TextStyle,TAG_3.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREEN
+116,TextStyle,TAG_3.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC RED
+117,TextStyle,TAG_3.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC ORANGE
+118,TextStyle,TAG_3.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC PURPLE
+119,TextStyle,TAG_3.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREY
+120,TextStyle,TAG_3.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC WHITE
+121,TextStyle,TAG_3.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLACK
+122,TextStyle,TAG_3.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLUE
+123,TextStyle,TAG_3.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREEN
+124,TextStyle,TAG_3.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC RED
+125,TextStyle,TAG_3.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC ORANGE
+126,TextStyle,TAG_3.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC PURPLE
+127,TextStyle,TAG_3.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREY
+128,TextStyle,TAG_3.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC WHITE
+129,TierGate,TAG_PARA_STATE_1_BOOL,YESNO,1,Common,Switch,Shows tier 1 rows when true (depth N enables 1..N cumulatively)
+130,TierGate,TAG_PARA_STATE_2_BOOL,YESNO,0,Common,Switch,Shows tier 2 rows when true (depth N enables 1..N cumulatively)
+131,TierGate,TAG_PARA_STATE_3_BOOL,YESNO,0,Common,Switch,Shows tier 3 rows when true (depth N enables 1..N cumulatively)
+132,TierGate,TAG_PARA_STATE_4_BOOL,YESNO,0,Common,Switch,Shows tier 4 rows when true (depth N enables 1..N cumulatively)
+133,TierGate,TAG_PARA_STATE_5_BOOL,YESNO,0,Common,Switch,Shows tier 5 rows when true (depth N enables 1..N cumulatively)
+134,TierGate,TAG_PARA_STATE_6_BOOL,YESNO,0,Common,Switch,Shows tier 6 rows when true (depth N enables 1..N cumulatively)
+135,TierGate,TAG_PARA_STATE_7_BOOL,YESNO,0,Common,Switch,Shows tier 7 rows when true (depth N enables 1..N cumulatively)
+136,TierGate,TAG_PARA_STATE_8_BOOL,YESNO,0,Common,Switch,Shows tier 8 rows when true (depth N enables 1..N cumulatively)
+137,TierGate,TAG_PARA_STATE_9_BOOL,YESNO,0,Common,Switch,Shows tier 9 rows when true (depth N enables 1..N cumulatively)
+138,TierGate,TAG_PARA_STATE_10_BOOL,YESNO,0,Common,Switch,Shows tier 10 rows when true (depth N enables 1..N cumulatively)
+139,Warning,TAG_WARN_VISIBLE_BOOL,YESNO,0,Common,Switch,Shows threshold warnings on the tag
+140,Warning,TAG_WARN_SEVERITY_FILTER_TXT,TEXT,HIGH,Common,Filter,Minimum warning severity to show (LOW | MEDIUM | HIGH | CRITICAL)
+141,Box,TAG_BOX_COLOR_R_INT,INTEGER,0,Common,Colour,Tag box colour — red channel 0-255
+142,Box,TAG_BOX_COLOR_G_INT,INTEGER,0,Common,Colour,Tag box colour — green channel 0-255
+143,Box,TAG_BOX_COLOR_B_INT,INTEGER,0,Common,Colour,Tag box colour — blue channel 0-255
+144,Box,TAG_BOX_VISIBLE_BOOL,YESNO,1,Common,Switch,Shows / hides the tag box
+145,Box,TAG_BOX_STYLE_TXT,TEXT,SOLID,Common,Style,Tag box style (SOLID | DASHED | NONE | ROUND)
+146,Leader,TAG_LEADER_COLOR_R_INT,INTEGER,0,Common,Colour,Leader colour — red channel 0-255
+147,Leader,TAG_LEADER_COLOR_G_INT,INTEGER,0,Common,Colour,Leader colour — green channel 0-255
+148,Leader,TAG_LEADER_COLOR_B_INT,INTEGER,0,Common,Colour,Leader colour — blue channel 0-255
+149,Scale,TAG_SCALE_TIER_AUTO_BOOL,YESNO,1,Common,Switch,Auto-compute depth tier from view scale
+150,Scale,TAG_DEPTH_TIER_INT,INTEGER,3,Common,Cache,Current depth tier (cached for fast redraw)
+
+# End of TAG STYLE PARAMETER CATALOG — 150 parameters
+═══════════════════════════════════════════════════════════════════════════════
+
 STING Tag Configuration v5.0 - ARCH (COMPLETE with Warnings)
 6A — Architectural
 Tag Family #1: STING - Wall Tag

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-22,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-22,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,FAMILIES=142,ADDS=tier_1_to_10_rows+style_parameter_catalog_150_params,SYNC=LABEL_DEFINITIONS.json_v5.9(138_categories)+PARAMETER_REGISTRY.json_extended_params.tier_4_10(33_entries)
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)
@@ -49,6 +49,182 @@
 #   Scale / depth cache            TAG_SCALE_TIER_AUTO_BOOL / TAG_DEPTH_TIER_INT
 #   Warnings                       TAG_WARN_VISIBLE_BOOL / TAG_WARN_SEVERITY_FILTER_TXT
 #
+
+═══════════════════════════════════════════════════════════════════════════════
+TAG STYLE PARAMETER CATALOG (v5.3) — Type parameters injected into every family
+═══════════════════════════════════════════════════════════════════════════════
+# Source: StingTools/Core/ParamRegistry.cs — injected by TagFamilyCreatorCommand.StyleParams
+# Copy-paste this list when authoring a STING seed tag family by hand. Every
+# parameter below is bound as a TYPE parameter on the tag family. ApplyTagStyleCommand
+# (visibility BOOLs) and SetBoxColor / SetLeaderColor (RGB ints) flip them at runtime.
+#
+# Group breakdown (150 parameters per family):
+#   128  TAG_{size}{style}_{color}_BOOL   — text style switch matrix (4 × 4 × 8)
+#    10  TAG_PARA_STATE_N_BOOL            — paragraph-depth gates (N=1..10)
+#     1  TAG_WARN_VISIBLE_BOOL            — threshold warning toggle
+#     1  TAG_WARN_SEVERITY_FILTER_TXT     — warning severity filter
+#     3  TAG_BOX_COLOR_{R/G/B}_INT        — tag box colour RGB
+#     1  TAG_BOX_VISIBLE_BOOL             — tag box visibility
+#     1  TAG_BOX_STYLE_TXT                — tag box style (SOLID | DASHED | NONE | ROUND)
+#     3  TAG_LEADER_COLOR_{R/G/B}_INT     — leader colour RGB
+#     1  TAG_SCALE_TIER_AUTO_BOOL         — auto-scale tier cache
+#     1  TAG_DEPTH_TIER_INT               — current depth tier (cache)
+
+#,Group,Parameter,Datatype,Default,Category,Role,Description
+1,TextStyle,TAG_2NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLACK
+2,TextStyle,TAG_2NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLUE
+3,TextStyle,TAG_2NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREEN
+4,TextStyle,TAG_2NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM RED
+5,TextStyle,TAG_2NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM ORANGE
+6,TextStyle,TAG_2NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM PURPLE
+7,TextStyle,TAG_2NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREY
+8,TextStyle,TAG_2NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM WHITE
+9,TextStyle,TAG_2BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLACK
+10,TextStyle,TAG_2BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLUE
+11,TextStyle,TAG_2BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREEN
+12,TextStyle,TAG_2BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD RED
+13,TextStyle,TAG_2BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD ORANGE
+14,TextStyle,TAG_2BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD PURPLE
+15,TextStyle,TAG_2BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREY
+16,TextStyle,TAG_2BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD WHITE
+17,TextStyle,TAG_2ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLACK
+18,TextStyle,TAG_2ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLUE
+19,TextStyle,TAG_2ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREEN
+20,TextStyle,TAG_2ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC RED
+21,TextStyle,TAG_2ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC ORANGE
+22,TextStyle,TAG_2ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC PURPLE
+23,TextStyle,TAG_2ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREY
+24,TextStyle,TAG_2ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC WHITE
+25,TextStyle,TAG_2BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLACK
+26,TextStyle,TAG_2BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLUE
+27,TextStyle,TAG_2BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREEN
+28,TextStyle,TAG_2BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC RED
+29,TextStyle,TAG_2BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC ORANGE
+30,TextStyle,TAG_2BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC PURPLE
+31,TextStyle,TAG_2BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREY
+32,TextStyle,TAG_2BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC WHITE
+33,TextStyle,TAG_2.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLACK
+34,TextStyle,TAG_2.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLUE
+35,TextStyle,TAG_2.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREEN
+36,TextStyle,TAG_2.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM RED
+37,TextStyle,TAG_2.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM ORANGE
+38,TextStyle,TAG_2.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM PURPLE
+39,TextStyle,TAG_2.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREY
+40,TextStyle,TAG_2.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM WHITE
+41,TextStyle,TAG_2.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLACK
+42,TextStyle,TAG_2.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLUE
+43,TextStyle,TAG_2.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREEN
+44,TextStyle,TAG_2.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD RED
+45,TextStyle,TAG_2.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD ORANGE
+46,TextStyle,TAG_2.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD PURPLE
+47,TextStyle,TAG_2.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREY
+48,TextStyle,TAG_2.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD WHITE
+49,TextStyle,TAG_2.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLACK
+50,TextStyle,TAG_2.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLUE
+51,TextStyle,TAG_2.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREEN
+52,TextStyle,TAG_2.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC RED
+53,TextStyle,TAG_2.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC ORANGE
+54,TextStyle,TAG_2.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC PURPLE
+55,TextStyle,TAG_2.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREY
+56,TextStyle,TAG_2.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC WHITE
+57,TextStyle,TAG_2.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLACK
+58,TextStyle,TAG_2.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLUE
+59,TextStyle,TAG_2.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREEN
+60,TextStyle,TAG_2.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC RED
+61,TextStyle,TAG_2.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC ORANGE
+62,TextStyle,TAG_2.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC PURPLE
+63,TextStyle,TAG_2.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREY
+64,TextStyle,TAG_2.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC WHITE
+65,TextStyle,TAG_3NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLACK
+66,TextStyle,TAG_3NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLUE
+67,TextStyle,TAG_3NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREEN
+68,TextStyle,TAG_3NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM RED
+69,TextStyle,TAG_3NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM ORANGE
+70,TextStyle,TAG_3NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM PURPLE
+71,TextStyle,TAG_3NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREY
+72,TextStyle,TAG_3NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM WHITE
+73,TextStyle,TAG_3BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLACK
+74,TextStyle,TAG_3BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLUE
+75,TextStyle,TAG_3BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREEN
+76,TextStyle,TAG_3BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD RED
+77,TextStyle,TAG_3BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD ORANGE
+78,TextStyle,TAG_3BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD PURPLE
+79,TextStyle,TAG_3BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREY
+80,TextStyle,TAG_3BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD WHITE
+81,TextStyle,TAG_3ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLACK
+82,TextStyle,TAG_3ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLUE
+83,TextStyle,TAG_3ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREEN
+84,TextStyle,TAG_3ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC RED
+85,TextStyle,TAG_3ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC ORANGE
+86,TextStyle,TAG_3ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC PURPLE
+87,TextStyle,TAG_3ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREY
+88,TextStyle,TAG_3ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC WHITE
+89,TextStyle,TAG_3BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLACK
+90,TextStyle,TAG_3BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLUE
+91,TextStyle,TAG_3BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREEN
+92,TextStyle,TAG_3BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC RED
+93,TextStyle,TAG_3BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC ORANGE
+94,TextStyle,TAG_3BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC PURPLE
+95,TextStyle,TAG_3BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREY
+96,TextStyle,TAG_3BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC WHITE
+97,TextStyle,TAG_3.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLACK
+98,TextStyle,TAG_3.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLUE
+99,TextStyle,TAG_3.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREEN
+100,TextStyle,TAG_3.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM RED
+101,TextStyle,TAG_3.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM ORANGE
+102,TextStyle,TAG_3.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM PURPLE
+103,TextStyle,TAG_3.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREY
+104,TextStyle,TAG_3.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM WHITE
+105,TextStyle,TAG_3.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLACK
+106,TextStyle,TAG_3.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLUE
+107,TextStyle,TAG_3.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREEN
+108,TextStyle,TAG_3.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD RED
+109,TextStyle,TAG_3.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD ORANGE
+110,TextStyle,TAG_3.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD PURPLE
+111,TextStyle,TAG_3.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREY
+112,TextStyle,TAG_3.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD WHITE
+113,TextStyle,TAG_3.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLACK
+114,TextStyle,TAG_3.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLUE
+115,TextStyle,TAG_3.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREEN
+116,TextStyle,TAG_3.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC RED
+117,TextStyle,TAG_3.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC ORANGE
+118,TextStyle,TAG_3.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC PURPLE
+119,TextStyle,TAG_3.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREY
+120,TextStyle,TAG_3.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC WHITE
+121,TextStyle,TAG_3.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLACK
+122,TextStyle,TAG_3.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLUE
+123,TextStyle,TAG_3.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREEN
+124,TextStyle,TAG_3.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC RED
+125,TextStyle,TAG_3.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC ORANGE
+126,TextStyle,TAG_3.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC PURPLE
+127,TextStyle,TAG_3.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREY
+128,TextStyle,TAG_3.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC WHITE
+129,TierGate,TAG_PARA_STATE_1_BOOL,YESNO,1,Common,Switch,Shows tier 1 rows when true (depth N enables 1..N cumulatively)
+130,TierGate,TAG_PARA_STATE_2_BOOL,YESNO,0,Common,Switch,Shows tier 2 rows when true (depth N enables 1..N cumulatively)
+131,TierGate,TAG_PARA_STATE_3_BOOL,YESNO,0,Common,Switch,Shows tier 3 rows when true (depth N enables 1..N cumulatively)
+132,TierGate,TAG_PARA_STATE_4_BOOL,YESNO,0,Common,Switch,Shows tier 4 rows when true (depth N enables 1..N cumulatively)
+133,TierGate,TAG_PARA_STATE_5_BOOL,YESNO,0,Common,Switch,Shows tier 5 rows when true (depth N enables 1..N cumulatively)
+134,TierGate,TAG_PARA_STATE_6_BOOL,YESNO,0,Common,Switch,Shows tier 6 rows when true (depth N enables 1..N cumulatively)
+135,TierGate,TAG_PARA_STATE_7_BOOL,YESNO,0,Common,Switch,Shows tier 7 rows when true (depth N enables 1..N cumulatively)
+136,TierGate,TAG_PARA_STATE_8_BOOL,YESNO,0,Common,Switch,Shows tier 8 rows when true (depth N enables 1..N cumulatively)
+137,TierGate,TAG_PARA_STATE_9_BOOL,YESNO,0,Common,Switch,Shows tier 9 rows when true (depth N enables 1..N cumulatively)
+138,TierGate,TAG_PARA_STATE_10_BOOL,YESNO,0,Common,Switch,Shows tier 10 rows when true (depth N enables 1..N cumulatively)
+139,Warning,TAG_WARN_VISIBLE_BOOL,YESNO,0,Common,Switch,Shows threshold warnings on the tag
+140,Warning,TAG_WARN_SEVERITY_FILTER_TXT,TEXT,HIGH,Common,Filter,Minimum warning severity to show (LOW | MEDIUM | HIGH | CRITICAL)
+141,Box,TAG_BOX_COLOR_R_INT,INTEGER,0,Common,Colour,Tag box colour — red channel 0-255
+142,Box,TAG_BOX_COLOR_G_INT,INTEGER,0,Common,Colour,Tag box colour — green channel 0-255
+143,Box,TAG_BOX_COLOR_B_INT,INTEGER,0,Common,Colour,Tag box colour — blue channel 0-255
+144,Box,TAG_BOX_VISIBLE_BOOL,YESNO,1,Common,Switch,Shows / hides the tag box
+145,Box,TAG_BOX_STYLE_TXT,TEXT,SOLID,Common,Style,Tag box style (SOLID | DASHED | NONE | ROUND)
+146,Leader,TAG_LEADER_COLOR_R_INT,INTEGER,0,Common,Colour,Leader colour — red channel 0-255
+147,Leader,TAG_LEADER_COLOR_G_INT,INTEGER,0,Common,Colour,Leader colour — green channel 0-255
+148,Leader,TAG_LEADER_COLOR_B_INT,INTEGER,0,Common,Colour,Leader colour — blue channel 0-255
+149,Scale,TAG_SCALE_TIER_AUTO_BOOL,YESNO,1,Common,Switch,Auto-compute depth tier from view scale
+150,Scale,TAG_DEPTH_TIER_INT,INTEGER,3,Common,Cache,Current depth tier (cached for fast redraw)
+
+# End of TAG STYLE PARAMETER CATALOG — 150 parameters
+═══════════════════════════════════════════════════════════════════════════════
+
 STING Tag Configuration v5.0 - GEN (COMPLETE with Warnings)
 6E — Generic / Site / Specialty
 Tag Family #1: STING - Generic Models Tag

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-22,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)
@@ -2332,12 +2332,9 @@ TAG7: SHT_TAG_7_TXT  •  Category: Sheets — MEP disciplines (M/E/P/FP/LV)
 #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula
 1,HIGH,WARN_SHT_MULTI_DISC_MEP,Multiple MEP disciplines on same sheet — coordination risk,ISO 19650-2 / PAS 1192-2,Common,Text,⚠ Warning: Multi-Discipline Sheet,"if(TAG_WARN_VISIBLE_BOOL, WARN_SHT_MULTI_DISC_MEP, """")"
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# TAG FAMILY #53 — STING - MEP Sleeve Tag
-# ═══════════════════════════════════════════════════════════════════════════════
+Tag Family #53: STING - MEP Sleeve Tag
 # Category: Generic Models | PROD: SLV | FUNC: PEN | Disciplines: M, E, P, FP
 # Fire-rated construction penetration sleeves per BS EN 1366-3 / BS 9999
-# ───────────────────────────────────────────────────────────────────────────────
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -2347,7 +2344,7 @@ TAG7: SHT_TAG_7_TXT  •  Category: Sheets — MEP disciplines (M/E/P/FP/LV)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
 1,T2,ASS_TAG_2_TXT,,,0,✓,---,---,---,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 2,T2,SLV_SZ_MM,Ø,mm,0,✓,Common,Text,Sleeve Size,"if(TAG_PARA_STATE_2_BOOL, SLV_SZ_MM, """")",NOM,BLACK,2.0,None,None
-3,T2,SLV_FIRE_RATING_TXT,,, 0,✓,Common,Text,Fire Rating,"if(TAG_PARA_STATE_2_BOOL, SLV_FIRE_RATING_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,SLV_FIRE_RATING_TXT,,,0,✓,Common,Text,Fire Rating,"if(TAG_PARA_STATE_2_BOOL, SLV_FIRE_RATING_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SLV_SERVICE_TXT,Service:,,0,✓,Common,Text,Service Through,"if(TAG_PARA_STATE_2_BOOL, SLV_SERVICE_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,SLV_STATUS_TXT,,,0,✓,Common,Text,Sleeve Status,"if(TAG_PARA_STATE_2_BOOL, SLV_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,FAMILIES=142,ADDS=tier_1_to_10_rows+style_parameter_catalog_150_params,SYNC=LABEL_DEFINITIONS.json_v5.9(138_categories)+PARAMETER_REGISTRY.json_extended_params.tier_4_10(33_entries)
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)
@@ -49,6 +49,182 @@
 #   Scale / depth cache            TAG_SCALE_TIER_AUTO_BOOL / TAG_DEPTH_TIER_INT
 #   Warnings                       TAG_WARN_VISIBLE_BOOL / TAG_WARN_SEVERITY_FILTER_TXT
 #
+
+═══════════════════════════════════════════════════════════════════════════════
+TAG STYLE PARAMETER CATALOG (v5.3) — Type parameters injected into every family
+═══════════════════════════════════════════════════════════════════════════════
+# Source: StingTools/Core/ParamRegistry.cs — injected by TagFamilyCreatorCommand.StyleParams
+# Copy-paste this list when authoring a STING seed tag family by hand. Every
+# parameter below is bound as a TYPE parameter on the tag family. ApplyTagStyleCommand
+# (visibility BOOLs) and SetBoxColor / SetLeaderColor (RGB ints) flip them at runtime.
+#
+# Group breakdown (150 parameters per family):
+#   128  TAG_{size}{style}_{color}_BOOL   — text style switch matrix (4 × 4 × 8)
+#    10  TAG_PARA_STATE_N_BOOL            — paragraph-depth gates (N=1..10)
+#     1  TAG_WARN_VISIBLE_BOOL            — threshold warning toggle
+#     1  TAG_WARN_SEVERITY_FILTER_TXT     — warning severity filter
+#     3  TAG_BOX_COLOR_{R/G/B}_INT        — tag box colour RGB
+#     1  TAG_BOX_VISIBLE_BOOL             — tag box visibility
+#     1  TAG_BOX_STYLE_TXT                — tag box style (SOLID | DASHED | NONE | ROUND)
+#     3  TAG_LEADER_COLOR_{R/G/B}_INT     — leader colour RGB
+#     1  TAG_SCALE_TIER_AUTO_BOOL         — auto-scale tier cache
+#     1  TAG_DEPTH_TIER_INT               — current depth tier (cache)
+
+#,Group,Parameter,Datatype,Default,Category,Role,Description
+1,TextStyle,TAG_2NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLACK
+2,TextStyle,TAG_2NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLUE
+3,TextStyle,TAG_2NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREEN
+4,TextStyle,TAG_2NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM RED
+5,TextStyle,TAG_2NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM ORANGE
+6,TextStyle,TAG_2NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM PURPLE
+7,TextStyle,TAG_2NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREY
+8,TextStyle,TAG_2NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM WHITE
+9,TextStyle,TAG_2BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLACK
+10,TextStyle,TAG_2BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLUE
+11,TextStyle,TAG_2BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREEN
+12,TextStyle,TAG_2BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD RED
+13,TextStyle,TAG_2BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD ORANGE
+14,TextStyle,TAG_2BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD PURPLE
+15,TextStyle,TAG_2BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREY
+16,TextStyle,TAG_2BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD WHITE
+17,TextStyle,TAG_2ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLACK
+18,TextStyle,TAG_2ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLUE
+19,TextStyle,TAG_2ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREEN
+20,TextStyle,TAG_2ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC RED
+21,TextStyle,TAG_2ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC ORANGE
+22,TextStyle,TAG_2ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC PURPLE
+23,TextStyle,TAG_2ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREY
+24,TextStyle,TAG_2ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC WHITE
+25,TextStyle,TAG_2BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLACK
+26,TextStyle,TAG_2BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLUE
+27,TextStyle,TAG_2BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREEN
+28,TextStyle,TAG_2BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC RED
+29,TextStyle,TAG_2BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC ORANGE
+30,TextStyle,TAG_2BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC PURPLE
+31,TextStyle,TAG_2BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREY
+32,TextStyle,TAG_2BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC WHITE
+33,TextStyle,TAG_2.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLACK
+34,TextStyle,TAG_2.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLUE
+35,TextStyle,TAG_2.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREEN
+36,TextStyle,TAG_2.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM RED
+37,TextStyle,TAG_2.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM ORANGE
+38,TextStyle,TAG_2.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM PURPLE
+39,TextStyle,TAG_2.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREY
+40,TextStyle,TAG_2.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM WHITE
+41,TextStyle,TAG_2.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLACK
+42,TextStyle,TAG_2.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLUE
+43,TextStyle,TAG_2.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREEN
+44,TextStyle,TAG_2.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD RED
+45,TextStyle,TAG_2.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD ORANGE
+46,TextStyle,TAG_2.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD PURPLE
+47,TextStyle,TAG_2.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREY
+48,TextStyle,TAG_2.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD WHITE
+49,TextStyle,TAG_2.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLACK
+50,TextStyle,TAG_2.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLUE
+51,TextStyle,TAG_2.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREEN
+52,TextStyle,TAG_2.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC RED
+53,TextStyle,TAG_2.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC ORANGE
+54,TextStyle,TAG_2.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC PURPLE
+55,TextStyle,TAG_2.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREY
+56,TextStyle,TAG_2.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC WHITE
+57,TextStyle,TAG_2.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLACK
+58,TextStyle,TAG_2.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLUE
+59,TextStyle,TAG_2.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREEN
+60,TextStyle,TAG_2.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC RED
+61,TextStyle,TAG_2.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC ORANGE
+62,TextStyle,TAG_2.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC PURPLE
+63,TextStyle,TAG_2.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREY
+64,TextStyle,TAG_2.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC WHITE
+65,TextStyle,TAG_3NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLACK
+66,TextStyle,TAG_3NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLUE
+67,TextStyle,TAG_3NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREEN
+68,TextStyle,TAG_3NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM RED
+69,TextStyle,TAG_3NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM ORANGE
+70,TextStyle,TAG_3NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM PURPLE
+71,TextStyle,TAG_3NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREY
+72,TextStyle,TAG_3NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM WHITE
+73,TextStyle,TAG_3BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLACK
+74,TextStyle,TAG_3BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLUE
+75,TextStyle,TAG_3BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREEN
+76,TextStyle,TAG_3BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD RED
+77,TextStyle,TAG_3BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD ORANGE
+78,TextStyle,TAG_3BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD PURPLE
+79,TextStyle,TAG_3BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREY
+80,TextStyle,TAG_3BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD WHITE
+81,TextStyle,TAG_3ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLACK
+82,TextStyle,TAG_3ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLUE
+83,TextStyle,TAG_3ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREEN
+84,TextStyle,TAG_3ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC RED
+85,TextStyle,TAG_3ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC ORANGE
+86,TextStyle,TAG_3ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC PURPLE
+87,TextStyle,TAG_3ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREY
+88,TextStyle,TAG_3ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC WHITE
+89,TextStyle,TAG_3BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLACK
+90,TextStyle,TAG_3BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLUE
+91,TextStyle,TAG_3BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREEN
+92,TextStyle,TAG_3BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC RED
+93,TextStyle,TAG_3BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC ORANGE
+94,TextStyle,TAG_3BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC PURPLE
+95,TextStyle,TAG_3BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREY
+96,TextStyle,TAG_3BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC WHITE
+97,TextStyle,TAG_3.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLACK
+98,TextStyle,TAG_3.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLUE
+99,TextStyle,TAG_3.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREEN
+100,TextStyle,TAG_3.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM RED
+101,TextStyle,TAG_3.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM ORANGE
+102,TextStyle,TAG_3.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM PURPLE
+103,TextStyle,TAG_3.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREY
+104,TextStyle,TAG_3.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM WHITE
+105,TextStyle,TAG_3.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLACK
+106,TextStyle,TAG_3.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLUE
+107,TextStyle,TAG_3.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREEN
+108,TextStyle,TAG_3.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD RED
+109,TextStyle,TAG_3.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD ORANGE
+110,TextStyle,TAG_3.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD PURPLE
+111,TextStyle,TAG_3.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREY
+112,TextStyle,TAG_3.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD WHITE
+113,TextStyle,TAG_3.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLACK
+114,TextStyle,TAG_3.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLUE
+115,TextStyle,TAG_3.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREEN
+116,TextStyle,TAG_3.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC RED
+117,TextStyle,TAG_3.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC ORANGE
+118,TextStyle,TAG_3.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC PURPLE
+119,TextStyle,TAG_3.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREY
+120,TextStyle,TAG_3.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC WHITE
+121,TextStyle,TAG_3.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLACK
+122,TextStyle,TAG_3.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLUE
+123,TextStyle,TAG_3.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREEN
+124,TextStyle,TAG_3.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC RED
+125,TextStyle,TAG_3.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC ORANGE
+126,TextStyle,TAG_3.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC PURPLE
+127,TextStyle,TAG_3.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREY
+128,TextStyle,TAG_3.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC WHITE
+129,TierGate,TAG_PARA_STATE_1_BOOL,YESNO,1,Common,Switch,Shows tier 1 rows when true (depth N enables 1..N cumulatively)
+130,TierGate,TAG_PARA_STATE_2_BOOL,YESNO,0,Common,Switch,Shows tier 2 rows when true (depth N enables 1..N cumulatively)
+131,TierGate,TAG_PARA_STATE_3_BOOL,YESNO,0,Common,Switch,Shows tier 3 rows when true (depth N enables 1..N cumulatively)
+132,TierGate,TAG_PARA_STATE_4_BOOL,YESNO,0,Common,Switch,Shows tier 4 rows when true (depth N enables 1..N cumulatively)
+133,TierGate,TAG_PARA_STATE_5_BOOL,YESNO,0,Common,Switch,Shows tier 5 rows when true (depth N enables 1..N cumulatively)
+134,TierGate,TAG_PARA_STATE_6_BOOL,YESNO,0,Common,Switch,Shows tier 6 rows when true (depth N enables 1..N cumulatively)
+135,TierGate,TAG_PARA_STATE_7_BOOL,YESNO,0,Common,Switch,Shows tier 7 rows when true (depth N enables 1..N cumulatively)
+136,TierGate,TAG_PARA_STATE_8_BOOL,YESNO,0,Common,Switch,Shows tier 8 rows when true (depth N enables 1..N cumulatively)
+137,TierGate,TAG_PARA_STATE_9_BOOL,YESNO,0,Common,Switch,Shows tier 9 rows when true (depth N enables 1..N cumulatively)
+138,TierGate,TAG_PARA_STATE_10_BOOL,YESNO,0,Common,Switch,Shows tier 10 rows when true (depth N enables 1..N cumulatively)
+139,Warning,TAG_WARN_VISIBLE_BOOL,YESNO,0,Common,Switch,Shows threshold warnings on the tag
+140,Warning,TAG_WARN_SEVERITY_FILTER_TXT,TEXT,HIGH,Common,Filter,Minimum warning severity to show (LOW | MEDIUM | HIGH | CRITICAL)
+141,Box,TAG_BOX_COLOR_R_INT,INTEGER,0,Common,Colour,Tag box colour — red channel 0-255
+142,Box,TAG_BOX_COLOR_G_INT,INTEGER,0,Common,Colour,Tag box colour — green channel 0-255
+143,Box,TAG_BOX_COLOR_B_INT,INTEGER,0,Common,Colour,Tag box colour — blue channel 0-255
+144,Box,TAG_BOX_VISIBLE_BOOL,YESNO,1,Common,Switch,Shows / hides the tag box
+145,Box,TAG_BOX_STYLE_TXT,TEXT,SOLID,Common,Style,Tag box style (SOLID | DASHED | NONE | ROUND)
+146,Leader,TAG_LEADER_COLOR_R_INT,INTEGER,0,Common,Colour,Leader colour — red channel 0-255
+147,Leader,TAG_LEADER_COLOR_G_INT,INTEGER,0,Common,Colour,Leader colour — green channel 0-255
+148,Leader,TAG_LEADER_COLOR_B_INT,INTEGER,0,Common,Colour,Leader colour — blue channel 0-255
+149,Scale,TAG_SCALE_TIER_AUTO_BOOL,YESNO,1,Common,Switch,Auto-compute depth tier from view scale
+150,Scale,TAG_DEPTH_TIER_INT,INTEGER,3,Common,Cache,Current depth tier (cached for fast redraw)
+
+# End of TAG STYLE PARAMETER CATALOG — 150 parameters
+═══════════════════════════════════════════════════════════════════════════════
+
 STING Tag Configuration v5.0 - MEP (COMPLETE with Warnings)
 6C — HVAC
 Tag Family #1: STING - Air Terminal Tag

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,FAMILIES=142,ADDS=tier_1_to_10_rows+style_parameter_catalog_150_params,SYNC=LABEL_DEFINITIONS.json_v5.9(138_categories)+PARAMETER_REGISTRY.json_extended_params.tier_4_10(33_entries)
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)
@@ -49,6 +49,182 @@
 #   Scale / depth cache            TAG_SCALE_TIER_AUTO_BOOL / TAG_DEPTH_TIER_INT
 #   Warnings                       TAG_WARN_VISIBLE_BOOL / TAG_WARN_SEVERITY_FILTER_TXT
 #
+
+═══════════════════════════════════════════════════════════════════════════════
+TAG STYLE PARAMETER CATALOG (v5.3) — Type parameters injected into every family
+═══════════════════════════════════════════════════════════════════════════════
+# Source: StingTools/Core/ParamRegistry.cs — injected by TagFamilyCreatorCommand.StyleParams
+# Copy-paste this list when authoring a STING seed tag family by hand. Every
+# parameter below is bound as a TYPE parameter on the tag family. ApplyTagStyleCommand
+# (visibility BOOLs) and SetBoxColor / SetLeaderColor (RGB ints) flip them at runtime.
+#
+# Group breakdown (150 parameters per family):
+#   128  TAG_{size}{style}_{color}_BOOL   — text style switch matrix (4 × 4 × 8)
+#    10  TAG_PARA_STATE_N_BOOL            — paragraph-depth gates (N=1..10)
+#     1  TAG_WARN_VISIBLE_BOOL            — threshold warning toggle
+#     1  TAG_WARN_SEVERITY_FILTER_TXT     — warning severity filter
+#     3  TAG_BOX_COLOR_{R/G/B}_INT        — tag box colour RGB
+#     1  TAG_BOX_VISIBLE_BOOL             — tag box visibility
+#     1  TAG_BOX_STYLE_TXT                — tag box style (SOLID | DASHED | NONE | ROUND)
+#     3  TAG_LEADER_COLOR_{R/G/B}_INT     — leader colour RGB
+#     1  TAG_SCALE_TIER_AUTO_BOOL         — auto-scale tier cache
+#     1  TAG_DEPTH_TIER_INT               — current depth tier (cache)
+
+#,Group,Parameter,Datatype,Default,Category,Role,Description
+1,TextStyle,TAG_2NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLACK
+2,TextStyle,TAG_2NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLUE
+3,TextStyle,TAG_2NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREEN
+4,TextStyle,TAG_2NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM RED
+5,TextStyle,TAG_2NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM ORANGE
+6,TextStyle,TAG_2NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM PURPLE
+7,TextStyle,TAG_2NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREY
+8,TextStyle,TAG_2NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM WHITE
+9,TextStyle,TAG_2BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLACK
+10,TextStyle,TAG_2BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLUE
+11,TextStyle,TAG_2BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREEN
+12,TextStyle,TAG_2BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD RED
+13,TextStyle,TAG_2BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD ORANGE
+14,TextStyle,TAG_2BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD PURPLE
+15,TextStyle,TAG_2BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREY
+16,TextStyle,TAG_2BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD WHITE
+17,TextStyle,TAG_2ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLACK
+18,TextStyle,TAG_2ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLUE
+19,TextStyle,TAG_2ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREEN
+20,TextStyle,TAG_2ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC RED
+21,TextStyle,TAG_2ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC ORANGE
+22,TextStyle,TAG_2ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC PURPLE
+23,TextStyle,TAG_2ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREY
+24,TextStyle,TAG_2ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC WHITE
+25,TextStyle,TAG_2BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLACK
+26,TextStyle,TAG_2BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLUE
+27,TextStyle,TAG_2BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREEN
+28,TextStyle,TAG_2BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC RED
+29,TextStyle,TAG_2BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC ORANGE
+30,TextStyle,TAG_2BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC PURPLE
+31,TextStyle,TAG_2BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREY
+32,TextStyle,TAG_2BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC WHITE
+33,TextStyle,TAG_2.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLACK
+34,TextStyle,TAG_2.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLUE
+35,TextStyle,TAG_2.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREEN
+36,TextStyle,TAG_2.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM RED
+37,TextStyle,TAG_2.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM ORANGE
+38,TextStyle,TAG_2.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM PURPLE
+39,TextStyle,TAG_2.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREY
+40,TextStyle,TAG_2.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM WHITE
+41,TextStyle,TAG_2.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLACK
+42,TextStyle,TAG_2.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLUE
+43,TextStyle,TAG_2.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREEN
+44,TextStyle,TAG_2.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD RED
+45,TextStyle,TAG_2.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD ORANGE
+46,TextStyle,TAG_2.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD PURPLE
+47,TextStyle,TAG_2.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREY
+48,TextStyle,TAG_2.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD WHITE
+49,TextStyle,TAG_2.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLACK
+50,TextStyle,TAG_2.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLUE
+51,TextStyle,TAG_2.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREEN
+52,TextStyle,TAG_2.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC RED
+53,TextStyle,TAG_2.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC ORANGE
+54,TextStyle,TAG_2.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC PURPLE
+55,TextStyle,TAG_2.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREY
+56,TextStyle,TAG_2.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC WHITE
+57,TextStyle,TAG_2.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLACK
+58,TextStyle,TAG_2.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLUE
+59,TextStyle,TAG_2.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREEN
+60,TextStyle,TAG_2.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC RED
+61,TextStyle,TAG_2.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC ORANGE
+62,TextStyle,TAG_2.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC PURPLE
+63,TextStyle,TAG_2.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREY
+64,TextStyle,TAG_2.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC WHITE
+65,TextStyle,TAG_3NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLACK
+66,TextStyle,TAG_3NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLUE
+67,TextStyle,TAG_3NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREEN
+68,TextStyle,TAG_3NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM RED
+69,TextStyle,TAG_3NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM ORANGE
+70,TextStyle,TAG_3NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM PURPLE
+71,TextStyle,TAG_3NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREY
+72,TextStyle,TAG_3NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM WHITE
+73,TextStyle,TAG_3BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLACK
+74,TextStyle,TAG_3BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLUE
+75,TextStyle,TAG_3BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREEN
+76,TextStyle,TAG_3BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD RED
+77,TextStyle,TAG_3BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD ORANGE
+78,TextStyle,TAG_3BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD PURPLE
+79,TextStyle,TAG_3BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREY
+80,TextStyle,TAG_3BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD WHITE
+81,TextStyle,TAG_3ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLACK
+82,TextStyle,TAG_3ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLUE
+83,TextStyle,TAG_3ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREEN
+84,TextStyle,TAG_3ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC RED
+85,TextStyle,TAG_3ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC ORANGE
+86,TextStyle,TAG_3ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC PURPLE
+87,TextStyle,TAG_3ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREY
+88,TextStyle,TAG_3ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC WHITE
+89,TextStyle,TAG_3BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLACK
+90,TextStyle,TAG_3BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLUE
+91,TextStyle,TAG_3BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREEN
+92,TextStyle,TAG_3BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC RED
+93,TextStyle,TAG_3BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC ORANGE
+94,TextStyle,TAG_3BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC PURPLE
+95,TextStyle,TAG_3BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREY
+96,TextStyle,TAG_3BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC WHITE
+97,TextStyle,TAG_3.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLACK
+98,TextStyle,TAG_3.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLUE
+99,TextStyle,TAG_3.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREEN
+100,TextStyle,TAG_3.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM RED
+101,TextStyle,TAG_3.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM ORANGE
+102,TextStyle,TAG_3.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM PURPLE
+103,TextStyle,TAG_3.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREY
+104,TextStyle,TAG_3.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM WHITE
+105,TextStyle,TAG_3.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLACK
+106,TextStyle,TAG_3.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLUE
+107,TextStyle,TAG_3.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREEN
+108,TextStyle,TAG_3.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD RED
+109,TextStyle,TAG_3.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD ORANGE
+110,TextStyle,TAG_3.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD PURPLE
+111,TextStyle,TAG_3.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREY
+112,TextStyle,TAG_3.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD WHITE
+113,TextStyle,TAG_3.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLACK
+114,TextStyle,TAG_3.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLUE
+115,TextStyle,TAG_3.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREEN
+116,TextStyle,TAG_3.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC RED
+117,TextStyle,TAG_3.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC ORANGE
+118,TextStyle,TAG_3.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC PURPLE
+119,TextStyle,TAG_3.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREY
+120,TextStyle,TAG_3.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC WHITE
+121,TextStyle,TAG_3.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLACK
+122,TextStyle,TAG_3.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLUE
+123,TextStyle,TAG_3.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREEN
+124,TextStyle,TAG_3.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC RED
+125,TextStyle,TAG_3.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC ORANGE
+126,TextStyle,TAG_3.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC PURPLE
+127,TextStyle,TAG_3.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREY
+128,TextStyle,TAG_3.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC WHITE
+129,TierGate,TAG_PARA_STATE_1_BOOL,YESNO,1,Common,Switch,Shows tier 1 rows when true (depth N enables 1..N cumulatively)
+130,TierGate,TAG_PARA_STATE_2_BOOL,YESNO,0,Common,Switch,Shows tier 2 rows when true (depth N enables 1..N cumulatively)
+131,TierGate,TAG_PARA_STATE_3_BOOL,YESNO,0,Common,Switch,Shows tier 3 rows when true (depth N enables 1..N cumulatively)
+132,TierGate,TAG_PARA_STATE_4_BOOL,YESNO,0,Common,Switch,Shows tier 4 rows when true (depth N enables 1..N cumulatively)
+133,TierGate,TAG_PARA_STATE_5_BOOL,YESNO,0,Common,Switch,Shows tier 5 rows when true (depth N enables 1..N cumulatively)
+134,TierGate,TAG_PARA_STATE_6_BOOL,YESNO,0,Common,Switch,Shows tier 6 rows when true (depth N enables 1..N cumulatively)
+135,TierGate,TAG_PARA_STATE_7_BOOL,YESNO,0,Common,Switch,Shows tier 7 rows when true (depth N enables 1..N cumulatively)
+136,TierGate,TAG_PARA_STATE_8_BOOL,YESNO,0,Common,Switch,Shows tier 8 rows when true (depth N enables 1..N cumulatively)
+137,TierGate,TAG_PARA_STATE_9_BOOL,YESNO,0,Common,Switch,Shows tier 9 rows when true (depth N enables 1..N cumulatively)
+138,TierGate,TAG_PARA_STATE_10_BOOL,YESNO,0,Common,Switch,Shows tier 10 rows when true (depth N enables 1..N cumulatively)
+139,Warning,TAG_WARN_VISIBLE_BOOL,YESNO,0,Common,Switch,Shows threshold warnings on the tag
+140,Warning,TAG_WARN_SEVERITY_FILTER_TXT,TEXT,HIGH,Common,Filter,Minimum warning severity to show (LOW | MEDIUM | HIGH | CRITICAL)
+141,Box,TAG_BOX_COLOR_R_INT,INTEGER,0,Common,Colour,Tag box colour — red channel 0-255
+142,Box,TAG_BOX_COLOR_G_INT,INTEGER,0,Common,Colour,Tag box colour — green channel 0-255
+143,Box,TAG_BOX_COLOR_B_INT,INTEGER,0,Common,Colour,Tag box colour — blue channel 0-255
+144,Box,TAG_BOX_VISIBLE_BOOL,YESNO,1,Common,Switch,Shows / hides the tag box
+145,Box,TAG_BOX_STYLE_TXT,TEXT,SOLID,Common,Style,Tag box style (SOLID | DASHED | NONE | ROUND)
+146,Leader,TAG_LEADER_COLOR_R_INT,INTEGER,0,Common,Colour,Leader colour — red channel 0-255
+147,Leader,TAG_LEADER_COLOR_G_INT,INTEGER,0,Common,Colour,Leader colour — green channel 0-255
+148,Leader,TAG_LEADER_COLOR_B_INT,INTEGER,0,Common,Colour,Leader colour — blue channel 0-255
+149,Scale,TAG_SCALE_TIER_AUTO_BOOL,YESNO,1,Common,Switch,Auto-compute depth tier from view scale
+150,Scale,TAG_DEPTH_TIER_INT,INTEGER,3,Common,Cache,Current depth tier (cached for fast redraw)
+
+# End of TAG STYLE PARAMETER CATALOG — 150 parameters
+═══════════════════════════════════════════════════════════════════════════════
+
 STING Tag Configuration v5.0 - STR (COMPLETE with Warnings)
 6B — Structural
 Tag Family #1: STING - Structural Column Tag

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
@@ -1,4 +1,4 @@
-#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-22,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue
+#SCHEMA_VERSION=5.3,CREATED=2026-03-16,UPDATED=2026-04-23,ADDS=tier_4_to_10_and_full_tag_style_param_catalogue,SYNC=LABEL_DEFINITIONS.json_v5.8+PARAMETER_REGISTRY.json_extended_params.tier_4_10
 #
 # SCHEMA v5.2 (2026-04-16) — Added 3 trailing columns: Style,Color,Size
 #   Style  : NOM | BOLD | ITALIC | BOLDITALIC               (default per tier: T1=NOM, T2=NOM, T3=NOM)

--- a/StingTools/Data/TAGGING_GUIDE.md
+++ b/StingTools/Data/TAGGING_GUIDE.md
@@ -611,11 +611,17 @@ Every STING tag family now carries all ten as type parameters, and
 | 9 | T1-T9 | + As-built deviation & health (`ASBUILT_*`, `HEALTH_SCORE_*`) | ITALIC GREY 2.0 |
 | 10 | T1-T10 | + Compliance / audit trail (`IFC_PSET_OVERRIDE_TXT`, `ACC_ISSUE_ID_TXT`, `ACC_SYNC_STATUS_TXT`) | NOM GREY 2.0 |
 
-The T4-T10 block is identical across all 142 families. Canonical definitions live in
-`Data/LABEL_DEFINITIONS.json` (`category_labels.*.tier_4..tier_10` + top-level
-`tier_style_defaults`). The authoring surface is the 4 CSVs
-(`STING_TAG_CONFIG_v5_0_{ARCH,MEP,STR,GEN}.csv`). Parameter GUIDs are in
-`PARAMETER_REGISTRY.json` → `extended_params.tier_4_10`.
+The T4-T10 block is identical across all 142 CSV tag-family entries (138 unique
+JSON categories after de-duplicating cross-discipline names). Canonical
+definitions live in `Data/LABEL_DEFINITIONS.json` v5.9 (`category_labels.*.tier_4..tier_10`
++ top-level `tier_style_defaults`). The authoring surface is the 4 CSVs
+(`STING_TAG_CONFIG_v5_0_{ARCH,MEP,STR,GEN}.csv`) — each now ships with a
+150-parameter `TAG STYLE PARAMETER CATALOG` header section listing every type
+parameter a manually-authored seed family needs (128 text-style BOOLs + 10 tier
+gates + 12 support params). Parameter GUIDs are in
+`PARAMETER_REGISTRY.json` → `extended_params.tier_4_10` (33 entries). JSON
+categories use Revit `BuiltInCategory` plural names ("Ducts"); CSV families use
+singular names ("Duct"); the `csv_family_alias` field in JSON links the two.
 
 > **Note — `_BOOL` Parameter Datatypes**: All `_BOOL` parameters — both the 11 **gating** parameters (`TAG_PARA_STATE_1_BOOL` through `TAG_PARA_STATE_10_BOOL` and `TAG_WARN_VISIBLE_BOOL`) and the 128 **style visibility** parameters (`TAG_{SIZE}{STYLE}_{COLOR}_BOOL`) — use **YESNO** datatype in `MR_PARAMETERS.txt`. Once a shared parameter GUID is created as YESNO in Revit, it cannot be changed to INTEGER without GUID conflicts. Both YESNO and INTEGER use `StorageType.Integer` internally — values are `1`/`0` in both cases.
 

--- a/StingTools/Data/TAGGING_GUIDE.md
+++ b/StingTools/Data/TAGGING_GUIDE.md
@@ -592,17 +592,34 @@ TAG7 is a human-readable descriptive tag with 6 sections (A-F):
 | Presentation | Identity + Spatial | Client presentations |
 | BOQ | Identity + Classification + Cost | Bill of Quantities |
 
-### Paragraph Depth Control
+### Paragraph Depth Control (schema v5.3 — tiers T1..T10)
 
-TAG7 visibility controlled by `TAG_PARA_STATE_1/2/3_BOOL` parameters:
-- Tier 1: Basic (identity + system)
-- Tier 2: Extended (+ spatial + lifecycle)
-- Tier 3: Full (+ technical + classification)
-- Tiers 4-10: Custom depth levels
+TAG7 visibility is controlled by `TAG_PARA_STATE_1_BOOL` through `TAG_PARA_STATE_10_BOOL`.
+Every STING tag family now carries all ten as type parameters, and
+`SetParagraphDepthCommand` supports cumulative depths (depth N enables states 1..N).
 
-> **Note — `_BOOL` Parameter Datatypes**: All `_BOOL` parameters — both the 12 **gating** parameters (`TAG_PARA_STATE_1_BOOL` through `TAG_PARA_STATE_10_BOOL` and `TAG_WARN_VISIBLE_BOOL`) and the 134 **style visibility** parameters (`TAG_{SIZE}{STYLE}_{COLOR}_BOOL`) — use **YESNO** datatype in `MR_PARAMETERS.txt`. Once a shared parameter GUID is created as YESNO in Revit, it cannot be changed to INTEGER without GUID conflicts. Both YESNO and INTEGER use `StorageType.Integer` internally — values are `1`/`0` in both cases.
+| Depth | Tier(s) enabled | Content | Style default |
+|-------|-----------------|---------|----------------|
+| 1 | T1 | Identity (`ASS_TAG_1_TXT`) | NOM BLACK 2.5 |
+| 2 | T1-T2 | + Description, dimensions, materials | NOM BLACK 2.0 |
+| 3 | T1-T3 | + Paragraph container + TAG7 sub-sections | NOM BLACK 2.0 |
+| 4 | T1-T4 | + Commissioning & handover (`COMM_*`) | BOLD BLUE 2.0 |
+| 5 | T1-T5 | + Cost & procurement (`CST_UG_PRICE_UGX`, `CST_INTL_PRICE_USD`, `CST_QUOTE_REF_TXT`) | NOM PURPLE 2.0 |
+| 6 | T1-T6 | + Carbon & sustainability (`CBN_A1_A3`, `CBN_A4`, `CBN_B6`) | ITALIC GREEN 2.0 |
+| 7 | T1-T7 | + Fabrication & QC (`ASS_SPOOL_NR_TXT`, `ASS_FAB_STATUS_TXT`, `ASS_QC_INSPECTOR_TXT`) | BOLD ORANGE 2.0 |
+| 8 | T1-T8 | + Clash & coordination (`CLASH_TRIAGE_*`, `CLASH_RESOLUTION_*`) | BOLD RED 2.0 |
+| 9 | T1-T9 | + As-built deviation & health (`ASBUILT_*`, `HEALTH_SCORE_*`) | ITALIC GREY 2.0 |
+| 10 | T1-T10 | + Compliance / audit trail (`IFC_PSET_OVERRIDE_TXT`, `ACC_ISSUE_ID_TXT`, `ACC_SYNC_STATUS_TXT`) | NOM GREY 2.0 |
 
-Set via: CREATE → Presentation → Set Paragraph Depth
+The T4-T10 block is identical across all 142 families. Canonical definitions live in
+`Data/LABEL_DEFINITIONS.json` (`category_labels.*.tier_4..tier_10` + top-level
+`tier_style_defaults`). The authoring surface is the 4 CSVs
+(`STING_TAG_CONFIG_v5_0_{ARCH,MEP,STR,GEN}.csv`). Parameter GUIDs are in
+`PARAMETER_REGISTRY.json` → `extended_params.tier_4_10`.
+
+> **Note — `_BOOL` Parameter Datatypes**: All `_BOOL` parameters — both the 11 **gating** parameters (`TAG_PARA_STATE_1_BOOL` through `TAG_PARA_STATE_10_BOOL` and `TAG_WARN_VISIBLE_BOOL`) and the 128 **style visibility** parameters (`TAG_{SIZE}{STYLE}_{COLOR}_BOOL`) — use **YESNO** datatype in `MR_PARAMETERS.txt`. Once a shared parameter GUID is created as YESNO in Revit, it cannot be changed to INTEGER without GUID conflicts. Both YESNO and INTEGER use `StorageType.Integer` internally — values are `1`/`0` in both cases.
+
+Set via: CREATE → Presentation → Set Paragraph Depth (TaskDialog path covers T1-T3; the Tag Studio Tokens & Depth slider covers T1-T10).
 
 ---
 

--- a/StingTools/Data/TAG_FAMILY_CREATION_GUIDE.md
+++ b/StingTools/Data/TAG_FAMILY_CREATION_GUIDE.md
@@ -421,15 +421,40 @@ For finer control, set paragraph depth per selection or project-wide:
 - **Standard (State 2)** — Tiers 1+2: adds materials, thermal, acoustic data
 - **Comprehensive (State 3)** — Tiers 1+2+3: full specification with regulatory, sustainability, QA
 
-### Extended Paragraph Depth (1-10 Tiers)
+### Extended Paragraph Depth (1-10 Tiers) — schema v5.3
 
-**Command**: `SetParagraphDepthExtCommand`
+**Command**: `SetParagraphDepthExtCommand` (and `SetParagraphDepthCommand` via the
+Tag Studio Tokens & Depth slider)
 **Button**: **`Set Depth (1-10)`** — VIEW tab → TAG STYLE ENGINE section → PARAGRAPH DEPTH sub-section
 
-For even finer control with up to 10 visibility tiers:
-- Tiers 1-3: Original compact/standard/comprehensive
-- Tiers 4-6: Extended detail (MEP specs, material properties, classification codes)
-- Tiers 7-10: Full specification (complete BOQ data, maintenance info, lifecycle data)
+Each tag family now carries `TAG_PARA_STATE_1_BOOL` .. `TAG_PARA_STATE_10_BOOL`
+(type parameters, injected by `TagFamilyCreatorCommand.VisibilityParams`).
+`SetParagraphDepthCommand` supports cumulative depths (depth N enables states 1..N).
+
+| Tier | Purpose | Canonical parameters | Style / Color (default) |
+|------|---------|-----------------------|------------------------|
+| T1 | Identity | `ASS_TAG_1_TXT` | NOM BLACK 2.5 |
+| T2 | Technical basics | `ASS_TAG_2_TXT`, `ASS_DESCRIPTION_TXT`, category specifics | NOM BLACK 2.0 |
+| T3 | Comprehensive spec | Paragraph container + TAG7 sub-sections | NOM BLACK 2.0 |
+| T4 | Commissioning & handover | `COMM_STATE_TXT`, `COMM_DATE_TXT`, `COMM_OPERATIVE_TXT` | BOLD BLUE 2.0 |
+| T5 | Cost & procurement | `CST_UG_PRICE_UGX`, `CST_INTL_PRICE_USD`, `CST_QUOTE_REF_TXT` | NOM PURPLE 2.0 |
+| T6 | Carbon & sustainability (BS EN 15978) | `CBN_A1_A3_KG_CO2E`, `CBN_A4_KG_CO2E`, `CBN_B6_KG_CO2E_YR` | ITALIC GREEN 2.0 |
+| T7 | Fabrication & QC (ISO 6412) | `ASS_SPOOL_NR_TXT`, `ASS_FAB_STATUS_TXT`, `ASS_QC_INSPECTOR_TXT` | BOLD ORANGE 2.0 |
+| T8 | Clash & coordination | `CLASH_TRIAGE_SEVERITY_NR`, `CLASH_TRIAGE_CATEGORY_TXT`, `CLASH_RESOLUTION_STATUS_TXT` | BOLD RED 2.0 |
+| T9 | As-built & health | `ASBUILT_DEVIATION_MM`, `ASBUILT_CAPTURE_DATE_TXT`, `HEALTH_SCORE_LAST_NR` | ITALIC GREY 2.0 |
+| T10 | Compliance / audit trail | `IFC_PSET_OVERRIDE_TXT`, `ACC_ISSUE_ID_TXT`, `ACC_SYNC_STATUS_TXT` | NOM GREY 2.0 |
+
+The canonical T4-T10 block is shared across all 142 tag families. Each row uses
+the Calculated Value pattern `if(TAG_PARA_STATE_N_BOOL, <param>, "")`.
+
+**Data-source alignment (schema v5.3 — 2026-04-23)**:
+
+| Source | Role | File |
+|--------|------|------|
+| CSV (human-readable spec) | Authoring surface for row order, prefix/suffix, style/color/size | `STING_TAG_CONFIG_v5_0_{ARCH,MEP,STR,GEN}.csv` |
+| JSON (code-consumed) | What `LabelDefinitionHelper` and `TagFamilyCreatorCommand` read at runtime — carries `tier_1..tier_10` arrays and the top-level `tier_style_defaults` block | `LABEL_DEFINITIONS.json` v5.8 |
+| Registry (GUID + binding) | `ParamRegistry.GetGuid()` / shared-parameter binding — all T4-T10 parameters live in `extended_params.tier_4_10` with valid-hex placeholder GUIDs `5753b5aa-000T-4000-8PPP-...` | `PARAMETER_REGISTRY.json` v5.6 |
+| C# constants | Source-level references from commands | `StingTools/Core/ParamRegistry.cs` V6/Tier-4-10 region |
 
 ### Warning Visibility
 

--- a/StingTools/Data/TAG_FAMILY_CREATION_GUIDE.md
+++ b/StingTools/Data/TAG_FAMILY_CREATION_GUIDE.md
@@ -451,10 +451,36 @@ the Calculated Value pattern `if(TAG_PARA_STATE_N_BOOL, <param>, "")`.
 
 | Source | Role | File |
 |--------|------|------|
-| CSV (human-readable spec) | Authoring surface for row order, prefix/suffix, style/color/size | `STING_TAG_CONFIG_v5_0_{ARCH,MEP,STR,GEN}.csv` |
-| JSON (code-consumed) | What `LabelDefinitionHelper` and `TagFamilyCreatorCommand` read at runtime — carries `tier_1..tier_10` arrays and the top-level `tier_style_defaults` block | `LABEL_DEFINITIONS.json` v5.8 |
-| Registry (GUID + binding) | `ParamRegistry.GetGuid()` / shared-parameter binding — all T4-T10 parameters live in `extended_params.tier_4_10` with valid-hex placeholder GUIDs `5753b5aa-000T-4000-8PPP-...` | `PARAMETER_REGISTRY.json` v5.6 |
+| CSV (human-readable spec) | Authoring surface — 142 Tag Family entries, full tier_1..tier_10 rows, Style/Color/Size per row, plus 150-parameter TAG STYLE PARAMETER CATALOG block | `STING_TAG_CONFIG_v5_0_{ARCH,MEP,STR,GEN}.csv` |
+| JSON (code-consumed) | Runtime data read by `LabelDefinitionHelper` and `TagFamilyCreatorCommand` — 138 categories, each with tier_1..tier_10 arrays, plus top-level `tier_style_defaults` block | `LABEL_DEFINITIONS.json` v5.9 |
+| Registry (GUID + binding) | `ParamRegistry.GetGuid()` / shared-parameter binding — T4-T10 parameters in `extended_params.tier_4_10` (33 entries) with valid-hex placeholder GUIDs `5753b5aa-000T-4000-8PPP-...` | `PARAMETER_REGISTRY.json` v5.6 |
 | C# constants | Source-level references from commands | `StingTools/Core/ParamRegistry.cs` V6/Tier-4-10 region |
+
+**Naming mapping** (CSV ↔ JSON): CSV uses singular family-friendly names
+("Duct", "Wall") while JSON uses Revit `BuiltInCategory` display names (plural:
+"Ducts", "Walls"). 39 JSON entries carry a `csv_family_alias` field linking
+back to the CSV. 12 CSV-only families (Tie-In Point tags, Sheet tags for
+Architectural/MEP/Structural, Brace / Truss, Generic Model, etc.) are added as
+JSON entries tagged with `source_csv`. The gap from 142 CSV entries to 138 JSON
+entries is 6 duplicates (same category name appearing in two discipline CSVs,
+e.g. "Specialty Equipment", "Internal Area Loads" — the JSON de-duplicates
+while CSV tolerates the duplication per discipline).
+
+### TAG STYLE PARAMETER CATALOG (150 parameters per family)
+
+Every STING tag family is injected with a fixed 150-parameter set of **type**
+parameters that the Tag Style Engine flips at runtime. The complete list lives
+at the top of each v5 CSV (section titled `TAG STYLE PARAMETER CATALOG (v5.3)`)
+and is generated in C# by `TagFamilyCreatorCommand.StyleParams`:
+
+| Group | Count | Pattern |
+|-------|------:|---------|
+| Text style switch matrix | 128 | `TAG_{size}{style}_{color}_BOOL` (sizes 2/2.5/3/3.5 × styles NOM/BOLD/ITALIC/BOLDITALIC × 8 colors) |
+| Paragraph-depth gates | 10 | `TAG_PARA_STATE_1_BOOL` .. `TAG_PARA_STATE_10_BOOL` |
+| Warnings | 2 | `TAG_WARN_VISIBLE_BOOL`, `TAG_WARN_SEVERITY_FILTER_TXT` |
+| Tag box | 5 | `TAG_BOX_COLOR_{R,G,B}_INT`, `TAG_BOX_VISIBLE_BOOL`, `TAG_BOX_STYLE_TXT` |
+| Leader | 3 | `TAG_LEADER_COLOR_{R,G,B}_INT` |
+| Scale / depth cache | 2 | `TAG_SCALE_TIER_AUTO_BOOL`, `TAG_DEPTH_TIER_INT` |
 
 ### Warning Visibility
 

--- a/StingTools/Tags/PresentationModeCommand.cs
+++ b/StingTools/Tags/PresentationModeCommand.cs
@@ -281,6 +281,28 @@ namespace StingTools.Tags
             sb.AppendLine("  Calculated value (Type: Text): if(TAG_PARA_STATE_3_BOOL, <param>, \"\")");
             FormatTierParams(sb, catDef["tier_3"] as JArray, paramText);
 
+            // Tier 4..10 (shared across all families — commissioning / cost / carbon /
+            // fabrication / clash / as-built / compliance)
+            string[] tierLabels = new[]
+            {
+                "TIER 4 (Commissioning & handover)",
+                "TIER 5 (Cost & procurement)",
+                "TIER 6 (Carbon & sustainability — BS EN 15978)",
+                "TIER 7 (Fabrication & QC — ISO 6412)",
+                "TIER 8 (Clash & coordination)",
+                "TIER 9 (As-built & health)",
+                "TIER 10 (Compliance / audit trail)",
+            };
+            for (int i = 0; i < 7; i++)
+            {
+                int t = i + 4;
+                var arr = catDef[$"tier_{t}"] as JArray;
+                if (arr == null || arr.Count == 0) continue;
+                sb.AppendLine($"  ── {tierLabels[i]} (Gated by TAG_PARA_STATE_{t}_BOOL) ──");
+                sb.AppendLine($"  Calculated value (Type: Text): if(TAG_PARA_STATE_{t}_BOOL, <param>, \"\")");
+                FormatTierParams(sb, arr, paramText);
+            }
+
             sb.AppendLine();
         }
 
@@ -293,8 +315,23 @@ namespace StingTools.Tags
                 return;
             }
 
-            sb.AppendLine("  Parameter            | Prefix      | Suffix      | Spc | Brk");
-            sb.AppendLine("  " + new string('-', 70));
+            bool anyStyle = false;
+            foreach (JObject e in tierParams)
+            {
+                if (e["style"] != null || e["color"] != null || e["size"] != null)
+                { anyStyle = true; break; }
+            }
+
+            if (anyStyle)
+            {
+                sb.AppendLine("  Parameter            | Prefix      | Suffix      | Spc | Brk | Style  | Color  | Sz");
+                sb.AppendLine("  " + new string('-', 92));
+            }
+            else
+            {
+                sb.AppendLine("  Parameter            | Prefix      | Suffix      | Spc | Brk");
+                sb.AppendLine("  " + new string('-', 70));
+            }
 
             foreach (JObject entry in tierParams)
             {
@@ -315,9 +352,21 @@ namespace StingTools.Tags
                 suffix = suffix ?? "";
 
                 string paramShort = param.Length > 20 ? param.Substring(0, 17) + "..." : param;
-                sb.AppendLine($"  {paramShort,-20} | \"{prefix}\"" +
-                    $"{new string(' ', Math.Max(0, 10 - prefix.Length - 2))}| \"{suffix}\"" +
-                    $"{new string(' ', Math.Max(0, 10 - suffix.Length - 2))}| {spaces}   | {(brk ? "YES" : "")}");
+                string prefixCell = "\"" + prefix + "\"" + new string(' ', Math.Max(0, 10 - prefix.Length - 2));
+                string suffixCell = "\"" + suffix + "\"" + new string(' ', Math.Max(0, 10 - suffix.Length - 2));
+                string baseLine = $"  {paramShort,-20} | {prefixCell}| {suffixCell}| {spaces}   | {(brk ? "YES" : "")}";
+
+                if (anyStyle)
+                {
+                    string style = entry["style"]?.ToString() ?? "";
+                    string color = entry["color"]?.ToString() ?? "";
+                    string size  = entry["size"]?.ToString() ?? "";
+                    sb.AppendLine(baseLine.PadRight(50) + $" | {style,-6} | {color,-6} | {size}");
+                }
+                else
+                {
+                    sb.AppendLine(baseLine);
+                }
             }
         }
 
@@ -492,6 +541,24 @@ namespace StingTools.Tags
                 "if(TAG_PARA_STATE_2_BOOL, <param>, \"\")");
             FormatTier(sb, "TIER 3 — Comprehensive (gate: TAG_PARA_STATE_3_BOOL)", catDef["tier_3"] as JArray, paramText,
                 "if(TAG_PARA_STATE_3_BOOL, <param>, \"\")");
+            // Tiers 4..10: shared commissioning / cost / carbon / fabrication / clash /
+            // as-built / compliance rows (v5.3 schema).
+            string[] extTitles = new[]
+            {
+                "TIER 4 — Commissioning & handover (gate: TAG_PARA_STATE_4_BOOL)",
+                "TIER 5 — Cost & procurement (gate: TAG_PARA_STATE_5_BOOL)",
+                "TIER 6 — Carbon & sustainability (gate: TAG_PARA_STATE_6_BOOL)",
+                "TIER 7 — Fabrication & QC (gate: TAG_PARA_STATE_7_BOOL)",
+                "TIER 8 — Clash & coordination (gate: TAG_PARA_STATE_8_BOOL)",
+                "TIER 9 — As-built & health (gate: TAG_PARA_STATE_9_BOOL)",
+                "TIER 10 — Compliance / audit trail (gate: TAG_PARA_STATE_10_BOOL)",
+            };
+            for (int i = 0; i < 7; i++)
+            {
+                int t = i + 4;
+                FormatTier(sb, extTitles[i], catDef[$"tier_{t}"] as JArray, paramText,
+                    $"if(TAG_PARA_STATE_{t}_BOOL, <param>, \"\")");
+            }
 
             sb.AppendLine();
         }
@@ -511,8 +578,23 @@ namespace StingTools.Tags
                 return;
             }
 
-            sb.AppendLine($"  {"Parameter",-40} {"Prefix",-15} {"Suffix",-12} {"Spc",3} {"Brk",4}");
-            sb.AppendLine("  " + new string('─', 75));
+            bool anyStyle = false;
+            foreach (JObject e in tierParams)
+            {
+                if (e["style"] != null || e["color"] != null || e["size"] != null)
+                { anyStyle = true; break; }
+            }
+
+            if (anyStyle)
+            {
+                sb.AppendLine($"  {"Parameter",-40} {"Prefix",-15} {"Suffix",-12} {"Spc",3} {"Brk",4}  {"Style",-6}  {"Color",-6}  Sz");
+                sb.AppendLine("  " + new string('─', 102));
+            }
+            else
+            {
+                sb.AppendLine($"  {"Parameter",-40} {"Prefix",-15} {"Suffix",-12} {"Spc",3} {"Brk",4}");
+                sb.AppendLine("  " + new string('─', 75));
+            }
 
             foreach (JObject entry in tierParams)
             {
@@ -531,8 +613,20 @@ namespace StingTools.Tags
                 prefix = prefix ?? "";
                 suffix = suffix ?? "";
 
-                sb.AppendLine($"  {param,-40} \"{prefix}\"{new string(' ', Math.Max(0, 12 - prefix.Length))} " +
-                    $"\"{suffix}\"{new string(' ', Math.Max(0, 9 - suffix.Length))} {spaces,3} {(brk ? "YES" : ""),4}");
+                string baseLine = $"  {param,-40} \"{prefix}\"{new string(' ', Math.Max(0, 12 - prefix.Length))} " +
+                    $"\"{suffix}\"{new string(' ', Math.Max(0, 9 - suffix.Length))} {spaces,3} {(brk ? "YES" : ""),4}";
+
+                if (anyStyle)
+                {
+                    string style = entry["style"]?.ToString() ?? "";
+                    string color = entry["color"]?.ToString() ?? "";
+                    string size  = entry["size"]?.ToString() ?? "";
+                    sb.AppendLine(baseLine + $"  {style,-6}  {color,-6}  {size}");
+                }
+                else
+                {
+                    sb.AppendLine(baseLine);
+                }
             }
 
             sb.AppendLine();
@@ -850,16 +944,18 @@ namespace StingTools.Tags
 
             var catDef = cats[categoryName] as JObject;
 
-            // Visibility control params (always added)
-            result.Add("TAG_PARA_STATE_1_BOOL");
-            result.Add("TAG_PARA_STATE_2_BOOL");
-            result.Add("TAG_PARA_STATE_3_BOOL");
+            // Visibility control params (always added) — full 1..10 set matches
+            // TagFamilyCreatorCommand.VisibilityParams and SetParagraphDepthCommand (MaxTier=10).
+            for (int t = 1; t <= 10; t++)
+                result.Add($"TAG_PARA_STATE_{t}_BOOL");
             result.Add("TAG_WARN_VISIBLE_BOOL");
 
-            // Collect params from all tiers
-            foreach (string tierKey in new[] { "tier_1", "tier_2", "tier_3" })
+            // Collect params from all tiers (tier_1..tier_10). Tiers 4-10 hold the cross-family
+            // commissioning / cost / carbon / fabrication / clash / as-built / compliance rows
+            // mirrored from STING_TAG_CONFIG_v5_0_*.csv schema v5.3.
+            for (int t = 1; t <= 10; t++)
             {
-                var tier = catDef[tierKey] as JArray;
+                var tier = catDef[$"tier_{t}"] as JArray;
                 if (tier == null) continue;
                 foreach (JObject entry in tier)
                 {

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -2195,6 +2195,33 @@ namespace StingTools.Tags
                     FormatTierTable(sb, tier3, paramText);
                 }
 
+                // Tiers 4..10 — shared commissioning / cost / carbon / fabrication /
+                // clash / as-built / compliance rows (v5.3 schema). Gated by matching
+                // TAG_PARA_STATE_N_BOOL type parameter so SetParagraphDepthCommand can
+                // progressively widen visible tiers.
+                string[] extLabels = new[]
+                {
+                    "TIER 4 (Commissioning & handover)",
+                    "TIER 5 (Cost & procurement)",
+                    "TIER 6 (Carbon & sustainability — BS EN 15978)",
+                    "TIER 7 (Fabrication & QC — ISO 6412)",
+                    "TIER 8 (Clash & coordination)",
+                    "TIER 9 (As-built & health)",
+                    "TIER 10 (Compliance / audit trail)",
+                };
+                for (int i = 0; i < 7; i++)
+                {
+                    int t = i + 4;
+                    var arr = catDef[$"tier_{t}"] as JArray;
+                    if (arr == null || arr.Count == 0) continue;
+                    sb.AppendLine();
+                    sb.AppendLine($"── {extLabels[i]} ──");
+                    sb.AppendLine("Use CALCULATED VALUES (Type: Text) for each parameter:");
+                    sb.AppendLine($"  Formula: if(TAG_PARA_STATE_{t}_BOOL, <param>, \"\")");
+                    sb.AppendLine();
+                    FormatTierTable(sb, arr, paramText);
+                }
+
                 // Paragraph container
                 string paraCont = catDef["paragraph_container"]?.ToString();
                 if (!string.IsNullOrEmpty(paraCont) && paraCont != "null")
@@ -2281,8 +2308,25 @@ namespace StingTools.Tags
                 return;
             }
 
-            sb.AppendLine("  Parameter                    | Prefix         | Suffix         | Spc | Brk");
-            sb.AppendLine("  " + new string('─', 80));
+            // Header includes Style/Color/Size columns when any row in this tier carries them
+            // (v5.3 schema — tier_4..tier_10 ship with style/color/size; tier_1..3 inherit defaults).
+            bool anyStyle = false;
+            foreach (JObject e in tierParams)
+            {
+                if (e["style"] != null || e["color"] != null || e["size"] != null)
+                { anyStyle = true; break; }
+            }
+
+            if (anyStyle)
+            {
+                sb.AppendLine("  Parameter                    | Prefix         | Suffix         | Spc | Brk | Style  | Color  | Size");
+                sb.AppendLine("  " + new string('─', 108));
+            }
+            else
+            {
+                sb.AppendLine("  Parameter                    | Prefix         | Suffix         | Spc | Brk");
+                sb.AppendLine("  " + new string('─', 80));
+            }
 
             foreach (JObject entry in tierParams)
             {
@@ -2307,7 +2351,17 @@ namespace StingTools.Tags
                 string prefixDisp = prefix.Length > 0 ? $"\"{prefix}\"" : "";
                 string suffixDisp = suffix.Length > 0 ? $"\"{suffix}\"" : "";
 
-                sb.AppendLine($"  {paramShort,-30} | {prefixDisp,-14} | {suffixDisp,-14} | {spaces,-3} | {(brk ? "YES" : "")}");
+                if (anyStyle)
+                {
+                    string style = entry["style"]?.ToString() ?? "";
+                    string color = entry["color"]?.ToString() ?? "";
+                    string size = entry["size"]?.ToString() ?? "";
+                    sb.AppendLine($"  {paramShort,-30} | {prefixDisp,-14} | {suffixDisp,-14} | {spaces,-3} | {(brk ? "YES" : ""),-3} | {style,-6} | {color,-6} | {size}");
+                }
+                else
+                {
+                    sb.AppendLine($"  {paramShort,-30} | {prefixDisp,-14} | {suffixDisp,-14} | {spaces,-3} | {(brk ? "YES" : "")}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR extends the STING Tools tagging system to support tiers 4-10, introducing new parameters for commissioning, cost, carbon, and fabrication data. The changes update the parameter registry, tag configuration files, and related documentation to reflect the expanded tier structure.

## Key Changes

- **Parameter Registry**: Added V6/Tier 4-10 parameter definitions in `ParamRegistry.cs` to back the new tag label tiers with support for commissioning, cost, carbon, and fabrication specifications
- **Tag Configuration Files**: Updated schema version metadata in all tag configuration CSV files (MEP, ARCH, GEN, STR) to reflect the expanded tier structure with 142 families and tier 1-10 row support
- **Label Definitions**: Significantly expanded `LABEL_DEFINITIONS.json` with new tier 4-10 label definitions and parameter mappings
- **Presentation Logic**: Enhanced `PresentationModeCommand.cs` to format and display tier 4-10 parameters in category specifications
- **Tag Family Creation**: Extended `TagFamilyCreatorCommand.cs` with tier 4-10 label specification building logic
- **Documentation**: Updated `TAG_FAMILY_CREATION_GUIDE.md` and `TAGGING_GUIDE.md` to document the new tier 4-10 capabilities and their use cases

## Implementation Details

- Schema version remains at 5.3 but now supports tiers 1-10 (previously 1-3)
- Updated timestamps across configuration files to 2026-04-23
- New tier parameters follow the existing parameter naming and binding conventions
- Documentation clarifies the purpose of each tier level and when to use tier 4-10 data

https://claude.ai/code/session_01Cjnsy7waSpZJjnZkLPsgcc