### PR TITLE
Add scale-tier configuration and dual-wire tag family authoring

### DIFF
--- a/StingTools/Core/HandoverModeHelper.cs
+++ b/StingTools/Core/HandoverModeHelper.cs
@@ -23,19 +23,23 @@ namespace StingTools.Core
     {
         public const string DefaultMode = "Handover";
 
-        /// <summary>Handover (built-in universal CSV) + DC sibling. Others can be added.</summary>
-        public static readonly string[] BuiltInModes = { "Handover", "DesignConstruction" };
+        /// <summary>Handover (built-in universal CSV) + DC sibling. Custom is user-edited,
+        /// gated by <c>HANDOVER_MODE_CUSTOM_BOOL</c>; its label rows only live inside
+        /// dual-wired families if a Custom CSV variant ships on disk.</summary>
+        public static readonly string[] BuiltInModes = { "Handover", "DesignConstruction", "Custom" };
 
         /// <summary>
         /// Maps a built-in mode to the project-level YESNO selector BOOL that
-        /// gates its T4-T10 label rows inside dual-wired tag families. A mode
-        /// without an entry here is treated as "no gate" (single-mode fallback).
+        /// gates its T4-T10 label rows inside dual-wired tag families. Exactly
+        /// one is true at a time; a mode without an entry here is treated as
+        /// "no gate" (single-mode fallback).
         /// </summary>
         public static readonly IReadOnlyDictionary<string, string> ModeSelectorBool =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "Handover",           "HANDOVER_MODE_HANDOVER_BOOL" },
                 { "DesignConstruction", "HANDOVER_MODE_DC_BOOL" },
+                { "Custom",             "HANDOVER_MODE_CUSTOM_BOOL" },
             };
 
         private static readonly string[] Disciplines = { "ARCH", "GEN", "MEP", "STR" };

--- a/StingTools/Core/HandoverModeHelper.cs
+++ b/StingTools/Core/HandoverModeHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Autodesk.Revit.DB;
 using Newtonsoft.Json.Linq;
@@ -24,6 +25,18 @@ namespace StingTools.Core
 
         /// <summary>Handover (built-in universal CSV) + DC sibling. Others can be added.</summary>
         public static readonly string[] BuiltInModes = { "Handover", "DesignConstruction" };
+
+        /// <summary>
+        /// Maps a built-in mode to the project-level YESNO selector BOOL that
+        /// gates its T4-T10 label rows inside dual-wired tag families. A mode
+        /// without an entry here is treated as "no gate" (single-mode fallback).
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, string> ModeSelectorBool =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Handover",           "HANDOVER_MODE_HANDOVER_BOOL" },
+                { "DesignConstruction", "HANDOVER_MODE_DC_BOOL" },
+            };
 
         private static readonly string[] Disciplines = { "ARCH", "GEN", "MEP", "STR" };
 
@@ -117,6 +130,61 @@ namespace StingTools.Core
             for (int i = 0; i < Disciplines.Length; i++)
                 outNames[i] = GetTagConfigCsv(Disciplines[i], mode);
             return outNames;
+        }
+
+        /// <summary>
+        /// Enumerate CSV filenames for EVERY built-in mode whose variant actually
+        /// ships on disk. Unlike <see cref="GetAllTagConfigCsvs"/>, this does NOT
+        /// fall back to the Handover CSV when a variant is missing — it just
+        /// omits that mode. Used by the dual-wire authoring path so families get
+        /// stamped with both pattern row sets in one pass.
+        /// </summary>
+        /// <returns>Dictionary keyed by mode name (e.g. "Handover",
+        /// "DesignConstruction"), each value the 4-discipline CSV name array.</returns>
+        public static Dictionary<string, string[]> GetAllTagConfigCsvsForAllModes(Document doc)
+        {
+            var result = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            foreach (string mode in BuiltInModes)
+            {
+                var names = new List<string>(Disciplines.Length);
+                for (int i = 0; i < Disciplines.Length; i++)
+                {
+                    string csv = TryGetTagConfigCsvStrict(Disciplines[i], mode);
+                    if (!string.IsNullOrEmpty(csv)) names.Add(csv);
+                }
+                if (names.Count > 0) result[mode] = names.ToArray();
+            }
+            return result;
+        }
+
+        /// <summary>Resolves <paramref name="mode"/> to its selector BOOL name, or null if unmapped.</summary>
+        public static string GetSelectorBool(string mode)
+        {
+            if (string.IsNullOrEmpty(mode)) return null;
+            return ModeSelectorBool.TryGetValue(mode, out string b) ? b : null;
+        }
+
+        /// <summary>
+        /// Strict variant of <see cref="GetTagConfigCsv(string,string)"/>:
+        /// returns null if the variant CSV is missing instead of falling back
+        /// to the default Handover CSV. The Handover mode itself still resolves
+        /// to the non-suffixed base CSV.
+        /// </summary>
+        private static string TryGetTagConfigCsvStrict(string discipline, string mode)
+        {
+            string baseName = $"STING_TAG_CONFIG_v5_0_{discipline}";
+            if (string.Equals(mode, DefaultMode, StringComparison.OrdinalIgnoreCase))
+            {
+                string defaultCsv = baseName + ".csv";
+                string resolvedDefault = StingToolsApp.FindDataFile(defaultCsv);
+                return string.IsNullOrEmpty(resolvedDefault) || !File.Exists(resolvedDefault)
+                    ? null
+                    : defaultCsv;
+            }
+
+            string variantCsv = $"{baseName}_{mode}.csv";
+            string resolved = StingToolsApp.FindDataFile(variantCsv);
+            return string.IsNullOrEmpty(resolved) || !File.Exists(resolved) ? null : variantCsv;
         }
 
         private static string ProjectConfigPath(Document doc)

--- a/StingTools/Core/ParamRegistry.cs
+++ b/StingTools/Core/ParamRegistry.cs
@@ -545,6 +545,8 @@ namespace StingTools.Core
         public static string MODE_HANDOVER { get; private set; } = "HANDOVER_MODE_HANDOVER_BOOL";
         /// <summary>Pattern selector — Design & Construction T4-T10 payload is visible.</summary>
         public static string MODE_DC { get; private set; } = "HANDOVER_MODE_DC_BOOL";
+        /// <summary>Pattern selector — Custom (user-defined) T4-T10 payload is visible.</summary>
+        public static string MODE_CUSTOM { get; private set; } = "HANDOVER_MODE_CUSTOM_BOOL";
 
         // ── Warning threshold definitions (v5.5) ─────────────────────────
         // Loaded from warning_thresholds section of PARAMETER_REGISTRY.json.

--- a/StingTools/Core/ParamRegistry.cs
+++ b/StingTools/Core/ParamRegistry.cs
@@ -536,6 +536,16 @@ namespace StingTools.Core
         /// <summary>Warning severity filter: CRITICAL, HIGH, MEDIUM, ALL.</summary>
         public static string WARN_SEVERITY_FILTER { get; private set; } = "TAG_WARN_SEVERITY_FILTER_TXT";
 
+        // ── Paragraph pattern selectors (2026-04, dual-wire T4-T10) ──
+        // Families carry BOTH the Handover and Design & Construction row sets.
+        // Each row's formula AND-gates TAG_PARA_STATE_N_BOOL with one of these so
+        // flipping the pattern is a project-level BOOL toggle instead of a
+        // family re-author pass.
+        /// <summary>Pattern selector — Handover / FM T4-T10 payload is visible.</summary>
+        public static string MODE_HANDOVER { get; private set; } = "HANDOVER_MODE_HANDOVER_BOOL";
+        /// <summary>Pattern selector — Design & Construction T4-T10 payload is visible.</summary>
+        public static string MODE_DC { get; private set; } = "HANDOVER_MODE_DC_BOOL";
+
         // ── Warning threshold definitions (v5.5) ─────────────────────────
         // Loaded from warning_thresholds section of PARAMETER_REGISTRY.json.
         // Each entry defines a compliance check with threshold, unit, and severity.

--- a/StingTools/Core/ParameterHelpers.cs
+++ b/StingTools/Core/ParameterHelpers.cs
@@ -305,9 +305,17 @@ namespace StingTools.Core
             if (existing.Length > 0 && !overwrite)
                 return false;
 
+            // PERF: skip the Parameter.Set round-trip (and undo-journal
+            // entry) when the value is already correct. Meaningful on the
+            // overwrite=true path that BatchTag / ReTag / TagAndCombine use
+            // — thousands of no-op Set() calls otherwise.
+            string newValue = value ?? string.Empty;
+            if (string.Equals(existing, newValue, StringComparison.Ordinal))
+                return true;
+
             try
             {
-                p.Set(value ?? string.Empty);
+                p.Set(newValue);
                 return true;
             }
             catch (Exception ex)
