### PR TITLE
Add persistent shop drawing configuration UI to Fabrication tab

### DIFF
--- a/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
+++ b/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
@@ -89,7 +89,12 @@ namespace StingTools.Commands.Fabrication
             // specific title block + view template + sheet-number
             // pattern instead of the per-discipline STING_TB_ASSEMBLY_*
             // default. Cancelling the dialog aborts the command.
-            if (FabricationOptions.GenerateSheets)
+            //
+            // Skipped when the Fabrication tab's "Configure…" button has
+            // already populated FabricationOptions.ShopDrawing — that
+            // inline picker is the persistent path; the popup is only the
+            // one-shot fallback when no panel choice exists.
+            if (FabricationOptions.GenerateSheets && FabricationOptions.ShopDrawing == null)
             {
                 var dlg = new StingTools.UI.ShopDrawingOptionsDialog(doc);
                 try { dlg.Owner = System.Windows.Application.Current?.MainWindow; } catch { }

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -296,6 +296,25 @@ namespace StingTools.UI
                     // ── v4 Phase D: hanger placement ──
                     case "Routing_PlaceHangers": RunCommand<Commands.Routing.PlaceHangersCommand>(app); break;
                     case "Fabrication_PlaceISOSymbols": TaskDialog.Show("STING v4 — ISO 6412 Symbols", "Place is wired through GenerateFabPackageCommand;\nrun Generate Fabrication Package against your selection."); break;
+                    case "Fabrication_ConfigureShopDrawing":
+                    {
+                        var doc = app?.ActiveUIDocument?.Document;
+                        if (doc == null) { TaskDialog.Show("STING v4", "Open a project first."); break; }
+                        var dlg = new UI.ShopDrawingOptionsDialog(doc);
+                        try { dlg.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+                        if (dlg.ShowDialog() == true)
+                        {
+                            Commands.Fabrication.FabricationOptions.ShopDrawing = dlg.Result;
+                            UI.StingDockPanel.LastInstance?.UpdateFabShopDrawingStatus(doc, dlg.Result);
+                        }
+                        break;
+                    }
+                    case "Fabrication_ClearShopDrawing":
+                    {
+                        Commands.Fabrication.FabricationOptions.ShopDrawing = null;
+                        UI.StingDockPanel.LastInstance?.UpdateFabShopDrawingStatus(null, null);
+                        break;
+                    }
 
                     // ── Selection scope ──
                     case "SetScopeView": Select.SelectionScopeHelper.SetScope(false); TaskDialog.Show("Scope", "Selection scope: ACTIVE VIEW"); break;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -4409,10 +4409,22 @@
                                                 </StackPanel>
                                             </Border>
 
-                                            <TextBlock Text="TITLE BLOCK" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,8,0,4"/>
+                                            <TextBlock Text="TITLE BLOCK &amp; VIEW TEMPLATE" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,8,0,4"/>
                                             <Border Style="{StaticResource GroupBorder}">
                                                 <StackPanel>
-                                                    <TextBlock Text="Auto-resolved per discipline (STING_TB_ASSEMBLY_*).&#x0A;Falls back to first available title block when missing." FontSize="9" TextWrapping="Wrap"/>
+                                                    <TextBlock x:Name="txtFabShopDrawingStatus"
+                                                               Text="Auto-resolved per discipline (STING_TB_ASSEMBLY_*).&#x0A;Falls back to first available title block when missing."
+                                                               FontSize="9" TextWrapping="Wrap" Margin="0,0,0,4"/>
+                                                    <WrapPanel>
+                                                        <Button Style="{StaticResource ActionBtn}" Content="Configure…"
+                                                                Tag="Fabrication_ConfigureShopDrawing" Click="Cmd_Click"
+                                                                Width="90" Height="22" Margin="0,0,4,0"
+                                                                ToolTip="Pick a specific title block + view template + sheet name/number pattern. Saved for the Revit session — applies to every Generate package run until cleared."/>
+                                                        <Button Style="{StaticResource ActionBtn}" Content="Clear"
+                                                                Tag="Fabrication_ClearShopDrawing" Click="Cmd_Click"
+                                                                Width="55" Height="22"
+                                                                ToolTip="Reset to auto-resolve (per-discipline STING_TB_ASSEMBLY_*)."/>
+                                                    </WrapPanel>
                                                 </StackPanel>
                                             </Border>
 

--- a/StingTools/UI/StingDockPanel.xaml.cs
+++ b/StingTools/UI/StingDockPanel.xaml.cs
@@ -750,6 +750,52 @@ namespace StingTools.UI
             return t.Length >= 1 ? t.Substring(0, 1).ToUpperInvariant() : "A";
         }
 
+        /// <summary>
+        /// Refreshes the "TITLE BLOCK &amp; VIEW TEMPLATE" status line on the
+        /// Fabrication tab after the user picks / clears a ShopDrawingOptions
+        /// bundle via Fabrication_ConfigureShopDrawing. Called from
+        /// StingCommandHandler on the Revit API thread — marshals to WPF.
+        /// Pass null for both args to show the Auto fallback message.
+        /// </summary>
+        public void UpdateFabShopDrawingStatus(Autodesk.Revit.DB.Document doc, UI.ShopDrawingOptions opts)
+        {
+            try
+            {
+                string msg;
+                if (opts == null)
+                {
+                    msg = "Auto-resolved per discipline (STING_TB_ASSEMBLY_*).\nFalls back to first available title block when missing.";
+                }
+                else
+                {
+                    string tb = "Auto (per-discipline)";
+                    if (doc != null && opts.TitleBlockSymbolId != null
+                        && opts.TitleBlockSymbolId != Autodesk.Revit.DB.ElementId.InvalidElementId)
+                    {
+                        var fs = doc.GetElement(opts.TitleBlockSymbolId) as Autodesk.Revit.DB.FamilySymbol;
+                        if (fs != null) tb = $"{fs.FamilyName} : {fs.Name}";
+                    }
+                    string vt = "None";
+                    if (doc != null && opts.ViewTemplateId != null
+                        && opts.ViewTemplateId != Autodesk.Revit.DB.ElementId.InvalidElementId)
+                    {
+                        var v = doc.GetElement(opts.ViewTemplateId) as Autodesk.Revit.DB.View;
+                        if (v != null) vt = v.Name;
+                    }
+                    msg = $"Title block: {tb}\nView template: {vt}";
+                    if (!string.IsNullOrWhiteSpace(opts.SheetNumberPattern))
+                        msg += $"\nSheet #: {opts.SheetNumberPattern}";
+                    if (!string.IsNullOrWhiteSpace(opts.SheetNamePattern))
+                        msg += $"\nSheet name: {opts.SheetNamePattern}";
+                }
+                Dispatcher.Invoke(() =>
+                {
+                    if (FindName("txtFabShopDrawingStatus") is TextBlock tb) tb.Text = msg;
+                });
+            }
+            catch (Exception ex) { StingLog.Warn($"UpdateFabShopDrawingStatus failed: {ex.Message}"); }
+        }
+
         private void SetV4FabricationOptions()
         {
             try


### PR DESCRIPTION
## Summary
This change adds a persistent shop drawing configuration interface to the Fabrication tab, allowing users to select and save a specific title block, view template, and sheet naming pattern for the current Revit session. Previously, users could only configure these options via a one-shot dialog during package generation.

## Key Changes
- **New UI Controls**: Added "Configure…" and "Clear" buttons to the Fabrication tab's "TITLE BLOCK & VIEW TEMPLATE" section, replacing the static status text with a dynamic `TextBlock` (`txtFabShopDrawingStatus`)
- **New Command Handlers**: Implemented two new command cases in `StingCommandHandler`:
  - `Fabrication_ConfigureShopDrawing`: Opens the shop drawing options dialog, saves the result to `FabricationOptions.ShopDrawing`, and updates the status display
  - `Fabrication_ClearShopDrawing`: Resets the shop drawing configuration to null and updates the status display
- **New Status Update Method**: Added `UpdateFabShopDrawingStatus()` to `StingDockPanel` to refresh the status line with either the auto-resolve fallback message or details of the selected title block, view template, and sheet patterns
- **Conditional Dialog Logic**: Modified `GenerateFabPackageCommand` to skip the popup dialog when `FabricationOptions.ShopDrawing` is already populated from the panel's persistent picker, making the panel the primary configuration path

## Implementation Details
- The status update method marshals UI updates to the WPF dispatcher since it's called from the Revit API thread
- The method safely handles null document/options and invalid element IDs, displaying appropriate fallback text
- Configuration persists for the Revit session and applies to all subsequent Generate Fabrication Package runs until explicitly cleared
- Error handling logs warnings without interrupting the workflow

https://claude.ai/code/session_01BnYUTJY51CrsDRwzatpqJL