### PR TITLE
Refactor levels & scope boxes to use DataGrids with inline editing

### DIFF
--- a/StingTools/Temp/ProjectSetupCommand.cs
+++ b/StingTools/Temp/ProjectSetupCommand.cs
@@ -109,18 +109,48 @@ namespace StingTools.Temp
                     $"Create Levels ({data.Levels.Count} definitions)",
                     () => CreateLevels(doc, data.Levels));
 
+                // Step: Rename scope boxes (must run before grids so scoping uses new names)
+                if (data.RenameScopeBoxes && data.ScopeBoxRenames != null && data.ScopeBoxRenames.Count > 0)
+                {
+                    passed += RunStep(ref stepNum, report,
+                        $"Rename Scope Boxes ({data.ScopeBoxRenames.Count})",
+                        () => RenameScopeBoxes(doc, data));
+                }
+                else
+                {
+                    stepNum++;
+                    report.AppendLine($"  {stepNum,2}. Rename Scope Boxes — SKIPPED");
+                    skipped++;
+                }
+
                 // Step: Create Grids
                 if (data.CreateGrids && (data.GridHCount > 0 || data.GridVCount > 0))
                 {
                     int gridTotal = data.GridHCount + data.GridVCount;
-                    passed += RunStep(ref stepNum, report,
-                        $"Create Grids ({gridTotal} lines)",
+                    string label = $"Create Grids ({gridTotal} lines" +
+                        (data.AlignToScopeBoxOrientation ? ", scope-box aligned" : "") +
+                        (data.AssignGridsToScopeBoxes ? ", scoped" : "") + ")";
+                    passed += RunStep(ref stepNum, report, label,
                         () => CreateGrids(doc, data));
                 }
                 else
                 {
                     stepNum++;
                     report.AppendLine($"  {stepNum,2}. Create Grids — SKIPPED (not selected)");
+                    skipped++;
+                }
+
+                // Step: Two sections per scope box (centred, both directions)
+                if (data.TwoSectionsPerScopeBox && data.ScopeBoxSelection != null && data.ScopeBoxSelection.Count > 0)
+                {
+                    passed += RunStep(ref stepNum, report,
+                        $"Scope-Box Sections ({data.ScopeBoxSelection.Count * 2} views)",
+                        () => CreateTwoSectionsPerScopeBox(doc, data));
+                }
+                else
+                {
+                    stepNum++;
+                    report.AppendLine($"  {stepNum,2}. Scope-Box Sections — SKIPPED");
                     skipped++;
                 }
 
@@ -259,57 +289,87 @@ namespace StingTools.Temp
                 // ════════════════════════════════════════════════════
                 report.AppendLine("\n── Phase 3: Standards ──");
 
-                // Step: Create Styles (fill patterns, line patterns, line styles, text/dim styles)
-                if (data.CreateStyles)
+                if (data.UseLatestTemplateSetup)
                 {
-                    passed += RunStep(ref stepNum, report, "Create Fill Patterns",
+                    // Latest 15-step TemplateSetupWizard ordering (matches TemplateManagerCommands.cs)
+                    report.AppendLine("  (latest Template Setup pipeline)");
+                    passed += RunStep(ref stepNum, report, "Fill Patterns (12 ISO)",
                         () => RunCommand(new CreateFillPatternsCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Create Line Patterns (10 ISO 128)",
+                    passed += RunStep(ref stepNum, report, "Line Patterns (10 ISO 128)",
                         () => RunCommand(new CreateLinePatternsCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Create Line Styles",
+                    passed += RunStep(ref stepNum, report, "Line Styles (16)",
                         () => RunCommand(new CreateLineStylesCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Create Object Styles",
+                    passed += RunStep(ref stepNum, report, "Object Styles (40)",
                         () => RunCommand(new CreateObjectStylesCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Create Text Styles",
+                    passed += RunStep(ref stepNum, report, "Text Styles (12 ISO 3098)",
                         () => RunCommand(new CreateTextStylesCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Create Dimension Styles",
+                    passed += RunStep(ref stepNum, report, "Dimension Styles (7)",
                         () => RunCommand(new CreateDimensionStylesCommand(), commandData, elements));
-                }
-                else
-                {
-                    stepNum++;
-                    report.AppendLine($"  {stepNum,2}. Create Styles — SKIPPED");
-                    skipped++;
-                }
-
-                // Step: Create View Filters
-                if (data.CreateFilters)
-                {
-                    passed += RunStep(ref stepNum, report, "Create View Filters (28+)",
+                    passed += RunStep(ref stepNum, report, "View Filters (28+)",
                         () => RunCommand(new CreateFiltersCommand(), commandData, elements));
-                }
-                else
-                {
-                    stepNum++;
-                    report.AppendLine($"  {stepNum,2}. Create Filters — SKIPPED");
-                    skipped++;
-                }
-
-                // Step: Create View Templates
-                if (data.CreateTemplates)
-                {
-                    passed += RunStep(ref stepNum, report, "Create View Templates (23)",
+                    passed += RunStep(ref stepNum, report, "View Templates (23 w/ VG)",
                         () => RunCommand(new ViewTemplatesCommand(), commandData, elements));
                     passed += RunStep(ref stepNum, report, "Apply Filters to Templates",
                         () => RunCommand(new ApplyFiltersToViewsCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Apply VG Overrides (5-layer)",
+                    passed += RunStep(ref stepNum, report, "VG Overrides (5-layer)",
                         () => RunCommand(new CreateVGOverridesCommand(), commandData, elements));
+                    passed += RunStep(ref stepNum, report, "Batch Family Parameters (CSV)",
+                        () => RunCommand(new BatchAddFamilyParamsCommand(), commandData, elements));
+                    passed += RunStep(ref stepNum, report, "Template Metadata Schedules",
+                        () => RunCommand(new CreateTemplateSchedulesCommand(), commandData, elements));
                 }
                 else
                 {
-                    stepNum++;
-                    report.AppendLine($"  {stepNum,2}. Create Templates — SKIPPED");
-                    skipped++;
+                    // Legacy granular steps — user unchecked "Use latest Template Setup"
+                    if (data.CreateStyles)
+                    {
+                        passed += RunStep(ref stepNum, report, "Create Fill Patterns",
+                            () => RunCommand(new CreateFillPatternsCommand(), commandData, elements));
+                        passed += RunStep(ref stepNum, report, "Create Line Patterns (10 ISO 128)",
+                            () => RunCommand(new CreateLinePatternsCommand(), commandData, elements));
+                        passed += RunStep(ref stepNum, report, "Create Line Styles",
+                            () => RunCommand(new CreateLineStylesCommand(), commandData, elements));
+                        passed += RunStep(ref stepNum, report, "Create Object Styles",
+                            () => RunCommand(new CreateObjectStylesCommand(), commandData, elements));
+                        passed += RunStep(ref stepNum, report, "Create Text Styles",
+                            () => RunCommand(new CreateTextStylesCommand(), commandData, elements));
+                        passed += RunStep(ref stepNum, report, "Create Dimension Styles",
+                            () => RunCommand(new CreateDimensionStylesCommand(), commandData, elements));
+                    }
+                    else
+                    {
+                        stepNum++;
+                        report.AppendLine($"  {stepNum,2}. Create Styles — SKIPPED");
+                        skipped++;
+                    }
+
+                    if (data.CreateFilters)
+                    {
+                        passed += RunStep(ref stepNum, report, "Create View Filters (28+)",
+                            () => RunCommand(new CreateFiltersCommand(), commandData, elements));
+                    }
+                    else
+                    {
+                        stepNum++;
+                        report.AppendLine($"  {stepNum,2}. Create Filters — SKIPPED");
+                        skipped++;
+                    }
+
+                    if (data.CreateTemplates)
+                    {
+                        passed += RunStep(ref stepNum, report, "Create View Templates (23)",
+                            () => RunCommand(new ViewTemplatesCommand(), commandData, elements));
+                        passed += RunStep(ref stepNum, report, "Apply Filters to Templates",
+                            () => RunCommand(new ApplyFiltersToViewsCommand(), commandData, elements));
+                        passed += RunStep(ref stepNum, report, "Apply VG Overrides (5-layer)",
+                            () => RunCommand(new CreateVGOverridesCommand(), commandData, elements));
+                    }
+                    else
+                    {
+                        stepNum++;
+                        report.AppendLine($"  {stepNum,2}. Create Templates — SKIPPED");
+                        skipped++;
+                    }
                 }
 
                 // Step: Create Phases (report only — API limitation)
@@ -426,12 +486,15 @@ namespace StingTools.Temp
                 // ════════════════════════════════════════════════════
                 report.AppendLine("\n── Phase 5: Intelligence ──");
 
-                // Auto-assign templates to all views
-                if (data.CreateTemplates)
+                // Auto-assign + auto-fix templates — runs whenever templates are in scope
+                bool doTemplatePost = data.UseLatestTemplateSetup || data.CreateTemplates;
+                if (doTemplatePost)
                 {
-                    passed += RunStep(ref stepNum, report, "Auto-Assign Templates (5-layer)",
+                    passed += RunStep(ref stepNum, report,
+                        "Auto-Assign Templates to Views (by view type + name + phase + level)",
                         () => RunCommand(new AutoAssignTemplatesCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Auto-Fix Template Health",
+                    passed += RunStep(ref stepNum, report,
+                        "Auto-Fix Template Health (fill missing settings per view type)",
                         () => RunCommand(new AutoFixTemplateCommand(), commandData, elements));
                 }
                 else
@@ -446,8 +509,13 @@ namespace StingTools.Temp
                 {
                     passed += RunStep(ref stepNum, report, "Full Auto-Populate (tokens+dims+MEP+formulas+tags)",
                         () => RunCommand(new FullAutoPopulateCommand(), commandData, elements));
-                    passed += RunStep(ref stepNum, report, "Batch Family Parameters (CSV)",
-                        () => RunCommand(new BatchAddFamilyParamsCommand(), commandData, elements));
+
+                    // Avoid running BatchAddFamilyParamsCommand twice — Phase 3 already ran it in latest mode.
+                    if (!data.UseLatestTemplateSetup)
+                    {
+                        passed += RunStep(ref stepNum, report, "Batch Family Parameters (CSV)",
+                            () => RunCommand(new BatchAddFamilyParamsCommand(), commandData, elements));
+                    }
                 }
 
                 // Set starting view
@@ -823,10 +891,11 @@ namespace StingTools.Temp
                     {
                         Level newLevel = Level.Create(doc, elevFeet);
                         newLevel.Name = def.Name;
+                        ApplyLevelStoryFlag(newLevel, def.IsStory);
                         created++;
                         existingByName[def.Name] = newLevel;
                         existingByElev[roundedM] = newLevel;
-                        StingLog.Info($"Created level '{def.Name}' at {def.ElevationMeters:F2}m");
+                        StingLog.Info($"Created level '{def.Name}' at {def.ElevationMeters:F2}m (type={def.LevelType}, story={def.IsStory})");
                     }
                     catch (Exception ex)
                     {
@@ -841,7 +910,237 @@ namespace StingTools.Temp
             return (created + renamed > 0 || skipped > 0) ? Result.Succeeded : Result.Failed;
         }
 
-        /// <summary>Create structural grids from wizard data.</summary>
+        /// <summary>Set LEVEL_IS_BUILDING_STORY on a level (best-effort).</summary>
+        private static void ApplyLevelStoryFlag(Level level, bool isStory)
+        {
+            try
+            {
+                Parameter p = level.get_Parameter(BuiltInParameter.LEVEL_IS_BUILDING_STORY);
+                if (p != null && !p.IsReadOnly)
+                    p.Set(isStory ? 1 : 0);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Could not set story flag on '{level.Name}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Rename scope boxes according to the wizard's rename map.
+        /// Skips entries where the target name already exists on a different scope box.
+        /// </summary>
+        private static Result RenameScopeBoxes(Document doc, ProjectSetupData data)
+        {
+            try
+            {
+                var scopeBoxes = new FilteredElementCollector(doc)
+                    .OfCategory(BuiltInCategory.OST_VolumeOfInterest)
+                    .WhereElementIsNotElementType()
+                    .ToList();
+
+                var byCurrent = scopeBoxes
+                    .GroupBy(e => e.Name, StringComparer.Ordinal)
+                    .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+                var takenNames = new HashSet<string>(scopeBoxes.Select(e => e.Name), StringComparer.Ordinal);
+
+                int renamed = 0, skipped = 0;
+                using (Transaction tx = new Transaction(doc, "STING Rename Scope Boxes"))
+                {
+                    tx.Start();
+                    foreach (var kv in data.ScopeBoxRenames)
+                    {
+                        if (!byCurrent.TryGetValue(kv.Key, out Element sb))
+                        {
+                            skipped++;
+                            continue;
+                        }
+                        string newName = kv.Value?.Trim();
+                        if (string.IsNullOrEmpty(newName) || string.Equals(newName, sb.Name, StringComparison.Ordinal))
+                        {
+                            skipped++;
+                            continue;
+                        }
+                        // Prevent collisions
+                        if (takenNames.Contains(newName))
+                        {
+                            StingLog.Warn($"Scope-box rename skipped: '{newName}' already used.");
+                            skipped++;
+                            continue;
+                        }
+                        try
+                        {
+                            string old = sb.Name;
+                            sb.Name = newName;
+                            takenNames.Remove(old);
+                            takenNames.Add(newName);
+                            renamed++;
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"Scope-box rename '{kv.Key}' → '{newName}' failed: {ex.Message}");
+                            skipped++;
+                        }
+                    }
+                    tx.Commit();
+                }
+
+                // Patch the wizard's selection list so subsequent steps use the new names
+                if (data.ScopeBoxSelection != null && data.ScopeBoxRenames.Count > 0)
+                {
+                    for (int i = 0; i < data.ScopeBoxSelection.Count; i++)
+                    {
+                        if (data.ScopeBoxRenames.TryGetValue(data.ScopeBoxSelection[i], out string n))
+                            data.ScopeBoxSelection[i] = n;
+                    }
+                }
+
+                StingLog.Info($"Scope boxes: {renamed} renamed, {skipped} skipped");
+                return renamed > 0 ? Result.Succeeded : (skipped > 0 ? Result.Succeeded : Result.Failed);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("RenameScopeBoxes failed", ex);
+                return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// Create two building sections per checked scope box — one through the centre in each
+        /// principal direction of the box (handles tilted scope boxes via BoundingBox.Transform).
+        /// </summary>
+        private static Result CreateTwoSectionsPerScopeBox(Document doc, ProjectSetupData data)
+        {
+            // Find the section ViewFamilyType
+            ViewFamilyType sectionVft = new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>()
+                .FirstOrDefault(v => v.ViewFamily == ViewFamily.Section);
+            if (sectionVft == null)
+            {
+                StingLog.Error("No Section ViewFamilyType in project");
+                return Result.Failed;
+            }
+
+            // Collect checked scope boxes by name
+            var selected = new HashSet<string>(data.ScopeBoxSelection ?? new List<string>(), StringComparer.Ordinal);
+            var scopeBoxes = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_VolumeOfInterest)
+                .WhereElementIsNotElementType()
+                .Where(e => selected.Contains(e.Name))
+                .ToList();
+            if (scopeBoxes.Count == 0)
+                return Result.Failed;
+
+            // Existing view-name cache to avoid duplicates
+            var viewNames = new HashSet<string>(
+                new FilteredElementCollector(doc)
+                    .OfClass(typeof(View))
+                    .Cast<View>()
+                    .Where(v => !v.IsTemplate)
+                    .Select(v => v.Name),
+                StringComparer.Ordinal);
+
+            int created = 0;
+            using (Transaction tx = new Transaction(doc, "STING Scope-Box Sections"))
+            {
+                tx.Start();
+                foreach (var sb in scopeBoxes)
+                {
+                    BoundingBoxXYZ box = sb.get_BoundingBox(null);
+                    if (box == null) continue;
+
+                    Transform boxT = box.Transform ?? Transform.Identity;
+                    XYZ boxBX = Normalise(boxT.BasisX);
+                    XYZ boxBY = Normalise(boxT.BasisY);
+
+                    // Centre in world coordinates (BB.Min/Max are in the box's local frame when a Transform is set)
+                    XYZ localCentre = (box.Min + box.Max) * 0.5;
+                    XYZ worldCentre = boxT.OfPoint(localCentre);
+
+                    // Extents along each local axis
+                    double halfX = (box.Max.X - box.Min.X) * 0.5;
+                    double halfY = (box.Max.Y - box.Min.Y) * 0.5;
+                    double halfZ = (box.Max.Z - box.Min.Z) * 0.5;
+
+                    // Two sections: one looking along −BoxY (cuts perpendicular to Y), one along −BoxX
+                    // Section 1: section line runs along BoxX, view looks towards −BoxY
+                    created += TryCreateSection(
+                        doc, sectionVft, $"Section - {sb.Name} - A", worldCentre,
+                        viewRight: boxBX, viewUp: XYZ.BasisZ, viewDir: -boxBY,
+                        halfWidth: halfX, halfHeight: halfZ, halfDepth: halfY,
+                        scopeBoxId: sb.Id, viewNames: viewNames) ? 1 : 0;
+
+                    // Section 2: section line runs along BoxY, view looks towards −BoxX
+                    created += TryCreateSection(
+                        doc, sectionVft, $"Section - {sb.Name} - B", worldCentre,
+                        viewRight: boxBY, viewUp: XYZ.BasisZ, viewDir: -boxBX,
+                        halfWidth: halfY, halfHeight: halfZ, halfDepth: halfX,
+                        scopeBoxId: sb.Id, viewNames: viewNames) ? 1 : 0;
+                }
+                tx.Commit();
+            }
+
+            StingLog.Info($"Scope-box sections: {created} created");
+            return created > 0 ? Result.Succeeded : Result.Failed;
+        }
+
+        private static bool TryCreateSection(Document doc, ViewFamilyType vft, string name,
+            XYZ origin, XYZ viewRight, XYZ viewUp, XYZ viewDir,
+            double halfWidth, double halfHeight, double halfDepth,
+            ElementId scopeBoxId, HashSet<string> viewNames)
+        {
+            // Guard against degenerate geometry
+            halfWidth = Math.Max(halfWidth, 1.0);
+            halfHeight = Math.Max(halfHeight, 1.0);
+            halfDepth = Math.Max(halfDepth, 1.0);
+
+            string unique = name;
+            int i = 2;
+            while (viewNames.Contains(unique)) { unique = $"{name} ({i++})"; }
+
+            try
+            {
+                var sectionBox = new BoundingBoxXYZ();
+                var t = Transform.Identity;
+                t.Origin = origin;
+                t.BasisX = Normalise(viewRight);
+                t.BasisY = Normalise(viewUp);
+                t.BasisZ = Normalise(viewDir);
+                sectionBox.Transform = t;
+                sectionBox.Min = new XYZ(-halfWidth, -halfHeight, 0);
+                sectionBox.Max = new XYZ(halfWidth, halfHeight, halfDepth * 2);
+
+                ViewSection view = ViewSection.CreateSection(doc, vft.Id, sectionBox);
+                if (view == null) return false;
+                try { view.Name = unique; viewNames.Add(unique); } catch { }
+
+                // Assign scope box to the section view
+                try
+                {
+                    Parameter p = view.get_Parameter(BuiltInParameter.VIEWER_VOLUME_OF_INTEREST_CROP);
+                    if (p != null && !p.IsReadOnly) p.Set(scopeBoxId);
+                }
+                catch { }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Section '{name}': {ex.Message}");
+                return false;
+            }
+        }
+
+        private static XYZ Normalise(XYZ v)
+        {
+            if (v == null || v.IsZeroLength()) return XYZ.BasisX;
+            return v.Normalize();
+        }
+
+        /// <summary>
+        /// Create structural grids from wizard data. When scope-box integration is enabled,
+        /// grids are rotated to the primary scope box's orientation (handles tilted boxes),
+        /// origined at that scope box's centre, and optionally scoped to the checked boxes.
+        /// </summary>
         private static Result CreateGrids(Document doc, ProjectSetupData data)
         {
             // Build index of existing grids
@@ -862,26 +1161,60 @@ namespace StingTools.Temp
             double vSpacingFt = UnitUtils.ConvertToInternalUnits(
                 data.GridVSpacing > 0 ? data.GridVSpacing : 6.0, UnitTypeId.Meters);
 
+            // Default grid frame (world-aligned at origin)
+            XYZ origin = XYZ.Zero;
+            XYZ axisX = XYZ.BasisX;
+            XYZ axisY = XYZ.BasisY;
+
+            // Resolve scope boxes to align to + scope into
+            var selectedNames = new HashSet<string>(
+                data.ScopeBoxSelection ?? new List<string>(), StringComparer.Ordinal);
+            var selectedScopeBoxes = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_VolumeOfInterest)
+                .WhereElementIsNotElementType()
+                .Where(e => selectedNames.Contains(e.Name))
+                .ToList();
+
+            // Use first checked scope box as the alignment reference
+            if (data.AlignToScopeBoxOrientation && selectedScopeBoxes.Count > 0)
+            {
+                Element refSb = selectedScopeBoxes[0];
+                BoundingBoxXYZ bb = refSb.get_BoundingBox(null);
+                if (bb != null)
+                {
+                    Transform bt = bb.Transform ?? Transform.Identity;
+                    axisX = Normalise(bt.BasisX);
+                    axisY = Normalise(bt.BasisY);
+                    XYZ localCentre = (bb.Min + bb.Max) * 0.5;
+                    origin = bt.OfPoint(localCentre);
+                    StingLog.Info($"Grids aligned to scope box '{refSb.Name}' " +
+                                  $"(X={axisX.X:F3},{axisX.Y:F3}, centre={origin.X:F2},{origin.Y:F2})");
+                }
+            }
+
+            // Compute overhang so grids extend past the grid block
+            double hHalf = (data.GridHCount > 1 ? (data.GridHCount - 1) * hSpacingFt : 0) * 0.5;
+            double vHalf = (data.GridVCount > 1 ? (data.GridVCount - 1) * vSpacingFt : 0) * 0.5;
+
             using (Transaction tx = new Transaction(doc, "STING Create Grids"))
             {
                 tx.Start();
 
-                // Horizontal grids (lettered A, B, C...) — lines running in X direction
+                // Horizontal grids (lettered A, B, C...) — run along axisX, stepped along axisY
                 for (int i = 0; i < data.GridHCount; i++)
                 {
                     string name = GetGridLetter(i);
-                    if (existingNames.Contains(name))
-                        continue;
+                    if (existingNames.Contains(name)) continue;
 
-                    double y = i * hSpacingFt;
-                    XYZ start = new XYZ(-vLengthFt * 0.1, y, 0);
-                    XYZ end = new XYZ(vLengthFt * 1.1, y, 0);
+                    double offsetY = i * hSpacingFt - hHalf;
+                    XYZ start = origin + axisY * offsetY + axisX * (-vLengthFt * 0.55);
+                    XYZ end   = origin + axisY * offsetY + axisX * ( vLengthFt * 0.55);
 
                     try
                     {
-                        Line line = Line.CreateBound(start, end);
-                        Grid grid = Grid.Create(doc, line);
+                        Grid grid = Grid.Create(doc, Line.CreateBound(start, end));
                         grid.Name = name;
+                        AssignScopeBoxToGrid(grid, selectedScopeBoxes, data.AssignGridsToScopeBoxes);
                         created++;
                     }
                     catch (Exception ex)
@@ -890,22 +1223,21 @@ namespace StingTools.Temp
                     }
                 }
 
-                // Vertical grids (numbered 1, 2, 3...) — lines running in Y direction
+                // Vertical grids (numbered 1, 2, 3...) — run along axisY, stepped along axisX
                 for (int i = 0; i < data.GridVCount; i++)
                 {
                     string name = (i + 1).ToString();
-                    if (existingNames.Contains(name))
-                        continue;
+                    if (existingNames.Contains(name)) continue;
 
-                    double x = i * vSpacingFt;
-                    XYZ start = new XYZ(x, -hLengthFt * 0.1, 0);
-                    XYZ end = new XYZ(x, hLengthFt * 1.1, 0);
+                    double offsetX = i * vSpacingFt - vHalf;
+                    XYZ start = origin + axisX * offsetX + axisY * (-hLengthFt * 0.55);
+                    XYZ end   = origin + axisX * offsetX + axisY * ( hLengthFt * 0.55);
 
                     try
                     {
-                        Line line = Line.CreateBound(start, end);
-                        Grid grid = Grid.Create(doc, line);
+                        Grid grid = Grid.Create(doc, Line.CreateBound(start, end));
                         grid.Name = name;
+                        AssignScopeBoxToGrid(grid, selectedScopeBoxes, data.AssignGridsToScopeBoxes);
                         created++;
                     }
                     catch (Exception ex)
@@ -917,8 +1249,29 @@ namespace StingTools.Temp
                 tx.Commit();
             }
 
-            StingLog.Info($"Grids: {created} created");
+            StingLog.Info($"Grids: {created} created" +
+                          (data.AlignToScopeBoxOrientation ? " (scope-box aligned)" : "") +
+                          (data.AssignGridsToScopeBoxes ? ", scoped" : ""));
             return created > 0 ? Result.Succeeded : Result.Failed;
+        }
+
+        /// <summary>
+        /// Set a grid's scope box (DATUM_VOLUME_OF_INTEREST). When multiple boxes are checked,
+        /// the first one is used — scope boxes are 1:1 with datums in Revit.
+        /// </summary>
+        private static void AssignScopeBoxToGrid(Grid grid, List<Element> selectedScopeBoxes, bool enabled)
+        {
+            if (!enabled || selectedScopeBoxes == null || selectedScopeBoxes.Count == 0) return;
+            try
+            {
+                Parameter p = grid.get_Parameter(BuiltInParameter.DATUM_VOLUME_OF_INTEREST);
+                if (p != null && !p.IsReadOnly)
+                    p.Set(selectedScopeBoxes[0].Id);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Could not scope grid '{grid.Name}': {ex.Message}");
+            }
         }
 
         /// <summary>Enable worksharing on the document.</summary>

--- a/StingTools/UI/ProjectSetupWizard.xaml
+++ b/StingTools/UI/ProjectSetupWizard.xaml
@@ -217,15 +217,50 @@
 
                         <Border Style="{StaticResource WizGroupBox}">
                             <StackPanel>
-                                <TextBlock Style="{StaticResource WizSubHeader}" Text="Level Definitions"/>
-                                <TextBlock Text="Name | Elevation (m) | Type (one per line)"
-                                           FontSize="10" Foreground="#777" Margin="0,0,0,4"/>
-                                <TextBox x:Name="txtLevels" AcceptsReturn="True" TextWrapping="Wrap"
-                                         Height="220" FontSize="11" FontFamily="Consolas"
-                                         VerticalScrollBarVisibility="Auto"
-                                         Padding="6" BorderBrush="#CCC"/>
-                                <TextBlock Text="Format: Name | Elevation(m)   Example: Ground Floor | 0.0"
-                                           FontSize="9" Foreground="#999" Margin="0,4,0,0"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Style="{StaticResource WizSubHeader}" Text="Level Definitions"/>
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                        <Button Content="+ Add" Click="LevelAdd_Click" Padding="8,2" Margin="2,0" FontSize="10"
+                                                ToolTip="Insert a new level row below the selection"/>
+                                        <Button Content="Delete" Click="LevelDelete_Click" Padding="8,2" Margin="2,0" FontSize="10"
+                                                ToolTip="Delete selected rows"/>
+                                        <Button Content="▲" Click="LevelMoveUp_Click" Padding="6,2" Margin="2,0" FontSize="10"
+                                                ToolTip="Move selection up"/>
+                                        <Button Content="▼" Click="LevelMoveDown_Click" Padding="6,2" Margin="2,0" FontSize="10"
+                                                ToolTip="Move selection down"/>
+                                        <Button Content="Sort by Elev." Click="LevelSort_Click" Padding="8,2" Margin="2,0" FontSize="10"
+                                                ToolTip="Sort rows by elevation ascending"/>
+                                    </StackPanel>
+                                </Grid>
+                                <TextBlock Text="Edit any cell inline. Name must be unique; elevation in metres."
+                                           FontSize="10" Foreground="#777" Margin="0,2,0,4"/>
+                                <DataGrid x:Name="dgLevels"
+                                          Height="240" FontSize="11"
+                                          AutoGenerateColumns="False"
+                                          CanUserAddRows="True"
+                                          CanUserDeleteRows="True"
+                                          HeadersVisibility="Column"
+                                          GridLinesVisibility="Horizontal"
+                                          AlternatingRowBackground="#F7F3FA"
+                                          RowHeaderWidth="0"
+                                          SelectionMode="Extended" SelectionUnit="FullRow"
+                                          BorderBrush="#CCC">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="#" Binding="{Binding Index, Mode=OneWay}" Width="30" IsReadOnly="True"/>
+                                        <DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                                        <DataGridTextColumn Header="Elevation (m)" Binding="{Binding ElevationText, UpdateSourceTrigger=PropertyChanged}" Width="110"/>
+                                        <DataGridComboBoxColumn x:Name="colLevelType" Header="Type"
+                                                                SelectedValueBinding="{Binding LevelType}" Width="140"/>
+                                        <DataGridCheckBoxColumn Header="Story" Binding="{Binding IsStory}" Width="60"
+                                                                ElementStyle="{x:Null}"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                                <TextBlock Text="Tip: the 'Story' checkbox marks the level as a building story (affects rooms, views, scheduling). Untick for sub-levels/reference planes."
+                                           FontSize="9" Foreground="#999" Margin="0,4,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
 
@@ -295,6 +330,67 @@
                                     <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Length (m):"/>
                                     <TextBox Grid.Row="2" Grid.Column="1" x:Name="txtGridVLength" Style="{StaticResource WizInput}" Width="80" Text="30" HorizontalAlignment="Left"/>
                                 </Grid>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- ─── Scope Box Integration ─── -->
+                        <TextBlock Style="{StaticResource WizSubHeader}" Text="Scope Box Integration" Margin="0,10,0,2"/>
+                        <Border Style="{StaticResource WizGroupBox}">
+                            <StackPanel>
+                                <TextBlock Text="Keep drawings clean on tilted scope boxes: grids, sections and elevations align to the box direction, and grids can be scoped to selected boxes only."
+                                           FontSize="10" Foreground="#777" Margin="0,0,0,6" TextWrapping="Wrap"/>
+
+                                <CheckBox x:Name="chkAlignToScopeBoxes" Style="{StaticResource WizCheck}"
+                                          Content="Align grids / sections / elevations to scope-box orientation (handles tilted boxes)"/>
+                                <CheckBox x:Name="chkAssignGridsToScopeBoxes" Style="{StaticResource WizCheck}"
+                                          Content="Scope created grids to the ticked scope boxes (uses the checked rows below)"/>
+                                <CheckBox x:Name="chkTwoSectionsPerScopeBox" Style="{StaticResource WizCheck}"
+                                          Content="Create two building sections per scope box (through centre, both directions)"/>
+                                <CheckBox x:Name="chkRenameScopeBoxes" Style="{StaticResource WizCheck}"
+                                          Content="Rename scope boxes to the standard pattern on Run"/>
+
+                                <TextBlock x:Name="lblScopeBoxEmpty"
+                                           Text="No scope boxes in this project yet. Create scope boxes first, or skip this section."
+                                           FontSize="10" Foreground="#B71C1C" FontStyle="Italic"
+                                           Margin="0,6,0,2" Visibility="Collapsed"/>
+
+                                <TextBlock Style="{StaticResource WizSubHeader}" Text="Scope Boxes in Project" FontWeight="Normal" Margin="0,6,0,2"/>
+                                <DataGrid x:Name="dgScopeBoxes"
+                                          Height="130" FontSize="11"
+                                          AutoGenerateColumns="False"
+                                          CanUserAddRows="False"
+                                          CanUserDeleteRows="False"
+                                          HeadersVisibility="Column"
+                                          GridLinesVisibility="Horizontal"
+                                          AlternatingRowBackground="#F7F3FA"
+                                          RowHeaderWidth="0"
+                                          SelectionMode="Extended" SelectionUnit="FullRow"
+                                          BorderBrush="#CCC">
+                                    <DataGrid.Columns>
+                                        <DataGridCheckBoxColumn Header="Use" Binding="{Binding Include}" Width="40"/>
+                                        <DataGridTextColumn Header="Current Name" Binding="{Binding CurrentName, Mode=OneWay}" Width="*" IsReadOnly="True"/>
+                                        <DataGridTextColumn Header="Rename To" Binding="{Binding NewName, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                                        <DataGridTextColumn Header="Angle" Binding="{Binding RotationText, Mode=OneWay}" Width="60" IsReadOnly="True"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+
+                                <Grid Margin="0,6,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="140"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Style="{StaticResource WizLabel}" Text="Rename pattern:"
+                                               ToolTip="Supported tokens: {BLD}, {LOC}, {ZONE}, {INDEX}, {NAME}"/>
+                                    <TextBox Grid.Column="1" x:Name="txtScopeBoxPattern" Style="{StaticResource WizInput}"
+                                             Text="{}{BLD}-{ZONE}-{INDEX}"/>
+                                    <Button Grid.Column="2" Content="Apply to checked"
+                                            Click="ScopeBoxPatternApply_Click"
+                                            Padding="8,2" Margin="4,2,0,2" FontSize="10"
+                                            ToolTip="Regenerate the 'Rename To' column from the pattern for ticked rows"/>
+                                </Grid>
+                                <TextBlock Text="Tokens: {BLD}=first LOC code · {LOC}=location code (cycles) · {ZONE}=zone code (cycles) · {INDEX}=1,2,3… · {NAME}=current name"
+                                           FontSize="9" Foreground="#999" Margin="0,2,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
                     </StackPanel>
@@ -709,6 +805,10 @@
                         <Border Style="{StaticResource WizGroupBox}">
                             <StackPanel>
                                 <TextBlock Style="{StaticResource WizSubHeader}" Text="Styles &amp; Templates"/>
+                                <CheckBox x:Name="chkUseLatestTemplateSetup" Style="{StaticResource WizCheck}"
+                                          Content="Use latest Template Setup pipeline (15-step: fill/line/object/text/dim styles + filters + 23 templates + VG + family params + schedules)"
+                                          IsChecked="True"
+                                          ToolTip="Runs the full TemplateSetupWizard ordering. Overrides the individual steps below when checked."/>
                                 <CheckBox x:Name="chkCreateStyles" Style="{StaticResource WizCheck}"
                                           Content="Create styles (fill/line patterns, line/text/dimension/object styles)" IsChecked="True"/>
                                 <CheckBox x:Name="chkCreateFilters" Style="{StaticResource WizCheck}"

--- a/StingTools/UI/ProjectSetupWizard.xaml.cs
+++ b/StingTools/UI/ProjectSetupWizard.xaml.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -27,11 +30,38 @@ namespace StingTools.UI
         /// <summary>True when user clicked Run (not Cancel).</summary>
         public bool RunRequested { get; private set; }
 
+        /// <summary>Bound to the Levels DataGrid on page 2.</summary>
+        public ObservableCollection<LevelRow> LevelRows { get; } = new ObservableCollection<LevelRow>();
+
+        /// <summary>Bound to the Scope-Box DataGrid on page 3.</summary>
+        public ObservableCollection<ScopeBoxRow> ScopeBoxRows { get; } = new ObservableCollection<ScopeBoxRow>();
+
+        /// <summary>Allowed values for the 'Type' column in the levels grid.</summary>
+        private static readonly string[] LevelTypeOptions =
+        {
+            "Standard", "Structural", "Reference", "Ceiling", "Sub-level", "Roof", "Parapet"
+        };
+
         public ProjectSetupWizard()
         {
             InitializeComponent();
+
+            // Bind level grid
+            dgLevels.ItemsSource = LevelRows;
+            colLevelType.ItemsSource = LevelTypeOptions;
+            LevelRows.CollectionChanged += (_, __) => RenumberLevelRows();
+
+            // Bind scope-box grid
+            dgScopeBoxes.ItemsSource = ScopeBoxRows;
+
             BuildStepIndicators();
             UpdateNavigation();
+        }
+
+        private void RenumberLevelRows()
+        {
+            for (int i = 0; i < LevelRows.Count; i++)
+                LevelRows[i].Index = i + 1;
         }
 
         // ── Pre-populate from Revit data ─────────────────────────────
@@ -69,7 +99,7 @@ namespace StingTools.UI
                 StingLog.Warn($"ProjectSetup: could not read ProjectInfo: {ex.Message}");
             }
 
-            // Existing levels
+            // Existing levels — populate editable DataGrid
             try
             {
                 var levels = new FilteredElementCollector(doc)
@@ -77,21 +107,55 @@ namespace StingTools.UI
                     .Cast<Level>()
                     .OrderBy(l => l.Elevation)
                     .ToList();
-                if (levels.Count > 0)
+
+                LevelRows.Clear();
+                foreach (var lv in levels)
                 {
-                    var sb = new StringBuilder();
-                    foreach (var lv in levels)
+                    double elevM = UnitUtils.ConvertFromInternalUnits(lv.Elevation, UnitTypeId.Meters);
+                    LevelRows.Add(new LevelRow
                     {
-                        double elevM = UnitUtils.ConvertFromInternalUnits(
-                            lv.Elevation, UnitTypeId.Meters);
-                        sb.AppendLine($"{lv.Name} | {elevM:F2}");
-                    }
-                    txtLevels.Text = sb.ToString().TrimEnd();
+                        Name = lv.Name,
+                        ElevationText = elevM.ToString("F2", CultureInfo.InvariantCulture),
+                        LevelType = GuessLevelType(lv.Name),
+                        IsStory = IsStoryLevel(lv),
+                        ExistingId = lv.Id.IntegerValue
+                    });
                 }
+                RenumberLevelRows();
             }
             catch (Exception ex)
             {
                 StingLog.Warn($"ProjectSetup: could not read levels: {ex.Message}");
+            }
+
+            // Existing scope boxes — populate the scope-box DataGrid
+            try
+            {
+                var scopeBoxes = new FilteredElementCollector(doc)
+                    .OfCategory(BuiltInCategory.OST_VolumeOfInterest)
+                    .WhereElementIsNotElementType()
+                    .OrderBy(e => e.Name)
+                    .ToList();
+
+                ScopeBoxRows.Clear();
+                foreach (var sb in scopeBoxes)
+                {
+                    double rotDeg = GetScopeBoxRotationDegrees(sb);
+                    ScopeBoxRows.Add(new ScopeBoxRow
+                    {
+                        Include = true,
+                        CurrentName = sb.Name,
+                        NewName = sb.Name,
+                        RotationDegrees = rotDeg,
+                        RevitIdValue = sb.Id.IntegerValue
+                    });
+                }
+                lblScopeBoxEmpty.Visibility = ScopeBoxRows.Count == 0
+                    ? Visibility.Visible : Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ProjectSetup: could not read scope boxes: {ex.Message}");
             }
 
             // Title blocks
@@ -109,6 +173,58 @@ namespace StingTools.UI
             catch (Exception ex)
             {
                 StingLog.Warn($"ProjectSetup: could not read workshared state: {ex.Message}");
+            }
+        }
+
+        /// <summary>Best-effort guess of a level's type from its name.</summary>
+        private static string GuessLevelType(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return "Standard";
+            string n = name.ToUpperInvariant();
+            if (n.Contains("ROOF")) return "Roof";
+            if (n.Contains("PARAPET")) return "Parapet";
+            if (n.Contains("CEILING") || n.Contains("SOFIT") || n.Contains("SOFFIT")) return "Ceiling";
+            if (n.Contains("RING BEAM") || n.Contains("BEAM") || n.Contains("FOOTING") || n.Contains("SLAB")) return "Structural";
+            if (n.Contains("SILL") || n.Contains("DATUM") || n.Contains("REF")) return "Reference";
+            if (n.Contains("MEZZANINE") || n.Contains("SUB")) return "Sub-level";
+            return "Standard";
+        }
+
+        /// <summary>Detect whether a Revit level is flagged as a building story.</summary>
+        private static bool IsStoryLevel(Level lv)
+        {
+            try
+            {
+                Parameter p = lv.get_Parameter(BuiltInParameter.LEVEL_IS_BUILDING_STORY);
+                if (p != null) return p.AsInteger() != 0;
+            }
+            catch { }
+            return true;
+        }
+
+        /// <summary>
+        /// Return the rotation (degrees) of a scope box's primary axis relative to world X.
+        /// Uses the element's bounding-box Transform (which carries the box's orientation).
+        /// </summary>
+        internal static double GetScopeBoxRotationDegrees(Element scopeBox)
+        {
+            try
+            {
+                BoundingBoxXYZ bb = scopeBox.get_BoundingBox(null);
+                if (bb == null) return 0.0;
+                Transform t = bb.Transform ?? Transform.Identity;
+                XYZ bx = t.BasisX;
+                if (bx == null || bx.IsZeroLength()) return 0.0;
+                double angleRad = Math.Atan2(bx.Y, bx.X);
+                double deg = angleRad * 180.0 / Math.PI;
+                // Normalise to [-180, 180]
+                while (deg > 180) deg -= 360;
+                while (deg < -180) deg += 360;
+                return Math.Round(deg, 1);
+            }
+            catch
+            {
+                return 0.0;
             }
         }
 
@@ -325,17 +441,46 @@ namespace StingTools.UI
                     }
                     return true;
 
-                case 1: // Levels — require at least one
-                    var levels = ParseLevels();
-                    if (levels.Count == 0)
+                case 1: // Levels — require at least one and validate each row
                     {
-                        MessageBox.Show(
-                            "Please define at least one building level.\n" +
-                            "Use a preset or enter lines in the format: Name | Elevation(m)",
-                            "STING Setup", MessageBoxButton.OK, MessageBoxImage.Warning);
-                        return false;
+                        var parsed = ParseLevels();
+                        if (parsed.Count == 0)
+                        {
+                            MessageBox.Show(
+                                "Please define at least one building level.\n" +
+                                "Use a preset or add rows to the table (Name + Elevation in metres).",
+                                "STING Setup", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            return false;
+                        }
+                        // Flag invalid elevation rows
+                        var bad = LevelRows
+                            .Where(r => !string.IsNullOrWhiteSpace(r.Name)
+                                        && !double.TryParse(r.ElevationText, NumberStyles.Float,
+                                            CultureInfo.InvariantCulture, out _))
+                            .ToList();
+                        if (bad.Count > 0)
+                        {
+                            MessageBox.Show(
+                                $"{bad.Count} row(s) have an invalid elevation. Use a number in metres (e.g. 0.0, 3.5, -1.20).",
+                                "STING Setup", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            return false;
+                        }
+                        // Duplicate names
+                        var dupNames = LevelRows
+                            .Where(r => !string.IsNullOrWhiteSpace(r.Name))
+                            .GroupBy(r => r.Name.Trim(), StringComparer.OrdinalIgnoreCase)
+                            .Where(g => g.Count() > 1)
+                            .Select(g => g.Key)
+                            .ToList();
+                        if (dupNames.Count > 0)
+                        {
+                            MessageBox.Show(
+                                $"Duplicate level names: {string.Join(", ", dupNames)}.\nEach level must have a unique name.",
+                                "STING Setup", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            return false;
+                        }
+                        return true;
                     }
-                    return true;
 
                 case 2: // Grids — validate numeric inputs if grids are enabled
                     if (chkCreateGrids.IsChecked == true)
@@ -407,74 +552,186 @@ namespace StingTools.UI
                 return;
 
             double floorH = 3.5;
-            if (double.TryParse(txtFloorHeight.Text, out double h) && h > 0)
+            if (double.TryParse(txtFloorHeight.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out double h) && h > 0)
                 floorH = h;
 
-            var lines = new List<string>();
+            LevelRows.Clear();
+
+            void Add(string name, double elev, string type, bool isStory = true)
+            {
+                LevelRows.Add(new LevelRow
+                {
+                    Name = name,
+                    ElevationText = elev.ToString("F2", CultureInfo.InvariantCulture),
+                    LevelType = type,
+                    IsStory = isStory
+                });
+            }
+
             switch (tag)
             {
                 case "residential":
-                    lines.Add("Ground Floor | 0.00");
-                    for (int i = 1; i <= 3; i++)
-                        lines.Add($"Level {i:D2} | {(i * floorH):F2}");
-                    lines.Add($"Roof | {(4 * floorH):F2}");
+                    Add("Ground Floor", 0.00, "Standard");
+                    for (int i = 1; i <= 3; i++) Add($"Level {i:D2}", i * floorH, "Standard");
+                    Add("Roof", 4 * floorH, "Roof", isStory: false);
                     break;
 
                 case "commercial":
-                    lines.Add($"Basement 01 | {(-floorH):F2}");
-                    lines.Add("Ground Floor | 0.00");
-                    for (int i = 1; i <= 5; i++)
-                        lines.Add($"Level {i:D2} | {(i * floorH):F2}");
-                    lines.Add($"Roof | {(6 * floorH):F2}");
+                    Add("Basement 01", -floorH, "Sub-level");
+                    Add("Ground Floor", 0.00, "Standard");
+                    for (int i = 1; i <= 5; i++) Add($"Level {i:D2}", i * floorH, "Standard");
+                    Add("Roof", 6 * floorH, "Roof", isStory: false);
                     break;
 
                 case "highrise":
-                    lines.Add($"Basement 02 | {(-2 * floorH):F2}");
-                    lines.Add($"Basement 01 | {(-floorH):F2}");
-                    lines.Add("Ground Floor | 0.00");
-                    for (int i = 1; i <= 15; i++)
-                        lines.Add($"Level {i:D2} | {(i * floorH):F2}");
-                    lines.Add($"Roof | {(16 * floorH):F2}");
+                    Add("Basement 02", -2 * floorH, "Sub-level");
+                    Add("Basement 01", -floorH, "Sub-level");
+                    Add("Ground Floor", 0.00, "Standard");
+                    for (int i = 1; i <= 15; i++) Add($"Level {i:D2}", i * floorH, "Standard");
+                    Add("Roof", 16 * floorH, "Roof", isStory: false);
                     break;
 
                 case "industrial":
-                    lines.Add("Ground Floor | 0.00");
-                    lines.Add($"Mezzanine | {(floorH):F2}");
-                    lines.Add($"Roof | {(2 * floorH):F2}");
+                    Add("Ground Floor", 0.00, "Standard");
+                    Add("Mezzanine", floorH, "Sub-level");
+                    Add("Roof", 2 * floorH, "Roof", isStory: false);
                     break;
 
                 case "clear":
-                    lines.Clear();
+                    // already cleared
                     break;
             }
+            RenumberLevelRows();
+        }
 
-            txtLevels.Text = string.Join(Environment.NewLine, lines);
+        // ── Level toolbar handlers ───────────────────────────────────
+
+        private void LevelAdd_Click(object sender, RoutedEventArgs e)
+        {
+            // Guess next elevation = last row + floor height
+            double nextElev = 0.0;
+            double floorH = 3.5;
+            if (double.TryParse(txtFloorHeight.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out double h) && h > 0)
+                floorH = h;
+            var last = LevelRows.LastOrDefault();
+            if (last != null && double.TryParse(last.ElevationText,
+                NumberStyles.Float, CultureInfo.InvariantCulture, out double lastEl))
+            {
+                nextElev = lastEl + floorH;
+            }
+
+            int insertAt = dgLevels.SelectedIndex >= 0 ? dgLevels.SelectedIndex + 1 : LevelRows.Count;
+            var row = new LevelRow
+            {
+                Name = $"Level {LevelRows.Count + 1:D2}",
+                ElevationText = nextElev.ToString("F2", CultureInfo.InvariantCulture),
+                LevelType = "Standard",
+                IsStory = true
+            };
+            if (insertAt >= LevelRows.Count) LevelRows.Add(row); else LevelRows.Insert(insertAt, row);
+            RenumberLevelRows();
+            dgLevels.SelectedItem = row;
+            dgLevels.ScrollIntoView(row);
+        }
+
+        private void LevelDelete_Click(object sender, RoutedEventArgs e)
+        {
+            var selected = dgLevels.SelectedItems.OfType<LevelRow>().ToList();
+            if (selected.Count == 0) return;
+            foreach (var r in selected) LevelRows.Remove(r);
+            RenumberLevelRows();
+        }
+
+        private void LevelMoveUp_Click(object sender, RoutedEventArgs e)
+        {
+            var selected = dgLevels.SelectedItems.OfType<LevelRow>().ToList();
+            if (selected.Count == 0) return;
+            foreach (var r in selected.OrderBy(x => LevelRows.IndexOf(x)))
+            {
+                int i = LevelRows.IndexOf(r);
+                if (i > 0) LevelRows.Move(i, i - 1);
+            }
+            RenumberLevelRows();
+        }
+
+        private void LevelMoveDown_Click(object sender, RoutedEventArgs e)
+        {
+            var selected = dgLevels.SelectedItems.OfType<LevelRow>().ToList();
+            if (selected.Count == 0) return;
+            foreach (var r in selected.OrderByDescending(x => LevelRows.IndexOf(x)))
+            {
+                int i = LevelRows.IndexOf(r);
+                if (i >= 0 && i < LevelRows.Count - 1) LevelRows.Move(i, i + 1);
+            }
+            RenumberLevelRows();
+        }
+
+        private void LevelSort_Click(object sender, RoutedEventArgs e)
+        {
+            var sorted = LevelRows
+                .OrderBy(r =>
+                {
+                    return double.TryParse(r.ElevationText, NumberStyles.Float,
+                        CultureInfo.InvariantCulture, out double v) ? v : double.MaxValue;
+                })
+                .ToList();
+            LevelRows.Clear();
+            foreach (var r in sorted) LevelRows.Add(r);
+            RenumberLevelRows();
+        }
+
+        // ── Scope-box pattern handler ────────────────────────────────
+
+        private void ScopeBoxPatternApply_Click(object sender, RoutedEventArgs e)
+        {
+            string pattern = txtScopeBoxPattern.Text?.Trim();
+            if (string.IsNullOrEmpty(pattern))
+            {
+                MessageBox.Show(
+                    "Enter a rename pattern (e.g. {BLD}-{ZONE}-{INDEX}).",
+                    "STING Setup", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+            var locs = ParseCodes(txtLocCodes.Text);
+            var zones = ParseCodes(txtZoneCodes.Text);
+            string bld = locs.FirstOrDefault() ?? "BLD1";
+
+            int idx = 1;
+            foreach (var sb in ScopeBoxRows)
+            {
+                if (!sb.Include) continue;
+                string loc = locs.Count > 0 ? locs[(idx - 1) % locs.Count] : bld;
+                string zone = zones.Count > 0 ? zones[(idx - 1) % zones.Count] : "Z01";
+                string newName = pattern
+                    .Replace("{BLD}", bld)
+                    .Replace("{LOC}", loc)
+                    .Replace("{ZONE}", zone)
+                    .Replace("{INDEX}", idx.ToString("D2"))
+                    .Replace("{NAME}", sb.CurrentName ?? "");
+                sb.NewName = newName;
+                idx++;
+            }
         }
 
         // ── Parse helpers ────────────────────────────────────────────
 
+        /// <summary>Read the Levels DataGrid into strongly-typed definitions.</summary>
         private List<LevelDefinition> ParseLevels()
         {
             var result = new List<LevelDefinition>();
-            if (string.IsNullOrWhiteSpace(txtLevels.Text))
-                return result;
-
-            foreach (string line in txtLevels.Text.Split('\n'))
+            foreach (var row in LevelRows)
             {
-                string trimmed = line.Trim();
-                if (string.IsNullOrEmpty(trimmed))
+                if (string.IsNullOrWhiteSpace(row.Name)) continue;
+                if (!double.TryParse(row.ElevationText, NumberStyles.Float,
+                    CultureInfo.InvariantCulture, out double elev))
                     continue;
-
-                string[] parts = trimmed.Split('|');
-                if (parts.Length < 2)
-                    continue;
-
-                string name = parts[0].Trim();
-                if (string.IsNullOrEmpty(name))
-                    continue;
-
-                if (double.TryParse(parts[1].Trim(), out double elev))
-                    result.Add(new LevelDefinition { Name = name, ElevationMeters = elev });
+                result.Add(new LevelDefinition
+                {
+                    Name = row.Name.Trim(),
+                    ElevationMeters = elev,
+                    LevelType = row.LevelType ?? "Standard",
+                    IsStory = row.IsStory
+                });
             }
             return result;
         }
@@ -519,11 +776,27 @@ namespace StingTools.UI
             // Page 3: Grids
             data.CreateGrids = chkCreateGrids.IsChecked == true;
             if (int.TryParse(txtGridHCount.Text, out int ghc)) data.GridHCount = ghc;
-            if (double.TryParse(txtGridHSpacing.Text, out double ghs)) data.GridHSpacing = ghs;
-            if (double.TryParse(txtGridHLength.Text, out double ghl)) data.GridHLength = ghl;
+            if (double.TryParse(txtGridHSpacing.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out double ghs)) data.GridHSpacing = ghs;
+            if (double.TryParse(txtGridHLength.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out double ghl)) data.GridHLength = ghl;
             if (int.TryParse(txtGridVCount.Text, out int gvc)) data.GridVCount = gvc;
-            if (double.TryParse(txtGridVSpacing.Text, out double gvs)) data.GridVSpacing = gvs;
-            if (double.TryParse(txtGridVLength.Text, out double gvl)) data.GridVLength = gvl;
+            if (double.TryParse(txtGridVSpacing.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out double gvs)) data.GridVSpacing = gvs;
+            if (double.TryParse(txtGridVLength.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out double gvl)) data.GridVLength = gvl;
+
+            // Page 3: Scope-box integration
+            data.AlignToScopeBoxOrientation = chkAlignToScopeBoxes.IsChecked == true;
+            data.AssignGridsToScopeBoxes = chkAssignGridsToScopeBoxes.IsChecked == true;
+            data.TwoSectionsPerScopeBox = chkTwoSectionsPerScopeBox.IsChecked == true;
+            data.RenameScopeBoxes = chkRenameScopeBoxes.IsChecked == true;
+            data.ScopeBoxRenamePattern = txtScopeBoxPattern.Text?.Trim() ?? "";
+            data.ScopeBoxRenames = ScopeBoxRows
+                .Where(sb => sb.Include
+                             && !string.IsNullOrWhiteSpace(sb.NewName)
+                             && !string.Equals(sb.NewName, sb.CurrentName, StringComparison.Ordinal))
+                .ToDictionary(sb => sb.CurrentName, sb => sb.NewName.Trim());
+            data.ScopeBoxSelection = ScopeBoxRows
+                .Where(sb => sb.Include)
+                .Select(sb => sb.CurrentName)
+                .ToList();
 
             // Page 4: Disciplines
             data.Disciplines = new List<string>();
@@ -555,6 +828,7 @@ namespace StingTools.UI
             CollectDisciplineConfig(data);
 
             // Page 6: Automation
+            data.UseLatestTemplateSetup = chkUseLatestTemplateSetup.IsChecked == true;
             data.LoadParams = chkLoadParams.IsChecked == true;
             data.CreateMaterials = chkCreateMaterials.IsChecked == true;
             data.CreateFamilyTypes = chkCreateFamilyTypes.IsChecked == true;
@@ -715,6 +989,23 @@ namespace StingTools.UI
                 sb.AppendLine("  Grids:         SKIPPED");
             }
 
+            // Scope boxes
+            int sbChecked = data.ScopeBoxSelection?.Count ?? 0;
+            sb.AppendLine();
+            sb.AppendLine("SCOPE BOXES");
+            sb.AppendLine(new string('─', 55));
+            sb.AppendLine($"  Checked:          {sbChecked}");
+            sb.AppendLine($"  Align to orient.: {(data.AlignToScopeBoxOrientation ? "YES (tilted-aware)" : "NO")}");
+            sb.AppendLine($"  Scope grids:      {(data.AssignGridsToScopeBoxes && sbChecked > 0 ? "YES" : "NO")}");
+            sb.AppendLine($"  2 sections each:  {(data.TwoSectionsPerScopeBox && sbChecked > 0 ? $"YES ({sbChecked * 2} sections)" : "NO")}");
+            int renames = data.ScopeBoxRenames?.Count ?? 0;
+            sb.AppendLine($"  Rename on Run:    {(data.RenameScopeBoxes && renames > 0 ? $"YES ({renames} rename(s))" : "NO")}");
+            if (data.RenameScopeBoxes && renames > 0)
+            {
+                foreach (var kv in data.ScopeBoxRenames)
+                    sb.AppendLine($"      {kv.Key}  →  {kv.Value}");
+            }
+
             // Disciplines
             sb.AppendLine();
             sb.AppendLine("DISCIPLINES");
@@ -783,29 +1074,48 @@ namespace StingTools.UI
 
             // Phase 3: Standards
             sb.AppendLine("  Phase 3: Standards");
-            if (data.CreateStyles)
+            if (data.UseLatestTemplateSetup)
             {
-                AddStep(true, "Create fill patterns");
-                AddStep(true, "Create line patterns (10 ISO 128)");
-                AddStep(true, "Create line styles");
-                AddStep(true, "Create object styles");
-                AddStep(true, "Create text styles");
-                AddStep(true, "Create dimension styles");
+                // 15-step Template Setup Wizard ordering (latest)
+                AddStep(true, "[LATEST] Fill patterns (12 ISO)");
+                AddStep(true, "[LATEST] Line patterns (10 ISO 128)");
+                AddStep(true, "[LATEST] Line styles (16)");
+                AddStep(true, "[LATEST] Object styles (40)");
+                AddStep(true, "[LATEST] Text styles (12 ISO 3098)");
+                AddStep(true, "[LATEST] Dimension styles (7)");
+                AddStep(true, "[LATEST] View filters (28+)");
+                AddStep(true, "[LATEST] View templates (23 w/ VG)");
+                AddStep(true, "[LATEST] Apply filters to templates");
+                AddStep(true, "[LATEST] VG overrides (5-layer)");
+                AddStep(true, "[LATEST] Batch family parameters (CSV)");
+                AddStep(true, "[LATEST] Template metadata schedules");
             }
             else
             {
-                AddStep(false, "Create styles (6 sub-steps)");
-            }
-            AddStep(data.CreateFilters, "Create view filters (28+)");
-            if (data.CreateTemplates)
-            {
-                AddStep(true, "Create view templates (23)");
-                AddStep(true, "Apply filters to templates");
-                AddStep(true, "Apply VG overrides (5-layer)");
-            }
-            else
-            {
-                AddStep(false, "Create view templates (3 sub-steps)");
+                if (data.CreateStyles)
+                {
+                    AddStep(true, "Create fill patterns");
+                    AddStep(true, "Create line patterns (10 ISO 128)");
+                    AddStep(true, "Create line styles");
+                    AddStep(true, "Create object styles");
+                    AddStep(true, "Create text styles");
+                    AddStep(true, "Create dimension styles");
+                }
+                else
+                {
+                    AddStep(false, "Create styles (6 sub-steps)");
+                }
+                AddStep(data.CreateFilters, "Create view filters (28+)");
+                if (data.CreateTemplates)
+                {
+                    AddStep(true, "Create view templates (23)");
+                    AddStep(true, "Apply filters to templates");
+                    AddStep(true, "Apply VG overrides (5-layer)");
+                }
+                else
+                {
+                    AddStep(false, "Create view templates (3 sub-steps)");
+                }
             }
             AddStep(data.CreatePhases, "Audit project phases (report only)");
             AddStep(data.EnableWorksharing, "Create worksets (35 ISO 19650)");
@@ -822,10 +1132,11 @@ namespace StingTools.UI
 
             // Phase 5: Intelligence
             sb.AppendLine("  Phase 5: Intelligence");
-            AddStep(data.CreateTemplates, "Auto-assign templates (5-layer)");
-            AddStep(data.CreateTemplates, "Auto-fix template health");
+            bool doTemplatePost = data.UseLatestTemplateSetup || data.CreateTemplates;
+            AddStep(doTemplatePost, "Auto-assign view templates by view type / name / phase / level");
+            AddStep(doTemplatePost, "Auto-fix template health (fill missing settings per view type)");
             AddStep(data.LoadParams, "Full auto-populate (tokens + dims + MEP + formulas)");
-            AddStep(data.LoadParams, "Batch add family parameters");
+            AddStep(data.LoadParams && !data.UseLatestTemplateSetup, "Batch add family parameters");
             AddStep(true, "Set starting view");
 
             sb.AppendLine();
@@ -946,6 +1257,41 @@ namespace StingTools.UI
     {
         public string Name { get; set; }
         public double ElevationMeters { get; set; }
+        /// <summary>User-facing classification (Standard, Structural, Reference, Ceiling, Sub-level, Roof, Parapet).</summary>
+        public string LevelType { get; set; } = "Standard";
+        /// <summary>Whether the level is marked as a building story in Revit.</summary>
+        public bool IsStory { get; set; } = true;
+    }
+
+    /// <summary>Row bound to the Levels DataGrid.</summary>
+    public class LevelRow : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void Raise(string n) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+
+        private int _index; public int Index { get => _index; set { _index = value; Raise(nameof(Index)); } }
+        private string _name; public string Name { get => _name; set { _name = value; Raise(nameof(Name)); } }
+        private string _elev = "0.00"; public string ElevationText { get => _elev; set { _elev = value; Raise(nameof(ElevationText)); } }
+        private string _type = "Standard"; public string LevelType { get => _type; set { _type = value; Raise(nameof(LevelType)); } }
+        private bool _story = true; public bool IsStory { get => _story; set { _story = value; Raise(nameof(IsStory)); } }
+
+        /// <summary>Revit ElementId.IntegerValue if this row came from an existing level; 0 for new.</summary>
+        public int ExistingId { get; set; }
+    }
+
+    /// <summary>Row bound to the Scope-Box DataGrid.</summary>
+    public class ScopeBoxRow : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void Raise(string n) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+
+        private bool _include = true; public bool Include { get => _include; set { _include = value; Raise(nameof(Include)); } }
+        public string CurrentName { get; set; }
+        private string _newName; public string NewName { get => _newName; set { _newName = value; Raise(nameof(NewName)); } }
+        public double RotationDegrees { get; set; }
+        public string RotationText => RotationDegrees == 0 ? "0°" : $"{RotationDegrees:F1}°";
+        /// <summary>Revit ElementId.IntegerValue for the scope box.</summary>
+        public int RevitIdValue { get; set; }
     }
 
     /// <summary>
@@ -978,6 +1324,22 @@ namespace StingTools.UI
         public double GridVSpacing { get; set; }
         public double GridVLength { get; set; }
 
+        // Page 3: Scope-box integration
+        /// <summary>When true, align grids/sections/elevations to the checked scope boxes' orientation (handles tilted boxes).</summary>
+        public bool AlignToScopeBoxOrientation { get; set; }
+        /// <summary>When true, assign created grids to the checked scope boxes (DATUM_VOLUME_OF_INTEREST).</summary>
+        public bool AssignGridsToScopeBoxes { get; set; }
+        /// <summary>When true, create two building sections (through centre, both directions) per checked scope box.</summary>
+        public bool TwoSectionsPerScopeBox { get; set; }
+        /// <summary>When true, rename scope boxes using the <see cref="ScopeBoxRenames"/> map on Run.</summary>
+        public bool RenameScopeBoxes { get; set; }
+        /// <summary>User-entered rename pattern (for audit; the actual map is in <see cref="ScopeBoxRenames"/>).</summary>
+        public string ScopeBoxRenamePattern { get; set; } = "";
+        /// <summary>Current-name → new-name map for checked scope boxes where the name actually changed.</summary>
+        public Dictionary<string, string> ScopeBoxRenames { get; set; } = new Dictionary<string, string>();
+        /// <summary>Current names of checked scope boxes (used for grid scoping + section creation).</summary>
+        public List<string> ScopeBoxSelection { get; set; } = new List<string>();
+
         // Page 4: Disciplines
         public List<string> Disciplines { get; set; } = new List<string>();
         public string TitleBlockName { get; set; }
@@ -996,6 +1358,8 @@ namespace StingTools.UI
         public GenericConfig GenConfig { get; set; } = new GenericConfig();
 
         // Page 6: Automation
+        /// <summary>When true, Phase 3 runs the full 15-step TemplateSetupWizard ordering (latest pipeline).</summary>
+        public bool UseLatestTemplateSetup { get; set; } = true;
         public bool LoadParams { get; set; }
         public bool CreateMaterials { get; set; }
         public bool CreateFamilyTypes { get; set; }


### PR DESCRIPTION
## Summary
Replaced text-based level input with an interactive DataGrid UI, added scope-box management with rename patterns, and integrated scope-box-aware grid creation and sectioning.

## Key Changes

### UI & Data Binding
- **Levels DataGrid**: Replaced `txtLevels` TextBox with `dgLevels` DataGrid supporting inline editing of Name, Elevation, Type (dropdown), and Story flag
- **Scope Boxes DataGrid**: Added `dgScopeBoxes` for managing existing scope boxes with Include/Exclude, rename preview, and rotation display
- **Toolbar buttons**: Added Add, Delete, Move Up/Down, and Sort by Elevation for level management
- **Observable collections**: Introduced `LevelRows` and `ScopeBoxRows` bound to respective grids with auto-renumbering

### Level Processing
- **Type guessing**: New `GuessLevelType()` method infers level type (Roof, Parapet, Ceiling, etc.) from name patterns
- **Story flag detection**: `IsStoryLevel()` reads `LEVEL_IS_BUILDING_STORY` parameter from Revit levels
- **Validation**: Enhanced to check for duplicate names, invalid elevations, and minimum row count
- **Preset updates**: Refactored to populate DataGrid rows instead of text; presets now assign level types and story flags

### Scope Box Integration
- **Pre-population**: `PrePopulate()` now reads existing scope boxes and populates the grid with rotation detection
- **Rotation calculation**: `GetScopeBoxRotationDegrees()` extracts orientation from BoundingBox.Transform
- **Rename pattern**: New `ScopeBoxPatternApply_Click()` applies templated renaming with {BLD}, {LOC}, {ZONE}, {INDEX}, {NAME} tokens
- **Rename execution**: `RenameScopeBoxes()` in ProjectSetupCommand applies renames with collision detection

### Grid & Section Creation
- **Scope-box alignment**: Grids can now align to scope-box orientation via `AlignToScopeBoxOrientation` flag
- **Grid scoping**: `AssignGridsToScopeBoxes` option assigns grids to selected scope boxes
- **Scope-box sections**: New `CreateTwoSectionsPerScopeBox()` generates two perpendicular building sections per scope box (handles tilted boxes)
- **Level story flag**: `ApplyLevelStoryFlag()` sets the story parameter when creating levels

### Data Model
- **LevelDefinition**: Extended with `LevelType` and `IsStory` properties
- **ProjectSetupData**: Added scope-box fields (`ScopeBoxRenames`, `ScopeBoxSelection`, `RenameScopeBoxes`, `TwoSectionsPerScopeBox`, etc.)
- **LevelRow & ScopeBoxRow**: New view-model classes for DataGrid binding with Index, Name, ElevationText, LevelType, IsStory, etc.

### Template Setup Pipeline
- **Latest mode**: New `UseLatestTemplateSetup` checkbox consolidates 15 template-creation steps in the documented order
- **Deduplication**: Avoids running `BatchAddFamilyParamsCommand` twice when latest mode is enabled
- **Conditional execution**: Legacy granular steps still available when latest mode is unchecked

### Parsing & Validation
- **Invariant culture**: All `double.TryParse()` calls now use `NumberStyles.Float` and `CultureInfo.InvariantCulture` for consistency
- **DataGrid-based parsing**: `ParseLevels()` reads from `LevelRows` collection instead of text splitting
- **Enhanced error messages**: More specific feedback for duplicate names, invalid elevations, and missing data

## Notable Implementation Details
- Level rows auto-renumber on collection changes via `CollectionChanged` event
- Scope-box rotation uses `BoundingBox.Transform.BasisX` to handle tilted boxes
- Section creation generates view names with scope-box name and direction suffix (A/B)
- Rename pattern supports fallback to first location code or default "BLD1" if lists are empty
- All numeric parsing uses invariant culture to

https://claude.ai/code/session_01VDVD5L7SVMuSqLhuBwQY2b