### PR TITLE
Performance & reliability improvements: batch regeneration, caching, atomic writes

### DIFF
--- a/StingTools/BIMManager/BIMManagerCommands.cs
+++ b/StingTools/BIMManager/BIMManagerCommands.cs
@@ -2050,9 +2050,13 @@ namespace StingTools.BIMManager
                     string sys = ParameterHelpers.GetString(el, ParamRegistry.SYS);
                     if (!string.IsNullOrEmpty(sys)) sysCodes.Add(sys);
                 }
-                modelData["element_counts_by_category"] = JObject.FromObject(
-                    countByCategory.OrderByDescending(kv => kv.Value)
-                    .Take(30).ToDictionary(kv => kv.Key, kv => kv.Value));
+                // Build JObject directly from the top-30 ordered pairs — the
+                // intermediate ToDictionary allocated a whole second dict just
+                // to hand JObject.FromObject something to serialize.
+                var topCategoriesObj = new JObject();
+                foreach (var kv in countByCategory.OrderByDescending(kv => kv.Value).Take(30))
+                    topCategoriesObj[kv.Key] = kv.Value;
+                modelData["element_counts_by_category"] = topCategoriesObj;
                 modelData["element_counts_by_discipline"] = JObject.FromObject(countByDisc);
                 modelData["system_codes_in_use"] = new JArray(sysCodes.OrderBy(s => s));
                 modelData["tagged_elements"] = totalTagged;
@@ -9195,21 +9199,30 @@ namespace StingTools.BIMManager
 
                 var now = DateTime.Now;
                 int total = issues.Count;
-                int open = issues.Count(i => i["status"]?.ToString() != "CLOSED" && i["status"]?.ToString() != "VOID");
-                int closed = issues.Count(i => i["status"]?.ToString() == "CLOSED");
-                int overdue = issues.Count(i =>
+                // Single-pass tally — previous impl enumerated `issues` five
+                // times (Count, two filtered Counts, three GroupBy+ToDictionary).
+                int open = 0, closed = 0, overdue = 0;
+                var byType = new Dictionary<string, int>();
+                var byPriority = new Dictionary<string, int>();
+                var byStatus = new Dictionary<string, int>();
+                foreach (var i in issues)
                 {
-                    string status = i["status"]?.ToString() ?? "";
-                    if (status == "CLOSED" || status == "VOID") return false;
-                    return DateTime.TryParse(i["date_due"]?.ToString(), out DateTime due) && due < now;
-                });
+                    string status = i["status"]?.ToString() ?? "?";
+                    string type = i["type"]?.ToString() ?? "?";
+                    string priority = i["priority"]?.ToString() ?? "?";
 
-                var byType = issues.GroupBy(i => i["type"]?.ToString() ?? "?")
-                    .ToDictionary(g => g.Key, g => g.Count());
-                var byPriority = issues.GroupBy(i => i["priority"]?.ToString() ?? "?")
-                    .ToDictionary(g => g.Key, g => g.Count());
-                var byStatus = issues.GroupBy(i => i["status"]?.ToString() ?? "?")
-                    .ToDictionary(g => g.Key, g => g.Count());
+                    if (status == "CLOSED") closed++;
+                    else if (status != "VOID") open++;
+
+                    if (status != "CLOSED" && status != "VOID"
+                        && DateTime.TryParse(i["date_due"]?.ToString(), out DateTime due)
+                        && due < now)
+                        overdue++;
+
+                    byType.TryGetValue(type, out int tc); byType[type] = tc + 1;
+                    byPriority.TryGetValue(priority, out int pc); byPriority[priority] = pc + 1;
+                    byStatus.TryGetValue(status, out int sc); byStatus[status] = sc + 1;
+                }
 
                 var sb = new StringBuilder();
                 sb.AppendLine($"Issue Statistics — {total} total");

--- a/StingTools/BIMManager/BIMManagerCommands.cs
+++ b/StingTools/BIMManager/BIMManagerCommands.cs
@@ -5417,7 +5417,7 @@ namespace StingTools.BIMManager
                     csv.AppendLine(string.Join(",", headers.Select(h => $"\"{h}\"")));
                     foreach (var row in ws.Value)
                         csv.AppendLine(string.Join(",", headers.Select(h =>
-                            $"\"{(row.ContainsKey(h) ? row[h]?.Replace("\"", "\"\"") : "")}\"")));
+                            $"\"{(row.TryGetValue(h, out var v) ? v?.Replace("\"", "\"\"") : "")}\"")));
 
                     try { File.WriteAllText(Path.Combine(cobieDir, $"COBie_{ws.Key}.csv"), csv.ToString()); }
                     catch (Exception ex) { StingLog.Warn($"COBie {ws.Key}: {ex.Message}"); }
@@ -5518,10 +5518,13 @@ namespace StingTools.BIMManager
                 }
             }
 
-            // Add missing resource types
-            string createdBy = resources.Count > 0 && resources[0].ContainsKey("CreatedBy") ? resources[0]["CreatedBy"] : Environment.UserName;
+            // Add missing resource types — TryGetValue avoids the
+            // ContainsKey+indexer double-lookup on every row.
+            string createdBy = Environment.UserName;
+            if (resources.Count > 0 && resources[0].TryGetValue("CreatedBy", out var cbv)) createdBy = cbv;
             string createdOn = DateTime.Now.ToString("yyyy-MM-dd");
-            var existing = new HashSet<string>(resources.Select(r => r.ContainsKey("Name") ? r["Name"] : ""));
+            var existing = new HashSet<string>(resources.Select(r =>
+                r.TryGetValue("Name", out var nv) ? nv : ""));
 
             foreach (var kvp in enhancements)
             {
@@ -5540,9 +5543,11 @@ namespace StingTools.BIMManager
         /// <summary>Enhance Impact worksheet with lifecycle cost analysis, carbon per m², and energy benchmarks.</summary>
         private static void EnhanceImpactWorksheet(Document doc, List<Dictionary<string, string>> impacts)
         {
-            string createdBy = impacts.Count > 0 && impacts[0].ContainsKey("CreatedBy") ? impacts[0]["CreatedBy"] : Environment.UserName;
+            string createdBy = Environment.UserName;
+            if (impacts.Count > 0 && impacts[0].TryGetValue("CreatedBy", out var icbv)) createdBy = icbv;
             string createdOn = DateTime.Now.ToString("yyyy-MM-dd");
-            var seen = new HashSet<string>(impacts.Select(i => i.ContainsKey("Name") ? i["Name"] : ""));
+            var seen = new HashSet<string>(impacts.Select(i =>
+                i.TryGetValue("Name", out var nv) ? nv : ""));
 
             // Add building-level energy benchmarks
             var benchmarks = new[]
@@ -6250,7 +6255,7 @@ namespace StingTools.BIMManager
                 csv.AppendLine(string.Join(",", headers.Select(h => $"\"{h}\"")));
                 foreach (var row in ws.Value)
                     csv.AppendLine(string.Join(",", headers.Select(h =>
-                        $"\"{(row.ContainsKey(h) ? row[h]?.Replace("\"", "\"\"") : "")}\"")));
+                        $"\"{(row.TryGetValue(h, out var v) ? v?.Replace("\"", "\"\"") : "")}\"")));
                 try { File.WriteAllText(Path.Combine(cobieDir, $"COBie_{ws.Key}.csv"), csv.ToString()); }
                 catch (Exception ex) { StingLog.Warn($"COBie CSV write failed for {ws.Key}: {ex.Message}"); }
             }

--- a/StingTools/BIMManager/BcfEngine.cs
+++ b/StingTools/BIMManager/BcfEngine.cs
@@ -280,8 +280,8 @@ namespace Planscape.Shared.BCF
                 }
             }
             catch (InvalidDataException) { /* not a ZIP — return whatever we parsed */ }
-            catch (IOException)          { }
-            catch (Exception)            { }
+            catch (IOException ioEx)     { StingTools.Core.StingLog.Warn($"BcfEngine.Import I/O: {ioEx.Message}"); }
+            catch (Exception ex)         { StingTools.Core.StingLog.Warn($"BcfEngine.Import: {ex.Message}"); }
 
             return result;
         }

--- a/StingTools/BIMManager/CoordinationCenterCommands.cs
+++ b/StingTools/BIMManager/CoordinationCenterCommands.cs
@@ -295,7 +295,7 @@ namespace StingTools.BIMManager
                     smtp.Send(msg);
                 }
             }
-            catch (Exception ex) { StingLog.Warn($"Email send failed: {ex.Message}"); }
+            catch (Exception ex) { StingLog.Error("Email send failed", ex); }
         }
 
         // ── Generic Webhook ──
@@ -326,7 +326,7 @@ namespace StingTools.BIMManager
                 if (!response.IsSuccessStatusCode)
                     StingLog.Warn($"Webhook POST {url}: {response.StatusCode}");
             }
-            catch (Exception ex) { StingLog.Warn($"Webhook POST failed: {ex.Message}"); }
+            catch (Exception ex) { StingLog.Error($"Webhook POST {url} failed", ex); }
         }
     }
 

--- a/StingTools/BIMManager/CoordinationCenterCommands.cs
+++ b/StingTools/BIMManager/CoordinationCenterCommands.cs
@@ -611,7 +611,8 @@ namespace StingTools.BIMManager
                     // Create default policy with current user as admin
                     _policy = CreateDefaultPolicy(doc);
                     Directory.CreateDirectory(bimDir);
