### PR TITLE
Refactor repeat levels UI and fix dark dialog theme issues

### DIFF
--- a/StingTools/Model/StructuralCADWizard.cs
+++ b/StingTools/Model/StructuralCADWizard.cs
@@ -31,6 +31,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -966,19 +967,7 @@ namespace StingTools.Model
                 FontWeight = FontWeights.Bold, FontSize = 10,
                 Foreground = DarkBlue, Margin = new Thickness(0, 12, 0, 4),
             });
-            _repeatLevelCheckboxesCad.Clear();
-            var repeatWrap = new WrapPanel { Margin = new Thickness(0, 0, 0, 4) };
-            foreach (var lvl in levels)
-            {
-                var cb = new CheckBox
-                {
-                    Content = lvl.Name, Tag = lvl.Name,
-                    Margin = new Thickness(0, 0, 8, 4), FontSize = 10,
-                };
-                _repeatLevelCheckboxesCad.Add(cb);
-                repeatWrap.Children.Add(cb);
-            }
-            levelStack.Children.Add(repeatWrap);
+            levelStack.Children.Add(BuildRepeatLevelsDropdown(levels));
             _chkColumnsContinuousCad = new CheckBox
             {
                 Content = "Columns continuous through repeat levels",
@@ -1033,6 +1022,15 @@ namespace StingTools.Model
             var wallSlabStack = new StackPanel { Margin = new Thickness(12, 0, 0, 0) };
 
             wallSlabStack.Children.Add(MakeDimRow2("Wall:", "Height:", "3000", out _txtWallHeight, "Thick:", "200", out _txtWallThick));
+            _chkStructuralWall = new CheckBox
+            {
+                Content = "Wall is structural (unchecked = architectural)",
+                IsChecked = true, FontSize = 11,
+                Margin = new Thickness(0, 0, 0, 4),
+                ToolTip = "Controls whether detected walls are created as " +
+                    "Structural Walls (load-bearing) or Architectural Walls.",
+            };
+            wallSlabStack.Children.Add(_chkStructuralWall);
             wallSlabStack.Children.Add(MakeDimRow("Slab Thick:", "200", out _txtSlabThick));
             wallSlabStack.Children.Add(MakeDimRow("Fdn Depth:", "600", out _txtFdnDepth));
 
@@ -1080,17 +1078,10 @@ namespace StingTools.Model
                 Margin = new Thickness(0, 2, 0, 2), FontSize = 11,
                 Foreground = GreenFg,
             };
-            _chkStructuralWall = new CheckBox
-            {
-                Content = "Create as Structural Walls (not architectural)", IsChecked = true,
-                Margin = new Thickness(0, 2, 0, 2), FontSize = 11,
-                Foreground = GreenFg,
-            };
 
             leftStack.Children.Add(_chkBeamsOnWalls);
             leftStack.Children.Add(_chkBeamsConnectSlabs);
             leftStack.Children.Add(_chkColumnsStopAtSoffit);