@@ -637,12 +645,49 @@ namespace StingTools.Core
     /// </summary>
     public static class SpatialAutoDetect
     {
+        // PERF: cache the per-document room index so five back-to-back
+        // tagging commands don't each do a fresh Rooms collector scan.
+        // Invalidated by StingAutoTagger when a Room is added / modified /
+        // deleted (see StingAutoTagger.Execute), and by TTL as a fallback
+        // for edits that bypass the updater (journal replay, API scripts).
+        private static readonly TimeSpan _roomCacheTtl = TimeSpan.FromSeconds(30);
+        private static readonly object _roomCacheLock = new object();
+        private static string _roomCacheDocKey;
+        private static DateTime _roomCacheStamp;
+        private static Dictionary<ElementId, Room> _roomCacheIndex;
+
+        /// <summary>
+        /// Invalidate the cached room index — called by
+        /// <c>StingAutoTagger</c> when a Room changes so the next spatial
+        /// auto-detect call rebuilds fresh.
+        /// </summary>
+        public static void InvalidateRoomIndex()
+        {
+            lock (_roomCacheLock)
+            {
+                _roomCacheDocKey = null;
+                _roomCacheIndex = null;
+            }
+        }
+
         /// <summary>
         /// Pre-scan all rooms in the project and build a lookup by ElementId.
-        /// Call once before a batch loop for performance.
+        /// Cached per-document with a 30-second TTL; use
+        /// <see cref="InvalidateRoomIndex"/> to force a rebuild.
         /// </summary>
         public static Dictionary<ElementId, Room> BuildRoomIndex(Document doc)
         {
+            string key = doc?.PathName ?? doc?.Title ?? "";
+            lock (_roomCacheLock)
+            {
+                if (_roomCacheIndex != null
+                    && string.Equals(_roomCacheDocKey, key, StringComparison.Ordinal)
+                    && (DateTime.UtcNow - _roomCacheStamp) < _roomCacheTtl)
+                {
+                    return _roomCacheIndex;
+                }
+            }
+
             var index = new Dictionary<ElementId, Room>();
             try
             {
@@ -663,6 +708,13 @@ namespace StingTools.Core
             // will fall back to project-level defaults instead of room-based spatial detection
             if (index.Count == 0)
                 StingLog.Info("BuildRoomIndex: no placed rooms found — spatial detection (LOC/ZONE) will use project-level defaults");
+
+            lock (_roomCacheLock)
+            {
+                _roomCacheIndex = index;
+                _roomCacheDocKey = key;
+                _roomCacheStamp = DateTime.UtcNow;
+            }
             return index;
         }
 
@@ -3649,85 +3701,102 @@ namespace StingTools.Core
                 // Plugin hook: notify third-party plugins before tagging
                 StingPluginHooks.FireBeforeTag(doc, el);
 
-                // P4: Inherit token values from family type before populating
-                TokenAutoPopulator.TypeTokenInherit(doc, el);
+                // PERF: skip the token-derivation block (TypeTokenInherit +
+                // locked-token snapshot/restore + PopulateAll + overrides)
+                // when the element already has a complete tag and the caller
+                // isn't overwriting. PopulateAll's writes would all short-
+                // circuit via SetIfEmpty anyway, but its detection logic
+                // (room lookup, family-aware PROD resolution, phase detect)
+                // runs regardless. NativeParamMapper + FormulaEngine + the
+                // BuildAndWriteTag / container / audit tail still run below
+                // so side-effect params (cost, carbon, grid-ref) stay fresh.
+                bool skipDerivation = !overwrite
+                    && skipComplete
+                    && TagConfig.TagIsComplete(_prevTag);
 
-                // FIX-DEEP01: Snapshot locked token values AFTER TypeTokenInherit so inherited
-                // values are preserved, but BEFORE PopulateAll/overrides can change them
-                // Phase 74d: Only allocate locked snapshot when token lock is non-empty (rare)
                 Dictionary<string, string> lockedSnapshot = null;
-                try
+
+                if (!skipDerivation)
                 {
-                    string preLockStr = ParameterHelpers.GetString(el, "ASS_TOKEN_LOCK_TXT");
-                    if (!string.IsNullOrWhiteSpace(preLockStr))
+                    // P4: Inherit token values from family type before populating
+                    TokenAutoPopulator.TypeTokenInherit(doc, el);
+
+                    // FIX-DEEP01: Snapshot locked token values AFTER TypeTokenInherit so inherited
+                    // values are preserved, but BEFORE PopulateAll/overrides can change them
+                    // Phase 74d: Only allocate locked snapshot when token lock is non-empty (rare)
+                    try
                     {
-                        lockedSnapshot = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                        string[] lockKeys = preLockStr.Split(',')
-                            .Select(s => s.Trim().ToUpperInvariant()).ToArray();
-                        foreach (string lockKey in lockKeys)
+                        string preLockStr = ParameterHelpers.GetString(el, "ASS_TOKEN_LOCK_TXT");
+                        if (!string.IsNullOrWhiteSpace(preLockStr))
                         {
-                            if (TokenParamMap.TryGetValue(lockKey, out string paramName))
+                            lockedSnapshot = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                            string[] lockKeys = preLockStr.Split(',')
+                                .Select(s => s.Trim().ToUpperInvariant()).ToArray();
+                            foreach (string lockKey in lockKeys)
                             {
-                                string val = ParameterHelpers.GetString(el, paramName);
-                                if (!string.IsNullOrEmpty(val))
-                                    lockedSnapshot[lockKey] = val;
+                                if (TokenParamMap.TryGetValue(lockKey, out string paramName))
+                                {
+                                    string val = ParameterHelpers.GetString(el, paramName);
+                                    if (!string.IsNullOrEmpty(val))
+                                        lockedSnapshot[lockKey] = val;
+                                }
                             }
                         }
                     }
-                }
-                catch (Exception lockEx) { StingLog.Warn($"Token lock read: {lockEx.Message}"); }
+                    catch (Exception lockEx) { StingLog.Warn($"Token lock read: {lockEx.Message}"); }
 
-                // P2 / PopulateAll: Populate all 9 tokens (DISC/LOC/ZONE/LVL/SYS/FUNC/PROD/STATUS/REV)
-                TokenAutoPopulator.PopulateAll(doc, el, ctx, overwrite: overwrite);
+                    // P2 / PopulateAll: Populate all 9 tokens (DISC/LOC/ZONE/LVL/SYS/FUNC/PROD/STATUS/REV)
+                    TokenAutoPopulator.PopulateAll(doc, el, ctx, overwrite: overwrite);
 
-                // G1.1: Apply CATEGORY_FORCE_SYS override after PopulateAll
-                if (TagConfig.CategoryForceSys.TryGetValue(catName, out string forcedSys)
-                    && !string.IsNullOrEmpty(forcedSys))
-                    ParameterHelpers.SetString(el, ParamRegistry.SYS, forcedSys, overwrite: true);
+                    // G1.1: Apply CATEGORY_FORCE_SYS override after PopulateAll
+                    if (TagConfig.CategoryForceSys.TryGetValue(catName, out string forcedSys)
+                        && !string.IsNullOrEmpty(forcedSys))
+                        ParameterHelpers.SetString(el, ParamRegistry.SYS, forcedSys, overwrite: true);
 
-                // FE-06: Apply full per-category token overrides
-                if (TagConfig.CategoryTokenOverrides.TryGetValue(catName, out var tokenOverrides))
-                {
-                    // Check SKIP flag FIRST — avoid writing tokens to skipped categories
-                    if (tokenOverrides.TryGetValue("SKIP", out string skipVal)
-                        && skipVal.Equals("true", StringComparison.OrdinalIgnoreCase))
-                        return false;
-
-                    foreach (var kv in tokenOverrides)
+                    // FE-06: Apply full per-category token overrides
+                    if (TagConfig.CategoryTokenOverrides.TryGetValue(catName, out var tokenOverrides))
                     {
-                        if (kv.Key.Equals("SKIP", StringComparison.OrdinalIgnoreCase)) continue;
-                        string paramName = kv.Key.ToUpperInvariant() switch
-                        {
-                            "DISC" => ParamRegistry.DISC, "LOC" => ParamRegistry.LOC,
-                            "ZONE" => ParamRegistry.ZONE, "LVL" => ParamRegistry.LVL,
-                            "SYS" => ParamRegistry.SYS, "FUNC" => ParamRegistry.FUNC,
-                            "PROD" => ParamRegistry.PROD, "STATUS" => ParamRegistry.STATUS,
-                            _ => null
-                        };
-                        if (!string.IsNullOrEmpty(paramName))
-                            ParameterHelpers.SetString(el, paramName, kv.Value, overwrite: true);
-                    }
-                }
+                        // Check SKIP flag FIRST — avoid writing tokens to skipped categories
+                        if (tokenOverrides.TryGetValue("SKIP", out string skipVal)
+                            && skipVal.Equals("true", StringComparison.OrdinalIgnoreCase))
+                            return false;
 
-                // FIX-DEEP01: Restore locked token values (overrides above may have changed them)
-                // Phase 74d: Use static TokenParamMap + null check (lockedSnapshot only allocated when lock exists)
-                if (lockedSnapshot != null && lockedSnapshot.Count > 0)
-                {
-                    foreach (var kvp in lockedSnapshot)
-                    {
-                        if (TokenParamMap.TryGetValue(kvp.Key, out string paramName))
+                        foreach (var kv in tokenOverrides)
                         {
-                            try { ParameterHelpers.SetString(el, paramName, kvp.Value, overwrite: true); }
-                            catch (Exception lockEx)
+                            if (kv.Key.Equals("SKIP", StringComparison.OrdinalIgnoreCase)) continue;
+                            string paramName = kv.Key.ToUpperInvariant() switch
                             {
-                                StingLog.Warn($"TagPipeline: failed to restore locked token {kvp.Key} on {el.Id}: {lockEx.Message}");
-                            }
+                                "DISC" => ParamRegistry.DISC, "LOC" => ParamRegistry.LOC,
+                                "ZONE" => ParamRegistry.ZONE, "LVL" => ParamRegistry.LVL,
+                                "SYS" => ParamRegistry.SYS, "FUNC" => ParamRegistry.FUNC,
+                                "PROD" => ParamRegistry.PROD, "STATUS" => ParamRegistry.STATUS,
+                                _ => null
+                            };
+                            if (!string.IsNullOrEmpty(paramName))
+                                ParameterHelpers.SetString(el, paramName, kv.Value, overwrite: true);
                         }
                     }
-                    // Finding-5 FIX: Throttle locked token log — only log first 5 + every 100th
-                    _lockedTokenRestoreCount++;
-                    if (_lockedTokenRestoreCount <= 5 || _lockedTokenRestoreCount % 100 == 0)
-                        StingLog.Info($"TagPipeline: restored {lockedSnapshot.Count} locked tokens on {el.Id}: {string.Join(",", lockedSnapshot.Keys)} (#{_lockedTokenRestoreCount})");
+
+                    // FIX-DEEP01: Restore locked token values (overrides above may have changed them)
+                    // Phase 74d: Use static TokenParamMap + null check (lockedSnapshot only allocated when lock exists)
+                    if (lockedSnapshot != null && lockedSnapshot.Count > 0)
+                    {
+                        foreach (var kvp in lockedSnapshot)
+                        {
+                            if (TokenParamMap.TryGetValue(kvp.Key, out string paramName))
+                            {
+                                try { ParameterHelpers.SetString(el, paramName, kvp.Value, overwrite: true); }
+                                catch (Exception lockEx)
+                                {
+                                    StingLog.Warn($"TagPipeline: failed to restore locked token {kvp.Key} on {el.Id}: {lockEx.Message}");
+                                }
+                            }
+                        }
+                        // Finding-5 FIX: Throttle locked token log — only log first 5 + every 100th
+                        _lockedTokenRestoreCount++;
+                        if (_lockedTokenRestoreCount <= 5 || _lockedTokenRestoreCount % 100 == 0)
+                            StingLog.Info($"TagPipeline: restored {lockedSnapshot.Count} locked tokens on {el.Id}: {string.Join(",", lockedSnapshot.Keys)} (#{_lockedTokenRestoreCount})");
+                    }
                 }
 
                 // P2: Bridge Revit native params → STING shared params

--- a/StingTools/Core/ScaleTiers.cs
+++ b/StingTools/Core/ScaleTiers.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json.Linq;
+
+namespace StingTools.Core
+{
+    /// <summary>
+    /// Scale-to-offset and scale-to-text-size mapping used by
+    /// <c>SmartTagPlacementCommand.GetModelOffset</c> and
+    /// <c>SetScaleAwareTagSizeCommand</c>.
+    ///
+    /// Resolution order (first win): project_config.json key "SCALE_TIERS" →
+    /// Data/SCALE_TIERS.json → hardcoded fallback (2/5/8/12/20 mm, 30 ft cap,
+    /// 3.5/3/2.5/2/2 mm text). The loader caches after the first read; call
+    /// <see cref="Reload"/> to pick up slider-driven project overrides.
+    /// </summary>
+    public static class ScaleTiers
+    {
+        public sealed class Tier
+        {
+            public int MaxDenominator { get; set; }
+            public string Label { get; set; } = "";
+            public double OffsetMm { get; set; }
+            public string TextSizeMm { get; set; } = "2.5";
+        }
+
+        private static readonly object _lock = new object();
+        private static List<Tier> _cached;
+        private static double _cachedCapFt = 30.0;
+        private static string _cachedSource = "";
+
+        /// <summary>Ordered tiers (ascending by <see cref="Tier.MaxDenominator"/>).</summary>
+        public static IReadOnlyList<Tier> Current
+        {
+            get { EnsureLoaded(null); return _cached; }
+        }
+
+        /// <summary>Max model-space offset in feet; clamp applied by <c>GetModelOffset</c>.</summary>
+        public static double OffsetCapFt
+        {
+            get { EnsureLoaded(null); return _cachedCapFt; }
+        }
+
+        /// <summary>Where the active tier table came from (diagnostic string).</summary>
+        public static string Source
+        {
+            get { EnsureLoaded(null); return _cachedSource; }
+        }
+
+        /// <summary>
+        /// Pick the tier whose <see cref="Tier.MaxDenominator"/> first meets or
+        /// exceeds <paramref name="view"/>.Scale. Falls back to the last tier
+        /// when the view scale is larger than every defined max.
+        /// </summary>
+        public static Tier ForView(View view)
+        {
+            EnsureLoaded(view?.Document);
+            int scale = (view != null && view.Scale > 0) ? view.Scale : 100;
+            foreach (Tier t in _cached)
+                if (scale <= t.MaxDenominator) return t;
+            return _cached[_cached.Count - 1];
+        }
+
+        /// <summary>Force a re-read on the next access — call after slider persistence.</summary>
+        public static void Reload(Document doc = null)
+        {
+            lock (_lock) { _cached = null; }
+            EnsureLoaded(doc);
+        }
+
+        /// <summary>
+        /// Persist a fresh set of tiers into the project's project_config.json
+        /// under the "SCALE_TIERS" key. Subsequent <see cref="ForView"/> calls
+        /// on this document read the override. Returns the file path written,
+        /// or null if the document is unsaved.
+        /// </summary>
+        public static string SaveProjectOverride(Document doc,
+            IList<Tier> tiers, double offsetCapFt)
+        {
+            if (doc == null || tiers == null || tiers.Count == 0) return null;
+            string cfgPath = ProjectConfigPath(doc);
+            if (string.IsNullOrEmpty(cfgPath)) return null;
+
+            JObject jo = File.Exists(cfgPath)
+                ? JObject.Parse(File.ReadAllText(cfgPath))
+                : new JObject();
+
+            var block = new JObject
+            {
+                ["offset_cap_ft"] = offsetCapFt,
+                ["tiers"] = new JArray(tiers.Select(t => new JObject
+                {
+                    ["max_denominator"] = t.MaxDenominator,
+                    ["label"]           = t.Label ?? "",
+                    ["offset_mm"]       = t.OffsetMm,
+                    ["text_size_mm"]    = t.TextSizeMm ?? "2.5",
+                })),
+            };
+            jo["SCALE_TIERS"] = block;
+            File.WriteAllText(cfgPath, jo.ToString(Newtonsoft.Json.Formatting.Indented));
+
+            Reload(doc);
+            return cfgPath;
+        }
+
+        private static void EnsureLoaded(Document doc)
+        {
+            lock (_lock)
+            {
+                if (_cached != null) return;
+
+                if (TryLoadFromProjectConfig(doc, out var tiers, out double cap))
+                {
+                    _cached = tiers; _cachedCapFt = cap; _cachedSource = "project_config.json";
+                    return;
+                }
+                if (TryLoadFromDataFile(out tiers, out cap))
+                {
+                    _cached = tiers; _cachedCapFt = cap; _cachedSource = "SCALE_TIERS.json";
+                    return;
+                }
+                _cached = HardcodedFallback();
+                _cachedCapFt = 30.0;
+                _cachedSource = "hardcoded";
+            }
+        }
+
+        private static bool TryLoadFromProjectConfig(Document doc,
+            out List<Tier> tiers, out double cap)
+        {
+            tiers = null; cap = 30.0;
+            string path = ProjectConfigPath(doc);
+            if (string.IsNullOrEmpty(path) || !File.Exists(path)) return false;
+            try
+            {
+                var jo = JObject.Parse(File.ReadAllText(path));
+                var block = jo["SCALE_TIERS"] as JObject;
+                if (block == null) return false;
+                tiers = ParseTiers(block["tiers"] as JArray);
+                if (tiers == null || tiers.Count == 0) { tiers = null; return false; }
+                cap = (double?)block["offset_cap_ft"] ?? 30.0;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ScaleTiers: project_config read failed — {ex.Message}");
+                return false;
+            }
+        }
+
+        private static bool TryLoadFromDataFile(out List<Tier> tiers, out double cap)
+        {
+            tiers = null; cap = 30.0;
+            string path = StingToolsApp.FindDataFile("SCALE_TIERS.json");
+            if (string.IsNullOrEmpty(path) || !File.Exists(path)) return false;
+            try
+            {
+                var jo = JObject.Parse(File.ReadAllText(path));
+                tiers = ParseTiers(jo["tiers"] as JArray);
+                if (tiers == null || tiers.Count == 0) { tiers = null; return false; }
+                cap = (double?)jo["offset_cap_ft"] ?? 30.0;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ScaleTiers: SCALE_TIERS.json read failed — {ex.Message}");
+                return false;
+            }
+        }
+
+        private static List<Tier> ParseTiers(JArray arr)
+        {
+            if (arr == null) return null;
+            var list = new List<Tier>();
+            foreach (var t in arr)
+            {
+                int max = (int?)t["max_denominator"] ?? 0;
+                double off = (double?)t["offset_mm"] ?? 0;
+                if (max <= 0 || off <= 0) continue;
+                list.Add(new Tier
+                {
+                    MaxDenominator = max,
+                    Label       = (string)t["label"] ?? "",
+                    OffsetMm    = off,
+                    TextSizeMm  = (string)t["text_size_mm"] ?? "2.5",
+                });
+            }
+            list.Sort((a, b) => a.MaxDenominator.CompareTo(b.MaxDenominator));
+            return list;
+        }
+
+        private static List<Tier> HardcodedFallback() => new List<Tier>
+        {
+            new Tier { MaxDenominator = 50,         Label = "1:1–1:50",    OffsetMm = 2.0,  TextSizeMm = "3.5" },
+            new Tier { MaxDenominator = 100,        Label = "1:50–1:100",  OffsetMm = 5.0,  TextSizeMm = "3"   },
+            new Tier { MaxDenominator = 200,        Label = "1:100–1:200", OffsetMm = 8.0,  TextSizeMm = "2.5" },
+            new Tier { MaxDenominator = 500,        Label = "1:200–1:500", OffsetMm = 12.0, TextSizeMm = "2"   },
+            new Tier { MaxDenominator = int.MaxValue, Label = "1:500+",    OffsetMm = 20.0, TextSizeMm = "2"   },
+        };
+
+        private static string ProjectConfigPath(Document doc)
+        {
+            try
+            {
+                string dir = Path.GetDirectoryName(doc?.PathName ?? "") ?? "";
+                return string.IsNullOrEmpty(dir) ? null : Path.Combine(dir, "project_config.json");
+            }
+            catch { return null; }
+        }
+    }
+}

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -680,7 +680,8 @@ namespace StingTools.Core
         {
             try
             {
-                Document currentDoc = e.CurrentActiveView?.Document;
+                Autodesk.Revit.DB.View view = e.CurrentActiveView;
+                Document currentDoc = view?.Document;
                 if (currentDoc != null && currentDoc != _lastActiveDoc)
                 {
                     _lastActiveDoc = currentDoc;
@@ -691,10 +692,78 @@ namespace StingTools.Core
                     ParameterHelpers.ClearParamCache();
                     StingLog.Info("ViewActivated: document switch detected — caches invalidated");
                 }
+
+                if (view != null) UpdateScaleTabInfo(view);
+                if (view != null && currentDoc != null) MaybeAutoApplyScaleSize(currentDoc, view);
             }
             catch (Exception ex)
             {
                 StingLog.Warn($"ViewActivated handler: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Push the active view's scale, resolved tier, and offset to the
+        /// three Scale-tab info labels. Safe to call from any thread — marshals
+        /// onto the Dispatcher and tolerates a closed / detached panel.
+        /// </summary>
+        private static void UpdateScaleTabInfo(Autodesk.Revit.DB.View view)
+        {
+            try
+            {
+                var panel = UI.StingDockPanel.LastInstance;
+                if (panel == null || !panel.IsLoaded) return;
+                ScaleTiers.Tier tier = ScaleTiers.ForView(view);
+                int scale = view.Scale > 0 ? view.Scale : 100;
+                double offsetFt = (tier.OffsetMm / 304.8) * scale;
+                double cappedFt = System.Math.Min(offsetFt, ScaleTiers.OffsetCapFt);
+
+                string scaleTxt  = $"Scale: 1:{scale}";
+                string tierTxt   = $"Tier: {tier.Label}  (size {tier.TextSizeMm}mm)";
+                string offsetTxt = $"Offset: {tier.OffsetMm:F1} mm ({cappedFt:F2} ft)";
+
+                panel.Dispatcher.BeginInvoke(new System.Action(() =>
+                {
+                    try { panel.UpdateScaleInfoLabels(scaleTxt, tierTxt, offsetTxt); }
+                    catch (Exception ex) { StingLog.Warn($"UpdateScaleTabInfo dispatch: {ex.Message}"); }
+                }));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"UpdateScaleTabInfo: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// When <c>TAG_SCALE_TIER_AUTO_BOOL</c> is set on Project Information,
+        /// auto-apply <see cref="Tags.SetScaleAwareTagSizeCommand"/> to the
+        /// activated view. Defaults to Instance mode so the switch is
+        /// side-effect free across views. Suppresses the task dialog.
+        /// </summary>
+        private static void MaybeAutoApplyScaleSize(Document doc, Autodesk.Revit.DB.View view)
+        {
+            try
+            {
+                Element projInfo = doc.ProjectInformation;
+                if (projInfo == null) return;
+                Parameter flag = projInfo.LookupParameter(ParamRegistry.TAG_SCALE_TIER_AUTO);
+                if (flag == null || flag.StorageType != StorageType.Integer) return;
+                if (flag.AsInteger() == 0) return;
+
+                ScaleTiers.Tier tier = ScaleTiers.ForView(view);
+                if (!ParamRegistry.TagStyleSizes.Contains(tier.TextSizeMm)) return;
+
+                var result = Tags.SetScaleAwareTagSizeCommand.ApplyToView(
+                    doc, view, tier.TextSizeMm, "Auto");
+                int total = result.InstanceSwitches + result.TypeMatrixFlips;
+                if (total > 0)
+                    StingLog.Info($"AutoScaleTagSize on view activation: view='{view.Name}' " +
+                                  $"changed={total} (instances={result.InstanceSwitches}, " +
+                                  $"typeFlips={result.TypeMatrixFlips})");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"MaybeAutoApplyScaleSize: {ex.Message}");
             }
         }
 

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -2681,11 +2681,15 @@ namespace StingTools.Core
                                    : "";
             string seq = BuildSeqString(sequenceCounters[seqKey], CurrentSeqScheme, seqSchemeContext);
 
-            string tag = string.Join(Separator, disc, loc, zone, lvl, sys, func, prod, seq);
+            // PERF: hoist the tag body ("[prefix-]disc-loc-zone-lvl-sys-func-prod-")
+            // and the suffix tail ("[-suffix]") outside the collision loop so only
+            // the SEQ segment needs to re-concatenate per collision iteration.
+            string tagBody = string.Join(Separator, disc, loc, zone, lvl, sys, func, prod);
+            if (!string.IsNullOrEmpty(TagPrefix)) tagBody = TagPrefix + Separator + tagBody;
+            tagBody += Separator;
+            string tagSuffix = string.IsNullOrEmpty(TagSuffix) ? string.Empty : Separator + TagSuffix;
 
-            // TW-03: Apply optional tag prefix and suffix
-            if (!string.IsNullOrEmpty(TagPrefix)) tag = TagPrefix + Separator + tag;
-            if (!string.IsNullOrEmpty(TagSuffix)) tag = tag + Separator + TagSuffix;
+            string tag = tagBody + seq + tagSuffix;
 
             // Collision detection: if this exact tag already exists, increment SEQ
             if (existingTags != null)
@@ -2706,10 +2710,7 @@ namespace StingTools.Core
                         return false; // Skip element to prevent duplicate tags
                     }
                     seq = BuildSeqString(sequenceCounters[seqKey], CurrentSeqScheme, seqSchemeContext);
-                    tag = string.Join(Separator, disc, loc, zone, lvl, sys, func, prod, seq);
-                    // TW-03: Re-apply prefix/suffix after collision rebuild
-                    if (!string.IsNullOrEmpty(TagPrefix)) tag = TagPrefix + Separator + tag;
-                    if (!string.IsNullOrEmpty(TagSuffix)) tag = tag + Separator + TagSuffix;
+                    tag = tagBody + seq + tagSuffix;
                 }
                 if (collisionCount > 0)
                     stats?.RecordCollision(tag, collisionCount);

--- a/StingTools/Data/PARAMETER_REGISTRY.json
+++ b/StingTools/Data/PARAMETER_REGISTRY.json
@@ -271,6 +271,14 @@
       "required": false
     },
     {
+      "param_name": "HANDOVER_MODE_CUSTOM_BOOL",
+      "guid": "a1b2c3d4-0002-5a01-b001-000000001003",
+      "description": "Pattern selector — Custom (user-defined) T4-T10 payload is live. Exactly one of HANDOVER_MODE_HANDOVER_BOOL / HANDOVER_MODE_DC_BOOL / HANDOVER_MODE_CUSTOM_BOOL is true per project.",
+      "binding": "universal",
+      "param_type": "YESNO",
+      "required": false
+    },
+    {
       "param_name": "TAG_TEXT_COLOUR_TEXT",
       "guid": "867fb0db-88ea-4a3d-9c01-000000000001",
       "description": "Tag text colour (Integer code)",

--- a/StingTools/Data/PARAMETER_REGISTRY.json
+++ b/StingTools/Data/PARAMETER_REGISTRY.json
@@ -255,6 +255,22 @@
       "required": false
     },
     {
+      "param_name": "HANDOVER_MODE_HANDOVER_BOOL",
+      "guid": "a1b2c3d4-0002-5a01-b001-000000001001",
+      "description": "Pattern selector — Handover / FM T4-T10 payload is live. Paired with HANDOVER_MODE_DC_BOOL; exactly one is true per project.",
+      "binding": "universal",
+      "param_type": "YESNO",
+      "required": false
+    },
+    {
+      "param_name": "HANDOVER_MODE_DC_BOOL",
+      "guid": "a1b2c3d4-0002-5a01-b001-000000001002",
+      "description": "Pattern selector — Design & Construction T4-T10 payload is live. Paired with HANDOVER_MODE_HANDOVER_BOOL; exactly one is true per project.",
+      "binding": "universal",
+      "param_type": "YESNO",
+      "required": false
+    },
+    {
       "param_name": "TAG_TEXT_COLOUR_TEXT",
       "guid": "867fb0db-88ea-4a3d-9c01-000000000001",
       "description": "Tag text colour (Integer code)",

--- a/StingTools/Data/SCALE_TIERS.json
+++ b/StingTools/Data/SCALE_TIERS.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "description": "Scale tier table for tag placement offset and text size selection. Each tier covers view-scale denominators up to max_denominator inclusive; the last tier catches everything larger. text_size_mm must be one of ParamRegistry.TagStyleSizes (\"2\", \"2.5\", \"3\", \"3.5\") so it maps directly to TAG_{size}{style}_{color}_BOOL.",
+  "offset_cap_ft": 30.0,
+  "tiers": [
+    { "max_denominator": 50,         "label": "1:1–1:50",    "offset_mm": 2.0,  "text_size_mm": "3.5" },
+    { "max_denominator": 100,        "label": "1:50–1:100",  "offset_mm": 5.0,  "text_size_mm": "3"   },
+    { "max_denominator": 200,        "label": "1:100–1:200", "offset_mm": 8.0,  "text_size_mm": "2.5" },
+    { "max_denominator": 500,        "label": "1:200–1:500", "offset_mm": 12.0, "text_size_mm": "2"   },
+    { "max_denominator": 2147483647, "label": "1:500+",      "offset_mm": 20.0, "text_size_mm": "2"   }
+  ]
+}

--- a/StingTools/Tags/ApplyParagraphPresetCommand.cs
+++ b/StingTools/Tags/ApplyParagraphPresetCommand.cs
@@ -395,10 +395,11 @@ namespace StingTools.Tags
                 }
                 catch (Exception ex) { StingLog.Warn($"SetHandoverMode: preset mirror failed: {ex.Message}"); }
 
-                // Flip the two selector BOOLs on Project Information so
-                // dual-wired tag families switch pattern live. Exactly one is
-                // true; unknown modes (e.g. Custom) clear both so no default
-                // pattern is rendered until the user maps Custom to a gate.
+                // Flip the selector BOOLs on Project Information so dual-wired
+                // tag families switch pattern live. Exactly one is true
+                // (Handover / DesignConstruction / Custom); a mode with no
+                // entry in HandoverModeHelper.ModeSelectorBool clears all
+                // three so tier rows stay hidden.
                 int boolsSet = SetPatternSelectors(doc, mode);
 
                 // Reload TagConfig so category warnings (loaded from the

--- a/StingTools/Tags/ApplyParagraphPresetCommand.cs
+++ b/StingTools/Tags/ApplyParagraphPresetCommand.cs
@@ -354,11 +354,14 @@ namespace StingTools.Tags
     }
 
     /// <summary>
