### PR TITLE
Wave-1 commit 2-3: CSV-driven tier-plan authoring for tag families

### DIFF
--- a/StingTools/Core/TagConfigCsvReader.cs
+++ b/StingTools/Core/TagConfigCsvReader.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace StingTools.Core
+{
+    /// <summary>
+    /// Parses the v5 tag config CSVs (STING_TAG_CONFIG_v5_0_{ARCH|MEP|STR|GEN}[_DesignConstruction].csv)
+    /// into <see cref="TierPlan"/> entries keyed by tag-family name. Reuses the row
+    /// schema defined in <see cref="PerFamilyTierMap"/> so downstream consumers
+    /// (FamilyLabelAuthor, drift detector, post-author validator) share one
+    /// data model with the hardcoded map.
+    /// </summary>
+    /// <remarks>
+    /// Pure C#: no Autodesk.Revit.* dependency so the reader can be exercised
+    /// from unit tests or headless scripts. Assembles only T4..T10 rows — T1..T3
+    /// are default-present in every family and live outside the tier-variation
+    /// plan (<see cref="PerFamilyTierMap"/> never stores T1..T3).
+    /// </remarks>
+    public static class TagConfigCsvReader
+    {
+        private static readonly Regex FamilyHeaderRegex =
+            new Regex(@"^\s*Tag Family\s+#\d+:\s*(?<name>.+?)\s*$",
+                RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex TierRegex =
+            new Regex(@"^T(?<n>\d{1,2})$",
+                RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        // Sentinel that ends a family's data rows. Matches the "⚠ WARNING PARAMETERS"
+        // banner the regenerator emits after the last tier row of each family.
+        private const string WarningBanner = "⚠ WARNING PARAMETERS";
+
+        // Column indexes inside the v5 data header:
+        //   #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+        private const int ColTier      = 1;
+        private const int ColParameter = 2;
+        private const int ColPrefix    = 3;
+        private const int ColSuffix    = 4;
+        private const int ColSpc       = 5;
+        private const int ColBrk       = 6;
+        private const int ColName      = 9;
+        private const int ColStyle     = 11;
+        private const int ColColor     = 12;
+        private const int ColSize      = 13;
+        private const int MinColumns   = 14;
+
+        /// <summary>
+        /// Load one CSV file and return a dictionary of family name → <see cref="TierPlan"/>.
+        /// Families whose blocks contain no T4..T10 rows still receive a plan
+        /// with all tiers marked <see cref="TierState.Omit"/> so callers can
+        /// tell "file has this family with nothing to author" apart from "file
+        /// does not mention this family at all".
+        /// </summary>
+        public static Dictionary<string, TierPlan> LoadFile(string csvPath)
+        {
+            if (string.IsNullOrEmpty(csvPath))
+                throw new ArgumentException("csvPath is required", nameof(csvPath));
+            if (!File.Exists(csvPath))
+                throw new FileNotFoundException("Tag config CSV not found", csvPath);
+
+            var lines = File.ReadAllLines(csvPath);
+            return Parse(lines, csvPath);
+        }
+
+        /// <summary>
+        /// Load every CSV in <paramref name="csvPaths"/> and merge into one
+        /// dictionary. When the same family name appears in more than one file
+        /// the later entry wins — callers should pass discipline CSVs in the
+        /// order they expect to shadow each other (typically GEN → disc-specific).
+        /// </summary>
+        public static Dictionary<string, TierPlan> LoadFiles(IEnumerable<string> csvPaths)
+        {
+            if (csvPaths == null) throw new ArgumentNullException(nameof(csvPaths));
+            var merged = new Dictionary<string, TierPlan>(StringComparer.Ordinal);
+            foreach (var path in csvPaths)
+            {
+                var perFile = LoadFile(path);
+                foreach (var kv in perFile)
+                    merged[kv.Key] = kv.Value;
+            }
+            return merged;
+        }
+
+        /// <summary>
+        /// Parse an in-memory CSV (one row per string). Exposed so unit tests
+        /// can exercise the parser without touching the filesystem.
+        /// </summary>
+        public static Dictionary<string, TierPlan> Parse(IEnumerable<string> lines, string sourcePath = null)
+        {
+            if (lines == null) throw new ArgumentNullException(nameof(lines));
+            var result = new Dictionary<string, TierPlan>(StringComparer.Ordinal);
+
+            string currentFamily = null;
+            TierPlan currentPlan = null;
+            int lineNo = 0;
+
+            foreach (var raw in lines)
+            {
+                lineNo++;
+                if (string.IsNullOrWhiteSpace(raw)) continue;
+                // Comments: the regenerator prefixes schema / legend lines with '#'.
+                // Data rows also start with a '#' column header so we only skip
+                // lines whose FIRST non-space char is '#' AND are not the data header.
+                var trimmed = raw.TrimStart();
+                if (trimmed.StartsWith("#") && !trimmed.StartsWith("#,"))
+                    continue;
+                if (trimmed.StartsWith(WarningBanner))
+                {
+                    // Warning rows follow this banner. They do not contribute to
+                    // TierPlan, but they may be followed by more family blocks
+                    // in the same file — so we just close the current family
+                    // and keep scanning.
+                    currentFamily = null;
+                    currentPlan = null;
+                    continue;
+                }
+
+                // Family block start? Commits the previous plan (if any) and
+                // opens a fresh one.
+                var famMatch = FamilyHeaderRegex.Match(raw);
+                if (famMatch.Success)
+                {
+                    var name = famMatch.Groups["name"].Value.Trim();
+                    if (!string.IsNullOrEmpty(currentFamily) && currentPlan != null)
+                        result[currentFamily] = Finalise(currentPlan);
+                    currentFamily = name;
+                    currentPlan = new TierPlan
+                    {
+                        T4 = TierState.Omit, T5 = TierState.Omit, T6 = TierState.Omit,
+                        T7 = TierState.Omit, T8 = TierState.Omit, T9 = TierState.Omit,
+                        T10 = TierState.Omit,
+                    };
+                    continue;
+                }
+
+                // Skip the data-header row itself (#,Tier,Parameter,...).
+                if (trimmed.StartsWith("#,")) continue;
+
+                if (currentPlan == null) continue; // pre-amble rows before the first family
+                TryAbsorbRow(raw, currentPlan, sourcePath, lineNo);
+            }
+
+            if (!string.IsNullOrEmpty(currentFamily) && currentPlan != null)
+                result[currentFamily] = Finalise(currentPlan);
+
+            return result;
+        }
+
+        private static void TryAbsorbRow(string rawLine, TierPlan plan, string sourcePath, int lineNo)
+        {
+            string[] cols;
+            try { cols = ParseCsvLine(rawLine); }
+            catch (Exception ex)
+            {
+                // StingLog is file-only so it is safe from headless contexts, but
+                // guard anyway so the parser stays usable before the plugin boots.
+                try { StingLog.Warn($"TagConfigCsvReader: malformed row at {sourcePath ?? "(in-memory)"}:{lineNo} — {ex.Message}"); }
+                catch { /* swallow — reader must stay pure */ }
+                return;
+            }
+            if (cols.Length < MinColumns) return;
+
+            var tierStr = cols[ColTier].Trim();
+            var tierMatch = TierRegex.Match(tierStr);
+            if (!tierMatch.Success) return;
+            if (!int.TryParse(tierMatch.Groups["n"].Value, out var tierNum)) return;
+            if (tierNum < 4 || tierNum > 10) return; // plan only covers T4..T10
+
+            var row = new TierRow
+            {
+                Tier      = tierStr,
+                Parameter = cols[ColParameter].Trim(),
+                Prefix    = cols[ColPrefix],
+                Suffix    = cols[ColSuffix],
+                Spc       = ParseInt(cols[ColSpc]),
+                Brk       = ParseBrk(cols[ColBrk]),
+                Name      = cols[ColName].Trim(),
+                Style     = cols[ColStyle].Trim(),
+                Color     = cols[ColColor].Trim(),
+                Size      = ParseDouble(cols[ColSize]),
+            };
+            if (string.IsNullOrEmpty(row.Parameter)) return;
+
+            switch (tierNum)
+            {
+                case 4:  plan.T4Rows.Add(row);  plan.T4  = TierState.Replace; break;
+                case 5:  plan.T5Rows.Add(row);  plan.T5  = TierState.Replace; break;
+                case 6:  plan.T6Rows.Add(row);  plan.T6  = TierState.Replace; break;
+                case 7:  plan.T7Rows.Add(row);  plan.T7  = TierState.Replace; break;
+                case 8:  plan.T8Rows.Add(row);  plan.T8  = TierState.Replace; break;
+                case 9:  plan.T9Rows.Add(row);  plan.T9  = TierState.Replace; break;
+                case 10: plan.T10Rows.Add(row); plan.T10 = TierState.Replace; break;
+            }
+        }
+
+        private static TierPlan Finalise(TierPlan plan) => plan;
+
+        private static int ParseInt(string s)
+            => int.TryParse((s ?? string.Empty).Trim(), out var n) ? n : 0;
+
+        private static double ParseDouble(string s)
+            => double.TryParse((s ?? string.Empty).Trim(),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var d) ? d : 0.0;
+
+        // Brk column uses '✓' / blank in the v5 CSVs; tolerate a few alternates.
+        private static bool ParseBrk(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            var t = s.Trim();
+            return t == "✓" || t.Equals("true", StringComparison.OrdinalIgnoreCase)
+                            || t == "1" || t.Equals("yes", StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Duplicated from StingToolsApp.ParseCsvLine so the reader has no
+        // transitive dependency on the Revit-bound entry point. Semantics must
+        // stay identical — the two implementations read the same CSV files.
+        private static string[] ParseCsvLine(string line)
+        {
+            var result = new List<string>();
+            bool inQuote = false;
+            var current = new System.Text.StringBuilder();
+            foreach (char c in line ?? string.Empty)
+            {
+                if (c == '"') { inQuote = !inQuote; }
+                else if (c == ',' && !inQuote)
+                {
+                    result.Add(current.ToString());
+                    current.Clear();
+                }
+                else
+                {
+                    current.Append(c);
+                }
+            }
+            result.Add(current.ToString());
+            return result.ToArray();
+        }
+    }
+}

--- a/StingTools/Tags/FamilyLabelAuthor.cs
+++ b/StingTools/Tags/FamilyLabelAuthor.cs
@@ -1,0 +1,390 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.ApplicationServices;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+
+namespace StingTools.Tags
+{
+    /// <summary>
+    /// Wave-1 commit 2: Revit-API wrapper that takes a parsed <see cref="TierPlan"/>
+    /// (from <see cref="TagConfigCsvReader"/>) and authors the corresponding
+    /// tier-row content inside a tag <see cref="Document"/> (FamilyDocument).
+    /// </summary>
+    /// <remarks>
+    /// Scope of work that DOES land here:
+    ///   • Bind every shared parameter referenced in the plan's T4..T10 rows.
+    ///   • Apply the CSV-derived <c>if(TAG_PARA_STATE_N_BOOL, PARAM, "")</c>
+    ///     calculated-value formula on each bound family parameter so tier
+    ///     visibility is gated correctly.
+    ///   • Honour <c>preserveHandEdits</c>: when any Dimension/TextNote in the
+    ///     family has a non-default (non-origin) position we skip formula
+    ///     re-writes for the rows that map to that tier, leaving a user's hand
+    ///     layout alone.
+    ///   • Save the family via <see cref="Document.SaveAs(string, SaveAsOptions)"/>.
+    ///
+    /// Scope that stays manual (documented Revit API limitation, same reason
+    /// the existing <c>TryRebindLabel</c> in TagFamilyCreatorCommand is
+    /// best-effort): creating NEW annotation Label elements at specific X/Y
+    /// positions in a tag .rft template. Where that is attempted below it is
+    /// marked with <c>// TODO-VERIFY-API</c>. If the plugin ever gains the
+    /// ability to create labels programmatically, the positioning block is
+    /// the only place that needs to change — the binding + formula work done
+    /// here is already exercised by existing commands (AddSharedParameters in
+    /// TagFamilyCreatorCommand:1538) and is stable.
+    ///
+    /// Called from <see cref="CreateTagFamiliesCommand"/> via
+    /// <see cref="HandoverModeHelper.GetAllTagConfigCsvs"/> → CSV read →
+    /// one call to <see cref="AuthorLabels"/> per family document.
+    /// </remarks>
+    internal static class FamilyLabelAuthor
+    {
+        /// <summary>Options passed from the outer command.</summary>
+        public sealed class Options
+        {
+            public Application App { get; set; }
+            public string SharedParamFile { get; set; }
+            public bool PreserveHandEdits { get; set; }
+            public string FamilyName { get; set; }
+        }
+
+        /// <summary>Per-family outcome, rolled up into the report by the command.</summary>
+        public sealed class Result
+        {
+            public int ParamsBound { get; set; }
+            public int FormulasApplied { get; set; }
+            public int FormulasSkipped { get; set; }
+            public int TiersPreserved { get; set; }
+            public bool LabelRebound { get; set; }
+            public List<string> Warnings { get; } = new List<string>();
+        }
+
+        /// <summary>
+        /// Author tier content into <paramref name="fdoc"/> per <paramref name="plan"/>.
+        /// Caller is responsible for saving (<see cref="Document.SaveAs(string, SaveAsOptions)"/>)
+        /// and closing the document.
+        /// </summary>
+        public static Result AuthorLabels(Document fdoc, TierPlan plan, Options opts)
+        {
+            if (fdoc == null) throw new ArgumentNullException(nameof(fdoc));
+            if (plan == null) throw new ArgumentNullException(nameof(plan));
+            if (opts == null) throw new ArgumentNullException(nameof(opts));
+            if (!fdoc.IsFamilyDocument) throw new InvalidOperationException("AuthorLabels requires a family document.");
+
+            var result = new Result();
+
+            // 1. Identify tiers whose rows should be skipped for hand-edit preservation.
+            HashSet<int> preservedTiers = opts.PreserveHandEdits
+                ? DetectPreservedTiers(fdoc)
+                : new HashSet<int>();
+            result.TiersPreserved = preservedTiers.Count;
+
+            // 2. Flatten all T4..T10 rows into a linear list the binding + formula
+            //    loops can iterate once. Omit tiers with empty row lists (TierState.Omit).
+            var flat = new List<(int Tier, TierRow Row)>();
+            void Accum(int t, List<TierRow> rows, TierState state)
+            {
+                if (state == TierState.Omit || rows == null) return;
+                foreach (var r in rows) flat.Add((t, r));
+            }
+            Accum(4, plan.T4Rows, plan.T4);
+            Accum(5, plan.T5Rows, plan.T5);
+            Accum(6, plan.T6Rows, plan.T6);
+            Accum(7, plan.T7Rows, plan.T7);
+            Accum(8, plan.T8Rows, plan.T8);
+            Accum(9, plan.T9Rows, plan.T9);
+            Accum(10, plan.T10Rows, plan.T10);
+
+            if (flat.Count == 0)
+            {
+                result.Warnings.Add($"{opts.FamilyName ?? "(unknown)"}: no T4..T10 rows to author.");
+                return result;
+            }
+
+            // 3. Bind every distinct parameter name referenced by the rows.
+            var distinctParams = flat
+                .Select(x => x.Row?.Parameter)
+                .Where(s => !string.IsNullOrEmpty(s))
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            result.ParamsBound = BindSharedParameters(fdoc, distinctParams, opts, result);
+
+            // 4. Apply the per-row visibility formula. Same shape the CSV regenerator
+            //    emits: if(TAG_PARA_STATE_N_BOOL, PARAM, "").
+            ApplyVisibilityFormulas(fdoc, flat, preservedTiers, result);
+
+            // 5. Best-effort label rebind: point the template's stub Label at
+            //    ASS_TAG_1_TXT so T1 display continues to work after re-author.
+            result.LabelRebound = TryRebindPrimaryLabel(fdoc, result);
+
+            // 6. TODO-VERIFY-API: programmatic Label creation at tier-specific
+            //    positions. Revit 2025 exposes FamilyItemFactory.NewTextNote
+            //    (plain text) but NOT a Label-with-parameter binding for
+            //    annotation tag families. Revision 2026+ may expose more — when
+            //    it does, positioning code goes here, driven by plan rows and
+            //    TierRow.Size/Style/Color. Until then the .rft template's
+            //    pre-existing single Label is retargeted by TryRebindPrimaryLabel
+            //    and the additional tier rows stay manual.
+            // var factory = fdoc.FamilyCreate; // TODO-VERIFY-API: NewTextNote overloads vary per Revit year.
+
+            return result;
+        }
+
+        // ------------------------------------------------------------------
+        // Hand-edit detection
+        // ------------------------------------------------------------------
+        private static HashSet<int> DetectPreservedTiers(Document fdoc)
+        {
+            // Heuristic: if the family has ANY Dimension or TextNote whose
+            // reported position is not at the family origin, we treat the
+            // family as hand-edited and preserve all tier formulas. The reader
+            // + author can still bind shared params idempotently (AddParameter
+            // skips existing), so hand-edit families keep up-to-date bindings
+            // without losing manual layout.
+            //
+            // TODO-VERIFY-API: Dimension.Origin is the canonical readable
+            // position in Revit 2025; TextNote.Coord is what the API exposes.
+            // Confirm both fields survive a re-load cycle on 2026/2027.
+            var preserved = new HashSet<int>();
+            try
+            {
+                bool anyMoved = false;
+
+                var texts = new FilteredElementCollector(fdoc)
+                    .OfClass(typeof(TextNote))
+                    .Cast<TextNote>()
+                    .ToList();
+                foreach (var tn in texts)
+                {
+                    try
+                    {
+                        XYZ p = tn.Coord;           // TODO-VERIFY-API: .Coord is the 2025 accessor.
+                        if (p != null && !p.IsAlmostEqualTo(XYZ.Zero)) { anyMoved = true; break; }
+                    }
+                    catch { /* tolerate API surface drift between Revit years */ }
+                }
+
+                if (!anyMoved)
+                {
+                    var dims = new FilteredElementCollector(fdoc)
+                        .OfClass(typeof(Dimension))
+                        .Cast<Dimension>()
+                        .ToList();
+                    foreach (var d in dims)
+                    {
+                        try
+                        {
+                            XYZ p = d.Origin;
+                            if (p != null && !p.IsAlmostEqualTo(XYZ.Zero)) { anyMoved = true; break; }
+                        }
+                        catch { /* tolerate API surface drift */ }
+                    }
+                }
+
+                if (anyMoved)
+                    for (int t = 4; t <= 10; t++) preserved.Add(t);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"FamilyLabelAuthor.DetectPreservedTiers: {ex.Message}");
+            }
+            return preserved;
+        }
+
+        // ------------------------------------------------------------------
+        // Shared-parameter binding — mirrors the proven pattern from
+        // TagFamilyCreatorCommand.AddSharedParameters (line 1538) but scoped
+        // to the row set supplied by the reader. Must run in its own
+        // Transaction because FamilyManager.AddParameter is a write.
+        // ------------------------------------------------------------------
+        private static int BindSharedParameters(Document fdoc,
+            List<string> paramNames, Options opts, Result result)
+        {
+            if (paramNames == null || paramNames.Count == 0) return 0;
+            if (opts.App == null || string.IsNullOrEmpty(opts.SharedParamFile))
+            {
+                result.Warnings.Add("Cannot bind shared params: App or SharedParamFile not supplied.");
+                return 0;
+            }
+            if (!File.Exists(opts.SharedParamFile))
+            {
+                result.Warnings.Add($"Shared parameter file missing: {opts.SharedParamFile}");
+                return 0;
+            }
+
+            string originalSpFile = opts.App.SharedParametersFilename;
+            int added = 0;
+            try
+            {
+                opts.App.SharedParametersFilename = opts.SharedParamFile;
+                DefinitionFile defFile = opts.App.OpenSharedParameterFile();
+                if (defFile == null)
+                {
+                    result.Warnings.Add($"OpenSharedParameterFile returned null for {opts.SharedParamFile}");
+                    return 0;
+                }
+
+                FamilyManager fm = fdoc.FamilyManager;
+                using (Transaction tx = new Transaction(fdoc, "STING AuthorLabels — bind tier params"))
+                {
+                    tx.Start();
+                    foreach (string name in paramNames)
+                    {
+                        ExternalDefinition ext = FindSharedDefinition(defFile, name);
+                        if (ext == null)
+                        {
+                            result.Warnings.Add($"Shared param '{name}' not in {Path.GetFileName(opts.SharedParamFile)}");
+                            continue;
+                        }
+                        if (HasParameter(fm, name)) continue;
+                        try
+                        {
+                            fm.AddParameter(ext, GroupTypeId.General, true); // instance
+                            added++;
+                        }
+                        catch (Exception ex)
+                        {
+                            result.Warnings.Add($"AddParameter('{name}') failed: {ex.Message}");
+                        }
+                    }
+                    tx.Commit();
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"BindSharedParameters: {ex.Message}");
+                StingLog.Error("FamilyLabelAuthor.BindSharedParameters", ex);
+            }
+            finally
+            {
+                try
+                {
+                    if (!string.IsNullOrEmpty(originalSpFile))
+                        opts.App.SharedParametersFilename = originalSpFile;
+                }
+                catch (Exception ex) { StingLog.Warn($"restore SP file: {ex.Message}"); }
+            }
+            return added;
+        }
+
+        // ------------------------------------------------------------------
+        // Per-row formula: set Formula on a family calculated-value parameter
+        // matching the row's Parameter name, gating visibility via the tier's
+        // TAG_PARA_STATE_N_BOOL. Rows whose target tier is in preservedTiers
+        // are skipped.
+        // ------------------------------------------------------------------
+        private static void ApplyVisibilityFormulas(Document fdoc,
+            List<(int Tier, TierRow Row)> flat, HashSet<int> preservedTiers, Result result)
+        {
+            if (flat.Count == 0) return;
+
+            FamilyManager fm = fdoc.FamilyManager;
+            using (Transaction tx = new Transaction(fdoc, "STING AuthorLabels — tier formulas"))
+            {
+                tx.Start();
+                foreach (var (tier, row) in flat)
+                {
+                    if (preservedTiers.Contains(tier)) { result.FormulasSkipped++; continue; }
+                    if (row == null || string.IsNullOrEmpty(row.Parameter)) { result.FormulasSkipped++; continue; }
+
+                    string gate = "TAG_PARA_STATE_" + tier + "_BOOL";
+                    // TODO-VERIFY-API: SetFormula only works on read-write family
+                    // params. AddParameter sets them read-write by default when
+                    // isInstance=true, which is what we passed. If a template
+                    // pre-binds a param as read-only this call throws — we log
+                    // and move on rather than abort the whole file.
+                    FamilyParameter target = null;
+                    foreach (FamilyParameter fp in fm.Parameters)
+                    {
+                        if (string.Equals(fp.Definition?.Name, row.Parameter, StringComparison.Ordinal))
+                        {
+                            target = fp; break;
+                        }
+                    }
+                    if (target == null) { result.FormulasSkipped++; continue; }
+
+                    string formula = "if(" + gate + ", " + row.Parameter + ", \"\")";
+                    try
+                    {
+                        fm.SetFormula(target, formula);
+                        result.FormulasApplied++;
+                    }
+                    catch (Exception ex)
+                    {
+                        result.FormulasSkipped++;
+                        result.Warnings.Add($"SetFormula('{row.Parameter}') failed: {ex.Message}");
+                    }
+                }
+                tx.Commit();
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Best-effort label rebind: same approach TagFamilyCreatorCommand
+        // (line 1652) uses today. Kept here so the author presents a single
+        // entry point to the command — TryRebindLabel is private in the
+        // existing command so we duplicate rather than expose it.
+        // ------------------------------------------------------------------
+        private static bool TryRebindPrimaryLabel(Document fdoc, Result result)
+        {
+            try
+            {
+                FamilyManager fm = fdoc.FamilyManager;
+                FamilyParameter tagParam = null;
+                foreach (FamilyParameter fp in fm.Parameters)
+                {
+                    if (fp.Definition?.Name == ParamRegistry.TAG1) { tagParam = fp; break; }
+                }
+                if (tagParam == null) return false;
+
+                using (Transaction tx = new Transaction(fdoc, "STING AuthorLabels — rebind primary label"))
+                {
+                    tx.Start();
+                    var dims = new FilteredElementCollector(fdoc)
+                        .OfClass(typeof(Dimension))
+                        .Cast<Dimension>()
+                        .ToList();
+                    foreach (Dimension d in dims)
+                    {
+                        try
+                        {
+                            // TODO-VERIFY-API: FamilyLabel setter throws when the
+                            // dimension is not label-capable; behaviour matches
+                            // the existing TryRebindLabel.
+                            d.FamilyLabel = tagParam;
+                            tx.Commit();
+                            return true;
+                        }
+                        catch { /* try next dimension */ }
+                    }
+                    tx.Commit();
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"TryRebindPrimaryLabel: {ex.Message}");
+            }
+            return false;
+        }
+
+        // ------------------------------------------------------------------
+        // Small helpers shared with the outer command's style.
+        // ------------------------------------------------------------------
+        private static ExternalDefinition FindSharedDefinition(DefinitionFile defFile, string paramName)
+        {
+            foreach (DefinitionGroup g in defFile.Groups)
+                foreach (Definition d in g.Definitions)
+                    if (d.Name == paramName && d is ExternalDefinition ext) return ext;
+            return null;
+        }
+
+        private static bool HasParameter(FamilyManager fm, string name)
+        {
+            foreach (FamilyParameter fp in fm.Parameters)
+                if (fp.Definition?.Name == name) return true;
+            return false;
+        }
+    }
+}

--- a/StingTools/Tags/TagConfigPlanResolver.cs
+++ b/StingTools/Tags/TagConfigPlanResolver.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+
+namespace StingTools.Tags
+{
+    /// <summary>
+    /// Wave-1 commit 3 helper: glues <see cref="HandoverModeHelper"/> to
+    /// <see cref="TagConfigCsvReader"/> so <see cref="CreateTagFamiliesCommand"/>
+    /// can ask "for the active mode on this document, give me a family-name
+    /// → TierPlan map across ARCH / GEN / MEP / STR".
+    ///
+    /// The resolver is the only place that needs to know about mode
+    /// resolution + CSV location + CSV parsing at the same time. Adding a
+    /// new discipline or a new mode variant is a one-line change to either
+    /// HandoverModeHelper or TagConfigCsvReader — the command stays unchanged.
+    /// </summary>
+    internal static class TagConfigPlanResolver
+    {
+        /// <summary>
+        /// Load every discipline's tag-config CSV for the document's active
+        /// mode and merge the results. Later files shadow earlier ones when
+        /// a family is listed twice (the discipline CSVs should not
+        /// overlap in practice).
+        /// </summary>
+        public static Dictionary<string, TierPlan> LoadAll(Document doc)
+        {
+            var merged = new Dictionary<string, TierPlan>(StringComparer.Ordinal);
+            string[] csvNames;
+            try { csvNames = HandoverModeHelper.GetAllTagConfigCsvs(doc); }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagConfigPlanResolver.LoadAll: GetAllTagConfigCsvs failed — {ex.Message}");
+                return merged;
+            }
+
+            foreach (string name in csvNames)
+            {
+                if (string.IsNullOrEmpty(name)) continue;
+                string path = StingToolsApp.FindDataFile(name);
+                if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                {
+                    StingLog.Warn($"TagConfigPlanResolver: CSV '{name}' not resolved on disk — skipping.");
+                    continue;
+                }
+                try
+                {
+                    var perFile = TagConfigCsvReader.LoadFile(path);
+                    foreach (var kv in perFile) merged[kv.Key] = kv.Value;
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagConfigPlanResolver: parsing '{name}' failed — {ex.Message}");
+                }
+            }
+            return merged;
+        }
+
+        /// <summary>
+        /// Read the PRESERVE_HAND_EDITS flag from project_config.json next to
+        /// the .rvt. Default false so a fresh project re-authors normally.
+        /// When the key is absent or the file is missing we return false
+        /// (same fall-through shape as <see cref="HandoverModeHelper.ReadProjectMode"/>).
+        /// </summary>
+        public static bool ReadPreserveHandEdits(Document doc)
+        {
+            try
+            {
+                if (doc == null) return false;
+                string dir = Path.GetDirectoryName(doc.PathName ?? "") ?? "";
+                if (string.IsNullOrEmpty(dir)) return false;
+                string cfg = Path.Combine(dir, "project_config.json");
+                if (!File.Exists(cfg)) return false;
+                var jo = Newtonsoft.Json.Linq.JObject.Parse(File.ReadAllText(cfg));
+                var tok = jo["PRESERVE_HAND_EDITS"];
+                if (tok == null) return false;
+                if (tok.Type == Newtonsoft.Json.Linq.JTokenType.Boolean) return (bool)tok;
+                return string.Equals(tok.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagConfigPlanResolver.ReadPreserveHandEdits: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -815,6 +815,15 @@ namespace StingTools.Tags
             Document doc = uidoc.Document;
             var app = uiApp.Application;
 
+            // ── Wave-1 commit 3: resolve the mode-appropriate TierPlans from
+            //    the v5 CSVs so each family can be authored (bind shared
+            //    params + apply visibility formulas) in addition to being
+            //    created from its .rft template. Missing CSVs are tolerated —
+            //    families without a plan keep the existing behaviour.
+            Dictionary<string, TierPlan> plansByFamily = TagConfigPlanResolver.LoadAll(doc);
+            bool preserveHandEdits = TagConfigPlanResolver.ReadPreserveHandEdits(doc);
+            string activeMode = HandoverModeHelper.GetActiveMode(doc);
+
             // ── Pre-check: Auto-fix any numeric label params to TEXT ──
             var typeMismatches = LabelParamTypeValidator.ValidateSourceFile();
             if (typeMismatches.Count > 0)
@@ -919,15 +928,24 @@ namespace StingTools.Tags
 
             TaskDialog confirm = new TaskDialog("Create Tag Families");
             confirm.MainInstruction = $"Create {toCreate} STING tag families?";
+            int familiesWithPlan = 0;
+            foreach (var bic in categories)
+            {
+                string fn = TagFamilyConfig.GetFamilyName(bic);
+                if (plansByFamily.ContainsKey(fn)) familiesWithPlan++;
+            }
             confirm.MainContent =
                 $"Total taggable categories: {total}\n" +
                 $"Already loaded: {alreadyLoaded}\n" +
                 $"To create: {toCreate}\n\n" +
+                $"Mode: {activeMode}  •  Preserve hand-edits: {(preserveHandEdits ? "on" : "off")}\n" +
+                $"Families with a CSV plan: {familiesWithPlan} (of {categories.Count} primary categories)\n\n" +
                 $"Templates: {templateDir}\n" +
                 $"Tag .rft files found: {tagRftCount} of {availableRft.Length} total\n" +
                 $"Output: {TagFamilyConfig.GetOutputDirectory()}\n\n" +
-                "Each family will be created from a Revit annotation template\n" +
-                "and loaded into the project with STING shared parameters.";
+                "Each family will be created from a Revit annotation template,\n" +
+                "loaded with STING shared parameters, and — when a plan is\n" +
+                "available — have T4..T10 visibility formulas re-authored.";
             confirm.CommonButtons = TaskDialogCommonButtons.Ok | TaskDialogCommonButtons.Cancel;
             if (confirm.Show() == TaskDialogResult.Cancel)
                 return Result.Cancelled;
@@ -1046,6 +1064,13 @@ namespace StingTools.Tags
                     // Attempt to rebind the existing Label to ASS_TAG_1_TXT
                     bool labelBound = TryRebindLabel(famDoc);
 
+                    // Wave-1 commit 3: if a TierPlan for this family is known,
+                    // bind T4..T10 shared params + apply visibility formulas
+                    // before saving. No-op when plansByFamily does not contain
+                    // the family (e.g. a category not yet listed in the CSVs).
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                        app, sharedParamFile, preserveHandEdits, report);
+
                     // Save the family document
                     SaveAsOptions saveOpts = new SaveAsOptions { OverwriteExistingFile = true };
                     famDoc.SaveAs(outputPath, saveOpts);
@@ -1156,6 +1181,9 @@ namespace StingTools.Tags
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, tieInParams);
 
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                        app, sharedParamFile, preserveHandEdits, report);
+
                     // Save and load — always proceeds even if params failed
                     string savePath = Path.Combine(outputDir, fileName);
                     var saveOpts = new SaveAsOptions { OverwriteExistingFile = true };
@@ -1261,6 +1289,9 @@ namespace StingTools.Tags
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, dsParams);
 
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                        app, sharedParamFile, preserveHandEdits, report);
+
                     string savePath = Path.Combine(outputDir, fileName);
                     var saveOpts = new SaveAsOptions { OverwriteExistingFile = true };
                     famDoc.SaveAs(savePath, saveOpts);
@@ -1364,6 +1395,9 @@ namespace StingTools.Tags
                         .Concat(TagFamilyConfig.VisibilityParamsFor(famName, sv.display))
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, svParams);
+
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                        app, sharedParamFile, preserveHandEdits, report);
 
                     string savePath = Path.Combine(outputDir, fileName);
                     var saveOpts = new SaveAsOptions { OverwriteExistingFile = true };
@@ -1469,6 +1503,9 @@ namespace StingTools.Tags
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, mvParams);
 
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                        app, sharedParamFile, preserveHandEdits, report);
+
                     string savePath = Path.Combine(outputDir, fileName);
                     var saveOpts = new SaveAsOptions { OverwriteExistingFile = true };
                     famDoc.SaveAs(savePath, saveOpts);