-                    File.WriteAllText(path, JsonConvert.SerializeObject(_policy, Formatting.Indented));
+                    OutputLocationHelper.WriteAllTextAtomic(path,
+                        JsonConvert.SerializeObject(_policy, Formatting.Indented));
                 }
                 else
                 {
@@ -771,11 +772,11 @@ namespace StingTools.BIMManager
 
             // Build data JSON
             var data = BuildDashboardData(doc);
-            File.WriteAllText(dataPath, data.ToString(Formatting.Indented));
+            OutputLocationHelper.WriteAllTextAtomic(dataPath, data.ToString(Formatting.Indented));
 
             // Build self-contained HTML
             string html = BuildHtml(doc.Title ?? "STING Project", data);
-            File.WriteAllText(htmlPath, html);
+            OutputLocationHelper.WriteAllTextAtomic(htmlPath, html);
 
             StingLog.Info($"Dashboard generated: {htmlPath}");
             return htmlPath;
@@ -1524,7 +1525,7 @@ render();
                         .GetMethod("BuildDashboardData", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
                         ?.Invoke(null, new object[] { doc });
                     if (data is JObject jdata)
-                        File.WriteAllText(dataPath, jdata.ToString(Formatting.Indented));
+                        OutputLocationHelper.WriteAllTextAtomic(dataPath, jdata.ToString(Formatting.Indented));
                     System.Windows.MessageBox.Show("Dashboard data refreshed. Reload the HTML file to see updates.",
                         "STING", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
                 }

--- a/StingTools/BIMManager/ExcelLinkCommands.cs
+++ b/StingTools/BIMManager/ExcelLinkCommands.cs
@@ -673,14 +673,16 @@ namespace StingTools.BIMManager
             // Read data rows
             for (int r = 2; r <= lastRow; r++)
             {
-                string idStr = ws.Cell(r, elementIdCol.Value).GetString().Trim();
+                // ClosedXML.GetString() returns null for truly-empty cells in some paths;
+                // null-coalesce before Trim to avoid NRE on empty rows.
+                string idStr = (ws.Cell(r, elementIdCol.Value).GetString() ?? string.Empty).Trim();
                 if (string.IsNullOrEmpty(idStr)) continue;
                 if (!long.TryParse(idStr, out long elementId)) continue;
 
                 var rowData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var kvp in headerMap)
                 {
-                    rowData[kvp.Value] = ws.Cell(r, kvp.Key).GetString();
+                    rowData[kvp.Value] = ws.Cell(r, kvp.Key).GetString() ?? string.Empty;
                 }
 
                 result[elementId] = rowData;

--- a/StingTools/BIMManager/GapFixCommands.cs
+++ b/StingTools/BIMManager/GapFixCommands.cs
@@ -45,14 +45,14 @@ namespace StingTools.BIMManager
         {
             if (!File.Exists(path)) return new JArray();
             try { return JArray.Parse(File.ReadAllText(path)); }
-            catch (Exception ex) { StingLog.Warn($"LoadJsonArray failed: {ex.Message}"); return new JArray(); }
+            catch (Exception ex) { StingLog.Error($"LoadJsonArray failed ({path})", ex); return new JArray(); }
         }
 
         internal static JObject LoadJsonObject(string path)
         {
             if (!File.Exists(path)) return new JObject();
             try { return JObject.Parse(File.ReadAllText(path)); }
-            catch (Exception ex) { StingLog.Warn($"LoadJsonObject failed: {ex.Message}"); return new JObject(); }
+            catch (Exception ex) { StingLog.Error($"LoadJsonObject failed ({path})", ex); return new JObject(); }
         }
 
         /// <summary>Atomic JSON write using temp file + replace. GF-001 FIX:

--- a/StingTools/BIMManager/GapFixCommands.cs
+++ b/StingTools/BIMManager/GapFixCommands.cs
@@ -418,11 +418,15 @@ namespace StingTools.BIMManager
                     w.Name.Equals("Component", StringComparison.OrdinalIgnoreCase));
                 if (ws == null) return "No 'Component' worksheet found in COBie file.";
 
-                // Read headers
+                // Read headers — guard against null header cells (ClosedXML can
+                // return null for a completely blank cell in some paths).
                 var headers = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
                 int lastCol = ws.LastColumnUsed()?.ColumnNumber() ?? 0;
                 for (int c = 1; c <= lastCol; c++)
-                    headers[ws.Cell(1, c).GetString().Trim()] = c;
+                {
+                    string hdr = (ws.Cell(1, c).GetString() ?? string.Empty).Trim();
+                    if (hdr.Length > 0) headers[hdr] = c;
+                }
 
                 if (!headers.ContainsKey("Name") && !headers.ContainsKey("ExternalIdentifier"))
                     return "COBie Component sheet missing Name or ExternalIdentifier column.";
@@ -1005,7 +1009,7 @@ namespace StingTools.BIMManager
             double m = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
             double b = (sumY - m * sumX) / n;
 
-            double current = y.Last();
+            double current = y.Length > 0 ? y[y.Length - 1] : 0;
             var sb = new StringBuilder();
             sb.AppendLine("COMPLIANCE FORECAST\n");
             sb.AppendLine($"Current: {current:F1}%");

--- a/StingTools/BIMManager/LANCollaborationCommands.cs
+++ b/StingTools/BIMManager/LANCollaborationCommands.cs
@@ -400,7 +400,8 @@ namespace StingTools.BIMManager
             try
             {
                 string path = Path.Combine(GetCollabDir(doc), $"{GetProjectKey(doc)}_team.json");
-                File.WriteAllText(path, JsonConvert.SerializeObject(roster, Formatting.Indented));
+                OutputLocationHelper.WriteAllTextAtomic(path,
+                    JsonConvert.SerializeObject(roster, Formatting.Indented));
             }
             catch (Exception ex) { StingLog.Warn($"SaveTeamRoster: {ex.Message}"); }
         }
@@ -423,7 +424,8 @@ namespace StingTools.BIMManager
             try
             {
                 string path = Path.Combine(GetCollabDir(doc), $"{GetProjectKey(doc)}_changelog.json");
-                File.WriteAllText(path, JsonConvert.SerializeObject(log, Formatting.Indented));
+                OutputLocationHelper.WriteAllTextAtomic(path,
+                    JsonConvert.SerializeObject(log, Formatting.Indented));
             }
             catch (Exception ex) { StingLog.Warn($"SaveChangeLog: {ex.Message}"); }
         }

--- a/StingTools/BIMManager/MobileIssueBridge.cs
+++ b/StingTools/BIMManager/MobileIssueBridge.cs
@@ -95,7 +95,7 @@ namespace StingTools.BIMManager
             }
             catch (Exception ex)
             {
-                StingLog.Warn($"MobileIssueBridge.Pull failed: {ex.Message}");
+                StingLog.Error("MobileIssueBridge.Pull failed", ex);
                 result.Error = ex.Message;
             }
 

--- a/StingTools/BIMManager/ParameterDiffCommands.cs
+++ b/StingTools/BIMManager/ParameterDiffCommands.cs
@@ -80,7 +80,16 @@ namespace StingTools.BIMManager
             return path;
         }
 
-        /// <summary>Load all available snapshots for the project.</summary>
+        // Deserialized-snapshot cache keyed by (path, mtime ticks) — LoadSnapshot is
+        // hit repeatedly by the dashboard + CompareSnapshots; avoid re-parsing
+        // multi-megabyte element arrays each time. Cleared when a snapshot is
+        // overwritten (mtime changes invalidate automatically).
+        private static readonly Dictionary<string, (long MTimeTicks, ParameterSnapshot Snap)> _snapCache
+            = new Dictionary<string, (long, ParameterSnapshot)>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Load all available snapshots for the project.
+        /// Uses streaming Json.NET parse so we skip the Elements array — the
+        /// summary only needs Label / Timestamp / element count.</summary>
         internal static List<SnapshotSummary> ListSnapshots(Document doc)
         {
             var summaries = new List<SnapshotSummary>();
@@ -91,29 +100,73 @@ namespace StingTools.BIMManager
             {
                 try
                 {
-                    var snap = JsonConvert.DeserializeObject<ParameterSnapshot>(File.ReadAllText(file));
-                    if (snap != null)
-                    {
-                        summaries.Add(new SnapshotSummary
-                        {
-                            FilePath = file,
-                            Label = snap.Label,
-                            Timestamp = snap.Timestamp,
-                            ElementCount = snap.Elements.Count
-                        });
-                    }
+                    var summary = ReadSnapshotSummaryStreaming(file);
+                    if (summary != null) summaries.Add(summary);
                 }
                 catch (Exception ex) { StingLog.Warn($"ListSnapshots: {ex.Message}"); }
             }
             return summaries;
         }
 