-    /// Writes HANDOVER_MODE to project_config.json and invalidates compliance cache.
-    /// Triggered by the Handover Mode toggle in Tag Studio > Tokens & Depth.
-    /// Mode is passed via extra-param "HandoverMode" (values: Handover / DesignConstruction / Custom).
+    /// Writes HANDOVER_MODE to project_config.json, mirrors the active_preset
+    /// in PARAGRAPH_PRESETS.json, and flips the two pattern-selector BOOLs on
+    /// Project Information so dual-wired tag families switch their T4-T10
+    /// payload live. Triggered by the Handover Mode toggle in Tag Studio >
+    /// Tokens & Depth. Mode is passed via extra-param "HandoverMode"
+    /// (values: Handover / DesignConstruction / Custom).
     /// </summary>
-    [Transaction(TransactionMode.ReadOnly)]
+    [Transaction(TransactionMode.Manual)]
     public class SetHandoverModeCommand : IExternalCommand
     {
         public Result Execute(ExternalCommandData commandData,
@@ -392,13 +395,19 @@ namespace StingTools.Tags
                 }
                 catch (Exception ex) { StingLog.Warn($"SetHandoverMode: preset mirror failed: {ex.Message}"); }
 
+                // Flip the two selector BOOLs on Project Information so
+                // dual-wired tag families switch pattern live. Exactly one is
+                // true; unknown modes (e.g. Custom) clear both so no default
+                // pattern is rendered until the user maps Custom to a gate.
+                int boolsSet = SetPatternSelectors(doc, mode);
+
                 // Reload TagConfig so category warnings (loaded from the
                 // mode-specific CSVs via HandoverModeHelper) refresh live
                 // instead of waiting for the next document open.
                 try { Core.TagConfig.LoadDefaults(); }
                 catch (Exception ex) { StingLog.Warn($"SetHandoverMode: TagConfig reload failed: {ex.Message}"); }
 
-                StingLog.Info($"Handover mode set to {mode}");
+                StingLog.Info($"Handover mode set to {mode} (pattern selectors updated: {boolsSet})");
                 if (string.IsNullOrEmpty(StingCommandHandler.GetExtraParam("SuppressDialog")))
                 {
                     TaskDialog.Show("Handover Mode",
@@ -413,6 +422,45 @@ namespace StingTools.Tags
                 StingLog.Error("SetHandoverMode failed", ex);
                 message = ex.Message;
                 return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// Writes HANDOVER_MODE_HANDOVER_BOOL / HANDOVER_MODE_DC_BOOL on the
+        /// Project Information element so dual-wired tag families flip their
+        /// T4-T10 payload live. Exactly one BOOL is set per call; unknown
+        /// modes clear both so tier rows stay hidden until a gate is mapped.
+        /// Returns the number of parameters actually updated.
+        /// </summary>
+        private static int SetPatternSelectors(Document doc, string mode)
+        {
+            try
+            {
+                Element projInfo = doc.ProjectInformation;
+                if (projInfo == null) return 0;
+
+                string activeBool = HandoverModeHelper.GetSelectorBool(mode);
+                int updated = 0;
+                using (Transaction tx = new Transaction(doc, "STING Handover Mode — pattern selectors"))
+                {
+                    tx.Start();
+                    foreach (string selBool in HandoverModeHelper.ModeSelectorBool.Values)
+                    {
+                        Parameter p = projInfo.LookupParameter(selBool);
+                        if (p == null || p.IsReadOnly || p.StorageType != StorageType.Integer) continue;
+                        int want = string.Equals(selBool, activeBool, StringComparison.Ordinal) ? 1 : 0;
+                        if (p.AsInteger() == want) continue;
+                        p.Set(want);
+                        updated++;
+                    }
+                    tx.Commit();
+                }
+                return updated;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"SetHandoverMode: SetPatternSelectors failed: {ex.Message}");
+                return 0;
             }
         }
     }

--- a/StingTools/Tags/FamilyLabelAuthor.cs
+++ b/StingTools/Tags/FamilyLabelAuthor.cs
@@ -50,6 +50,20 @@ namespace StingTools.Tags
             public string FamilyName { get; set; }
         }
 
