### PR TITLE
Add logging hook to BcfEngine for cross-assembly error reporting

### DIFF
--- a/StingTools/BIMManager/BcfEngine.cs
+++ b/StingTools/BIMManager/BcfEngine.cs
@@ -93,6 +93,19 @@ namespace Planscape.Shared.BCF
     /// </summary>
     public static class BcfEngine
     {
+        // ── Logging hook ───────────────────────────────────────────────────
+        //
+        // BcfEngine.cs is compiled into Planscape.Shared.dll (via linked
+        // <Compile Include>), which has no reference to the StingTools
+        // namespace. So we can't call StingTools.Core.StingLog.Warn directly
+        // from here without breaking the server/shared build.
+        //
+        // Instead, expose a nullable Action<string> that the plugin sets once
+        // at app startup (StingToolsApp.OnStartup wires it to StingLog.Warn).
+        // Server-side callers can leave it null — the silent-catch contract
+        // is preserved because Invoke is guarded by the null-conditional.
+        public static Action<string>? Warn { get; set; }
+
         // ── Priority / status / type mappings (kept here so server + plugin share them) ──
 
         internal static readonly Dictionary<string, string> StingToBcfType = new(StringComparer.OrdinalIgnoreCase)
@@ -280,8 +293,8 @@ namespace Planscape.Shared.BCF
                 }
             }
             catch (InvalidDataException) { /* not a ZIP — return whatever we parsed */ }
-            catch (IOException)          { }
-            catch (Exception)            { }
+            catch (IOException ioEx)     { Warn?.Invoke($"BcfEngine.Import I/O: {ioEx.Message}"); }
+            catch (Exception ex)         { Warn?.Invoke($"BcfEngine.Import: {ex.Message}"); }
 
             return result;
         }

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -84,6 +84,12 @@ namespace StingTools.Core
                 try { ProjectFolderEngine.LoadRootFromConfig(); }
                 catch (Exception ex) { StingLog.Warn($"ProjectFolderEngine config load: {ex.Message}"); }
 
+                // Route BcfEngine warnings into StingLog. BcfEngine.cs lives in
+                // Planscape.Shared.dll (server-compatible, no Revit dependency),
+                // so it can't reference StingLog directly — the hook bridges the
+                // two assemblies without creating a namespace dependency.
+                Planscape.Shared.BCF.BcfEngine.Warn = msg => StingLog.Warn(msg);
+
                 // CRASH FIX: Subscribe to DocumentClosing to clear stale static caches.
                 // ElementId-based caches and Definition caches become invalid when a
                 // document closes. Using them against a new document causes native crashes.


### PR DESCRIPTION
## Summary
Introduced a logging bridge to enable BcfEngine (compiled into the server-compatible Planscape.Shared.dll) to report warnings without creating a direct dependency on StingTools.Core.StingLog.

## Changes
- **BcfEngine.cs**: Added a nullable `Action<string>? Warn` property to serve as a logging hook that can be wired up by the plugin at startup
- **BcfEngine.cs**: Updated exception handlers in `ImportFromStream()` to capture exception details and invoke the logging hook via null-conditional operator (`Warn?.Invoke()`)
- **StingToolsApp.cs**: Wired the BcfEngine.Warn hook to StingLog.Warn during plugin initialization in `OnStartup()`

## Implementation Details
- The logging hook uses a nullable Action to maintain the silent-catch contract on the server side (where the hook remains null)
- Exception messages are now captured and logged instead of being silently swallowed
- This pattern allows BcfEngine to remain in a server-compatible assembly without introducing namespace dependencies on StingTools
- The hook is set once at application startup, avoiding repeated initialization overhead

https://claude.ai/code/session_01NyZv1FHc6LU3DTQjNNkf6E