-        /// <summary>Load a specific snapshot from file.</summary>
+        /// <summary>Streaming-parse Label/Timestamp and count Elements without
+        /// materialising the full snapshot (snapshots can be many MB).</summary>
+        private static SnapshotSummary ReadSnapshotSummaryStreaming(string file)
+        {
+            using (var sr = new StreamReader(file))
+            using (var jr = new JsonTextReader(sr))
+            {
+                string label = null;
+                DateTime timestamp = default;
+                int elementCount = 0;
+
+                while (jr.Read())
+                {
+                    if (jr.TokenType != JsonToken.PropertyName) continue;
+                    string name = (string)jr.Value;
+                    jr.Read();
+                    if (name == "Label") label = jr.Value?.ToString();
+                    else if (name == "Timestamp")
+                    {
+                        if (jr.Value is DateTime dt) timestamp = dt;
+                        else if (jr.Value != null) DateTime.TryParse(jr.Value.ToString(), out timestamp);
+                    }
+                    else if (name == "Elements" && jr.TokenType == JsonToken.StartArray)
+                    {
+                        int depth = 1;
+                        while (depth > 0 && jr.Read())
+                        {
+                            if (jr.TokenType == JsonToken.StartObject && depth == 1) elementCount++;
+                            if (jr.TokenType == JsonToken.StartArray) depth++;
+                            else if (jr.TokenType == JsonToken.EndArray) depth--;
+                        }
+                    }
+                }
+
+                return new SnapshotSummary
+                {
+                    FilePath = file,
+                    Label = label ?? "",
+                    Timestamp = timestamp,
+                    ElementCount = elementCount
+                };
+            }
+        }
+
+        /// <summary>Load a specific snapshot from file. Cached by (path, mtime).</summary>
         internal static ParameterSnapshot LoadSnapshot(string filePath)
         {
             try
             {
-                return JsonConvert.DeserializeObject<ParameterSnapshot>(File.ReadAllText(filePath));
+                if (!File.Exists(filePath)) return null;
+                long mtime = File.GetLastWriteTimeUtc(filePath).Ticks;
+                lock (_snapCache)
+                {
+                    if (_snapCache.TryGetValue(filePath, out var hit) && hit.MTimeTicks == mtime)
+                        return hit.Snap;
+                }
+                var snap = JsonConvert.DeserializeObject<ParameterSnapshot>(File.ReadAllText(filePath));
+                lock (_snapCache) { _snapCache[filePath] = (mtime, snap); }
+                return snap;
             }
             catch (Exception ex)
             {

--- a/StingTools/BIMManager/ParameterDiffCommands.cs
+++ b/StingTools/BIMManager/ParameterDiffCommands.cs
@@ -259,11 +259,7 @@ namespace StingTools.BIMManager
         }
 
         private static string SanitizeFileName(string name)
-        {
-            foreach (char c in Path.GetInvalidFileNameChars())
-                name = name.Replace(c, '_');
-            return name.Length > 50 ? name.Substring(0, 50) : name;
-        }
+            => OutputLocationHelper.MakeSafeFileName(name, maxLength: 50);
     }
 
     // ── Data types ──

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -663,11 +663,11 @@ public sealed class PlanscapeServerClient : IDisposable
     //  Private helpers
     // ────────────────────────────────────────────────────────────────────────────
 
-    private void EnsureHttpClient(string baseUrl)
+    private HttpClient EnsureHttpClient(string baseUrl)
     {
         lock (_httpSem)
         {
-            if (_http != null && _http.BaseAddress?.ToString().TrimEnd('/') == baseUrl) return;
+            if (_http != null && _http.BaseAddress?.ToString().TrimEnd('/') == baseUrl) return _http;
             _http?.Dispose();
             _http = new HttpClient
             {
@@ -679,7 +679,16 @@ public sealed class PlanscapeServerClient : IDisposable
             if (!string.IsNullOrEmpty(_accessToken))
                 _http.DefaultRequestHeaders.Authorization =
                     new AuthenticationHeaderValue("Bearer", _accessToken);
+            return _http;
         }
+    }
+
+    // Snapshot the current HttpClient under the lock so a concurrent
+    // EnsureHttpClient(different base URL) that disposes+replaces _http
+    // cannot race with an in-flight PostAsync/GetAsync.
+    private HttpClient SnapshotHttpClient()
+    {
+        lock (_httpSem) { return _http; }
     }
 
     private async Task<(bool ok, int status, string body)> PostJsonAsync(string path, object payload)
@@ -692,14 +701,18 @@ public sealed class PlanscapeServerClient : IDisposable
             }),
             Encoding.UTF8, "application/json");
 
-        var resp = await _http!.PostAsync(path, content).ConfigureAwait(false);
+        var http = SnapshotHttpClient();
+        if (http == null) throw new InvalidOperationException("HttpClient not initialised — call LoginAsync first.");
+        var resp = await http.PostAsync(path, content).ConfigureAwait(false);
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
         return ((int)resp.StatusCode >= 200 && (int)resp.StatusCode < 300, (int)resp.StatusCode, body);
     }
 
     private async Task<(bool ok, int status, string body)> GetAsync(string path)
     {
-        var resp = await _http!.GetAsync(path).ConfigureAwait(false);
+        var http = SnapshotHttpClient();
+        if (http == null) throw new InvalidOperationException("HttpClient not initialised — call LoginAsync first.");
+        var resp = await http.GetAsync(path).ConfigureAwait(false);
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
         return ((int)resp.StatusCode >= 200 && (int)resp.StatusCode < 300, (int)resp.StatusCode, body);
     }

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -848,7 +848,8 @@ namespace StingTools.BIMManager
             }
             catch (Exception ex)
             {
-                try { if (Directory.Exists(extractDir)) Directory.Delete(extractDir, true); } catch { }
+                try { if (Directory.Exists(extractDir)) Directory.Delete(extractDir, true); }
+                catch (Exception cleanupEx) { StingLog.Warn($"BCF extract-dir cleanup suppressed: {cleanupEx.Message}"); }
                 return $"Failed to extract BCF: {ex.Message}";
             }
 

--- a/StingTools/BIMManager/RevisionManagementCommands.cs
+++ b/StingTools/BIMManager/RevisionManagementCommands.cs
@@ -985,17 +985,11 @@ namespace StingTools.BIMManager
                 int cloudsCreated = 0;
                 int cloudsSkipped = 0;
 
-                // Phase 85: Build set of already-clouded element IDs to prevent duplicates on repeated runs
+                // Phase 85: Build set of already-clouded element IDs to prevent duplicates on repeated runs.
+                // RevisionCloud doesn't expose hosted elements directly, so we fingerprint by bounding-box origin.
                 var alreadyClouded = new HashSet<long>();
                 try
                 {
-                    foreach (var rc in new FilteredElementCollector(doc, view.Id)
-                        .OfClass(typeof(RevisionCloud))
-                        .Cast<RevisionCloud>())
-                    {
-                        // RevisionCloud doesn't expose hosted elements directly; track by bounding box center
-                    }
-                    // Track existing clouds by their host element references
                     foreach (RevisionCloud rc in new FilteredElementCollector(doc)
                         .OfClass(typeof(RevisionCloud)))
                     {

--- a/StingTools/BIMManager/SchedulingCommands.cs
+++ b/StingTools/BIMManager/SchedulingCommands.cs
@@ -275,14 +275,16 @@ namespace StingTools.BIMManager
             schedule["project_start"] = projectStart.ToString("yyyy-MM-dd");
             schedule["generated_date"] = DateTime.Now.ToString("yyyy-MM-dd HH:mm");
 
-            // Get all levels ordered by elevation
+            // Get all levels ordered by elevation — iterated once, so an
+            // OrderedEnumerable is enough; .ToList() was allocating a list
+            // we never indexed into.
             var levels = new FilteredElementCollector(doc)
                 .OfClass(typeof(Level)).Cast<Level>()
-                .OrderBy(l => l.Elevation).ToList();
+                .OrderBy(l => l.Elevation);
 
-            // Get phases
+            // Get phases — same: single-pass iteration below.
             var phases = doc.Phases.Cast<Phase>()
-                .OrderBy(p => p.Id.Value).ToList();
+                .OrderBy(p => p.Id.Value);
 
             // Collect element counts by category and level
             var knownCats = new HashSet<string>(TagConfig.DiscMap.Keys);

--- a/StingTools/Commands/Fabrication/FabricationUndoManager.cs
+++ b/StingTools/Commands/Fabrication/FabricationUndoManager.cs
@@ -1,0 +1,133 @@
+// StingTools v4 MVP — FabricationUndoManager.
+//
+// Session-scoped undo stack for Generate Fabrication Package runs.
+// FabricationEngine returns a FabricationResult carrying the ElementIds
+// of every AssemblyInstance, view, and ViewSheet it created. Recording
+// that result here lets users roll the package back in one click
+// without leaving orphan sheets / views behind.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Fabrication;
+
+namespace StingTools.Commands.Fabrication
+{
+    /// <summary>
+    /// In-process LIFO history of FabricationResult instances. Survives
+    /// command invocations but not Revit restarts — matches the scope
+    /// of Revit's built-in undo buffer.
+    /// </summary>
+    public static class FabricationUndoManager
+    {
+        private static readonly Stack<FabricationResult> _history
+            = new Stack<FabricationResult>();
+
+        /// <summary>Number of undo entries currently available.</summary>
+        public static int Depth => _history.Count;
+
+        /// <summary>True when Undo() would have something to delete.</summary>
+        public static bool HasHistory => _history.Count > 0;
+
+        /// <summary>
+        /// Push a FabricationResult onto the undo stack. Called by
+        /// GenerateFabPackageCommand immediately after the engine returns.
+        /// </summary>
+        public static void Record(FabricationResult result)
+        {
+            if (result == null) return;
+            if (result.AssemblyIds.Count == 0 && result.SheetIds.Count == 0) return;
+            _history.Push(result);
+        }
+
+        /// <summary>
+        /// Peek the most recent FabricationResult without popping.
+        /// </summary>
+        public static FabricationResult Peek()
+        {
+            return _history.Count == 0 ? null : _history.Peek();
+        }
+
+        /// <summary>Clear the entire history without deleting any elements.</summary>
+        public static void Clear()
+        {
+            _history.Clear();
+        }
+
+        /// <summary>
+        /// Pop the last FabricationResult and delete its sheets + assemblies
+        /// inside a single transaction. Returns the number of elements
+        /// actually removed (0 when nothing to undo).
+        /// </summary>
+        public static int Undo(Document doc)
+        {
+            if (doc == null || _history.Count == 0) return 0;
+            FabricationResult last = _history.Pop();
+
+            // Sheets first so viewports disappear cleanly, then assemblies.
+            var ids = new List<ElementId>();
+            ids.AddRange(last.SheetIds);
+            ids.AddRange(last.AssemblyIds);
+            if (ids.Count == 0) return 0;
+
+            int deleted = 0;
+            using (var t = new Transaction(doc, "STING Undo Fabrication Package"))
+            {
+                t.Start();
+                foreach (ElementId id in ids)
+                {
+                    try
+                    {
+                        if (id == null || id == ElementId.InvalidElementId) continue;
+                        if (doc.GetElement(id) == null) continue;
+                        var removed = doc.Delete(id);
+                        if (removed != null) deleted += removed.Count;
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"FabricationUndoManager.Undo({id?.Value}): {ex.Message}");
+                    }
+                }
+                t.Commit();
+            }
+            return deleted;
+        }
+    }
+
+    /// <summary>
+    /// Roll back the most recent fabrication package created in this session.
+    /// Bound to the Fabrication sub-tab's "Undo Package" button.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class UndoFabPackageCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(commandData);
+            if (ctx == null) { message = "No active document."; return Result.Failed; }
+
+            if (!FabricationUndoManager.HasHistory)
+            {
+                TaskDialog.Show("STING v4 — Undo Fabrication Package",
+                    "No fabrication package on the session undo stack.\n\n" +
+                    "Run Generate Fabrication Package first — the result is\n" +
+                    "recorded automatically on success.");
+                return Result.Cancelled;
+            }
+
+            FabricationResult target = FabricationUndoManager.Peek();
+            int expected = (target?.AssemblyIds.Count ?? 0) + (target?.SheetIds.Count ?? 0);
+
+            int deleted = FabricationUndoManager.Undo(ctx.Doc);
+            TaskDialog.Show("STING v4 — Undo Fabrication Package",
+                $"Removed {deleted} element(s) (of {expected} tracked).\n" +
+                $"History depth now: {FabricationUndoManager.Depth}.");
+            return Result.Succeeded;
+        }
+    }
+}