+        /// <summary>
+        /// A single pattern (Handover or DesignConstruction) paired with the
+        /// project-level YESNO selector BOOL that gates its T4-T10 rows when
+        /// the family is dual-wired. <see cref="GateParam"/> may be null/empty
+        /// for the single-mode back-compat path, in which case tier visibility
+        /// is gated on <c>TAG_PARA_STATE_N_BOOL</c> alone.
+        /// </summary>
+        public sealed class ModePlan
+        {
+            public string Mode { get; set; }
+            public string GateParam { get; set; }
+            public TierPlan Plan { get; set; }
+        }
+
         /// <summary>Per-family outcome, rolled up into the report by the command.</summary>
         public sealed class Result
         {
@@ -62,40 +76,60 @@ namespace StingTools.Tags
         }
 
         /// <summary>
-        /// Author tier content into <paramref name="fdoc"/> per <paramref name="plan"/>.
-        /// Caller is responsible for saving (<see cref="Document.SaveAs(string, SaveAsOptions)"/>)
-        /// and closing the document.
+        /// Single-mode entry point (back-compat). Delegates to
+        /// <see cref="AuthorLabelsMulti"/> with a no-gate plan so existing
+        /// callers that only know about one mode keep working unchanged.
         /// </summary>
         public static Result AuthorLabels(Document fdoc, TierPlan plan, Options opts)
         {
-            if (fdoc == null) throw new ArgumentNullException(nameof(fdoc));
             if (plan == null) throw new ArgumentNullException(nameof(plan));
+            var one = new List<ModePlan> { new ModePlan { Mode = "", GateParam = null, Plan = plan } };
+            return AuthorLabelsMulti(fdoc, one, opts);
+        }
+
+        /// <summary>
+        /// Dual-wire entry point: stamps every <paramref name="modePlans"/>
+        /// entry into the same family document, AND-gating each row's
+        /// visibility formula with the entry's <see cref="ModePlan.GateParam"/>.
+        /// When a source parameter appears in more than one mode it gets a
+        /// single OR-merged formula of the shape
+        /// <c>if(or(and(stateN, gateA), and(stateM, gateB), …), PARAM, "")</c>.
+        /// </summary>
+        public static Result AuthorLabelsMulti(Document fdoc,
+            IEnumerable<ModePlan> modePlans, Options opts)
+        {
+            if (fdoc == null) throw new ArgumentNullException(nameof(fdoc));
+            if (modePlans == null) throw new ArgumentNullException(nameof(modePlans));
             if (opts == null) throw new ArgumentNullException(nameof(opts));
             if (!fdoc.IsFamilyDocument) throw new InvalidOperationException("AuthorLabels requires a family document.");
 
             var result = new Result();
 
-            // 1. Identify tiers whose rows should be skipped for hand-edit preservation.
             HashSet<int> preservedTiers = opts.PreserveHandEdits
                 ? DetectPreservedTiers(fdoc)
                 : new HashSet<int>();
             result.TiersPreserved = preservedTiers.Count;
 
-            // 2. Flatten all T4..T10 rows into a linear list the binding + formula
-            //    loops can iterate once. Omit tiers with empty row lists (TierState.Omit).
-            var flat = new List<(int Tier, TierRow Row)>();
-            void Accum(int t, List<TierRow> rows, TierState state)
+            // Flatten every (tier, row, gate) triple across every mode plan.
+            // One entry per row so same-parameter-across-modes is handled by
+            // the gate accumulator below, not by dedup here.
+            var flat = new List<(int Tier, TierRow Row, string Gate)>();
+            foreach (ModePlan mp in modePlans)
             {
-                if (state == TierState.Omit || rows == null) return;
-                foreach (var r in rows) flat.Add((t, r));
+                if (mp?.Plan == null) continue;
+                void Accum(int t, List<TierRow> rows, TierState state)
+                {
+                    if (state == TierState.Omit || rows == null) return;
+                    foreach (var r in rows) flat.Add((t, r, mp.GateParam));
+                }
+                Accum(4,  mp.Plan.T4Rows,  mp.Plan.T4);
+                Accum(5,  mp.Plan.T5Rows,  mp.Plan.T5);
+                Accum(6,  mp.Plan.T6Rows,  mp.Plan.T6);
+                Accum(7,  mp.Plan.T7Rows,  mp.Plan.T7);
+                Accum(8,  mp.Plan.T8Rows,  mp.Plan.T8);
+                Accum(9,  mp.Plan.T9Rows,  mp.Plan.T9);
+                Accum(10, mp.Plan.T10Rows, mp.Plan.T10);
             }
-            Accum(4, plan.T4Rows, plan.T4);
-            Accum(5, plan.T5Rows, plan.T5);
-            Accum(6, plan.T6Rows, plan.T6);
-            Accum(7, plan.T7Rows, plan.T7);
-            Accum(8, plan.T8Rows, plan.T8);
-            Accum(9, plan.T9Rows, plan.T9);
-            Accum(10, plan.T10Rows, plan.T10);
 
             if (flat.Count == 0)
             {
@@ -103,32 +137,19 @@ namespace StingTools.Tags
                 return result;
             }
 
-            // 3. Bind every distinct parameter name referenced by the rows.
+            // Bind every parameter referenced by any row PLUS each distinct
+            // mode gate BOOL, so a later SetFormula(gate=…) resolves.
             var distinctParams = flat
                 .Select(x => x.Row?.Parameter)
                 .Where(s => !string.IsNullOrEmpty(s))
+                .Concat(flat.Select(x => x.Gate).Where(s => !string.IsNullOrEmpty(s)))
                 .Distinct(StringComparer.Ordinal)
                 .ToList();
             result.ParamsBound = BindSharedParameters(fdoc, distinctParams, opts, result);
 
-            // 4. Apply the per-row visibility formula. Same shape the CSV regenerator
-            //    emits: if(TAG_PARA_STATE_N_BOOL, PARAM, "").
             ApplyVisibilityFormulas(fdoc, flat, preservedTiers, result);
 
-            // 5. Best-effort label rebind: point the template's stub Label at
-            //    ASS_TAG_1_TXT so T1 display continues to work after re-author.
             result.LabelRebound = TryRebindPrimaryLabel(fdoc, result);
-
-            // 6. TODO-VERIFY-API: programmatic Label creation at tier-specific
-            //    positions. Revit 2025 exposes FamilyItemFactory.NewTextNote
-            //    (plain text) but NOT a Label-with-parameter binding for
-            //    annotation tag families. Revision 2026+ may expose more — when
-            //    it does, positioning code goes here, driven by plan rows and
-            //    TierRow.Size/Style/Color. Until then the .rft template's
-            //    pre-existing single Label is retargeted by TryRebindPrimaryLabel
-            //    and the additional tier rows stay manual.
-            // var factory = fdoc.FamilyCreate; // TODO-VERIFY-API: NewTextNote overloads vary per Revit year.
-
             return result;
         }
 
@@ -270,42 +291,64 @@ namespace StingTools.Tags
         }
 
         // ------------------------------------------------------------------