-            leftStack.Children.Add(_chkStructuralWall);
 
             leftStack.Children.Add(new TextBlock
             {
@@ -1354,7 +1345,7 @@ namespace StingTools.Model
 
         private FrameworkElement BuildSectionEaseBitDetection()
         {
-            var section = MakeSection("DETECTION — EaseBit-style controls");
+            var section = MakeSection("DETECTION");
             var stack = (StackPanel)((Border)section).Child;
 
             // Top row: three toggle checkboxes (Dry-Run, Explode, Detect Openings)
@@ -2144,6 +2135,107 @@ namespace StingTools.Model
             txt2 = new TextBox { Text = val2, Width = 55, Margin = new Thickness(2, 0, 0, 0) };
             row.Children.Add(txt2);
             return row;
+        }
+
+        // Multi-select dropdown of project levels. Populates
+        // _repeatLevelCheckboxesCad so BuildConfig() can read the picked
+        // names without changing its loop.
+        private FrameworkElement BuildRepeatLevelsDropdown(List<Level> levels)
+        {
+            _repeatLevelCheckboxesCad.Clear();
+
+            var btn = new ToggleButton
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                Padding = new Thickness(6, 3, 6, 3),
+                Margin = new Thickness(0, 0, 0, 4),
+                MinHeight = 22,
+                Background = Brushes.White,
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0xAB, 0xAD, 0xB3)),
+                BorderThickness = new Thickness(1),
+                Cursor = Cursors.Hand,
+            };
+            var btnGrid = new Grid();
+            btnGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            btnGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            var summary = new TextBlock
+            {
+                Text = "(none selected)", FontSize = 11,
+                VerticalAlignment = VerticalAlignment.Center, TextTrimming = TextTrimming.CharacterEllipsis,
+            };
+            Grid.SetColumn(summary, 0); btnGrid.Children.Add(summary);
+            var glyph = new TextBlock
+            {
+                Text = "▾", FontSize = 10, Margin = new Thickness(6, 0, 0, 0),
+                VerticalAlignment = VerticalAlignment.Center, Foreground = Brushes.Gray,
+            };
+            Grid.SetColumn(glyph, 1); btnGrid.Children.Add(glyph);
+            btn.Content = btnGrid;
+
+            var list = new StackPanel { Margin = new Thickness(6) };
+            foreach (var lvl in levels)
+            {
+                var cb = new CheckBox
+                {
+                    Content = lvl.Name, Tag = lvl.Name,
+                    Margin = new Thickness(0, 2, 0, 2), FontSize = 11,
+                };
+                _repeatLevelCheckboxesCad.Add(cb);
+                list.Children.Add(cb);
+            }
+
+            var popup = new Popup
+            {
+                PlacementTarget = btn,
+                Placement = PlacementMode.Bottom,
+                StaysOpen = false,
+                AllowsTransparency = true,
+                PopupAnimation = PopupAnimation.Fade,
+            };
+            var popupBorder = new Border
+            {
+                Background = Brushes.White,
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0xAB, 0xAD, 0xB3)),
+                BorderThickness = new Thickness(1),
+                MinWidth = 180,
+            };
+            var scroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                MaxHeight = 220,
+                Content = list,
+            };
+            popupBorder.Child = scroll;
+            popup.Child = popupBorder;
+
+            void UpdateSummary()
+            {
+                var picked = _repeatLevelCheckboxesCad
+                    .Where(c => c.IsChecked == true)
+                    .Select(c => c.Tag as string)
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .ToList();
+                if (picked.Count == 0) summary.Text = "(none selected)";
+                else if (picked.Count == _repeatLevelCheckboxesCad.Count) summary.Text = "All levels";
+                else if (picked.Count <= 3) summary.Text = string.Join(", ", picked);
+                else summary.Text = $"{picked.Count} levels selected";
+            }
+            foreach (var cb in _repeatLevelCheckboxesCad)
+            {
+                cb.Checked += (_, __) => UpdateSummary();
+                cb.Unchecked += (_, __) => UpdateSummary();
+            }
+
+            btn.Checked   += (_, __) => popup.IsOpen = true;
+            btn.Unchecked += (_, __) => popup.IsOpen = false;
+            popup.Closed  += (_, __) => btn.IsChecked = false;
+
+            UpdateSummary();
+
+            var host = new StackPanel();
+            host.Children.Add(btn);
+            host.Children.Add(popup);
+            return host;
         }
     }
 

--- a/StingTools/UI/ClashManagerDialog.cs
+++ b/StingTools/UI/ClashManagerDialog.cs
@@ -62,6 +62,10 @@ namespace StingTools.UI
             WindowStartupLocation = WindowStartupLocation.CenterScreen;
             Background = new SolidColorBrush(Color.FromRgb(0x2D, 0x2D, 0x30));
             Foreground = Brushes.White;
+            DarkDialogTheme.ApplyComboBoxFix(this,
+                Color.FromRgb(0x3E, 0x3E, 0x42),
+                Colors.White,
+                Color.FromRgb(0x55, 0x55, 0x58));
 
             BuildUi();
             LoadClashFile();

--- a/StingTools/UI/DarkDialogTheme.cs
+++ b/StingTools/UI/DarkDialogTheme.cs
@@ -1,0 +1,78 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace StingTools.UI
+{
+    /// <summary>
+    /// Fixes white-on-white text in ComboBox / TextBox dropdowns on dialogs
+    /// that use a custom dark Background + inherited white Foreground. WPF
+    /// popups render with default (light) chrome and do not inherit
+    /// Window.Background, so items in the dropdown become unreadable.
+    ///
+    /// Installs implicit Window-level styles for <see cref="ComboBoxItem"/>
+    /// (with a minimal ControlTemplate that actually honours Background) so
+    /// dropdown rows paint dark and keep white text readable.
+    /// </summary>
+    internal static class DarkDialogTheme
+    {
+        public static void ApplyComboBoxFix(Window window, Color itemBg, Color itemFg, Color hoverBg)
+        {
+            if (window == null) return;
+            var style = BuildComboBoxItemStyle(itemBg, itemFg, hoverBg);
+            window.Resources[typeof(ComboBoxItem)] = style;
+        }
+
+        private static Style BuildComboBoxItemStyle(Color itemBg, Color itemFg, Color hoverBg)
+        {
+            var itemBrush  = Freeze(new SolidColorBrush(itemBg));
+            var textBrush  = Freeze(new SolidColorBrush(itemFg));
+            var hoverBrush = Freeze(new SolidColorBrush(hoverBg));
+
+            // Minimal ControlTemplate where the Border's Background is
+            // TemplateBound, so Style/trigger Background actually paints.
+            var template = new ControlTemplate(typeof(ComboBoxItem));
+            var border = new FrameworkElementFactory(typeof(Border), "Bd");
+            border.SetValue(Border.BackgroundProperty,
+                new TemplateBindingExtension(Control.BackgroundProperty));
+            border.SetValue(Border.PaddingProperty,
+                new TemplateBindingExtension(Control.PaddingProperty));
+            border.SetValue(Border.SnapsToDevicePixelsProperty, true);
+            var content = new FrameworkElementFactory(typeof(ContentPresenter));
+            content.SetValue(ContentPresenter.HorizontalAlignmentProperty,
+                new TemplateBindingExtension(Control.HorizontalContentAlignmentProperty));
+            content.SetValue(ContentPresenter.VerticalAlignmentProperty,
+                new TemplateBindingExtension(Control.VerticalContentAlignmentProperty));
+            border.AppendChild(content);
+            template.VisualTree = border;
+
+            var style = new Style(typeof(ComboBoxItem));
+            style.Setters.Add(new Setter(Control.BackgroundProperty, itemBrush));
+            style.Setters.Add(new Setter(Control.ForegroundProperty, textBrush));
+            style.Setters.Add(new Setter(Control.PaddingProperty, new Thickness(6, 3, 6, 3)));
+            style.Setters.Add(new Setter(Control.TemplateProperty, template));
+            style.Setters.Add(new Setter(Control.HorizontalContentAlignmentProperty,
+                HorizontalAlignment.Left));
+            style.Setters.Add(new Setter(Control.VerticalContentAlignmentProperty,
+                VerticalAlignment.Center));
+
+            var hover = new Trigger { Property = UIElement.IsMouseOverProperty, Value = true };
+            hover.Setters.Add(new Setter(Control.BackgroundProperty, hoverBrush));
+            style.Triggers.Add(hover);
+
+            var selected = new Trigger { Property = ListBoxItem.IsSelectedProperty, Value = true };
+            selected.Setters.Add(new Setter(Control.BackgroundProperty, hoverBrush));
+            style.Triggers.Add(selected);
+
+            return style;
+        }
+
+        private static Brush Freeze(SolidColorBrush brush)
+        {
+            if (brush.CanFreeze) brush.Freeze();
+            return brush;
+        }
+    }
+}