@@ -1528,6 +1565,45 @@ namespace StingTools.Tags
                 $"skipped={alreadyLoaded}, missing={templateMissing}, failed={failed}");
 
             return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// Wave-1 commit 3 hook. When <paramref name="plansByFamily"/> has a
+        /// <see cref="TierPlan"/> for <paramref name="famName"/>, invoke
+        /// <see cref="FamilyLabelAuthor.AuthorLabels"/> and append a short
+        /// line to the report. When no plan is available (e.g. the family is
+        /// not listed in the active-mode CSVs yet) this is a no-op so the
+        /// outer command behaves exactly as it did pre-wave-1.
+        /// </summary>
+        private void AuthorFromPlanIfAvailable(Document famDoc, string famName,
+            Dictionary<string, TierPlan> plansByFamily,
+            Autodesk.Revit.ApplicationServices.Application app,
+            string sharedParamFile, bool preserveHandEdits,
+            StringBuilder report)
+        {
+            if (famDoc == null || string.IsNullOrEmpty(famName) || plansByFamily == null) return;
+            if (!plansByFamily.TryGetValue(famName, out TierPlan plan) || plan == null) return;
+
+            try
+            {
+                var opts = new FamilyLabelAuthor.Options
+                {
+                    App = app,
+                    SharedParamFile = sharedParamFile,
+                    PreserveHandEdits = preserveHandEdits,
+                    FamilyName = famName,
+                };
+                var r = FamilyLabelAuthor.AuthorLabels(famDoc, plan, opts);
+                report.AppendLine($"         author → bound={r.ParamsBound} " +
+                    $"formulas={r.FormulasApplied} skipped={r.FormulasSkipped} " +
+                    $"preserved={r.TiersPreserved} label-rebound={r.LabelRebound}");
+                foreach (var w in r.Warnings) StingLog.Warn($"{famName}: {w}");
+            }
+            catch (Exception ex)
+            {
+                report.AppendLine($"         author → FAILED: {ex.Message}");
+                StingLog.Error($"AuthorFromPlanIfAvailable({famName})", ex);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Implements CSV-driven authoring of tier visibility formulas (T4..T10) in tag family documents. Adds a pure-C# CSV parser that reads v5 tag-config CSVs into a `TierPlan` data model, and a Revit-API wrapper that binds shared parameters and applies per-tier visibility formulas to family documents based on the parsed plan.

## Key Changes

**New modules:**
- `TagConfigCsvReader`: Pure C# parser for v5 tag-config CSVs (STING_TAG_CONFIG_v5_0_{ARCH|MEP|STR|GEN}[_DesignConstruction].csv). Parses T4..T10 rows into `TierPlan` objects keyed by family name. No Revit dependency, suitable for unit tests and headless scripts.
- `FamilyLabelAuthor`: Revit-API wrapper that consumes a `TierPlan` and authors a family document by:
  - Binding all T4..T10 shared parameters referenced in the plan
  - Applying per-row visibility formulas: `if(TAG_PARA_STATE_N_BOOL, PARAM, "")`
  - Detecting hand-edited families (non-origin Dimension/TextNote positions) and skipping formula re-writes when `preserveHandEdits` is enabled
  - Rebinding the primary Label to `ASS_TAG_1_TXT` for T1 display continuity
- `TagConfigPlanResolver`: Helper that glues `HandoverModeHelper` to `TagConfigCsvReader`, resolving mode-appropriate CSVs and loading them into a merged family-name → `TierPlan` map.

**Modified modules:**
- `TagFamilyCreatorCommand`: Integrated CSV plan loading and authoring into the family creation workflow:
  - Calls `TagConfigPlanResolver.LoadAll()` to load all discipline CSVs for the active mode
  - Reads `PRESERVE_HAND_EDITS` flag from `project_config.json`
  - Calls `AuthorFromPlanIfAvailable()` after each family is created/loaded, before saving
  - Updated confirmation dialog to show active mode, hand-edit preservation setting, and count of families with a CSV plan

## Notable Implementation Details

- **Hand-edit preservation**: When enabled, detects families with moved Dimension/TextNote elements and skips formula re-writes for those tiers, allowing manual layouts to coexist with updated parameter bindings.
- **Idempotent binding**: Shared parameter binding reuses the proven pattern from `AddSharedParameters` (line 1538) and skips parameters already present in the family.
- **Graceful degradation**: Missing CSVs, malformed rows, and API failures are logged as warnings; the command continues processing remaining families.
- **CSV parsing**: Duplicates `StingToolsApp.ParseCsvLine` semantics so the reader has no transitive Revit dependency and can be exercised independently.
- **Label rebinding**: Best-effort approach matching the existing `TryRebindLabel` pattern; attempts to bind the first label-capable Dimension to `ASS_TAG_1_TXT`.
- **TODO-VERIFY-API markers**: Documents Revit 2025 API surface assumptions (TextNote.Coord, Dimension.Origin, FamilyLabel setter) that may drift in future versions.

https://claude.ai/code/session_011EtW4QQA6LAAETGxQci12d