-        // Per-row formula: set Formula on a family calculated-value parameter
-        // matching the row's Parameter name, gating visibility via the tier's
-        // TAG_PARA_STATE_N_BOOL. Rows whose target tier is in preservedTiers
-        // are skipped.
+        // Per-row formula: visibility is gated by TAG_PARA_STATE_N_BOOL; when a
+        // mode gate is supplied the gate becomes and(stateN, modeGate). When
+        // the same source parameter is referenced by multiple (tier, gate)
+        // pairs — which happens when Handover and Design & Construction both
+        // list it — we OR-merge them into a single formula of shape
+        //   if(or(and(stateN, gateA), and(stateM, gateB), …), PARAM, "").
+        // Rows whose target tier is in preservedTiers are skipped.
         // ------------------------------------------------------------------
         private static void ApplyVisibilityFormulas(Document fdoc,
-            List<(int Tier, TierRow Row)> flat, HashSet<int> preservedTiers, Result result)
+            List<(int Tier, TierRow Row, string Gate)> flat,
+            HashSet<int> preservedTiers, Result result)
         {
             if (flat.Count == 0) return;
+
+            var gatesByParam = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            int skippedRows = 0;
+            foreach (var (tier, row, modeGate) in flat)
+            {
+                if (preservedTiers.Contains(tier)) { skippedRows++; continue; }
+                if (row == null || string.IsNullOrEmpty(row.Parameter)) { skippedRows++; continue; }
+
+                string stateBool = "TAG_PARA_STATE_" + tier + "_BOOL";
+                string gateExpr = string.IsNullOrEmpty(modeGate)
+                    ? stateBool
+                    : "and(" + stateBool + ", " + modeGate + ")";
+
+                if (!gatesByParam.TryGetValue(row.Parameter, out var list))
+                {
+                    list = new List<string>();
+                    gatesByParam[row.Parameter] = list;
+                }
+                if (!list.Contains(gateExpr, StringComparer.Ordinal)) list.Add(gateExpr);
+            }
 
             FamilyManager fm = fdoc.FamilyManager;
             using (Transaction tx = new Transaction(fdoc, "STING AuthorLabels — tier formulas"))
             {
                 tx.Start();
-                foreach (var (tier, row) in flat)
+                result.FormulasSkipped += skippedRows;
+                foreach (var kv in gatesByParam)
                 {
-                    if (preservedTiers.Contains(tier)) { result.FormulasSkipped++; continue; }
-                    if (row == null || string.IsNullOrEmpty(row.Parameter)) { result.FormulasSkipped++; continue; }
+                    string paramName = kv.Key;
+                    List<string> gates = kv.Value;
 
-                    string gate = "TAG_PARA_STATE_" + tier + "_BOOL";
-                    // TODO-VERIFY-API: SetFormula only works on read-write family
-                    // params. AddParameter sets them read-write by default when
-                    // isInstance=true, which is what we passed. If a template
-                    // pre-binds a param as read-only this call throws — we log
-                    // and move on rather than abort the whole file.
                     FamilyParameter target = null;
                     foreach (FamilyParameter fp in fm.Parameters)
                     {
-                        if (string.Equals(fp.Definition?.Name, row.Parameter, StringComparison.Ordinal))
+                        if (string.Equals(fp.Definition?.Name, paramName, StringComparison.Ordinal))
                         {
                             target = fp; break;
                         }
                     }
                     if (target == null) { result.FormulasSkipped++; continue; }
 
-                    string formula = "if(" + gate + ", " + row.Parameter + ", \"\")";
+                    string combined = gates.Count == 1
+                        ? gates[0]
+                        : "or(" + string.Join(", ", gates) + ")";
+                    string formula = "if(" + combined + ", " + paramName + ", \"\")";
                     try
                     {
                         fm.SetFormula(target, formula);
@@ -314,7 +357,7 @@ namespace StingTools.Tags
                     catch (Exception ex)
                     {
                         result.FormulasSkipped++;
-                        result.Warnings.Add($"SetFormula('{row.Parameter}') failed: {ex.Message}");
+                        result.Warnings.Add($"SetFormula('{paramName}') failed: {ex.Message}");
                     }
                 }
                 tx.Commit();

--- a/StingTools/Tags/ScaleTierCommands.cs
+++ b/StingTools/Tags/ScaleTierCommands.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.UI;
+
+namespace StingTools.Tags
+{
+    /// <summary>
+    /// Persists the five scale-tier offset-mm sliders + the offset-cap slider
+    /// from the Tag Studio &gt; Scale tab into project_config.json under the
+    /// "SCALE_TIERS" key, then reloads <see cref="ScaleTiers"/> so
+    /// <see cref="SmartTagPlacementCommand.GetModelOffset"/> picks the new
+    /// values up immediately. Slider values arrive via extra-params keyed
+    /// Scale50Mm / Scale100Mm / Scale200Mm / Scale500Mm / Scale1000Mm /
+    /// OffsetCapFt (floats). Text-size-per-tier is not user-editable in the
+    /// current Scale tab UI, so we preserve whatever the loaded tiers say
+    /// (falling back to the bundled SCALE_TIERS.json sizes).
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    public class ApplyScaleTiersCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(commandData);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            double[] offsets = {
+                ReadDouble("Scale50Mm",    2.0),
+                ReadDouble("Scale100Mm",   5.0),
+                ReadDouble("Scale200Mm",   8.0),
+                ReadDouble("Scale500Mm",   12.0),
+                ReadDouble("Scale1000Mm",  20.0),
+            };
+            double cap = ReadDouble("OffsetCapFt", 30.0);
+
+            // Seed text-size-per-tier from the currently-loaded tiers so
+            // saving the offsets doesn't wipe them. Length-aligned with
+            // the 5 denominator buckets below.
+            var currentTiers = ScaleTiers.Current;
+            string[] textSizes = new string[5];
+            int[] maxDenoms = { 50, 100, 200, 500, int.MaxValue };
+            string[] labels  = { "1:1–1:50", "1:50–1:100", "1:100–1:200", "1:200–1:500", "1:500+" };
+            for (int i = 0; i < textSizes.Length; i++)
+            {
+                var match = currentTiers.FirstOrDefault(t => t.MaxDenominator == maxDenoms[i]);
+                textSizes[i] = match?.TextSizeMm ?? DefaultTextSize(maxDenoms[i]);
+            }
+
+            var tiers = new List<ScaleTiers.Tier>();
+            for (int i = 0; i < maxDenoms.Length; i++)
+            {
+                tiers.Add(new ScaleTiers.Tier
+                {
+                    MaxDenominator = maxDenoms[i],
+                    Label          = labels[i],
+                    OffsetMm       = offsets[i],
+                    TextSizeMm     = textSizes[i],
+                });
+            }
+
+            string written = ScaleTiers.SaveProjectOverride(doc, tiers, cap);
+            if (string.IsNullOrEmpty(written))
+            {
+                TaskDialog.Show("Apply Scale Tiers",
+                    "Cannot persist — document is unsaved. Save the project and retry.");
+                return Result.Cancelled;
+            }
+
+            StingLog.Info($"ScaleTiers persisted to {written}: " +
+                          $"[{string.Join(", ", offsets.Select(o => o.ToString("F1", CultureInfo.InvariantCulture)))}] mm, " +
+                          $"cap={cap:F1} ft");
+
+            if (string.IsNullOrEmpty(StingCommandHandler.GetExtraParam("SuppressDialog")))
+            {
+                TaskDialog.Show("Scale Tiers Applied",
+                    $"Offsets (mm): {string.Join(" · ", offsets.Select(o => o.ToString("F1", CultureInfo.InvariantCulture)))}\n" +
+                    $"Cap: {cap:F0} ft\n\n" +
+                    "SmartTagPlacementCommand will use the new values on its next run.");
+            }
+            return Result.Succeeded;
+        }
+
+        private static double ReadDouble(string key, double fallback)
+        {
+            string v = StingCommandHandler.GetExtraParam(key);
+            if (string.IsNullOrEmpty(v)) return fallback;
+            return double.TryParse(v, NumberStyles.Float, CultureInfo.InvariantCulture, out double d) ? d : fallback;
+        }
+
+        private static string DefaultTextSize(int maxDenom)
+        {
+            if (maxDenom <= 50)  return "3.5";
+            if (maxDenom <= 100) return "3";
+            if (maxDenom <= 200) return "2.5";
+            return "2";
+        }
+    }
+
+    /// <summary>
+    /// Flips the <c>TAG_{size}{style}_{colour}_BOOL</c> visibility matrix on
+    /// every tag family type used in the active view so the active size row
+    /// matches the view's scale tier (per <see cref="ScaleTiers.ForView"/>).
+    /// Style and colour are preserved: whichever BOOL was currently true keeps
+    /// its style + colour, only the size letter swaps.
+    ///
+    /// When no BOOL is currently true on a type (fresh family), we default to
+    /// NOM / BLACK at the scale-tier size.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    public class SetScaleAwareTagSizeCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(commandData);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+            View view = ctx.ActiveView;
+            if (view == null) { TaskDialog.Show("STING", "No active view."); return Result.Failed; }
+
+            ScaleTiers.Tier tier = ScaleTiers.ForView(view);
+            string size = tier.TextSizeMm;
+            if (!ParamRegistry.TagStyleSizes.Contains(size))
+            {
+                TaskDialog.Show("Scale-Aware Tag Size",
+                    $"Tier '{tier.Label}' maps to text_size_mm='{size}', which is not one of " +
+                    $"[{string.Join(", ", ParamRegistry.TagStyleSizes)}]. Fix SCALE_TIERS.json " +
+                    "and retry.");
+                return Result.Failed;
+            }
+
+            var tagTypeIds = CollectTagTypeIdsInView(doc, view);
+            if (tagTypeIds.Count == 0)
+            {
+                TaskDialog.Show("Scale-Aware Tag Size",
+                    "No tag annotations found in the active view.");
+                return Result.Cancelled;
+            }
+
+            int typesUpdated = 0, paramsChanged = 0, typesSkipped = 0;
+            using (Transaction tx = new Transaction(doc, $"STING Scale-Aware Tag Size · {view.Scale}"))
+            {
+                tx.Start();
+                foreach (ElementId tid in tagTypeIds)
+                {
+                    Element typeEl = doc.GetElement(tid);
+                    if (typeEl == null) { typesSkipped++; continue; }
+
+                    (string curSize, string curStyle, string curColour) = DetectActiveStyle(typeEl);
+                    string newStyle  = curStyle  ?? "NOM";
+                    string newColour = curColour ?? "BLACK";
+                    string targetBool = ParamRegistry.TagStyleParamName(size, newStyle, newColour);
+
+                    int flipped = ApplySizeMatrix(typeEl, targetBool);
+                    if (flipped > 0) { typesUpdated++; paramsChanged += flipped; }
+                    else             typesSkipped++;
+                }
+                tx.Commit();
+            }
+
+            StingLog.Info(
+                $"ScaleAwareTagSize: view='{view.Name}' scale=1:{view.Scale} tier='{tier.Label}' " +
+                $"size={size}mm typesUpdated={typesUpdated} paramsChanged={paramsChanged} " +
+                $"typesSkipped={typesSkipped}");
+
+            if (string.IsNullOrEmpty(StingCommandHandler.GetExtraParam("SuppressDialog")))
+            {
+                TaskDialog.Show("Scale-Aware Tag Size",
+                    $"View: {view.Name}  (1:{view.Scale}, tier '{tier.Label}')\n" +
+                    $"Target text size: {size} mm\n\n" +
+                    $"Tag types updated: {typesUpdated}\n" +
+                    $"Params flipped:    {paramsChanged}\n" +
+                    (typesSkipped > 0 ? $"Skipped (no matrix / read-only): {typesSkipped}" : ""));
+            }
+            return Result.Succeeded;
+        }
+
+        private static List<ElementId> CollectTagTypeIdsInView(Document doc, View view)
+        {
+            var set = new HashSet<ElementId>();
+            var tags = new FilteredElementCollector(doc, view.Id)
+                .OfClass(typeof(IndependentTag))
+                .WhereElementIsNotElementType()
+                .ToElements();
+            foreach (Element e in tags)
+            {
+                ElementId tid = e.GetTypeId();
+                if (tid != null && tid != ElementId.InvalidElementId) set.Add(tid);
+            }
+            return set.ToList();
+        }
+
+        private static (string size, string style, string colour) DetectActiveStyle(Element typeEl)
+        {
+            foreach (string pname in ParamRegistry.AllTagStyleParams)
+            {
+                Parameter p = typeEl.LookupParameter(pname);
+                if (p == null || p.StorageType != StorageType.Integer) continue;
+                if (p.AsInteger() == 0) continue;
+                return ParseTagStyleParamName(pname);
+            }
+            return (null, null, null);
+        }
+
+        private static (string size, string style, string colour) ParseTagStyleParamName(string pname)
+        {
+            if (string.IsNullOrEmpty(pname) || !pname.StartsWith("TAG_") || !pname.EndsWith("_BOOL"))
+                return (null, null, null);
+            string body = pname.Substring(4, pname.Length - 4 - 5);
+            int us = body.IndexOf('_');
+            if (us <= 0) return (null, null, null);
+            string sizeAndStyle = body.Substring(0, us);
+            string colour = body.Substring(us + 1);
+
+            foreach (string sz in ParamRegistry.TagStyleSizes.OrderByDescending(s => s.Length))
+            {
+                if (sizeAndStyle.StartsWith(sz, StringComparison.Ordinal))
+                    return (sz, sizeAndStyle.Substring(sz.Length), colour);
+            }
+            return (null, null, colour);
+        }
+
+        private static int ApplySizeMatrix(Element typeEl, string activeBool)
+        {
+            int changed = 0;
+            foreach (string pname in ParamRegistry.AllTagStyleParams)
+            {
+                Parameter p = typeEl.LookupParameter(pname);
+                if (p == null || p.IsReadOnly || p.StorageType != StorageType.Integer) continue;
+                int want = string.Equals(pname, activeBool, StringComparison.Ordinal) ? 1 : 0;
+                if (p.AsInteger() == want) continue;
+                p.Set(want);
+                changed++;
+            }
+            return changed;
+        }
+    }
+}

--- a/StingTools/Tags/ScaleTierCommands.cs
+++ b/StingTools/Tags/ScaleTierCommands.cs
@@ -104,18 +104,39 @@ namespace StingTools.Tags
     }
 
     /// <summary>
-    /// Flips the <c>TAG_{size}{style}_{colour}_BOOL</c> visibility matrix on
-    /// every tag family type used in the active view so the active size row
-    /// matches the view's scale tier (per <see cref="ScaleTiers.ForView"/>).
-    /// Style and colour are preserved: whichever BOOL was currently true keeps
-    /// its style + colour, only the size letter swaps.
+    /// Makes tags in the active view render at the scale-tier size (per
+    /// <see cref="ScaleTiers.ForView"/>), preserving each tag's current style
+    /// and colour. Two operating modes, selected via extra-param
+    /// <c>ScaleSizeMode</c> ("Instance" / "Type" / "Auto" — default Auto):
     ///