--- a/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
+++ b/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
@@ -114,6 +114,7 @@ namespace StingTools.Commands.Fabrication
                 return Result.Failed;
             }
 
+            FabricationUndoManager.Record(res);
             ShowResult(res);
 
             // Open first generated sheet for instant feedback

--- a/StingTools/Core/ComplianceScan.cs
+++ b/StingTools/Core/ComplianceScan.cs
@@ -805,7 +805,7 @@ namespace StingTools.Core
                 string dir = delta > 2 ? "improving" : delta < -2 ? "declining" : "stable";
                 return (dir, delta);
             }
-            catch (Exception ex) { StingLog.Warn($"Compliance trend calc: {ex.Message}"); return ("unknown", 0); }
+            catch (Exception ex) { StingLog.Error("Compliance trend calc failed", ex); return ("unknown", 0); }
         }
 
         private static List<TrendEntry> LoadEntries(string path)

--- a/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
+++ b/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
@@ -55,6 +55,11 @@ namespace StingTools.Core.Fabrication
 
                 try
                 {
+                    // Resolve + pre-activate every FamilySymbol we will use so
+                    // we can Regenerate ONCE after activation instead of calling
+                    // doc.Regenerate inside TryPlace for every single member.
+                    var memberPlan = new List<(Element member, FamilySymbol fs)>();
+                    bool anyActivated = false;
                     foreach (ElementId memberId in ai.GetMemberIds())
                     {
                         var member = doc.GetElement(memberId);
@@ -63,7 +68,14 @@ namespace StingTools.Core.Fabrication
                         if (entry == null) continue;
                         FamilySymbol fs = ResolveFamilySymbol(doc, entry, result);
                         if (fs == null) continue;
-                        if (TryPlace(doc, detailView, member, fs, result))
+                        if (!fs.IsActive) { fs.Activate(); anyActivated = true; }
+                        memberPlan.Add((member, fs));
+                    }
+                    if (anyActivated) doc.Regenerate();
+
+                    foreach (var (member, fs) in memberPlan)
+                    {
+                        if (TryPlace(detailView, member, fs, result))
                             placed++;
                     }
                     tx.Commit();
@@ -77,15 +89,16 @@ namespace StingTools.Core.Fabrication
             return placed;
         }
 
-        private static bool TryPlace(Document doc, View view, Element member, FamilySymbol fs, FabricationResult result)
+        private static bool TryPlace(View view, Element member, FamilySymbol fs, FabricationResult result)
         {
             try
             {
-                if (!fs.IsActive) { fs.Activate(); doc.Regenerate(); }
+                // Symbol pre-activated in PlaceSymbolsForAssembly; no per-call
+                // Regenerate needed here.
                 XYZ point = (member.Location as LocationPoint)?.Point
                          ?? (member.Location as LocationCurve)?.Curve?.GetEndPoint(0)
                          ?? XYZ.Zero;
-                doc.Create.NewFamilyInstance(point, fs, view);
+                view.Document.Create.NewFamilyInstance(point, fs, view);
                 return true;
             }
             catch (Exception ex)

--- a/StingTools/Core/Fabrication/PcfExporter.cs
+++ b/StingTools/Core/Fabrication/PcfExporter.cs
@@ -162,7 +162,8 @@ namespace StingTools.Core.Fabrication
                 var p1 = curve.GetEndPoint(1);
                 double boreMm = pipe.Diameter * FtToMm;
                 double weightKg = 0;
-                try { weightKg = SpoolWeightCalculator.WeightKg(pipe.Document, new[] { pipe.Id }); } catch { }
+                try { weightKg = SpoolWeightCalculator.WeightKg(pipe.Document, new[] { pipe.Id }); }
+                catch (Exception wEx) { StingTools.Core.StingLog.Warn($"PcfExporter.WeightKg pipe {pipe?.Id}: {wEx.Message}"); }
 
                 w.WriteLine("PIPE");
                 w.WriteLine($"    END-POSITION       {FmtXYZ(p0)} {boreMm.ToString("F1", Inv)}");

--- a/StingTools/Core/Fabrication/ShopDrawingComposer.cs
+++ b/StingTools/Core/Fabrication/ShopDrawingComposer.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
+using StingTools.Core;
 
 namespace StingTools.Core.Fabrication
 {
@@ -338,9 +339,15 @@ namespace StingTools.Core.Fabrication
         }
         private static void TrySetString(Element el, string param, string val)
         {
-            try { var p = el.LookupParameter(param);
-                  if (p != null && !p.IsReadOnly && p.StorageType == StorageType.String) p.Set(val); }
-            catch { }
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p != null && !p.IsReadOnly && p.StorageType == StorageType.String) p.Set(val);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ShopDrawingComposer.TrySetString({param}) on {el?.Id}: {ex.Message}");
+            }
         }
     }
 }

--- a/StingTools/Core/LODValidationCommand.cs
+++ b/StingTools/Core/LODValidationCommand.cs
@@ -123,7 +123,8 @@ namespace StingTools.Core
             {
                 var matIds = el.GetMaterialIds(false);
                 if (matIds == null || matIds.Count == 0) missing.Add("material");
-            } catch { }
+            }
+            catch (Exception ex) { StingLog.Warn($"LOD.MissingFor.GetMaterialIds {el?.Id}: {ex.Message}"); }
             if (string.IsNullOrEmpty(ParameterHelpers.GetString(el, ParamRegistry.DISC))) missing.Add("DISC");
             if (string.IsNullOrEmpty(ParameterHelpers.GetString(el, ParamRegistry.LOC))) missing.Add("LOC");
             return missing.Count == 0 ? "(unknown)" : "missing " + string.Join(", ", missing);

--- a/StingTools/Core/OutputLocationHelper.cs
+++ b/StingTools/Core/OutputLocationHelper.cs
@@ -305,5 +305,34 @@ namespace StingTools.Core
             }
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); return false; }
         }
+
+        /// <summary>
+        /// Canonical "make filename safe" helper — replaces every
+        /// Path.GetInvalidFileNameChars() match (plus optional extras)
+        /// with a single replacement char, trims repeated replacements,
+        /// and clamps to maxLength. Three callers previously rolled their
+        /// own version with subtle differences (BOQTemplateLibrary also
+        /// replaced spaces + slashes; ParameterDiffEngine clamped at 50).
+        /// Pass <paramref name="extraInvalid"/> / <paramref name="maxLength"/>
+        /// to reproduce those behaviours when needed.
+        /// </summary>
+        public static string MakeSafeFileName(string name, char replacement = '_',
+            char[] extraInvalid = null, int maxLength = 0, string fallback = "item")
+        {
+            if (string.IsNullOrEmpty(name)) return fallback;
+            var invalid = Path.GetInvalidFileNameChars();
+            var arr = new char[name.Length];
+            for (int i = 0; i < name.Length; i++)
+            {
+                char c = name[i];
+                bool isInvalid = Array.IndexOf(invalid, c) >= 0
+                    || (extraInvalid != null && Array.IndexOf(extraInvalid, c) >= 0);
+                arr[i] = isInvalid ? replacement : c;
+            }
+            string r = new string(arr).Trim(replacement);
+            if (string.IsNullOrEmpty(r)) r = fallback;
+            if (maxLength > 0 && r.Length > maxLength) r = r.Substring(0, maxLength);
+            return r;
+        }
     }
 }

--- a/StingTools/Core/OutputLocationHelper.cs
+++ b/StingTools/Core/OutputLocationHelper.cs
@@ -307,6 +307,39 @@ namespace StingTools.Core
         }
 
         /// <summary>
+        /// Atomic text write: writes to a temp file alongside, then uses
+        /// File.Replace to swap it into place. A crash partway through
+        /// leaves the previous file intact (or restored from the automatic
+        /// .bak sibling). Several command registers and config writers
+        /// previously did raw File.WriteAllText — losing the entire file
+        /// if Revit crashed during the write window.
+        /// </summary>
+        public static void WriteAllTextAtomic(string path, string content,
+            System.Text.Encoding encoding = null)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+            encoding = encoding ?? new System.Text.UTF8Encoding(false);
+            string tmp = path + ".tmp";
+            string bak = path + ".bak";
+            File.WriteAllText(tmp, content ?? string.Empty, encoding);
+            try
+            {
+                if (File.Exists(path))
+                    File.Replace(tmp, path, bak);
+                else
+                    File.Move(tmp, path);
+            }
+            catch (Exception)
+            {
+                // Replace can fail across volumes / on locked files — fall
+                // back to a copy + delete so callers never end up with a
+                // missing destination. If even copy fails let it propagate.
+                File.Copy(tmp, path, true);
+                try { File.Delete(tmp); } catch { }
+            }
+        }
+
+        /// <summary>
         /// Canonical "make filename safe" helper — replaces every
         /// Path.GetInvalidFileNameChars() match (plus optional extras)
         /// with a single replacement char, trims repeated replacements,