--- a/StingTools/UI/ParagraphBuilderDialog.cs
+++ b/StingTools/UI/ParagraphBuilderDialog.cs
@@ -55,6 +55,7 @@ namespace StingTools.UI
             Background = new SolidColorBrush(BgColor);
             FontFamily = new FontFamily("Segoe UI");
             WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            DarkDialogTheme.ApplyComboBoxFix(this, CardBg, FgColor, CardBorder);
             try
             {
                 var helper = new System.Windows.Interop.WindowInteropHelper(this);

--- a/StingTools/UI/ShopDrawingOptionsDialog.cs
+++ b/StingTools/UI/ShopDrawingOptionsDialog.cs
@@ -73,6 +73,10 @@ namespace StingTools.UI
             Background = new SolidColorBrush(Color.FromRgb(0x2D, 0x2D, 0x30));
             Foreground = Brushes.White;
             ResizeMode = ResizeMode.NoResize;
+            DarkDialogTheme.ApplyComboBoxFix(this,
+                Color.FromRgb(0x3E, 0x3E, 0x42),
+                Colors.White,
+                Color.FromRgb(0x55, 0x55, 0x58));
             BuildUi();
         }
 


### PR DESCRIPTION
## Summary
This PR improves the UI/UX for the Structural CAD Wizard and fixes rendering issues in dark-themed dialogs. The main changes include converting the repeat levels checkbox list to a dropdown control and applying a dark theme fix to ComboBox dropdowns in dark dialogs.

## Key Changes

- **Repeat Levels Dropdown**: Refactored the repeat levels selection from a horizontal WrapPanel of checkboxes to a collapsible dropdown (ToggleButton + Popup) with a summary display showing selection status ("none selected", "All levels", specific names, or count)
  - Extracted logic into new `BuildRepeatLevelsDropdown()` method
  - Maintains backward compatibility by populating `_repeatLevelCheckboxesCad` for existing `BuildConfig()` logic
  - Includes scrollable list for projects with many levels (max height 220px)

- **Structural Wall Checkbox Relocation**: Moved the "Wall is structural" checkbox from Section 4 (Construction Logic) to Section 3 (Levels and Properties) where wall dimensions are configured, improving logical grouping
  - Updated checkbox content and tooltip for clarity
  - Changed styling to match section 3 (removed green foreground)

- **Dark Dialog Theme Fix**: Created new `DarkDialogTheme` utility class to fix white-on-white text rendering in ComboBox/TextBox dropdowns on dark-themed dialogs
  - Applies implicit Window-level styles for `ComboBoxItem` with custom ControlTemplate
  - Includes hover and selected state styling
  - Applied to `ClashManagerDialog` and `ShopDrawingOptionsDialog`

- **Minor UI Updates**:
  - Changed "DETECTION — EaseBit-style controls" section header to just "DETECTION"
  - Added `using System.Windows.Controls.Primitives` for ToggleButton and Popup support

## Implementation Details

The dropdown implementation uses WPF's `Popup` control with `PlacementMode.Bottom` and `StaysOpen = false` for a native dropdown experience. The summary text updates dynamically as checkboxes are toggled, providing immediate visual feedback without requiring a separate "Apply" button.

https://claude.ai/code/session_01R3Up6qN4y2WGfEAt947pV9