-    /// When no BOOL is currently true on a type (fresh family), we default to
-    /// NOM / BLACK at the scale-tier size.
+    /// <list type="bullet">
+    /// <item><b>Instance</b>: for every <c>IndependentTag</c> in the view,
+    /// find a pre-existing family type named <c>{size}{style}_{colour}</c>
+    /// and call <c>tag.ChangeTypeId</c>. Side-effect free: another view that
+    /// uses the same family keeps its own tag types.</item>
+    /// <item><b>Type</b>: flips the <c>TAG_{size}{style}_{colour}_BOOL</c>
+    /// visibility matrix on each tag type used in the view. Simple but
+    /// project-wide — other views using the same type swap too.</item>
+    /// <item><b>Auto</b>: tries Instance per tag; any tag whose target type
+    /// is missing falls through to Type-mode for that type.</item>
+    /// </list>
+    ///
+    /// <para>Invokable programmatically via <see cref="ApplyToView"/>, which
+    /// is what <c>StingToolsApp.OnViewActivated</c> calls when
+    /// <c>TAG_SCALE_TIER_AUTO_BOOL</c> is set on Project Information.</para>
     /// </summary>
     [Transaction(TransactionMode.Manual)]
     public class SetScaleAwareTagSizeCommand : IExternalCommand
     {
+        public sealed class Result_
+        {
+            public int InstanceSwitches { get; set; }
+            public int TypeMatrixFlips { get; set; }
+            public int ParamsChanged { get; set; }
+            public int TypesMissingTarget { get; set; }
+            public int Skipped { get; set; }
+        }
+
         public Result Execute(ExternalCommandData commandData,
             ref string message, ElementSet elements)
         {
@@ -136,65 +157,129 @@ namespace StingTools.Tags
                 return Result.Failed;
             }
 
-            var tagTypeIds = CollectTagTypeIdsInView(doc, view);
-            if (tagTypeIds.Count == 0)
+            string modeExtra = StingCommandHandler.GetExtraParam("ScaleSizeMode");
+            if (string.IsNullOrEmpty(modeExtra)) modeExtra = "Auto";
+
+            Result_ r = ApplyToView(doc, view, size, modeExtra);
+            int total = r.InstanceSwitches + r.TypeMatrixFlips;
+            if (total == 0 && r.Skipped == 0 && r.TypesMissingTarget == 0)
             {
                 TaskDialog.Show("Scale-Aware Tag Size",
                     "No tag annotations found in the active view.");
                 return Result.Cancelled;
             }
 
-            int typesUpdated = 0, paramsChanged = 0, typesSkipped = 0;
-            using (Transaction tx = new Transaction(doc, $"STING Scale-Aware Tag Size · {view.Scale}"))
-            {
-                tx.Start();
-                foreach (ElementId tid in tagTypeIds)
-                {
-                    Element typeEl = doc.GetElement(tid);
-                    if (typeEl == null) { typesSkipped++; continue; }
-
-                    (string curSize, string curStyle, string curColour) = DetectActiveStyle(typeEl);
-                    string newStyle  = curStyle  ?? "NOM";
-                    string newColour = curColour ?? "BLACK";
-                    string targetBool = ParamRegistry.TagStyleParamName(size, newStyle, newColour);
-
-                    int flipped = ApplySizeMatrix(typeEl, targetBool);
-                    if (flipped > 0) { typesUpdated++; paramsChanged += flipped; }
-                    else             typesSkipped++;
-                }
-                tx.Commit();
-            }
-
-            StingLog.Info(
-                $"ScaleAwareTagSize: view='{view.Name}' scale=1:{view.Scale} tier='{tier.Label}' " +
-                $"size={size}mm typesUpdated={typesUpdated} paramsChanged={paramsChanged} " +
-                $"typesSkipped={typesSkipped}");
-
             if (string.IsNullOrEmpty(StingCommandHandler.GetExtraParam("SuppressDialog")))
             {
                 TaskDialog.Show("Scale-Aware Tag Size",
                     $"View: {view.Name}  (1:{view.Scale}, tier '{tier.Label}')\n" +
-                    $"Target text size: {size} mm\n\n" +
-                    $"Tag types updated: {typesUpdated}\n" +
-                    $"Params flipped:    {paramsChanged}\n" +
-                    (typesSkipped > 0 ? $"Skipped (no matrix / read-only): {typesSkipped}" : ""));
+                    $"Target text size: {size} mm\n" +
+                    $"Mode: {modeExtra}\n\n" +
+                    $"Tag instances switched:  {r.InstanceSwitches}\n" +
+                    $"Tag types matrix-flipped: {r.TypeMatrixFlips}\n" +
+                    $"Params changed:           {r.ParamsChanged}\n" +
+                    (r.TypesMissingTarget > 0 ? $"Types missing target:     {r.TypesMissingTarget}\n" : "") +
+                    (r.Skipped > 0 ? $"Skipped:                  {r.Skipped}" : ""));
             }
             return Result.Succeeded;
         }
 
-        private static List<ElementId> CollectTagTypeIdsInView(Document doc, View view)
+        /// <summary>
+        /// Programmatic entry point — runs without UI. Caller is responsible
+        /// for the open Revit transaction context; this method starts its own
+        /// <see cref="Transaction"/>. Safe to call from event handlers.
+        /// </summary>
+        public static Result_ ApplyToView(Document doc, View view, string size, string mode)
         {
-            var set = new HashSet<ElementId>();
-            var tags = new FilteredElementCollector(doc, view.Id)
+            var r = new Result_();
+            if (doc == null || view == null) return r;
+
+            var tagsInView = new FilteredElementCollector(doc, view.Id)
                 .OfClass(typeof(IndependentTag))
                 .WhereElementIsNotElementType()
-                .ToElements();
-            foreach (Element e in tags)
+                .Cast<IndependentTag>()
+                .ToList();
+            if (tagsInView.Count == 0) return r;
+
+            Dictionary<string, ElementId> typeIndex =
+                TagStyleRuleEngine.BuildTagTypeIndex(doc);
+
+            bool allowInstance = mode != "Type";
+            bool allowType     = mode != "Instance";
+
+            using (Transaction tx = new Transaction(doc, $"STING Scale-Aware Tag Size · 1:{view.Scale}"))
             {
-                ElementId tid = e.GetTypeId();
-                if (tid != null && tid != ElementId.InvalidElementId) set.Add(tid);
+                tx.Start();
+
+                // Instance pass: one ChangeTypeId per tag. We track which
+                // source types couldn't be matched so the Type pass only
+                // touches those.
+                var needTypePass = new HashSet<ElementId>();
+                foreach (IndependentTag tag in tagsInView)
+                {
+                    ElementId srcTypeId = tag.GetTypeId();
+                    if (srcTypeId == null || srcTypeId == ElementId.InvalidElementId) { r.Skipped++; continue; }
+                    Element typeEl = doc.GetElement(srcTypeId);
+                    if (typeEl == null) { r.Skipped++; continue; }
+
+                    (string curSize, string curStyle, string curColour) = DetectActiveStyle(typeEl);
+                    string style  = curStyle  ?? "NOM";
+                    string colour = curColour ?? "BLACK";
+
+                    if (allowInstance)
+                    {
+                        string targetTypeName = $"{size}{style}_{colour}";
+                        if (typeIndex.TryGetValue(targetTypeName, out ElementId targetId)
+                            && targetId != srcTypeId)
+                        {
+                            try
+                            {
+                                tag.ChangeTypeId(targetId);
+                                r.InstanceSwitches++;
+                                continue;
+                            }
+                            catch (Exception ex)
+                            {
+                                StingLog.Warn($"ChangeTypeId failed on tag {tag.Id}: {ex.Message}");
+                            }
+                        }
+                        else if (typeIndex.ContainsKey(targetTypeName))
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            r.TypesMissingTarget++;
+                            if (allowType) needTypePass.Add(srcTypeId);
+                            else           r.Skipped++;
+                        }
+                    }
+                    else
+                    {
+                        needTypePass.Add(srcTypeId);
+                    }
+                }
+
+                foreach (ElementId tid in needTypePass)
+                {
+                    Element typeEl = doc.GetElement(tid);
+                    if (typeEl == null) { r.Skipped++; continue; }
+                    (string _, string curStyle, string curColour) = DetectActiveStyle(typeEl);
+                    string targetBool = ParamRegistry.TagStyleParamName(
+                        size, curStyle ?? "NOM", curColour ?? "BLACK");
+                    int flipped = ApplySizeMatrix(typeEl, targetBool);
+                    if (flipped > 0) { r.TypeMatrixFlips++; r.ParamsChanged += flipped; }
+                }
+
+                tx.Commit();
             }
-            return set.ToList();
+
+            StingLog.Info(
+                $"ScaleAwareTagSize: view='{view.Name}' scale=1:{view.Scale} size={size}mm " +
+                $"mode={mode} instances={r.InstanceSwitches} typeFlips={r.TypeMatrixFlips} " +
+                $"paramsChanged={r.ParamsChanged} missingTarget={r.TypesMissingTarget} " +
+                $"skipped={r.Skipped}");
+            return r;
         }
 
         private static (string size, string style, string colour) DetectActiveStyle(Element typeEl)

--- a/StingTools/Tags/SmartTagPlacementCommand.cs
+++ b/StingTools/Tags/SmartTagPlacementCommand.cs
@@ -211,35 +211,30 @@ namespace StingTools.Tags
             };
         }
 
-        /// <summary>Configurable maximum offset cap in feet (default 30.0).</summary>
-        public static double MaxOffsetCapFt { get; set; } = 30.0;
+        /// <summary>
+        /// Back-compat shim. Reads the cap from <see cref="Core.ScaleTiers.OffsetCapFt"/>,
+        /// which is driven by <c>Data/SCALE_TIERS.json</c> or a per-project
+        /// <c>project_config.json:SCALE_TIERS.offset_cap_ft</c> override. Writing
+        /// to the setter is ignored — use <c>ScaleTiers.SaveProjectOverride</c>.
+        /// </summary>
+        public static double MaxOffsetCapFt
+        {
+            get => Core.ScaleTiers.OffsetCapFt;
+            set { /* cap is config-driven now; setter kept for API back-compat */ }
+        }
 
         /// <summary>
-        /// Scale-tier-aware offset: uses mm-based tiers that scale with view scale.
-        /// Tiers: 1:1–1:50 = 2mm, 1:50–1:100 = 5mm, 1:100–1:200 = 8mm,
-        ///        1:200–1:500 = 12mm, 1:500+ = 20mm.
-        /// Result is converted to feet and multiplied by viewScale, capped at MaxOffsetCapFt.
+        /// Scale-tier-aware offset. Tier mm and cap come from
+        /// <see cref="Core.ScaleTiers"/>, which resolves per-project
+        /// overrides then the bundled SCALE_TIERS.json then a hardcoded
+        /// fallback. Result is mm → ft × viewScale, clamped to the cap.
         /// </summary>
         public static double GetModelOffset(View view, double baseOffset = 0.01)
         {
-            int viewScale = view.Scale > 0 ? view.Scale : 100;
-
-            // Determine base mm from scale tier
-            double baseMm;
-            if (viewScale <= 50)
-                baseMm = 2.0;
-            else if (viewScale <= 100)
-                baseMm = 5.0;
-            else if (viewScale <= 200)
-                baseMm = 8.0;
-            else if (viewScale <= 500)
-                baseMm = 12.0;
-            else
-                baseMm = 20.0;
-
-            // Convert mm to feet, then multiply by view scale for model-space distance
-            double offsetFt = (baseMm / 304.8) * viewScale;
-            return Math.Min(offsetFt, MaxOffsetCapFt);
+            int viewScale = (view != null && view.Scale > 0) ? view.Scale : 100;
+            Core.ScaleTiers.Tier tier = Core.ScaleTiers.ForView(view);
+            double offsetFt = (tier.OffsetMm / 304.8) * viewScale;
+            return Math.Min(offsetFt, Core.ScaleTiers.OffsetCapFt);
         }
 
         /// <summary>Get element center point in view coordinates.</summary>

--- a/StingTools/Tags/TagConfigPlanResolver.cs
+++ b/StingTools/Tags/TagConfigPlanResolver.cs
@@ -59,6 +59,52 @@ namespace StingTools.Tags
         }
 
         /// <summary>
+        /// Load every built-in mode's tag-config CSVs and return a per-mode
+        /// family → <see cref="TierPlan"/> map. Used by the dual-wire authoring
+        /// path so a single family can be stamped with both Handover and
+        /// Design & Construction T4-T10 row sets, each row gated by its
+        /// mode selector BOOL (see <see cref="HandoverModeHelper.ModeSelectorBool"/>).
+        /// </summary>
+        /// <returns>
+        /// Outer dict keyed by mode name ("Handover", "DesignConstruction", …);
+        /// inner dict is the same shape <see cref="LoadAll"/> returns for a
+        /// single mode. Modes whose CSVs are missing from disk are omitted.
+        /// </returns>
+        public static Dictionary<string, Dictionary<string, TierPlan>> LoadAllPerMode(Document doc)
+        {
+            var result = new Dictionary<string, Dictionary<string, TierPlan>>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, string[]> perModeCsvs;
+            try { perModeCsvs = HandoverModeHelper.GetAllTagConfigCsvsForAllModes(doc); }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagConfigPlanResolver.LoadAllPerMode: {ex.Message}");
+                return result;
+            }
+
+            foreach (var modeKv in perModeCsvs)
+            {
+                var merged = new Dictionary<string, TierPlan>(StringComparer.Ordinal);
+                foreach (string name in modeKv.Value)
+                {
+                    if (string.IsNullOrEmpty(name)) continue;
+                    string path = StingToolsApp.FindDataFile(name);
+                    if (string.IsNullOrEmpty(path) || !File.Exists(path)) continue;
+                    try
+                    {
+                        var perFile = TagConfigCsvReader.LoadFile(path);
+                        foreach (var kv in perFile) merged[kv.Key] = kv.Value;
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"TagConfigPlanResolver.LoadAllPerMode: parsing '{name}' failed — {ex.Message}");
+                    }
+                }
+                if (merged.Count > 0) result[modeKv.Key] = merged;
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Read the PRESERVE_HAND_EDITS flag from project_config.json next to
         /// the .rvt. Default false so a fresh project re-authors normally.
         /// When the key is absent or the file is missing we return false

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -815,11 +815,15 @@ namespace StingTools.Tags
             Document doc = uidoc.Document;
             var app = uiApp.Application;
 
-            // ── Wave-1 commit 3: resolve the mode-appropriate TierPlans from
-            //    the v5 CSVs so each family can be authored (bind shared
-            //    params + apply visibility formulas) in addition to being
-            //    created from its .rft template. Missing CSVs are tolerated —
-            //    families without a plan keep the existing behaviour.
+            // ── Dual-wire authoring: load every built-in mode's TierPlans so
+            //    each family gets stamped with both Handover and Design &
+            //    Construction T4-T10 rows in a single pass. Switching between
+            //    the two patterns at runtime is then a project-level BOOL flip
+            //    (HANDOVER_MODE_HANDOVER_BOOL / HANDOVER_MODE_DC_BOOL) instead
+            //    of a family re-author. Modes whose CSVs are missing on disk
+            //    are silently skipped — families keep whatever rows are live.
+            Dictionary<string, Dictionary<string, TierPlan>> plansByMode =
+                TagConfigPlanResolver.LoadAllPerMode(doc);
             Dictionary<string, TierPlan> plansByFamily = TagConfigPlanResolver.LoadAll(doc);
             bool preserveHandEdits = TagConfigPlanResolver.ReadPreserveHandEdits(doc);
             string activeMode = HandoverModeHelper.GetActiveMode(doc);
@@ -1068,7 +1072,7 @@ namespace StingTools.Tags
                     // bind T4..T10 shared params + apply visibility formulas
                     // before saving. No-op when plansByFamily does not contain
                     // the family (e.g. a category not yet listed in the CSVs).