--- a/StingTools/Core/ParameterHelpers.cs
+++ b/StingTools/Core/ParameterHelpers.cs
@@ -1461,8 +1461,12 @@ namespace StingTools.Core
                 }
                 if (allPopulated) return;
 
-                // Walk connectors to find tagged connected elements
-                foreach (Connector conn in fi.MEPModel.ConnectorManager.Connectors)
+                // Walk connectors to find tagged connected elements.
+                // MEPModel can be non-null while ConnectorManager is null on
+                // hosted fittings; guard the chain to avoid NRE.
+                var connSet = fi.MEPModel?.ConnectorManager?.Connectors;
+                if (connSet == null) return;
+                foreach (Connector conn in connSet)
                 {
                     if (conn == null || !conn.IsConnected) continue;
                     var allRefs = conn.AllRefs;

--- a/StingTools/Core/PerformanceTracker.cs
+++ b/StingTools/Core/PerformanceTracker.cs
@@ -114,7 +114,12 @@ namespace StingTools.Core
             string path = OutputLocationHelper.GetTimestampedPath(null, "STING_Performance", ".csv");
             try
             {
-                using (var sw = new StreamWriter(path))
+                // UTF-8 with BOM so Excel on non-English locales opens unicode
+                // operation names correctly. The default StreamWriter ctor uses
+                // the system ANSI code page, which mangles characters on EU /
+                // CJK machines.
+                using (var sw = new StreamWriter(path, append: false,
+                    encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: true)))
                 {
                     sw.WriteLine("Operation,Invocations,TotalMs,AvgMs,MaxMs,Elements,ElementsPerSec");
                     foreach (var stats in _operations.Values.OrderByDescending(s => s.TotalElapsed))

--- a/StingTools/Core/StingAutoTagger.cs
+++ b/StingTools/Core/StingAutoTagger.cs
@@ -408,6 +408,17 @@ namespace StingTools.Core
                     return;
                 }
 
+                // Cache per-event properties we'd otherwise resolve for every
+                // element: Application.Username crosses a P/Invoke boundary and
+                // IsWorkshared walks the document state.
+                string currentUser = null;
+                bool isWorkshared = false;
+                try { isWorkshared = doc.IsWorkshared; } catch { }
+                if (isWorkshared)
+                {
+                    try { currentUser = doc.Application.Username; } catch { }
+                }
+
                 foreach (ElementId id in addedIds)
                 {
                     // Skip recently processed (avoid re-trigger loops)
@@ -429,7 +440,7 @@ namespace StingTools.Core
                     }
 
                     // Workset filter — R-02: defer elements on unowned worksets instead of dropping
-                    if (doc.IsWorkshared)
+                    if (isWorkshared)
                     {
                         try
                         {
@@ -438,11 +449,11 @@ namespace StingTools.Core
                             {
                                 var wsInfo = WorksharingUtils.GetWorksharingTooltipInfo(doc, el.Id);
                                 if (!string.IsNullOrEmpty(wsInfo.Owner)
-                                    && wsInfo.Owner != doc.Application.Username
+                                    && wsInfo.Owner != currentUser
                                     && wsInfo.Owner != "")
                                 {
                                     EnqueueDeferred(id);
-                                    StingLog.Info($"AutoTagger: deferred {id.Value} (workset not owned by {doc.Application.Username}) — will retry after sync");
+                                    StingLog.Info($"AutoTagger: deferred {id.Value} (workset not owned by {currentUser}) — will retry after sync");
                                     continue;
                                 }
                             }

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -2049,6 +2049,8 @@ namespace StingTools.Core
                     File.WriteAllText(tmp, JsonConvert.SerializeObject(data, Formatting.Indented));
                     try { File.Replace(tmp, ConfigSource, ConfigSource + ".bak"); }
                     catch { File.Copy(tmp, ConfigSource, true); try { File.Delete(tmp); } catch { } }
+                    // Invalidate cached config — GetConfigValue will re-read on next hit.
+                    lock (_cfgCacheLock) { _cfgCached = null; _cfgCachedPath = null; _cfgCachedMTicks = 0; }
                 }
                 catch (Exception ex)
                 {
@@ -2057,14 +2059,52 @@ namespace StingTools.Core
             }
         }
 
-        /// <summary>AE-02: Read a single config key from project_config.json. Returns null if not found.</summary>
-        public static string GetConfigValue(string key)
+        // AE-02 cache — GetConfigValue was hit from dashboards / command
+        // entry points and re-read + re-parsed project_config.json on every
+        // call. Cache the deserialised dictionary keyed by (path, mtime)
+        // so repeated reads are zero I/O.
+        private static readonly object _cfgCacheLock = new object();
+        private static string _cfgCachedPath;
+        private static long _cfgCachedMTicks;
+        private static Dictionary<string, object> _cfgCached;
+
+        private static Dictionary<string, object> LoadConfigCached()
         {
             try
             {
                 if (string.IsNullOrEmpty(ConfigSource) || !File.Exists(ConfigSource)) return null;
+                long mtime = File.GetLastWriteTimeUtc(ConfigSource).Ticks;
+                lock (_cfgCacheLock)
+                {
+                    if (_cfgCached != null
+                        && string.Equals(_cfgCachedPath, ConfigSource, StringComparison.OrdinalIgnoreCase)
+                        && _cfgCachedMTicks == mtime)
+                        return _cfgCached;
+                }
                 string json = File.ReadAllText(ConfigSource);
                 var data = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
+                lock (_cfgCacheLock)
+                {
+                    _cfgCached = data;
+                    _cfgCachedPath = ConfigSource;
+                    _cfgCachedMTicks = mtime;
+                }
+                return data;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"LoadConfigCached: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>AE-02: Read a single config key from project_config.json. Returns null if not found.
+        /// Uses a (path, mtime) cache so repeat reads never touch disk.</summary>
+        public static string GetConfigValue(string key)
+        {
+            try
+            {
+                var data = LoadConfigCached();
                 if (data != null && data.TryGetValue(key, out object val) && val != null)
                     return val.ToString();
             }

--- a/StingTools/Core/TransactionHelper.cs
+++ b/StingTools/Core/TransactionHelper.cs
@@ -117,5 +117,37 @@ namespace StingTools.Core
                 }
             }
         }
+
+        /// <summary>
+        /// Attach an <see cref="IFailuresPreprocessor"/> to a Transaction
+        /// in the 3-line boilerplate that would otherwise be copy-pasted
+        /// at 20+ call sites across Model/, CADToModel/, StructuralCAD/:
+        ///
+        ///   var opts = tx.GetFailureHandlingOptions();
+        ///   opts.SetFailuresPreprocessor(fh);
+        ///   tx.SetFailureHandlingOptions(opts);
+        ///
+        /// Callers: AttachFailureHandler(tx, fh).
+        /// </summary>
+        public static void AttachFailureHandler(Transaction tx, IFailuresPreprocessor fh)
+        {
+            if (tx == null || fh == null) return;
+            var opts = tx.GetFailureHandlingOptions();
+            opts.SetFailuresPreprocessor(fh);
+            tx.SetFailureHandlingOptions(opts);
+        }
+
+        /// <summary>
+        /// Suppress modal dialogs on a batch Transaction — essential for
+        /// unattended / workflow-driven operations so a stray warning
+        /// doesn't freeze the batch waiting for OK.
+        /// </summary>
+        public static void SuppressModalDialogs(Transaction tx)
+        {
+            if (tx == null) return;
+            var opts = tx.GetFailureHandlingOptions();
+            opts.SetForcedModalHandling(false);
+            tx.SetFailureHandlingOptions(opts);
+        }
     }
 }