-                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByMode, plansByFamily,
                         app, sharedParamFile, preserveHandEdits, report);
 
                     // Save the family document
@@ -1181,7 +1185,7 @@ namespace StingTools.Tags
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, tieInParams);
 
-                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByMode, plansByFamily,
                         app, sharedParamFile, preserveHandEdits, report);
 
                     // Save and load — always proceeds even if params failed
@@ -1289,7 +1293,7 @@ namespace StingTools.Tags
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, dsParams);
 
-                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByMode, plansByFamily,
                         app, sharedParamFile, preserveHandEdits, report);
 
                     string savePath = Path.Combine(outputDir, fileName);
@@ -1396,7 +1400,7 @@ namespace StingTools.Tags
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, svParams);
 
-                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByMode, plansByFamily,
                         app, sharedParamFile, preserveHandEdits, report);
 
                     string savePath = Path.Combine(outputDir, fileName);
@@ -1503,7 +1507,7 @@ namespace StingTools.Tags
                         .Append("ASS_DESCRIPTION_TXT").ToList();
                     bool paramsAdded = AddSharedParameters(famDoc, sharedParamFile, app, mvParams);
 
-                    AuthorFromPlanIfAvailable(famDoc, famName, plansByFamily,
+                    AuthorFromPlanIfAvailable(famDoc, famName, plansByMode, plansByFamily,
                         app, sharedParamFile, preserveHandEdits, report);
 
                     string savePath = Path.Combine(outputDir, fileName);
@@ -1568,21 +1572,49 @@ namespace StingTools.Tags
         }
 
         /// <summary>
-        /// Wave-1 commit 3 hook. When <paramref name="plansByFamily"/> has a
-        /// <see cref="TierPlan"/> for <paramref name="famName"/>, invoke
-        /// <see cref="FamilyLabelAuthor.AuthorLabels"/> and append a short
-        /// line to the report. When no plan is available (e.g. the family is
-        /// not listed in the active-mode CSVs yet) this is a no-op so the
-        /// outer command behaves exactly as it did pre-wave-1.
+        /// Per-family author hook. When <paramref name="plansByMode"/> has at
+        /// least one mode that lists this family, stamps BOTH pattern row sets
+        /// into the family via <see cref="FamilyLabelAuthor.AuthorLabelsMulti"/>
+        /// so switching between Handover and Design & Construction at runtime
+        /// is a selector-BOOL flip. Falls back to the single-plan path via
+        /// <paramref name="plansByFamily"/> when the per-mode dict is empty
+        /// (e.g. only the active-mode CSVs are on disk). No-op when no plan
+        /// mentions the family.
         /// </summary>
         private void AuthorFromPlanIfAvailable(Document famDoc, string famName,
+            Dictionary<string, Dictionary<string, TierPlan>> plansByMode,
             Dictionary<string, TierPlan> plansByFamily,
             Autodesk.Revit.ApplicationServices.Application app,
             string sharedParamFile, bool preserveHandEdits,
             StringBuilder report)
         {
-            if (famDoc == null || string.IsNullOrEmpty(famName) || plansByFamily == null) return;
-            if (!plansByFamily.TryGetValue(famName, out TierPlan plan) || plan == null) return;
+            if (famDoc == null || string.IsNullOrEmpty(famName)) return;
+
+            var modePlans = new List<FamilyLabelAuthor.ModePlan>();
+            if (plansByMode != null)
+            {
+                foreach (var kv in plansByMode)
+                {
+                    if (kv.Value == null) continue;
+                    if (!kv.Value.TryGetValue(famName, out TierPlan plan) || plan == null) continue;
+                    modePlans.Add(new FamilyLabelAuthor.ModePlan
+                    {
+                        Mode = kv.Key,
+                        GateParam = HandoverModeHelper.GetSelectorBool(kv.Key),
+                        Plan = plan,
+                    });
+                }
+            }
+
+            if (modePlans.Count == 0)
+            {
+                if (plansByFamily == null) return;
+                if (!plansByFamily.TryGetValue(famName, out TierPlan plan) || plan == null) return;
+                modePlans.Add(new FamilyLabelAuthor.ModePlan
+                {
+                    Mode = "", GateParam = null, Plan = plan,
+                });
+            }
 
             try
             {
@@ -1593,10 +1625,13 @@ namespace StingTools.Tags
                     PreserveHandEdits = preserveHandEdits,
                     FamilyName = famName,
                 };
-                var r = FamilyLabelAuthor.AuthorLabels(famDoc, plan, opts);
+                var r = FamilyLabelAuthor.AuthorLabelsMulti(famDoc, modePlans, opts);
+                string modeTag = modePlans.Count > 1
+                    ? $"modes=[{string.Join(",", modePlans.ConvertAll(m => m.Mode))}]"
+                    : "";
                 report.AppendLine($"         author → bound={r.ParamsBound} " +
                     $"formulas={r.FormulasApplied} skipped={r.FormulasSkipped} " +
-                    $"preserved={r.TiersPreserved} label-rebound={r.LabelRebound}");
+                    $"preserved={r.TiersPreserved} label-rebound={r.LabelRebound} {modeTag}".TrimEnd());
                 foreach (var w in r.Warnings) StingLog.Warn($"{famName}: {w}");
             }
             catch (Exception ex)

--- a/StingTools/UI/ParagraphBuilderDialog.cs
+++ b/StingTools/UI/ParagraphBuilderDialog.cs
@@ -64,7 +64,76 @@ namespace StingTools.UI
 
             LoadPresetsSafe();
             _paramCatalog = BuildParamCatalog();
+            RegisterDarkComboResources();
             Content = BuildLayout();
+        }
+
+        /// <summary>
+        /// Window-level styles that make ComboBox dropdown items render
+        /// dark-on-white-text to match the rest of the dialog. Without this
+        /// the popup's <see cref="ComboBoxItem"/> instances inherit the
+        /// system theme (black on white) — fine when the outer ComboBox
+        /// has no explicit <c>Foreground</c>, but the parameter dropdowns
+        /// set <c>Foreground=white</c> so the closed-state selected text
+        /// and the popup items render white-on-white and disappear.
+        /// </summary>
+        private void RegisterDarkComboResources()
+        {
+            var cardBg     = new SolidColorBrush(CardBg);     cardBg.Freeze();
+            var fg         = new SolidColorBrush(FgColor);    fg.Freeze();
+            var border     = new SolidColorBrush(CardBorder); border.Freeze();
+            var hoverBg    = new SolidColorBrush(Color.FromRgb(0x55, 0x55, 0x58)); hoverBg.Freeze();
+            var selectedBg = new SolidColorBrush(AccentColor); selectedBg.Freeze();
+            var selectedFg = new SolidColorBrush(Colors.Black); selectedFg.Freeze();
+
+            var itemStyle = new Style(typeof(ComboBoxItem));
+            itemStyle.Setters.Add(new Setter(ComboBoxItem.BackgroundProperty, cardBg));
+            itemStyle.Setters.Add(new Setter(ComboBoxItem.ForegroundProperty, fg));
+            itemStyle.Setters.Add(new Setter(ComboBoxItem.PaddingProperty, new Thickness(4, 2, 4, 2)));
+
+            var hover = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
+            hover.Setters.Add(new Setter(ComboBoxItem.BackgroundProperty, hoverBg));
+            itemStyle.Triggers.Add(hover);
+
+            var selected = new Trigger { Property = ComboBoxItem.IsSelectedProperty, Value = true };
+            selected.Setters.Add(new Setter(ComboBoxItem.BackgroundProperty, selectedBg));
+            selected.Setters.Add(new Setter(ComboBoxItem.ForegroundProperty, selectedFg));
+            itemStyle.Triggers.Add(selected);
+
+            Resources[typeof(ComboBoxItem)] = itemStyle;
+        }
+
+        /// <summary>
+        /// Ensure a ComboBox renders with the dialog's dark palette:
+        /// background, foreground, border, and — for editable combos —
+        /// the internal <c>PART_EditableTextBox</c> whose colours are
+        /// independent of the outer <c>Foreground</c>. Must be called
+        /// after instantiation; the editable-textbox hook defers until
+        /// <c>Loaded</c> so the template has been applied.
+        /// </summary>
+        private void ApplyComboTheme(ComboBox cb)
+        {
+            if (cb == null) return;
+            cb.Background  = new SolidColorBrush(CardBg);
+            cb.Foreground  = new SolidColorBrush(FgColor);
+            cb.BorderBrush = new SolidColorBrush(CardBorder);
+
+            if (cb.IsEditable)
+            {
+                cb.Loaded += (s, e) =>
+                {
+                    try
+                    {
+                        if (cb.Template?.FindName("PART_EditableTextBox", cb) is TextBox inner)
+                        {
+                            inner.Background = new SolidColorBrush(CardBg);
+                            inner.Foreground = new SolidColorBrush(FgColor);
+                            inner.CaretBrush = new SolidColorBrush(FgColor);
+                        }
+                    }
+                    catch (Exception ex) { StingLog.Warn($"ApplyComboTheme editable-textbox: {ex.Message}"); }
+                };
+            }
         }
 
         // ------------------------------------------------------------------
@@ -101,6 +170,7 @@ namespace StingTools.UI
 
             AddLabel(presetGrid, 0, "Preset");
             _cmbPreset = new ComboBox { Height = 24, Margin = new Thickness(4, 0, 8, 0) };
+            ApplyComboTheme(_cmbPreset);
             foreach (var kv in _presets.Entries) _cmbPreset.Items.Add(kv.Key);
             _cmbPreset.SelectedItem = _presets.ActivePreset;
             _cmbPreset.SelectionChanged += (s, e) => OnPresetChanged();
@@ -133,6 +203,7 @@ namespace StingTools.UI
             var actionBar = new DockPanel { Margin = new Thickness(0, 8, 0, 0), LastChildFill = false };
             AddLabel(actionBar, null, "Scope");
             _cmbScope = new ComboBox { Height = 24, Width = 140, Margin = new Thickness(4, 0, 12, 0) };
+            ApplyComboTheme(_cmbScope);
             _cmbScope.Items.Add("Selection (fallback: Active view)");
             _cmbScope.Items.Add("Active view");
             _cmbScope.Items.Add("Entire project");
@@ -291,11 +362,9 @@ namespace StingTools.UI
             {
                 IsEditable = true, IsReadOnly = readOnly,
                 Height = 22, FontSize = 10, Margin = new Thickness(2, 1, 2, 1),
-                Background = new SolidColorBrush(CardBg),
-                Foreground = new SolidColorBrush(FgColor),
-                BorderBrush = new SolidColorBrush(CardBorder),
                 Text = row.Parameter,
             };
+            ApplyComboTheme(cmbParam);
             foreach (var p in _paramCatalog) cmbParam.Items.Add(p);
             cmbParam.Text = row.Parameter;
             cmbParam.LostFocus += (s, e) => { row.Parameter = cmbParam.Text?.Trim() ?? ""; };

--- a/StingTools/UI/ParagraphBuilderDialog.cs
+++ b/StingTools/UI/ParagraphBuilderDialog.cs
@@ -64,76 +64,7 @@ namespace StingTools.UI
 
             LoadPresetsSafe();
             _paramCatalog = BuildParamCatalog();
-            RegisterDarkComboResources();
             Content = BuildLayout();
-        }
-
-        /// <summary>
-        /// Window-level styles that make ComboBox dropdown items render
-        /// dark-on-white-text to match the rest of the dialog. Without this
-        /// the popup's <see cref="ComboBoxItem"/> instances inherit the
-        /// system theme (black on white) — fine when the outer ComboBox
-        /// has no explicit <c>Foreground</c>, but the parameter dropdowns
-        /// set <c>Foreground=white</c> so the closed-state selected text
-        /// and the popup items render white-on-white and disappear.
-        /// </summary>
-        private void RegisterDarkComboResources()
-        {
-            var cardBg     = new SolidColorBrush(CardBg);     cardBg.Freeze();
-            var fg         = new SolidColorBrush(FgColor);    fg.Freeze();
-            var border     = new SolidColorBrush(CardBorder); border.Freeze();
-            var hoverBg    = new SolidColorBrush(Color.FromRgb(0x55, 0x55, 0x58)); hoverBg.Freeze();
-            var selectedBg = new SolidColorBrush(AccentColor); selectedBg.Freeze();
-            var selectedFg = new SolidColorBrush(Colors.Black); selectedFg.Freeze();
-
-            var itemStyle = new Style(typeof(ComboBoxItem));
-            itemStyle.Setters.Add(new Setter(ComboBoxItem.BackgroundProperty, cardBg));
-            itemStyle.Setters.Add(new Setter(ComboBoxItem.ForegroundProperty, fg));
-            itemStyle.Setters.Add(new Setter(ComboBoxItem.PaddingProperty, new Thickness(4, 2, 4, 2)));
-
-            var hover = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
-            hover.Setters.Add(new Setter(ComboBoxItem.BackgroundProperty, hoverBg));
-            itemStyle.Triggers.Add(hover);
-
-            var selected = new Trigger { Property = ComboBoxItem.IsSelectedProperty, Value = true };
-            selected.Setters.Add(new Setter(ComboBoxItem.BackgroundProperty, selectedBg));
-            selected.Setters.Add(new Setter(ComboBoxItem.ForegroundProperty, selectedFg));
-            itemStyle.Triggers.Add(selected);
-
-            Resources[typeof(ComboBoxItem)] = itemStyle;
-        }
-
-        /// <summary>
-        /// Ensure a ComboBox renders with the dialog's dark palette:
-        /// background, foreground, border, and — for editable combos —
-        /// the internal <c>PART_EditableTextBox</c> whose colours are
-        /// independent of the outer <c>Foreground</c>. Must be called
-        /// after instantiation; the editable-textbox hook defers until
-        /// <c>Loaded</c> so the template has been applied.
-        /// </summary>
-        private void ApplyComboTheme(ComboBox cb)
-        {
-            if (cb == null) return;
-            cb.Background  = new SolidColorBrush(CardBg);
-            cb.Foreground  = new SolidColorBrush(FgColor);
-            cb.BorderBrush = new SolidColorBrush(CardBorder);
-
-            if (cb.IsEditable)
-            {
-                cb.Loaded += (s, e) =>
-                {
-                    try
-                    {
-                        if (cb.Template?.FindName("PART_EditableTextBox", cb) is TextBox inner)
-                        {
-                            inner.Background = new SolidColorBrush(CardBg);
-                            inner.Foreground = new SolidColorBrush(FgColor);
-                            inner.CaretBrush = new SolidColorBrush(FgColor);
-                        }
-                    }
-                    catch (Exception ex) { StingLog.Warn($"ApplyComboTheme editable-textbox: {ex.Message}"); }
-                };
-            }
         }
 
         // ------------------------------------------------------------------
@@ -170,7 +101,6 @@ namespace StingTools.UI
 
             AddLabel(presetGrid, 0, "Preset");
             _cmbPreset = new ComboBox { Height = 24, Margin = new Thickness(4, 0, 8, 0) };
-            ApplyComboTheme(_cmbPreset);
             foreach (var kv in _presets.Entries) _cmbPreset.Items.Add(kv.Key);
             _cmbPreset.SelectedItem = _presets.ActivePreset;
             _cmbPreset.SelectionChanged += (s, e) => OnPresetChanged();
@@ -203,7 +133,6 @@ namespace StingTools.UI
             var actionBar = new DockPanel { Margin = new Thickness(0, 8, 0, 0), LastChildFill = false };
             AddLabel(actionBar, null, "Scope");
             _cmbScope = new ComboBox { Height = 24, Width = 140, Margin = new Thickness(4, 0, 12, 0) };
-            ApplyComboTheme(_cmbScope);
             _cmbScope.Items.Add("Selection (fallback: Active view)");
             _cmbScope.Items.Add("Active view");
             _cmbScope.Items.Add("Entire project");
@@ -285,9 +214,6 @@ namespace StingTools.UI
             var tbLabel = new TextBox
             {
                 Text = tier.Label, Height = 22, FontSize = 11,
-                Background = new SolidColorBrush(CardBg),
-                Foreground = new SolidColorBrush(FgColor),
-                BorderBrush = new SolidColorBrush(CardBorder),
                 IsReadOnly = readOnly,
             };
             tbLabel.TextChanged += (s, e) => { tier.Label = tbLabel.Text; RefreshHeader(expander, tierKey, tier); };
@@ -364,7 +290,6 @@ namespace StingTools.UI
                 Height = 22, FontSize = 10, Margin = new Thickness(2, 1, 2, 1),
                 Text = row.Parameter,
             };
-            ApplyComboTheme(cmbParam);
             foreach (var p in _paramCatalog) cmbParam.Items.Add(p);
             cmbParam.Text = row.Parameter;
             cmbParam.LostFocus += (s, e) => { row.Parameter = cmbParam.Text?.Trim() ?? ""; };
@@ -378,9 +303,6 @@ namespace StingTools.UI
             {
                 Text = row.Prefix, IsReadOnly = readOnly,
                 Height = 22, FontSize = 10, Margin = new Thickness(2, 1, 2, 1),
-                Background = new SolidColorBrush(CardBg),
-                Foreground = new SolidColorBrush(FgColor),
-                BorderBrush = new SolidColorBrush(CardBorder),
             };
             tbPrefix.TextChanged += (s, e) => row.Prefix = tbPrefix.Text;
             Grid.SetColumn(tbPrefix, 2); Grid.SetRow(tbPrefix, rowIndex); tbl.Children.Add(tbPrefix);
@@ -389,9 +311,6 @@ namespace StingTools.UI
             {
                 Text = row.Suffix, IsReadOnly = readOnly,
                 Height = 22, FontSize = 10, Margin = new Thickness(2, 1, 2, 1),
-                Background = new SolidColorBrush(CardBg),
-                Foreground = new SolidColorBrush(FgColor),
-                BorderBrush = new SolidColorBrush(CardBorder),
             };
             tbSuffix.TextChanged += (s, e) => row.Suffix = tbSuffix.Text;
             Grid.SetColumn(tbSuffix, 3); Grid.SetRow(tbSuffix, rowIndex); tbl.Children.Add(tbSuffix);

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -2213,6 +2213,10 @@ namespace StingTools.UI
                     case "TagStudio_ApplyScheme": RunCommand<Tags.ApplyColorSchemeCommand>(app); break;
                     case "TagStudio_ClearOverrides": RunCommand<Tags.ClearColorSchemeCommand>(app); break;
 
+                    // Tag Studio > Scale tab
+                    case "Scale_ApplyTiers":   RunCommand<Tags.ApplyScaleTiersCommand>(app); break;
+                    case "Scale_ApplyTagSize": RunCommand<Tags.SetScaleAwareTagSizeCommand>(app); break;
+
                     // ════════════════════════════════════════════════════════
                     // TIE-IN POINT COMMANDS (TI-01, TI-03)
                     // ════════════════════════════════════════════════════════

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -4095,6 +4095,22 @@
                                             </StackPanel>
                                         </Border>
 
+                                        <!-- APPLY -->
+                                        <TextBlock Text="APPLY" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,6,0,4"/>
+                                        <Border Style="{StaticResource GroupBorder}">
+                                            <StackPanel>
+                                                <Button Content="Save tiers to project"
+                                                        Tag="Scale_ApplyTiers"
+                                                        Click="Cmd_Click"
+                                                        Margin="0,0,0,4"
+                                                        ToolTip="Persist slider values to project_config.json:SCALE_TIERS. SmartTagPlacement picks them up live."/>
+                                                <Button Content="Apply size to tags in view"
+                                                        Tag="Scale_ApplyTagSize"
+                                                        Click="Cmd_Click"
+                                                        ToolTip="Flip the TAG_{size}{style}_{colour}_BOOL matrix on every tag type used in the active view so size matches the view's scale tier."/>
+                                            </StackPanel>
+                                        </Border>
+
                                         <!-- VIEW SCALE INFO -->
                                         <TextBlock Text="CURRENT VIEW" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,6,0,4"/>
                                         <Border Style="{StaticResource GroupBorder}">

--- a/StingTools/UI/StingDockPanel.xaml.cs
+++ b/StingTools/UI/StingDockPanel.xaml.cs
@@ -307,6 +307,23 @@ namespace StingTools.UI
         }
 
         /// <summary>
+        /// Push the three Scale-tab info labels from
+        /// <c>StingToolsApp.OnViewActivated</c>. Must be called on the WPF
+        /// dispatcher thread; tolerates null controls when the tab is still
+        /// in its deferred-loading placeholder.
+        /// </summary>
+        public void UpdateScaleInfoLabels(string scaleText, string tierText, string offsetText)
+        {
+            try
+            {
+                if (txtViewScale  != null) txtViewScale.Text  = scaleText  ?? "Scale: —";
+                if (txtViewTier   != null) txtViewTier.Text   = tierText   ?? "Tier: —";
+                if (txtViewOffset != null) txtViewOffset.Text = offsetText ?? "Offset: — mm (— ft)";
+            }
+            catch (Exception ex) { StingLog.Warn($"UpdateScaleInfoLabels: {ex.Message}"); }
+        }
+
+        /// <summary>
         /// Read the Scale tab sliders and pass them as ExtraParams for
         /// <c>ApplyScaleTiersCommand</c>. Keyed to the JSON schema that
         /// <c>Core.ScaleTiers.SaveProjectOverride</c> writes.

--- a/StingTools/UI/StingDockPanel.xaml.cs
+++ b/StingTools/UI/StingDockPanel.xaml.cs
@@ -228,6 +228,9 @@ namespace StingTools.UI
                     SetTagStyleParams();
                 }
 
+                // Pass Scale tab slider values to the tier persistence command
+                if (cmdTag == "Scale_ApplyTiers") SetScaleTabParams();
+
                 // ORPHAN-FIX: Pass Tokens & Depth controls to commands that honour them.
                 // Covers the Combine / Stage populate / Full auto / tagging pipeline paths
                 // plus the paragraph-depth command and the Categories sub-tab filter.
@@ -301,6 +304,25 @@ namespace StingTools.UI
                 StingCommandHandler.SetExtraParam("ArrowSize",  (sldArrowSize?.Value ?? 4).ToString("F0"));
             }
             catch (Exception ex) { StingLog.Warn($"Read leader/elbow params failed: {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// Read the Scale tab sliders and pass them as ExtraParams for
+        /// <c>ApplyScaleTiersCommand</c>. Keyed to the JSON schema that
+        /// <c>Core.ScaleTiers.SaveProjectOverride</c> writes.
+        /// </summary>
+        private void SetScaleTabParams()
+        {
+            try
+            {
+                StingCommandHandler.SetExtraParam("Scale50Mm",   (sldScale50?.Value   ?? 2.0 ).ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
+                StingCommandHandler.SetExtraParam("Scale100Mm",  (sldScale100?.Value  ?? 5.0 ).ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
+                StingCommandHandler.SetExtraParam("Scale200Mm",  (sldScale200?.Value  ?? 8.0 ).ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
+                StingCommandHandler.SetExtraParam("Scale500Mm",  (sldScale500?.Value  ?? 12.0).ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
+                StingCommandHandler.SetExtraParam("Scale1000Mm", (sldScale1000?.Value ?? 20.0).ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
+                StingCommandHandler.SetExtraParam("OffsetCapFt", (sldOffsetCap?.Value ?? 30.0).ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
+            }
+            catch (Exception ex) { StingLog.Warn($"Read Scale tab sliders failed: {ex.Message}"); }
         }
 
         /// <summary>FIX-4.1: Read Style &amp; Color sliders for style commands.</summary>


### PR DESCRIPTION
## Summary
This PR introduces scale-tier-aware tag placement and text sizing, plus dual-wire tag family authoring that allows families to carry both Handover and Design & Construction T4-T10 row sets simultaneously, switchable via project-level BOOLs.

## Key Changes

### Scale Tier System
- **New `ScaleTiers` class** (`Core/ScaleTiers.cs`): Centralized scale-to-offset and scale-to-text-size mapping with three-tier resolution (project override → bundled JSON → hardcoded fallback). Includes per-document caching with 30-second TTL.
- **New `ApplyScaleTiersCommand`** (`Tags/ScaleTierCommands.cs`): Persists five offset-mm sliders + offset-cap slider from the Scale tab into `project_config.json` under the `SCALE_TIERS` key, then reloads the tier table.
- **New `SetScaleAwareTagSizeCommand`** (`Tags/ScaleTierCommands.cs`): Makes tags render at scale-tier text sizes with three modes (Instance/Type/Auto). Instance mode switches individual tag types; Type mode flips visibility matrices project-wide; Auto tries Instance first, falls back to Type.
- **Scale tab UI integration**: Added info labels showing active view scale, resolved tier, and calculated offset. Labels update live on view activation via `StingToolsApp.OnViewActivated`.
- **New `SCALE_TIERS.json`** (`Data/SCALE_TIERS.json`): Bundled tier table with defaults (2/5/8/12/20 mm offsets, 30 ft cap, 3.5/3/2.5/2/2 mm text sizes).

### Dual-Wire Tag Family Authoring
- **Extended `FamilyLabelAuthor`** (`Tags/FamilyLabelAuthor.cs`): New `ModePlan` class and `AuthorLabelsMulti` entry point allow stamping multiple pattern sets (Handover + Design & Construction) into a single family in one pass. Rows are AND-gated with mode selector BOOLs; same parameters across modes get OR-merged formulas.
- **New mode selector BOOLs** (`Data/PARAMETER_REGISTRY.json`): Added `HANDOVER_MODE_HANDOVER_BOOL`, `HANDOVER_MODE_DC_BOOL`, `HANDOVER_MODE_CUSTOM_BOOL` to gate T4-T10 payload live.
- **Updated `HandoverModeHelper`** (`Core/HandoverModeHelper.cs`): Added "Custom" to `BuiltInModes`, new `ModeSelectorBool` dictionary mapping modes to their gate parameters, and `GetAllTagConfigCsvsForAllModes` to enumerate all available mode CSVs.
- **Updated `TagConfigPlanResolver`** (`Tags/TagConfigPlanResolver.cs`): New `LoadAllPerMode` method loads every built-in mode's TierPlans for dual-wire authoring.
- **Updated `SetHandoverModeCommand`** (`Tags/ApplyParagraphPresetCommand.cs`): Now flips the two pattern-selector BOOLs on Project Information so dual-wired families switch T4-T10 payload live.
- **Updated `TagFamilyCreatorCommand`** (`Tags/TagFamilyCreatorCommand.cs`): Loads all modes' plans and passes them to `AuthorFromPlanIfAvailable` for dual-wire stamping.

### Performance & Robustness
- **Room index caching** (`Core/ParameterHelpers.cs`): Added per-document room cache with 30-second TTL and invalidation hook (`InvalidateRoomIndex`) called by `StingAutoTagger` on room changes.
- **Parameter write optimization** (`Core/ParameterHelpers.cs`): `SetString` now skips the `Parameter.Set` round-trip when the value is already correct, eliminating thousands of no-op undo-journal entries in batch tagging.
- **Tag derivation skip** (`Core/ParameterHelpers.cs`): When a tag is complete and

https://claude.ai/code/session_013GBGLKskUEUYn3vvs1uju7