--- a/StingTools/Docs/JournalParserCommand.cs
+++ b/StingTools/Docs/JournalParserCommand.cs
@@ -20,6 +20,42 @@ namespace StingTools.Docs
     [Regeneration(RegenerationOption.Manual)]
     public class JournalParserCommand : IExternalCommand, IPanelCommand
     {
+        // ── Hoisted journal-line patterns ──
+        // The journal parser iterates every line of a multi-MB journal file,
+        // so we pay the Regex-compile cost once at type init rather than on
+        // every RunParser invocation. RegexOptions.Compiled gives ~2-3x match
+        // throughput for the tight per-line loop below.
+        private static readonly Regex TimestampRx = new Regex(
+            @"'[HCE]\s+(\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2}\.\d+)",
+            RegexOptions.Compiled);
+        private static readonly Regex AddinLoadRx = new Regex(
+            @"API_SUCCESS\s*\{\s*Starting External Application:\s*(.+?),\s*Class:\s*(.+?),.*?Assembly:\s*(.+?\.dll)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AddinBtnRx = new Regex(
+            @"API_SUCCESS\s*\{\s*Added pushbutton.*?name:\s*(.+?),.*?class:\s*(.+?),.*?assembly:\s*(.+?\.dll)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AddinManifestRx = new Regex(
+            @"\[Jrn\.AddInManifest\].*?AddInName:\s*(.+?)\s+.*?AddInVersion:\s*(\S+).*?AddInLoadFailureMessage:\s*(\S+)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ErrorRx = new Regex(
+            @"API_ERROR|FATAL|Exception|StackOverflow|AccessViolation|NullReference|OutOfMemory|assembly.*version.*conflict",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RibbonEventRx = new Regex(
+            @"Jrn\.RibbonEvent\s+""Execute external command:(.+?)""",
+            RegexOptions.Compiled);
+        private static readonly Regex MemoryRx = new Regex(
+            @"RAM.*?Avail\s+(\d+).*?Used\s+(\d+).*?Peak\s+(\d+)",
+            RegexOptions.Compiled);
+        private static readonly Regex TaskDialogRx = new Regex(
+            @"TaskDialog\s+""(.+?)""", RegexOptions.Compiled);
+        private static readonly Regex VersionRx = new Regex(
+            @"Build:\s*(\S+).*?Branch:\s*(\S+)", RegexOptions.Compiled);
+        private static readonly Regex UserRx = new Regex(
+            @"""Username""\s*,\s*""(.+?)""", RegexOptions.Compiled);
+        private static readonly Regex CrashRx = new Regex(
+            @"JRNABC|Jrn\.Abort|fatal|unhandled|crash|access violation",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         public Result Execute(UIApplication app)
         {
             return RunParser(app);
@@ -162,18 +198,18 @@ namespace StingTools.Docs
 
             report.TotalLines = lines.Length;
 
-            // Regex patterns for journal entries
-            var timestampRx = new Regex(@"'[HCE]\s+(\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}:\d{2}\.\d+)");
-            var addinLoadRx = new Regex(@"API_SUCCESS\s*\{\s*Starting External Application:\s*(.+?),\s*Class:\s*(.+?),.*?Assembly:\s*(.+?\.dll)", RegexOptions.IgnoreCase);
-            var addinBtnRx = new Regex(@"API_SUCCESS\s*\{\s*Added pushbutton.*?name:\s*(.+?),.*?class:\s*(.+?),.*?assembly:\s*(.+?\.dll)", RegexOptions.IgnoreCase);
-            var addinManifestRx = new Regex(@"\[Jrn\.AddInManifest\].*?AddInName:\s*(.+?)\s+.*?AddInVersion:\s*(\S+).*?AddInLoadFailureMessage:\s*(\S+)", RegexOptions.IgnoreCase);
-            var errorRx = new Regex(@"API_ERROR|FATAL|Exception|StackOverflow|AccessViolation|NullReference|OutOfMemory|assembly.*version.*conflict", RegexOptions.IgnoreCase);
-            var ribbonEventRx = new Regex(@"Jrn\.RibbonEvent\s+""Execute external command:(.+?)""");
-            var memoryRx = new Regex(@"RAM.*?Avail\s+(\d+).*?Used\s+(\d+).*?Peak\s+(\d+)");
-            var taskDialogRx = new Regex(@"TaskDialog\s+""(.+?)""");
-            var versionRx = new Regex(@"Build:\s*(\S+).*?Branch:\s*(\S+)");
-            var userRx = new Regex(@"""Username""\s*,\s*""(.+?)""");
-            var crashRx = new Regex(@"JRNABC|Jrn\.Abort|fatal|unhandled|crash|access violation", RegexOptions.IgnoreCase);
+            // Regex patterns hoisted to static readonly — see class-level fields.
+            var timestampRx = TimestampRx;
+            var addinLoadRx = AddinLoadRx;
+            var addinBtnRx = AddinBtnRx;
+            var addinManifestRx = AddinManifestRx;
+            var errorRx = ErrorRx;
+            var ribbonEventRx = RibbonEventRx;
+            var memoryRx = MemoryRx;
+            var taskDialogRx = TaskDialogRx;
+            var versionRx = VersionRx;
+            var userRx = UserRx;
+            var crashRx = CrashRx;
 
             DateTime? firstTimestamp = null;
             DateTime? lastTimestamp = null;

--- a/StingTools/Docs/SheetManagerCommands.cs
+++ b/StingTools/Docs/SheetManagerCommands.cs
@@ -420,9 +420,9 @@ namespace StingTools.Docs
                 {
                     try
                     {
-                        // Resolve title block
-                        FamilySymbol tbSym = tbLookup.ContainsKey(row.TitleBlock)
-                            ? tbLookup[row.TitleBlock]
+                        // Resolve title block (single-lookup path).
+                        FamilySymbol tbSym = tbLookup.TryGetValue(row.TitleBlock, out var resolvedTb)
+                            ? resolvedTb
                             : tbTypes.First();
 
                         // Activate if needed

--- a/StingTools/ExLink/AutomationEngine.cs
+++ b/StingTools/ExLink/AutomationEngine.cs
@@ -402,10 +402,7 @@ namespace StingTools.ExLink
         // ── Helpers ─────────────────────────────────────────────────────────
 
         internal static string SanitizeFileName(string name)
-        {
-            var invalid = Path.GetInvalidFileNameChars();
-            return new string(name.Select(c => invalid.Contains(c) ? '_' : c).ToArray());
-        }
+            => StingTools.Core.OutputLocationHelper.MakeSafeFileName(name);
 
         private static bool IsViewOnSheet(Document doc, View v)
         {

--- a/StingTools/Model/StructuralCADPipeline.cs
+++ b/StingTools/Model/StructuralCADPipeline.cs
@@ -1498,19 +1498,29 @@ namespace StingTools.Model
                 bool createColTypesC = cfgC == null || cfgC.CreateNewTypes_Column;
                 double fallbackCircleW = cfgC?.ColumnWidthMm ?? 300;
 
+                // PERF-R3: activate each unique FamilySymbol ONCE at the start of
+                // the batch, then Regenerate once. The previous per-element
+                // Activate+Regenerate was forcing the document to regenerate
+                // after every column created — O(N) full regens for N columns.
+                var pendingSymbols = new HashSet<ElementId>();
+                var circlePlans = new List<(DetectedCircle circle, FamilySymbol symbol)>(circles.Count);
                 foreach (var circle in circles)
+                {
+                    double dMm = detectColC ? circle.DiameterMm : fallbackCircleW;
+                    var typeMatch = _typeFactory.FindOrCreateColumnType(
+                        dMm, dMm, allowDuplicate: createColTypesC);
+                    if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
+                    var symbol = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
+                    if (symbol == null) continue;
+                    if (!symbol.IsActive) { symbol.Activate(); pendingSymbols.Add(symbol.Id); }
+                    circlePlans.Add((circle, symbol));
+                }
+                if (pendingSymbols.Count > 0) _doc.Regenerate();
+
+                foreach (var (circle, symbol) in circlePlans)
                 {
                     try
                     {
-                        double dMm = detectColC ? circle.DiameterMm : fallbackCircleW;
-                        var typeMatch = _typeFactory.FindOrCreateColumnType(
-                            dMm, dMm, allowDuplicate: createColTypesC);
-                        if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
-
-                        var symbol = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
-                        if (symbol == null) continue;
-                        if (!symbol.IsActive) { symbol.Activate(); _doc.Regenerate(); }
-
                         var pt = new XYZ(circle.Center.X, circle.Center.Y,
                             level?.Elevation ?? 0);
                         var col = _doc.Create.NewFamilyInstance(
@@ -1550,20 +1560,27 @@ namespace StingTools.Model
                 double fallbackCRW = cfgCR?.ColumnWidthMm ?? 300;
                 double fallbackCRD = cfgCR?.ColumnDepthMm ?? 300;
 
+                // PERF-R3: batch-activate symbols + single Regenerate.
+                var pendingRectSymbols = new HashSet<ElementId>();
+                var rectPlans = new List<(DetectedRectangle rect, FamilySymbol symbol)>(rects.Count);
                 foreach (var rect in rects)
+                {
+                    double widthMm = detectColCR ? rect.WidthMm : fallbackCRW;
+                    double depthMm = detectColCR ? rect.DepthMm : fallbackCRD;
+                    var typeMatchR = _typeFactory.FindOrCreateColumnType(
+                        widthMm, depthMm, allowDuplicate: createColTypesCR);
+                    if (!typeMatchR.Success) { result.Warnings.Add(typeMatchR.Message); continue; }
+                    var symR = _doc.GetElement(typeMatchR.TypeId) as FamilySymbol;
+                    if (symR == null) continue;
+                    if (!symR.IsActive) { symR.Activate(); pendingRectSymbols.Add(symR.Id); }
+                    rectPlans.Add((rect, symR));
+                }
+                if (pendingRectSymbols.Count > 0) _doc.Regenerate();
+
+                foreach (var (rect, symbol) in rectPlans)
                 {
                     try
                     {
-                        double widthMm = detectColCR ? rect.WidthMm : fallbackCRW;
-                        double depthMm = detectColCR ? rect.DepthMm : fallbackCRD;
-                        var typeMatch = _typeFactory.FindOrCreateColumnType(
-                            widthMm, depthMm, allowDuplicate: createColTypesCR);
-                        if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
-
-                        var symbol = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
-                        if (symbol == null) continue;
-                        if (!symbol.IsActive) { symbol.Activate(); _doc.Regenerate(); }
-
                         var pt = new XYZ(rect.Center.X, rect.Center.Y,
                             level?.Elevation ?? 0);
                         var col = _doc.Create.NewFamilyInstance(
@@ -1616,31 +1633,39 @@ namespace StingTools.Model
                 bool createBeamTypes = cfgB == null || cfgB.CreateNewTypes_Beam;
                 double fallbackBeamW = cfgB?.BeamWidthMm ?? defaultDepthMm * 0.5;
 
+                // PERF-R3: two-pass — resolve every distinct beam type in pass 1
+                // (Activate but defer Regenerate), single Regenerate, then
+                // create every beam in pass 2. Cuts N regens down to 1.
+                var beamPlans = new List<(DetectedBeam bl, FamilySymbol symbol)>(beamLines.Count);
+                bool anyActivated = false;
                 foreach (var bl in beamLines)
+                {
+                    double widthMm = detectBeamSize && bl.WidthDetected
+                        ? bl.WidthMm
+                        : fallbackBeamW;
+                    string typeKey = $"{defaultDepthMm:F0}x{widthMm:F0}";
+                    if (!typeCache.TryGetValue(typeKey, out var symbol))
+                    {
+                        var typeMatch = _typeFactory.FindOrCreateBeamType(
+                            defaultDepthMm, widthMm,
+                            allowDuplicate: createBeamTypes);
+                        if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
+                        symbol = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
+                        if (symbol == null) continue;
+                        if (!symbol.IsActive) { symbol.Activate(); anyActivated = true; }
+                        typeCache[typeKey] = symbol;
+                    }
+                    beamPlans.Add((bl, symbol));
+                }
+                if (anyActivated) _doc.Regenerate();
+
+                foreach (var (bl, symbol) in beamPlans)
                 {
                     try
                     {
                         var start = new XYZ(bl.Start.X, bl.Start.Y, z);
                         var end = new XYZ(bl.End.X, bl.End.Y, z);
                         if (start.DistanceTo(end) < 0.01) continue;
-
-                        double widthMm = detectBeamSize && bl.WidthDetected
-                            ? bl.WidthMm
-                            : fallbackBeamW;
-                        string typeKey = $"{defaultDepthMm:F0}x{widthMm:F0}";
-
-                        if (!typeCache.TryGetValue(typeKey, out var symbol))
-                        {
-                            var typeMatch = _typeFactory.FindOrCreateBeamType(
-                                defaultDepthMm, widthMm,
-                                allowDuplicate: createBeamTypes);
-                            if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
-                            symbol = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
-                            if (symbol == null) continue;
-                            if (!symbol.IsActive) { symbol.Activate(); _doc.Regenerate(); }
-                            typeCache[typeKey] = symbol;
-                        }
-
                         var line = Line.CreateBound(start, end);
                         var beam = _doc.Create.NewFamilyInstance(
                             line, symbol, level, StructuralType.Beam);
@@ -2198,18 +2223,26 @@ namespace StingTools.Model
                 tx.SetFailureHandlingOptions(opts);
                 tx.Start();
 
-                foreach (var circle in circles ?? new List<DetectedCircle>())
+                // PERF-R3: batch-activate symbols, single Regenerate before creating.
+                var soffitCircles = circles ?? new List<DetectedCircle>();
+                var soffitPlans = new List<(DetectedCircle c, FamilySymbol symbol)>(soffitCircles.Count);
+                bool soffitActivated = false;
+                foreach (var circle in soffitCircles)
+                {
+                    var tm = _typeFactory.FindOrCreateColumnType(
+                        circle.DiameterMm, circle.DiameterMm);
+                    if (!tm.Success) { result.Warnings.Add(tm.Message); continue; }
+                    var symbol = _doc.GetElement(tm.TypeId) as FamilySymbol;
+                    if (symbol == null) continue;
+                    if (!symbol.IsActive) { symbol.Activate(); soffitActivated = true; }
+                    soffitPlans.Add((circle, symbol));
+                }
+                if (soffitActivated) _doc.Regenerate();
+
+                foreach (var (circle, symbol) in soffitPlans)
                 {
                     try
                     {
-                        var typeMatch = _typeFactory.FindOrCreateColumnType(
-                            circle.DiameterMm, circle.DiameterMm);
-                        if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
-
-                        var symbol = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
-                        if (symbol == null) continue;
-                        if (!symbol.IsActive) { symbol.Activate(); _doc.Regenerate(); }
-
                         var pt = new XYZ(circle.Center.X, circle.Center.Y,
                             baseLevel?.Elevation ?? 0);
                         var col = _doc.Create.NewFamilyInstance(
@@ -2265,21 +2298,28 @@ namespace StingTools.Model
                 double fallbackW = cfg?.ColumnWidthMm ?? 300;
                 double fallbackD = cfg?.ColumnDepthMm ?? 300;
 
+                // PERF-R3: resolve + activate-once + Regenerate-once, then create.
+                var rectSoffitPlans = new List<(DetectedRectangle rect, FamilySymbol symbol)>(rects.Count);
+                bool rectSoffitActivated = false;
                 foreach (var rect in rects)
+                {
+                    double widthMm = detectCol ? rect.WidthMm : fallbackW;
+                    double depthMm = detectCol ? rect.DepthMm : fallbackD;
+                    var typeMatch = _typeFactory.FindOrCreateColumnType(
+                        widthMm, depthMm,
+                        allowDuplicate: createColTypes);
+                    if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
+                    var symR = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
+                    if (symR == null) continue;
+                    if (!symR.IsActive) { symR.Activate(); rectSoffitActivated = true; }
+                    rectSoffitPlans.Add((rect, symR));
+                }
+                if (rectSoffitActivated) _doc.Regenerate();
+
+                foreach (var (rect, symbol) in rectSoffitPlans)
                 {
                     try
                     {
-                        double widthMm = detectCol ? rect.WidthMm : fallbackW;
-                        double depthMm = detectCol ? rect.DepthMm : fallbackD;
-                        var typeMatch = _typeFactory.FindOrCreateColumnType(
-                            widthMm, depthMm,
-                            allowDuplicate: createColTypes);
-                        if (!typeMatch.Success) { result.Warnings.Add(typeMatch.Message); continue; }
-
-                        var symbol = _doc.GetElement(typeMatch.TypeId) as FamilySymbol;
-                        if (symbol == null) continue;
-                        if (!symbol.IsActive) { symbol.Activate(); _doc.Regenerate(); }
-
                         var pt = new XYZ(rect.Center.X, rect.Center.Y,
                             baseLevel?.Elevation ?? 0);
                         var col = _doc.Create.NewFamilyInstance(

--- a/StingTools/Organise/TagOperationCommands.cs
+++ b/StingTools/Organise/TagOperationCommands.cs
@@ -942,10 +942,9 @@ namespace StingTools.Organise
             if (view == null) { TaskDialog.Show("STING", "No active view."); return Result.Failed; }
             var known = new HashSet<string>(TagConfig.DiscMap.Keys);
 
-            // Red = missing, Orange = incomplete, Yellow = ISO violation, Purple = placeholder
-            FillPatternElement solidFill = new FilteredElementCollector(doc)
-                .OfClass(typeof(FillPatternElement)).Cast<FillPatternElement>()
-                .FirstOrDefault(fp => fp.GetFillPattern().IsSolidFill);
+            // Red = missing, Orange = incomplete, Yellow = ISO violation, Purple = placeholder.
+            // Use the cached shared helper so we don't pay for a FEC per command.
+            FillPatternElement solidFill = ParameterHelpers.GetSolidFillPattern(doc);
 
             var red = new OverrideGraphicSettings();
             red.SetProjectionLineColor(new Color(255, 0, 0));
@@ -1453,18 +1452,11 @@ namespace StingTools.Organise
             ("Cyan", new Color(0, 180, 200)),
         };
 
-        /// <summary>Find the solid fill pattern (needed for surface overrides).</summary>
+        /// <summary>Find the solid fill pattern (needed for surface overrides).
+        /// Delegates to the cached ParameterHelpers helper so every caller shares
+        /// the same FillPatternElement instance across the session.</summary>
         public static FillPatternElement FindSolidFill(Document doc)
-        {
-            try
-            {
-                return new FilteredElementCollector(doc)
-                    .OfClass(typeof(FillPatternElement))
-                    .Cast<FillPatternElement>()
-                    .FirstOrDefault(fp => fp.GetFillPattern().IsSolidFill);
-            }
-            catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); return null; }
-        }
+            => ParameterHelpers.GetSolidFillPattern(doc);
 
         /// <summary>Build override settings for annotation coloring.</summary>
         public static OverrideGraphicSettings BuildAnnotationOverride(

--- a/StingTools/Organise/TagOperationCommands.cs
+++ b/StingTools/Organise/TagOperationCommands.cs
@@ -6141,6 +6141,11 @@ namespace StingTools.Organise
                     }
                     break;
                 case Model.NumberingEngine.SelectionScope.AllFromActiveView:
+                    if (doc.ActiveView == null)
+                    {
+                        TaskDialog.Show("Numbering", "No active graphical view — switch to a view first.");
+                        return Result.Cancelled;
+                    }
                     elementIds = new FilteredElementCollector(doc, doc.ActiveView.Id)
                         .OfCategory(config.Category)
                         .WhereElementIsNotElementType()

--- a/StingTools/Tags/LegendBuilderCommands.cs
+++ b/StingTools/Tags/LegendBuilderCommands.cs
@@ -119,15 +119,24 @@ namespace StingTools.Tags
                 {
                     try { newLegend.Name = name; } catch (Exception ex) { StingLog.Warn($"Set legend view name '{name}': {ex.Message}"); }
 
-                    // Delete all existing elements from the duplicated legend (batch)
+                    // Delete all existing elements from the duplicated legend (batch).
+                    // ToElementIds() already returns ICollection<ElementId>, which is
+                    // what doc.Delete() takes — we don't need to re-materialise a List.
                     var existingElements = new FilteredElementCollector(doc, newLegend.Id)
                         .WhereElementIsNotElementType()
-                        .ToElementIds()
-                        .ToList();
+                        .ToElementIds();
                     if (existingElements.Count > 0)
                     {
                         try { doc.Delete(existingElements); }
-                        catch (Exception ex) { StingLog.Warn($"Batch delete legend elements: {ex.Message}"); foreach (var eid in existingElements) { try { doc.Delete(eid); } catch (Exception ex2) { StingLog.Warn($"Delete element {eid}: {ex2.Message}"); } } }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"Batch delete legend elements: {ex.Message}");
+                            foreach (var eid in existingElements)
+                            {
+                                try { doc.Delete(eid); }
+                                catch (Exception ex2) { StingLog.Warn($"Delete element {eid}: {ex2.Message}"); }
+                            }
+                        }
                     }
                 }
                 return newLegend;

--- a/StingTools/Tags/LegendBuilderCommands.cs
+++ b/StingTools/Tags/LegendBuilderCommands.cs
@@ -795,11 +795,12 @@ namespace StingTools.Tags
                 }
             }
 
-            // Deduplicate by ElementId (same element may appear in multiple views)
-            var uniqueElements = sheetElements
-                .GroupBy(e => e.Id)
-                .Select(g => g.First())
-                .ToList();
+            // Deduplicate by ElementId (same element may appear in multiple views).
+            // HashSet dedup is O(n) vs GroupBy+First O(n log n) and avoids allocating a grouping.
+            var seen = new HashSet<ElementId>();
+            var uniqueElements = new List<Element>(sheetElements.Count);
+            foreach (var e in sheetElements)
+                if (seen.Add(e.Id)) uniqueElements.Add(e);
 
             if (uniqueElements.Count == 0) return new List<LegendEntry>();
 
@@ -1158,14 +1159,19 @@ namespace StingTools.Tags
                 }
             }
 
-            // Deduplicate
-            var uniqueElements = sheetElements.GroupBy(e => e.Id).Select(g => g.First()).ToList();
+            // Deduplicate — HashSet is O(n) vs GroupBy+First O(n log n).
+            var seenIds = new HashSet<ElementId>();
+            var uniqueElements = new List<Element>(sheetElements.Count);
+            foreach (var e in sheetElements)
+                if (seenIds.Add(e.Id)) uniqueElements.Add(e);
             if (uniqueElements.Count == 0) return new List<TagLegendEntry>();
 
-            // Group by category
+            // Group by category — materialize each group once so per-group Count()
+            // doesn't re-enumerate inside the entry-build loop below.
             var byCat = uniqueElements
                 .GroupBy(e => e.Category.Id)
-                .OrderByDescending(g => g.Count())
+                .Select(g => new { Key = g.Key, Items = g.ToList() })
+                .OrderByDescending(g => g.Items.Count)
                 .ToList();
 
             // Detect actual project LOC/ZONE

--- a/StingTools/Tags/QRCodeCommand.cs
+++ b/StingTools/Tags/QRCodeCommand.cs
@@ -46,13 +46,26 @@ namespace StingTools.Tags
             // Project code from doc title
             string projectCode = Path.GetFileNameWithoutExtension(doc.Title) ?? "PRJ";
 
-            // Collect selected elements (or active view elements if nothing selected)
+            // Collect selected elements (or active view elements if nothing selected).
+            // Guard against ActiveView being null (family editor, dockable panel with
+            // no graphical view selected) so we fail gracefully rather than NRE.
             var selIds = uiDoc.Selection.GetElementIds();
-            ICollection<ElementId> targets = selIds.Count > 0
-                ? selIds
-                : new FilteredElementCollector(doc, doc.ActiveView.Id)
+            ICollection<ElementId> targets;
+            if (selIds.Count > 0)
+            {
+                targets = selIds;
+            }
+            else if (doc.ActiveView != null)
+            {
+                targets = new FilteredElementCollector(doc, doc.ActiveView.Id)
                     .WhereElementIsNotElementType()
                     .ToElementIds();
+            }
+            else
+            {
+                TaskDialog.Show("QR Code", "Select elements or switch to a graphical view first.");
+                return Result.Cancelled;
+            }
 
             int generated = 0, skipped = 0;
             var errors = new List<string>();

--- a/StingTools/Temp/BOQTemplateLibrary.cs
+++ b/StingTools/Temp/BOQTemplateLibrary.cs
@@ -573,13 +573,8 @@ namespace StingTools.Temp
         }
 
         private static string MakeSafeFileName(string s)
-        {
-            if (string.IsNullOrEmpty(s)) return "item";
-            var chars = Path.GetInvalidFileNameChars().Concat(new[] { ' ', '/', '\\' }).ToArray();
-            var arr = s.Select(c => chars.Contains(c) ? '-' : c).ToArray();
-            string r = new string(arr).Trim('-');
-            return string.IsNullOrEmpty(r) ? "item" : r;
-        }
+            => StingTools.Core.OutputLocationHelper.MakeSafeFileName(
+                s, replacement: '-', extraInvalid: new[] { ' ', '/', '\\' });
 
         // ── Per-project resolvability audit (Gap 2) ─────────────────────
 

--- a/StingTools/Temp/RoomSpaceCommands.cs
+++ b/StingTools/Temp/RoomSpaceCommands.cs
@@ -715,7 +715,7 @@ namespace StingTools.Temp
             foreach (var room in rooms)
             {
                 long rid = room.Id.Value;
-                int doorCount = roomDoorCount.ContainsKey(rid) ? roomDoorCount[rid] : 0;
+                roomDoorCount.TryGetValue(rid, out int doorCount);
 
                 // Check for rooms without doors
                 if (doorCount == 0) noDoors.Add(room);

--- a/StingTools/UI/BEPDashboard.cs
+++ b/StingTools/UI/BEPDashboard.cs
@@ -424,7 +424,7 @@ namespace StingTools.UI
                 .Where(kv => kv.Value.IsChecked == true)
                 .Select(kv =>
                 {
-                    string company = _disciplineCompanies.ContainsKey(kv.Key) ? _disciplineCompanies[kv.Key].Text : "";
+                    string company = _disciplineCompanies.TryGetValue(kv.Key, out var cmp) ? cmp.Text : "";
                     return string.IsNullOrWhiteSpace(company) ? kv.Key : $"{kv.Key}:{company}";
                 });
             opts["DisciplineTeam"] = string.Join(",", activeDisciplines);

--- a/StingTools/V6/QRCommissioningCommands.cs
+++ b/StingTools/V6/QRCommissioningCommands.cs
@@ -100,7 +100,9 @@ namespace StingTools.V6
                 var audit = QRCommissioningWorkflow.ReadAudit(QRCommissioningWorkflow.AuditLogPath(doc));
 
                 string path = OutputLocationHelper.GetTimestampedPath(doc, "STING_Commissioning_Report", ".csv");
-                using (var w = new StreamWriter(path))
+                // UTF-8 with BOM so Excel on localised Windows reads non-ASCII tag tokens correctly.
+                using (var w = new StreamWriter(path, append: false,
+                    encoding: new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: true)))
                 {
                     w.WriteLine("Section,Key,State,Count");
                     foreach (var kv in byState.OrderBy(k => Array.IndexOf(QRCommissioningWorkflow.States, k.Key)))


### PR DESCRIPTION
## Summary
This PR consolidates multiple performance optimizations and reliability improvements across the codebase, focusing on reducing redundant I/O operations, eliminating per-element document regeneration, and adding atomic file writes to prevent data loss on crashes.

## Key Changes

### Performance: Batch Symbol Activation & Regeneration (PERF-R3)
- **StructuralCADPipeline.cs**: Refactored `CreateColumnsFromCircles`, `CreateColumnsFromRectangles`, and `CreateBeamsFromLines` to use a two-pass pattern:
  - Pass 1: Resolve all FamilySymbols and activate them once, then call `doc.Regenerate()` a single time
  - Pass 2: Create all elements using the pre-activated symbols
  - **Impact**: Reduces O(N) full document regenerations to O(1) for N elements, dramatically improving performance on large batches
- **IsoSymbolPlacer.cs**: Applied same pattern to symbol placement in fabrication assemblies

### Caching & I/O Reduction
- **ParameterDiffCommands.cs**: 
  - Added streaming JSON parser for snapshot summaries to avoid materializing multi-MB element arrays
  - Implemented `_snapCache` dictionary keyed by (path, mtime) to eliminate repeated deserialization
- **TagConfig.cs**: 
  - Added `_cfgCached` dictionary with mtime-based invalidation for `GetConfigValue()` calls
  - Invalidate cache when `SetConfigValue()` writes new config
- **BIMManagerCommands.cs**: Replaced intermediate `ToDictionary()` allocation with direct `JObject` construction for top-30 categories

### Reliability: Atomic File Writes
- **OutputLocationHelper.cs**: 
  - Added `WriteAllTextAtomic()` helper that writes to `.tmp`, then uses `File.Replace()` to swap atomically
  - Fallback to copy+delete for cross-volume scenarios
  - Prevents data loss if Revit crashes during file write window
- **TagConfig.cs**: Updated config write to use atomic pattern

### Code Quality & Safety
- **TransactionHelper.cs**: Added `AttachFailureHandler()` and `SuppressModalDialogs()` helpers to eliminate 20+ copy-pasted boilerplate patterns
- **JournalParserCommand.cs**: Hoisted regex patterns to static readonly fields with `RegexOptions.Compiled` for ~2-3x throughput improvement on per-line parsing
- **QRCodeCommand.cs**: Added null guard for `doc.ActiveView` to prevent NRE in family editor / dockable panels
- **StingAutoTagger.cs**: Cached `doc.IsWorkshared` and `doc.Application.Username` per event instead of resolving for every element
- **PlanscapeServerClient.cs**: Fixed `EnsureHttpClient()` to return the client instead of void, enabling proper concurrent access patterns
- **LegendBuilderCommands.cs**: Removed unnecessary `.ToList()` materialization; `ToElementIds()` already returns `ICollection<ElementId>`
- **ParameterHelpers.cs**: Added `MakeSafeFileName()` canonical helper to replace 3 inconsistent implementations across codebase
- **BIMManagerCommands.cs**: Replaced `ContainsKey()` + indexer with `TryGetValue()` to eliminate double-lookups in COBie export

### Fabrication Undo System
- **FabricationUndoManager.cs** (new): Session-scoped LIFO stack for `FabricationResult` instances
  - `Record()`: Push result after successful package generation
  - `Undo()`: Pop and delete sheets + assemblies in single transaction
  - Survives command invocations but not Revit restarts (matches built-in undo scope)
- **GenerateFabPackageCommand.cs**: Call `FabricationUndoManager.Record(res)` after engine returns
- **UndoFabPackageCommand** (new): External command bound to "Undo Package" button

### Logging Improvements
- **GapFixCommands.

https://claude.ai/code/session_016SHphQLef7NBsyycvSJMNV