### PR TITLE
Add Fabrication Workspace dialog with live scope & category preview

### DIFF
--- a/StingTools/Commands/Fabrication/FabricationStubCommands.cs
+++ b/StingTools/Commands/Fabrication/FabricationStubCommands.cs
@@ -1,0 +1,115 @@
+// StingTools v4 MVP — Fabrication Workspace stub commands.
+//
+// These commands back the new buttons added by the Fabrication
+// Workspace dialog (Smart group / Clash pre-flight / Incremental
+// rebuild / BOM roll-up / Doc Register link). Full implementations
+// land later — for now they surface a clear roadmap so the workspace
+// can dispatch them without "command not wired" errors.
+//
+// UndoFabPackageCommand already exists in FabricationUndoManager.cs,
+// it just needed a tag in StingCommandHandler.
+
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.UI;
+
+namespace StingTools.Commands.Fabrication
+{
+    /// <summary>
+    /// Smart group — re-clusters the spool grouping for the current
+    /// scope using STING_FAB_RULES.json transport / lift / weight
+    /// limits before assemblies are emitted. Stub for v4 MVP.
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class SmartGroupCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, Autodesk.Revit.DB.ElementSet els)
+        {
+            TaskDialog.Show("STING v4 — Smart Group",
+                "Smart Group will re-cluster spools by transport / lift / weight " +
+                "limits from STING_FAB_RULES.json before Generate Package runs.\n\n" +
+                "Roadmap entry — wiring lands alongside the rule-driven AssemblyGrouper update.");
+            return Result.Succeeded;
+        }
+    }
+
+    /// <summary>
+    /// Clash pre-flight — runs Navisworks-style hard-clash detection
+    /// against the current selection BEFORE assemblies are created so
+    /// the operator sees and fixes interferences first. Stub for v4 MVP.
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ClashPreflightCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, Autodesk.Revit.DB.ElementSet els)
+        {
+            TaskDialog.Show("STING v4 — Clash Pre-flight",
+                "Pre-flight will run STING_CLASH against the workspace scope and " +
+                "block Generate Package until the clash count drops to zero.\n\n" +
+                "Roadmap entry — surfaces the existing ClashManager pipeline through " +
+                "the Fabrication workspace.");
+            return Result.Succeeded;
+        }
+    }
+
+    /// <summary>
+    /// Incremental rebuild — re-runs Generate Package only for spools
+    /// whose member elements have changed since the last successful
+    /// run. Stub for v4 MVP.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class IncrementalRebuildCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, Autodesk.Revit.DB.ElementSet els)
+        {
+            TaskDialog.Show("STING v4 — Incremental Rebuild",
+                "Incremental Rebuild compares the current workspace scope against the " +
+                "last FabricationResult on the undo stack and only regenerates affected " +
+                "spools — saves a full project sweep.\n\n" +
+                "Roadmap entry — landing alongside the FabricationUndoManager hash diff.");
+            return Result.Succeeded;
+        }
+    }
+
+    /// <summary>
+    /// BOM roll-up — aggregates per-discipline cut list / weld map /
+    /// PCF data into a single multi-sheet XLSX bill of materials.
+    /// Stub for v4 MVP.
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class BomRollupCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, Autodesk.Revit.DB.ElementSet els)
+        {
+            TaskDialog.Show("STING v4 — BOM Roll-up",
+                "BOM Roll-up will combine cut list, weld map and PCF outputs into " +
+                "STING_v4_bom_rollup.xlsx (one sheet per discipline + a project total).\n\n" +
+                "Roadmap entry — uses the existing ClosedXML pipeline.");
+            return Result.Succeeded;
+        }
+    }
+
+    /// <summary>
+    /// Link → Doc Register — registers all generated shop drawings
+    /// with the BIM Manager document register for ISO 19650 compliance.
+    /// Stub for v4 MVP.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class LinkDocRegisterCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, Autodesk.Revit.DB.ElementSet els)
+        {
+            TaskDialog.Show("STING v4 — Link to Doc Register",
+                "Link → Doc Register will push every SP-… sheet emitted on the last " +
+                "successful Generate Package into the project document register " +
+                "(STATUS = WIP, REV = P01) so it shows up in the next transmittal.\n\n" +
+                "Roadmap entry — bridges FabricationResult.SheetIds to the existing " +
+                "document register pipeline.");
+            return Result.Succeeded;
+        }
+    }
+}

--- a/StingTools/Commands/Fabrication/FabricationWorkspaceCommand.cs
+++ b/StingTools/Commands/Fabrication/FabricationWorkspaceCommand.cs
@@ -22,8 +22,24 @@ namespace StingTools.Commands.Fabrication
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                // RunCommand<T> on the dock panel passes null for `data` and
+                // expects callers to fall back to StingCommandHandler.CurrentApp.
+                var app = data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp;
+                if (app == null)
+                {
+                    msg = "No active Revit application.";
+                    StingLog.Warn("FabricationWorkspaceCommand: no UIApplication available.");
+                    return Result.Failed;
+                }
+                var doc = app.ActiveUIDocument?.Document;
+
                 var dlg = new FabricationWorkspaceDialog(doc);
+                try
+                {
+                    var helper = new System.Windows.Interop.WindowInteropHelper(dlg);
+                    helper.Owner = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+                }
+                catch { }
                 dlg.ShowDialog();
                 return Result.Succeeded;
             }

--- a/StingTools/Commands/Fabrication/FabricationWorkspaceCommand.cs
+++ b/StingTools/Commands/Fabrication/FabricationWorkspaceCommand.cs
@@ -1,0 +1,38 @@
+// StingTools v4 MVP — Fabrication Workspace launcher.
+//
+// Modal IExternalCommand that opens the light-themed
+// FabricationWorkspaceDialog. The dialog itself is read-only with
+// respect to the document; every action button it surfaces routes
+// back through the dock panel command handler so the underlying
+// fabrication commands run on the Revit API thread.
+
+using System;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.UI;
+
+namespace StingTools.Commands.Fabrication
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class FabricationWorkspaceCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, Autodesk.Revit.DB.ElementSet els)
+        {
+            try
+            {
+                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var dlg = new FabricationWorkspaceDialog(doc);
+                dlg.ShowDialog();
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("FabricationWorkspaceCommand", ex);
+                msg = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
+++ b/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
@@ -85,22 +85,16 @@ namespace StingTools.Commands.Fabrication
             }
             StingLog.Info($"GenerateFabPackage: collected {ids.Count} element(s) via {scopeLabelUsed} scope.");
 
-            // Shop-drawing composition dialog — lets users pick a
-            // specific title block + view template + sheet-number
-            // pattern instead of the per-discipline STING_TB_ASSEMBLY_*
-            // default. Cancelling the dialog aborts the command.
-            //
-            // Skipped when the Fabrication tab's "Configure…" button has
-            // already populated FabricationOptions.ShopDrawing — that
-            // inline picker is the persistent path; the popup is only the
-            // one-shot fallback when no panel choice exists.
-            if (FabricationOptions.GenerateSheets && FabricationOptions.ShopDrawing == null)
-            {
-                var dlg = new StingTools.UI.ShopDrawingOptionsDialog(doc);
-                try { dlg.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
-                if (dlg.ShowDialog() != true) return Result.Cancelled;
-                FabricationOptions.ShopDrawing = dlg.Result;
-            }
+            // Shop-drawing composition is now configured up front via the
+            // Fabrication Workspace (Configure… button on the Title Block
+            // strip) or the dock panel's Configure… button — both
+            // populate FabricationOptions.ShopDrawing for the Revit
+            // session. When ShopDrawing is null the engine falls back to
+            // per-discipline STING_TB_ASSEMBLY_* auto-resolution, so we
+            // no longer pop a one-shot picker mid-command (which used to
+            // surface the basic Shop Drawing Composition dialog every
+            // time the user clicked Generate Package without first
+            // configuring).
 
             FabricationResult res;
             try

--- a/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
+++ b/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
@@ -72,15 +72,26 @@ namespace StingTools.Commands.Fabrication
             var ids = CollectScopeWithFallback(doc, uidoc, out scopeLabelUsed);
             if (ids == null || ids.Count == 0)
             {
-                TaskDialog.Show("STING v4 — Generate Fabrication Package",
-                    "No MEP elements found in selection, active view, or the project.\n\n" +
-                    "FabricationEngine will:\n" +
-                    "  1. Group elements per discipline rules (STING_FAB_RULES.json)\n" +
-                    "  2. Create AssemblyInstances with SP-{DISC}-{SYS}-{LVL}-{SEQ} naming\n" +
-                    "  3. Generate 5 views per assembly + BOM schedule\n" +
-                    "  4. Lay out shop drawing sheets with title block populated\n" +
-                    "  5. Emit per-discipline CSV sidecars (bend / weld / seam)\n\n" +
-                    "Open a view containing pipes / ducts / conduits and try again.");
+                // Last-resort: open the Fabrication Workspace instead of
+                // showing an error dialog. The workspace surfaces live
+                // category counts + scope radios so the user can see the
+                // 341 pipes that exist and pick a scope that includes
+                // them. This eliminates the "no MEP elements" dead-end
+                // that happens when Selection scope is on with nothing
+                // selected.
+                try
+                {
+                    var dlg = new StingTools.UI.FabricationWorkspaceDialog(doc);
+                    try { dlg.Owner = System.Windows.Application.Current?.MainWindow; } catch { }
+                    dlg.ShowDialog();
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"GenerateFabPackage: workspace fallback failed: {ex.Message}");
+                    TaskDialog.Show("STING v4 — Generate Fabrication Package",
+                        "No MEP elements found in selection, active view, or the project.\n\n" +
+                        "Open a view containing pipes / ducts / conduits and try again.");
+                }
                 return Result.Cancelled;
             }
             StingLog.Info($"GenerateFabPackage: collected {ids.Count} element(s) via {scopeLabelUsed} scope.");
@@ -215,6 +226,10 @@ namespace StingTools.Commands.Fabrication
             {
                 var view = doc?.ActiveView;
                 if (view == null) return ids;
+                // Sheet views aren't valid view filters for the
+                // collector — bail early so the caller falls through
+                // to the project-level fallback.
+                if (view is ViewSheet) return ids;
                 var col = new FilteredElementCollector(doc, view.Id)
                     .WherePasses(new ElementMulticategoryFilter(MepCats))
                     .WhereElementIsNotElementType();

--- a/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
+++ b/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
@@ -62,28 +62,28 @@ namespace StingTools.Commands.Fabrication
             var doc = ctx.Doc;
             var uidoc = ctx.UIDoc;
 
-            // Scope resolution — Fabrication sub-tab radio buttons drive
-            // which MEP elements feed the engine. Selection (default)
-            // means "current uidoc selection"; Active view means "all
-            // MEP curves visible in the active view"; Project means
-            // "every MEP curve in the document".
-            var ids = CollectScope(doc, uidoc);
+            // Scope resolution — Fabrication tab radio buttons drive which
+            // MEP elements feed the engine: Selection / Active view /
+            // Project. CollectScopeWithFallback honours the chosen scope
+            // first, then falls back through Selection → Active view →
+            // Project so a click on Generate package never silently fails
+            // when the user simply forgot to pre-select.
+            string scopeLabelUsed;
+            var ids = CollectScopeWithFallback(doc, uidoc, out scopeLabelUsed);
             if (ids == null || ids.Count == 0)
             {
-                string scopeLabel =
-                    FabricationOptions.ScopeProject    ? "project"       :
-                    FabricationOptions.ScopeActiveView ? "active view"   :
-                                                         "current selection";
                 TaskDialog.Show("STING v4 — Generate Fabrication Package",
-                    $"Scope '{scopeLabel}' contains no MEP elements to package.\n\n" +
+                    "No MEP elements found in selection, active view, or the project.\n\n" +
                     "FabricationEngine will:\n" +
                     "  1. Group elements per discipline rules (STING_FAB_RULES.json)\n" +
                     "  2. Create AssemblyInstances with SP-{DISC}-{SYS}-{LVL}-{SEQ} naming\n" +
                     "  3. Generate 5 views per assembly + BOM schedule\n" +
                     "  4. Lay out shop drawing sheets with title block populated\n" +
-                    "  5. Emit per-discipline CSV sidecars (bend / weld / seam)");
+                    "  5. Emit per-discipline CSV sidecars (bend / weld / seam)\n\n" +
+                    "Open a view containing pipes / ducts / conduits and try again.");
                 return Result.Cancelled;
             }
+            StingLog.Info($"GenerateFabPackage: collected {ids.Count} element(s) via {scopeLabelUsed} scope.");
 
             // Shop-drawing composition dialog — lets users pick a
             // specific title block + view template + sheet-number
@@ -131,66 +131,124 @@ namespace StingTools.Commands.Fabrication
             return Result.Succeeded;
         }
 
-        private static List<ElementId> CollectScope(Document doc, Autodesk.Revit.UI.UIDocument uidoc)
+        private static readonly BuiltInCategory[] MepCats = new[]
+        {
+            BuiltInCategory.OST_PipeCurves,
+            BuiltInCategory.OST_FlexPipeCurves,
+            BuiltInCategory.OST_PipeFitting,
+            BuiltInCategory.OST_PipeAccessory,
+            BuiltInCategory.OST_DuctCurves,
+            BuiltInCategory.OST_FlexDuctCurves,
+            BuiltInCategory.OST_DuctFitting,
+            BuiltInCategory.OST_DuctAccessory,
+            BuiltInCategory.OST_Conduit,
+            BuiltInCategory.OST_ConduitFitting,
+            BuiltInCategory.OST_CableTray,
+            BuiltInCategory.OST_CableTrayFitting,
+        };
+
+        /// <summary>
+        /// Resolve elements honouring FabricationOptions, then auto-fall
+        /// back through Selection → Active view → Project so a click on
+        /// Generate package never silently fails when the user simply
+        /// forgot to pre-select.
+        /// </summary>
+        private static List<ElementId> CollectScopeWithFallback(
+            Document doc,
+            Autodesk.Revit.UI.UIDocument uidoc,
+            out string scopeLabelUsed)
+        {
+            scopeLabelUsed = "selection";
+
+            // 1) Honour the chosen scope first.
+            if (FabricationOptions.ScopeProject)
+            {
+                scopeLabelUsed = "project";
+                return CollectFromProject(doc);
+            }
+            if (FabricationOptions.ScopeActiveView)
+            {
+                scopeLabelUsed = "active view";
+                var v = CollectFromActiveView(doc);
+                if (v.Count > 0) return v;
+                // Fallback: view was empty / non-graphical → try project.
+                scopeLabelUsed = "project (active view empty)";
+                return CollectFromProject(doc);
+            }
+
+            // 2) Selection scope.
+            var sel = CollectFromSelection(doc, uidoc);
+            if (sel.Count > 0) { scopeLabelUsed = "selection"; return sel; }
+
+            // 3) Auto-fallback: active view.
+            var view = CollectFromActiveView(doc);
+            if (view.Count > 0)
+            {
+                scopeLabelUsed = "active view (auto-fallback from empty selection)";
+                return view;
+            }
+
+            // 4) Auto-fallback: project.
+            var proj = CollectFromProject(doc);
+            if (proj.Count > 0)
+            {
+                scopeLabelUsed = "project (auto-fallback from empty selection)";
+                return proj;
+            }
+
+            scopeLabelUsed = "selection";
+            return new List<ElementId>();
+        }
+
+        private static List<ElementId> CollectFromProject(Document doc)
         {
             var ids = new List<ElementId>();
-            var mepCats = new[]
-            {
-                BuiltInCategory.OST_PipeCurves,
-                BuiltInCategory.OST_FlexPipeCurves,
-                BuiltInCategory.OST_PipeFitting,
-                BuiltInCategory.OST_PipeAccessory,
-                BuiltInCategory.OST_DuctCurves,
-                BuiltInCategory.OST_FlexDuctCurves,
-                BuiltInCategory.OST_DuctFitting,
-                BuiltInCategory.OST_DuctAccessory,
-                BuiltInCategory.OST_Conduit,
-                BuiltInCategory.OST_ConduitFitting,
-                BuiltInCategory.OST_CableTray,
-                BuiltInCategory.OST_CableTrayFitting,
-            };
             try
             {
-                if (FabricationOptions.ScopeProject)
-                {
-                    var col = new FilteredElementCollector(doc)
-                        .WherePasses(new ElementMulticategoryFilter(mepCats))
-                        .WhereElementIsNotElementType();
-                    foreach (var e in col) ids.Add(e.Id);
-                }
-                else if (FabricationOptions.ScopeActiveView)
-                {
-                    var view = doc.ActiveView;
-                    if (view != null)
-                    {
-                        var col = new FilteredElementCollector(doc, view.Id)
-                            .WherePasses(new ElementMulticategoryFilter(mepCats))
-                            .WhereElementIsNotElementType();
-                        foreach (var e in col) ids.Add(e.Id);
-                    }
-                }
-                else
-                {
-                    var sel = uidoc.Selection.GetElementIds();
-                    if (sel != null)
-                    {
-                        foreach (var id in sel)
-                        {
-                            var el = doc.GetElement(id);
-                            if (el?.Category == null) continue;
-                            int bic = (int)el.Category.Id.Value;
-                            foreach (var c in mepCats)
-                            {
-                                if ((int)c == bic) { ids.Add(id); break; }
-                            }
-                        }
-                    }
-                }
+                var col = new FilteredElementCollector(doc)
+                    .WherePasses(new ElementMulticategoryFilter(MepCats))
+                    .WhereElementIsNotElementType();
+                foreach (var e in col) ids.Add(e.Id);
             }
-            catch (Exception ex)
+            catch (Exception ex) { StingLog.Warn($"GenerateFabPackage.CollectFromProject: {ex.Message}"); }
+            return ids;
+        }
+
+        private static List<ElementId> CollectFromActiveView(Document doc)
+        {
+            var ids = new List<ElementId>();
+            try
             {
-                StingLog.Warn($"GenerateFabPackage.CollectScope: {ex.Message}");
+                var view = doc?.ActiveView;
+                if (view == null) return ids;
+                var col = new FilteredElementCollector(doc, view.Id)
+                    .WherePasses(new ElementMulticategoryFilter(MepCats))
+                    .WhereElementIsNotElementType();
+                foreach (var e in col) ids.Add(e.Id);
             }
+            catch (Exception ex) { StingLog.Warn($"GenerateFabPackage.CollectFromActiveView: {ex.Message}"); }
+            return ids;
+        }
+
+        private static List<ElementId> CollectFromSelection(Document doc, Autodesk.Revit.UI.UIDocument uidoc)
+        {
+            var ids = new List<ElementId>();
+            try
+            {
+                var sel = uidoc?.Selection?.GetElementIds();
+                if (sel == null) return ids;
+                foreach (var id in sel)
+                {
+                    var el = doc.GetElement(id);
+                    if (el?.Category == null) continue;
+                    int bic = (int)el.Category.Id.Value;
+                    foreach (var c in MepCats)
+                    {
+                        if ((int)c == bic) { ids.Add(id); break; }
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GenerateFabPackage.CollectFromSelection: {ex.Message}"); }
             return ids;
         }
 

--- a/StingTools/UI/FabricationWorkspaceDialog.cs
+++ b/StingTools/UI/FabricationWorkspaceDialog.cs
@@ -598,7 +598,7 @@ namespace StingTools.UI
                 {
                     scopeLabel = "active view";
                     var view = _doc.ActiveView;
-                    if (view == null) return ids;
+                    if (view == null || view is ViewSheet) return ids;
                     foreach (var e in new FilteredElementCollector(_doc, view.Id)
                         .WherePasses(filter).WhereElementIsNotElementType()) ids.Add(e.Id);
                     return ids;
@@ -623,10 +623,11 @@ namespace StingTools.UI
                 }
                 if (ids.Count > 0) { scopeLabel = "selection"; return ids; }
 
-                // Auto-fallback: active view.
+                // Auto-fallback: active view (skip sheet views — the
+                // collector throws on those).
                 fellBack = true;
                 var v2 = _doc.ActiveView;
-                if (v2 != null)
+                if (v2 != null && !(v2 is ViewSheet))
                 {
                     foreach (var e in new FilteredElementCollector(_doc, v2.Id)
                         .WherePasses(filter).WhereElementIsNotElementType()) ids.Add(e.Id);

--- a/StingTools/UI/FabricationWorkspaceDialog.cs
+++ b/StingTools/UI/FabricationWorkspaceDialog.cs
@@ -67,14 +67,10 @@ namespace StingTools.UI
         // FILTER (system / level text)
         private TextBox _txtSystemFilter, _txtLevelFilter;
 
-        // RULES card (collapsed into the filter strip)
-        private CheckBox _chkPipe, _chkPipeLB, _chkDuct, _chkDuctPitt, _chkConduit;
-
-        // OUTPUT card
-        private CheckBox _chkAssy, _chkViews, _chkSheets, _chkSymbols, _chkCsv;
-
-        // CONTENT MODE
-        private RadioButton _rbIso6412, _rbGeneric;
+        // Rules / Output / Content mode are configured via the dock-panel
+        // Fabrication tab and read by the engine directly off
+        // FabricationOptions — the workspace dialog deliberately does not
+        // mirror them here so the layout matches the spec mockup.
 
         // Tabs
         private TabControl _tabs;
@@ -237,7 +233,7 @@ namespace StingTools.UI
             return grid;
         }
 
-        // ─── CATEGORY breakdown card ────────────────────────────────────
+        // ─── CATEGORY breakdown card — checkbox + count rows ────────────
 
         private UIElement BuildCategoryCard()
         {
@@ -252,7 +248,7 @@ namespace StingTools.UI
                 Foreground = new SolidColorBrush(AccentColor),
                 FontSize = 11,
                 FontWeight = FontWeights.SemiBold,
-                Margin = new Thickness(0, 6, 0, 0),
+                Margin = new Thickness(0, 8, 0, 4),
             };
             body.Children.Add(_txtDisciplineSummary);
 
@@ -260,87 +256,60 @@ namespace StingTools.UI
             // RefreshScopeAndCategories.
             foreach (var info in MepCategories)
             {
-                var row = new CategoryRow(info.bic, info.label, info.disc, NeutralBtn, FgColor, AccentColor, AltRowBg, CardBorder);
+                var row = new CategoryRow(info.bic, info.label, info.disc,
+                    FgColor, AccentColor, CardBorder,
+                    onToggle: () => RefreshPackagePreview());
                 _catRows[info.bic] = row;
                 _categoryListHost.Children.Add(row.RowElement);
             }
 
-            return Card("Categories in scope", body);
+            return Card("Categories", body);
         }
 
-        // ─── FILTERS / RULES / OUTPUT / CONTENT ─────────────────────────
+        // ─── FILTERS — single inline System / Level row ─────────────────
 
         private UIElement BuildFiltersCard()
         {
-            var grid = new Grid { Margin = new Thickness(0, 0, 0, 0) };
+            var grid = new Grid { Margin = new Thickness(0, 4, 0, 0) };
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 
-            // Filter (System / Level)
-            var filterBody = new StackPanel();
-            filterBody.Children.Add(new TextBlock
+            var lblSys = new TextBlock
             {
-                Text = "Free-text filters; blank = no filter.",
-                Foreground = new SolidColorBrush(SubtleColor), FontSize = 10,
-                Margin = new Thickness(0, 0, 0, 4),
-            });
-            _txtSystemFilter = new TextBox { Height = 22 };
+                Text = "System:",
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(lblSys, 0); Grid.SetRow(lblSys, 0);
+            grid.Children.Add(lblSys);
+
+            _txtSystemFilter = new TextBox { Height = 22, Margin = new Thickness(0, 0, 12, 0) };
             DarkDialogTheme.StyleInput(_txtSystemFilter, CardBg, FgColor, CardBorder);
             _txtSystemFilter.LostFocus += (s, e) => RefreshPackagePreview();
-            filterBody.Children.Add(LabelInline("System", 70));
-            filterBody.Children.Add(_txtSystemFilter);
-            _txtLevelFilter = new TextBox { Height = 22, Margin = new Thickness(0, 4, 0, 0) };
+            Grid.SetColumn(_txtSystemFilter, 1); Grid.SetRow(_txtSystemFilter, 0);
+            grid.Children.Add(_txtSystemFilter);
+
+            var lblLvl = new TextBlock
+            {
+                Text = "Level:",
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(lblLvl, 2); Grid.SetRow(lblLvl, 0);
+            grid.Children.Add(lblLvl);
+
+            _txtLevelFilter = new TextBox { Height = 22 };
             DarkDialogTheme.StyleInput(_txtLevelFilter, CardBg, FgColor, CardBorder);
             _txtLevelFilter.LostFocus += (s, e) => RefreshPackagePreview();
-            filterBody.Children.Add(LabelInline("Level", 70));
-            filterBody.Children.Add(_txtLevelFilter);
-            var filterCard = Card("Filter", filterBody);
-            Grid.SetColumn(filterCard, 0);
-            grid.Children.Add(filterCard);
-
-            // Rules
-            var rulesBody = new StackPanel();
-            _chkPipe     = CheckRow("Pipe (max 6 m / 4 bends)",                FabricationOptions.RulePipe,     v => FabricationOptions.RulePipe     = v);
-            _chkPipeLB   = CheckRow("Pipe large bore (max 3 m)",               FabricationOptions.RulePipeLB,   v => FabricationOptions.RulePipeLB   = v);
-            _chkDuct     = CheckRow("Duct TDF (max 3 m / 3 bends)",            FabricationOptions.RuleDuct,     v => FabricationOptions.RuleDuct     = v);
-            _chkDuctPitt = CheckRow("Duct Pittsburgh (max 2.4 m)",             FabricationOptions.RuleDuctPitt, v => FabricationOptions.RuleDuctPitt = v);
-            _chkConduit  = CheckRow("Conduit (max 6 m / 3 bends, BS 7671)",    FabricationOptions.RuleConduit,  v => FabricationOptions.RuleConduit  = v);
-            rulesBody.Children.Add(_chkPipe);
-            rulesBody.Children.Add(_chkPipeLB);
-            rulesBody.Children.Add(_chkDuct);
-            rulesBody.Children.Add(_chkDuctPitt);
-            rulesBody.Children.Add(_chkConduit);
-            var rulesCard = Card("Rules", rulesBody);
-            Grid.SetColumn(rulesCard, 1);
-            grid.Children.Add(rulesCard);
-
-            // Output + Content mode (combined)
-            var outBody = new StackPanel();
-            _chkAssy    = CheckRow("Generate AssemblyInstances",  FabricationOptions.GenerateAssemblies,  v => FabricationOptions.GenerateAssemblies  = v);
-            _chkViews   = CheckRow("Generate views (5 + BOM)",    FabricationOptions.GenerateViews,       v => FabricationOptions.GenerateViews       = v);
-            _chkSheets  = CheckRow("Generate shop drawing sheets",FabricationOptions.GenerateSheets,      v => FabricationOptions.GenerateSheets      = v);
-            _chkSymbols = CheckRow("Place ISO 6412 symbols",      FabricationOptions.PlaceISO6412Symbols, v => FabricationOptions.PlaceISO6412Symbols = v);
-            _chkCsv     = CheckRow("Emit per-discipline CSVs",    FabricationOptions.EmitPerDisciplineCsv,v => FabricationOptions.EmitPerDisciplineCsv= v);
-            outBody.Children.Add(_chkAssy);
-            outBody.Children.Add(_chkViews);
-            outBody.Children.Add(_chkSheets);
-            outBody.Children.Add(_chkSymbols);
-            outBody.Children.Add(_chkCsv);
-            outBody.Children.Add(new TextBlock { Text = "Content mode",
-                Foreground = new SolidColorBrush(SubtleColor), FontSize = 10,
-                Margin = new Thickness(0, 6, 0, 2) });
-            var contentRow = new StackPanel { Orientation = Orientation.Horizontal };
-            _rbIso6412 = MakeRadio("ISO 6412 (workshop)",     "FabContent",  FabricationOptions.ContentModeIso6412);
-            _rbGeneric = MakeRadio("Generic (geometry only)", "FabContent", !FabricationOptions.ContentModeIso6412);
-            _rbIso6412.Checked += (s, e) => FabricationOptions.ContentModeIso6412 = true;
-            _rbGeneric.Checked += (s, e) => FabricationOptions.ContentModeIso6412 = false;
-            contentRow.Children.Add(_rbIso6412);
-            contentRow.Children.Add(_rbGeneric);
-            outBody.Children.Add(contentRow);
-            var outCard = Card("Output", outBody);
-            Grid.SetColumn(outCard, 2);
-            grid.Children.Add(outCard);
+            Grid.SetColumn(_txtLevelFilter, 3); Grid.SetRow(_txtLevelFilter, 0);
+            grid.Children.Add(_txtLevelFilter);
 
             return grid;
         }
@@ -709,7 +678,10 @@ namespace StingTools.UI
                 foreach (var id in ids)
                 {
                     var el = _doc.GetElement(id);
-                    if (el == null) continue;
+                    if (el?.Category == null) continue;
+                    var bic = (BuiltInCategory)(int)el.Category.Id.Value;
+                    // Skip categories the user unticked in the breakdown.
+                    if (_catRows.TryGetValue(bic, out var crow) && !crow.IsChecked) continue;
                     string disc = DisciplineFor(el);
                     if (!RuleEnabledFor(disc)) continue;
                     string sys = ParameterHelpers.GetString(el, "PLM_SYS_TXT");
@@ -1000,24 +972,13 @@ namespace StingTools.UI
 
         private void HydrateFromOptions()
         {
+            // Workspace mirrors the SCOPE radios only — the rules /
+            // output / content-mode toggles are read by the engine
+            // directly off FabricationOptions and configured via the
+            // dock panel.
             if (_rbScopeSel  != null) _rbScopeSel.IsChecked  = FabricationOptions.ScopeSelection;
             if (_rbScopeView != null) _rbScopeView.IsChecked = FabricationOptions.ScopeActiveView;
             if (_rbScopeProj != null) _rbScopeProj.IsChecked = FabricationOptions.ScopeProject;
-
-            if (_chkPipe     != null) _chkPipe.IsChecked     = FabricationOptions.RulePipe;
-            if (_chkPipeLB   != null) _chkPipeLB.IsChecked   = FabricationOptions.RulePipeLB;
-            if (_chkDuct     != null) _chkDuct.IsChecked     = FabricationOptions.RuleDuct;
-            if (_chkDuctPitt != null) _chkDuctPitt.IsChecked = FabricationOptions.RuleDuctPitt;
-            if (_chkConduit  != null) _chkConduit.IsChecked  = FabricationOptions.RuleConduit;
-
-            if (_chkAssy    != null) _chkAssy.IsChecked    = FabricationOptions.GenerateAssemblies;
-            if (_chkViews   != null) _chkViews.IsChecked   = FabricationOptions.GenerateViews;
-            if (_chkSheets  != null) _chkSheets.IsChecked  = FabricationOptions.GenerateSheets;
-            if (_chkSymbols != null) _chkSymbols.IsChecked = FabricationOptions.PlaceISO6412Symbols;
-            if (_chkCsv     != null) _chkCsv.IsChecked     = FabricationOptions.EmitPerDisciplineCsv;
-
-            if (_rbIso6412 != null) _rbIso6412.IsChecked =  FabricationOptions.ContentModeIso6412;
-            if (_rbGeneric != null) _rbGeneric.IsChecked = !FabricationOptions.ContentModeIso6412;
         }
 
         // ═══════════════════════════════════════════════════════════════
@@ -1178,45 +1139,40 @@ namespace StingTools.UI
     //  Helper types
     // ═══════════════════════════════════════════════════════════════════
 
-    /// <summary>One row in the live category-breakdown card. The row is
-    /// just a presentation surface — the underlying selection always
-    /// flows from the SCOPE radio buttons + free-text filters.</summary>
+    /// <summary>One row in the live category-breakdown card. The CheckBox
+    /// gates whether elements of that category contribute to the package
+    /// preview / scope, and the right-aligned count tracks the live
+    /// element count returned by RefreshScopeAndCategories.</summary>
     internal sealed class CategoryRow
     {
+        private readonly CheckBox _check;
         private readonly TextBlock _txtCount;
         public BuiltInCategory Category { get; }
         public Grid RowElement { get; }
+        public bool IsChecked => _check?.IsChecked == true;
 
         public CategoryRow(BuiltInCategory bic, string label, string disc,
-            Color rowBg, Color fg, Color accent, Color altRowBg, Color border)
+            Color fg, Color accent, Color border, Action onToggle)
         {
             Category = bic;
 
             RowElement = new Grid { Margin = new Thickness(0, 1, 0, 1) };
-            RowElement.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(28) });
             RowElement.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
             RowElement.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
 
-            var dot = new Border
+            _check = new CheckBox
             {
-                Width = 10, Height = 10,
-                CornerRadius = new CornerRadius(5),
-                Background = new SolidColorBrush(accent),
-                Margin = new Thickness(2, 4, 8, 4),
-                VerticalAlignment = VerticalAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Center,
-            };
-            Grid.SetColumn(dot, 0); RowElement.Children.Add(dot);
-
-            var lbl = new TextBlock
-            {
-                Text = $"{label}   ({disc})",
+                Content = label,
+                IsChecked = true,
                 Foreground = new SolidColorBrush(fg),
                 FontSize = 11,
-                Margin = new Thickness(0, 4, 0, 4),
+                Margin = new Thickness(0, 2, 0, 2),
                 VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = $"Discipline: {disc}",
             };
-            Grid.SetColumn(lbl, 1); RowElement.Children.Add(lbl);
+            _check.Checked   += (s, e) => onToggle?.Invoke();
+            _check.Unchecked += (s, e) => onToggle?.Invoke();
+            Grid.SetColumn(_check, 0); RowElement.Children.Add(_check);
 
             _txtCount = new TextBlock
             {
@@ -1228,7 +1184,7 @@ namespace StingTools.UI
                 TextAlignment = TextAlignment.Right,
                 VerticalAlignment = VerticalAlignment.Center,
             };
-            Grid.SetColumn(_txtCount, 2); RowElement.Children.Add(_txtCount);
+            Grid.SetColumn(_txtCount, 1); RowElement.Children.Add(_txtCount);
         }
 
         public void SetCount(int n)

--- a/StingTools/UI/FabricationWorkspaceDialog.cs
+++ b/StingTools/UI/FabricationWorkspaceDialog.cs
@@ -1,0 +1,808 @@
+// StingTools v4 MVP — Fabrication Workspace dialog.
+//
+// Light-themed corporate workspace mirroring the DrawingTypeEditorDialog
+// pattern: 2-column grid (left = preset / scope / filter cards;
+// right = output / content-mode / title-block cards), plus a footer
+// row of action buttons (Generate package, Cut list, Weld map,
+// Isometrics, PCF, MAJ, BOM roll-up, Doc Register link, Close).
+//
+// All state is funnelled through StingTools.Commands.Fabrication.
+// FabricationOptions before the underlying commands are dispatched
+// via the IExternalEventHandler / Cmd_Click pipeline. Pressing an
+// action button raises the matching Fabrication_* tag on the dock
+// panel command handler so the existing IExternalCommand wiring is
+// reused without duplication.
+//
+// Palette is the same LightPalette used by DrawingTypeEditorDialog
+// — no dark mode anywhere.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json;
+using StingTools.Core;
+using StingTools.Commands.Fabrication;
+
+// Disambiguate WPF vs Revit types.
+using Color    = System.Windows.Media.Color;
+using Grid     = System.Windows.Controls.Grid;
+using TextBox  = System.Windows.Controls.TextBox;
+using ComboBox = System.Windows.Controls.ComboBox;
+using CheckBox = System.Windows.Controls.CheckBox;
+
+namespace StingTools.UI
+{
+    public sealed class FabricationWorkspaceDialog : Window
+    {
+        // ── palette (light, contrast-safe — same as DrawingTypeEditorDialog) ──
+        private static readonly Color BgColor     = Color.FromRgb(0xFA, 0xFA, 0xFA);
+        private static readonly Color AccentColor = Color.FromRgb(0xE8, 0x91, 0x2D);
+        private static readonly Color CardBg      = Color.FromRgb(0xFF, 0xFF, 0xFF);
+        private static readonly Color CardBorder  = Color.FromRgb(0xCF, 0xD8, 0xDC);
+        private static readonly Color FgColor     = Color.FromRgb(0x22, 0x22, 0x22);
+        private static readonly Color SubtleColor = Color.FromRgb(0x66, 0x66, 0x66);
+        private static readonly Color GreenBtn    = Color.FromRgb(0x4C, 0xAF, 0x50);
+        private static readonly Color OrangeBtn   = Color.FromRgb(0xFF, 0x98, 0x00);
+        private static readonly Color NeutralBtn  = Color.FromRgb(0xE8, 0xE8, 0xE8);
+
+        // ── state ──
+        private readonly Document _doc;
+
+        // Preset
+        private ComboBox  _cmbPreset;
+
+        // Scope
+        private RadioButton _rbScopeSel;
+        private RadioButton _rbScopeView;
+        private RadioButton _rbScopeProj;
+        private TextBlock   _txtScopeStatus;
+
+        // Filter (discipline rules)
+        private CheckBox _chkPipe, _chkPipeLB, _chkDuct, _chkDuctPitt, _chkConduit;
+
+        // Output
+        private CheckBox _chkAssy, _chkViews, _chkSheets, _chkSymbols, _chkCsv;
+
+        // Content mode
+        private RadioButton _rbIso6412, _rbGeneric;
+
+        // Title block / view template
+        private TextBlock _txtShopDrawingStatus;
+
+        public FabricationWorkspaceDialog(Document doc)
+        {
+            _doc = doc;
+
+            Title = "STING v4 — Fabrication Workspace";
+            Width = 1080; Height = 720;
+            MinWidth = 900; MinHeight = 560;
+            Background = new SolidColorBrush(BgColor);
+            FontFamily = new FontFamily("Segoe UI");
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            DarkDialogTheme.ApplyComboBoxFix(this, CardBg, FgColor, CardBorder);
+
+            try
+            {
+                var helper = new System.Windows.Interop.WindowInteropHelper(this);
+                helper.Owner = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+            }
+            catch { }
+
+            Content = BuildLayout();
+            HydrateFromOptions();
+            RefreshScopeStatus();
+            RefreshShopDrawingStatus();
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        //  LAYOUT — 2-column grid + footer
+        // ═══════════════════════════════════════════════════════════════
+
+        private UIElement BuildLayout()
+        {
+            var root = new Grid { Margin = new Thickness(12) };
+            root.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(360) });
+            root.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var left = BuildLeftPanel();
+            Grid.SetColumn(left, 0); Grid.SetRow(left, 0);
+            root.Children.Add(left);
+
+            var right = BuildRightPanel();
+            Grid.SetColumn(right, 1); Grid.SetRow(right, 0);
+            root.Children.Add(right);
+
+            var footer = BuildFooter();
+            Grid.SetColumn(footer, 0); Grid.SetRow(footer, 1); Grid.SetColumnSpan(footer, 2);
+            root.Children.Add(footer);
+
+            return root;
+        }
+
+        // ─── Left panel ─────────────────────────────────────────────────
+
+        private UIElement BuildLeftPanel()
+        {
+            var scroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Margin = new Thickness(0, 0, 8, 0),
+            };
+            var stack = new StackPanel();
+            stack.Children.Add(BuildPresetCard());
+            stack.Children.Add(BuildScopeCard());
+            stack.Children.Add(BuildFilterCard());
+            scroll.Content = stack;
+            return scroll;
+        }
+
+        private UIElement BuildPresetCard()
+        {
+            var body = new StackPanel();
+
+            _cmbPreset = new ComboBox { Height = 24, IsEditable = true };
+            DarkDialogTheme.StyleInput(_cmbPreset, CardBg, FgColor, CardBorder);
+            foreach (var name in ListPresetNames()) _cmbPreset.Items.Add(name);
+
+            var row = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 4) };
+            row.Children.Add(LabelInline("Preset", 60));
+            _cmbPreset.Width = 180;
+            row.Children.Add(_cmbPreset);
+            row.Children.Add(MakeSmallBtn("Load",   () => LoadPreset()));
+            row.Children.Add(MakeSmallBtn("Save…",  () => SavePreset()));
+            row.Children.Add(MakeSmallBtn("Delete", () => DeletePreset()));
+            body.Children.Add(row);
+
+            return Card("Preset", body);
+        }
+
+        private UIElement BuildScopeCard()
+        {
+            var body = new StackPanel();
+
+            _rbScopeSel  = MakeRadio("Selection",   "FabScope", FabricationOptions.ScopeSelection);
+            _rbScopeView = MakeRadio("Active view", "FabScope", FabricationOptions.ScopeActiveView);
+            _rbScopeProj = MakeRadio("Project",     "FabScope", FabricationOptions.ScopeProject);
+            _rbScopeSel.Checked  += (s, e) => { CommitScope(); RefreshScopeStatus(); };
+            _rbScopeView.Checked += (s, e) => { CommitScope(); RefreshScopeStatus(); };
+            _rbScopeProj.Checked += (s, e) => { CommitScope(); RefreshScopeStatus(); };
+
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            row.Children.Add(_rbScopeSel);
+            row.Children.Add(_rbScopeView);
+            row.Children.Add(_rbScopeProj);
+            row.Children.Add(MakeSmallBtn("Refresh", RefreshScopeStatus));
+            body.Children.Add(row);
+
+            _txtScopeStatus = new TextBlock
+            {
+                Text = "Scope: …",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 6, 0, 0),
+            };
+            body.Children.Add(_txtScopeStatus);
+
+            return Card("Scope", body);
+        }
+
+        private UIElement BuildFilterCard()
+        {
+            var body = new StackPanel();
+            body.Children.Add(new TextBlock
+            {
+                Text = "Discipline rules from STING_FAB_RULES.json",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11,
+                Margin = new Thickness(0, 0, 0, 4),
+            });
+
+            _chkPipe     = CheckRow("Pipe (max 6 m / 4 bends)",                   FabricationOptions.RulePipe,     v => FabricationOptions.RulePipe     = v);
+            _chkPipeLB   = CheckRow("Pipe large bore (max 3 m)",                  FabricationOptions.RulePipeLB,   v => FabricationOptions.RulePipeLB   = v);
+            _chkDuct     = CheckRow("Duct TDF (max 3 m / 3 bends)",               FabricationOptions.RuleDuct,     v => FabricationOptions.RuleDuct     = v);
+            _chkDuctPitt = CheckRow("Duct Pittsburgh (max 2.4 m)",                FabricationOptions.RuleDuctPitt, v => FabricationOptions.RuleDuctPitt = v);
+            _chkConduit  = CheckRow("Conduit (max 6 m / 3 bends, BS 7671)",       FabricationOptions.RuleConduit,  v => FabricationOptions.RuleConduit  = v);
+
+            body.Children.Add(_chkPipe);
+            body.Children.Add(_chkPipeLB);
+            body.Children.Add(_chkDuct);
+            body.Children.Add(_chkDuctPitt);
+            body.Children.Add(_chkConduit);
+
+            return Card("Filter", body);
+        }
+
+        // ─── Right panel ────────────────────────────────────────────────
+
+        private UIElement BuildRightPanel()
+        {
+            var scroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Margin = new Thickness(8, 0, 0, 0),
+            };
+            var stack = new StackPanel();
+            stack.Children.Add(BuildOutputCard());
+            stack.Children.Add(BuildContentModeCard());
+            stack.Children.Add(BuildShopDrawingCard());
+            stack.Children.Add(BuildExportsCard());
+            scroll.Content = stack;
+            return scroll;
+        }
+
+        private UIElement BuildOutputCard()
+        {
+            var body = new StackPanel();
+            _chkAssy    = CheckRow("Generate AssemblyInstances",  FabricationOptions.GenerateAssemblies,  v => FabricationOptions.GenerateAssemblies  = v);
+            _chkViews   = CheckRow("Generate views (5 + BOM)",    FabricationOptions.GenerateViews,       v => FabricationOptions.GenerateViews       = v);
+            _chkSheets  = CheckRow("Generate shop drawing sheets",FabricationOptions.GenerateSheets,      v => FabricationOptions.GenerateSheets      = v);
+            _chkSymbols = CheckRow("Place ISO 6412 symbols",      FabricationOptions.PlaceISO6412Symbols, v => FabricationOptions.PlaceISO6412Symbols = v);
+            _chkCsv     = CheckRow("Emit per-discipline CSVs",    FabricationOptions.EmitPerDisciplineCsv,v => FabricationOptions.EmitPerDisciplineCsv= v);
+            body.Children.Add(_chkAssy);
+            body.Children.Add(_chkViews);
+            body.Children.Add(_chkSheets);
+            body.Children.Add(_chkSymbols);
+            body.Children.Add(_chkCsv);
+            return Card("Output", body);
+        }
+
+        private UIElement BuildContentModeCard()
+        {
+            var body = new StackPanel { Orientation = Orientation.Horizontal };
+            _rbIso6412 = MakeRadio("ISO 6412 (workshop)",     "FabContent", FabricationOptions.ContentModeIso6412);
+            _rbGeneric = MakeRadio("Generic (geometry only)", "FabContent", !FabricationOptions.ContentModeIso6412);
+            _rbIso6412.Checked += (s, e) => FabricationOptions.ContentModeIso6412 = true;
+            _rbGeneric.Checked += (s, e) => FabricationOptions.ContentModeIso6412 = false;
+            body.Children.Add(_rbIso6412);
+            body.Children.Add(_rbGeneric);
+            return Card("Content mode", body);
+        }
+
+        private UIElement BuildShopDrawingCard()
+        {
+            var body = new StackPanel();
+            _txtShopDrawingStatus = new TextBlock
+            {
+                Foreground = new SolidColorBrush(FgColor),
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 6),
+            };
+            body.Children.Add(_txtShopDrawingStatus);
+
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            row.Children.Add(MakeSmallBtn("Configure…", ConfigureShopDrawing));
+            row.Children.Add(MakeSmallBtn("Clear",      ClearShopDrawing));
+            body.Children.Add(row);
+
+            return Card("Title block & view template", body);
+        }
+
+        private UIElement BuildExportsCard()
+        {
+            var body = new StackPanel();
+            body.Children.Add(new TextBlock
+            {
+                Text = "Re-emit per-discipline sidecars without rebuilding the full package.",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 6),
+            });
+
+            var wrap = new WrapPanel();
+            wrap.Children.Add(MakeAccentBtn("Cut list",    "Fabrication_ExportCutList"));
+            wrap.Children.Add(MakeAccentBtn("Weld map",    "Fabrication_ExportWeldMap"));
+            wrap.Children.Add(MakeAccentBtn("Isometrics",  "Fabrication_ExportIsometrics"));
+            wrap.Children.Add(MakeAccentBtn("PCF",         "Fabrication_ExportPcf"));
+            wrap.Children.Add(MakeAccentBtn("MAJ",         "Fabrication_ExportMaj"));
+            wrap.Children.Add(MakeAccentBtn("ISO symbols", "Fabrication_PlaceISOSymbols"));
+            body.Children.Add(wrap);
+
+            return Card("Exports", body);
+        }
+
+        // ─── Footer ─────────────────────────────────────────────────────
+
+        private UIElement BuildFooter()
+        {
+            var row = new DockPanel
+            {
+                Margin = new Thickness(0, 10, 0, 0),
+                LastChildFill = false,
+            };
+
+            var hint = new TextBlock
+            {
+                Text = "Settings persist on FabricationOptions for the Revit session. " +
+                       "Generate package builds assemblies, views, sheets and (optionally) ISO 6412 symbols.",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11,
+                VerticalAlignment = VerticalAlignment.Center,
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 520,
+            };
+            DockPanel.SetDock(hint, Dock.Left);
+            row.Children.Add(hint);
+
+            var right = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+            };
+            DockPanel.SetDock(right, Dock.Right);
+
+            right.Children.Add(MakeBigBtn("Close",            NeutralBtn, false, () => { DialogResult = false; }));
+            right.Children.Add(MakeBigBtn("Generate package", GreenBtn,   true,  () => Dispatch("Fabrication_GeneratePackage")));
+            row.Children.Add(right);
+
+            return row;
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        //  ACTIONS
+        // ═══════════════════════════════════════════════════════════════
+
+        private void CommitScope()
+        {
+            FabricationOptions.ScopeSelection  = _rbScopeSel?.IsChecked  == true;
+            FabricationOptions.ScopeActiveView = _rbScopeView?.IsChecked == true;
+            FabricationOptions.ScopeProject    = _rbScopeProj?.IsChecked == true;
+        }
+
+        private void RefreshScopeStatus()
+        {
+            try
+            {
+                int n = CountScopeElements();
+                string label =
+                    FabricationOptions.ScopeProject    ? "project"     :
+                    FabricationOptions.ScopeActiveView ? "active view" :
+                                                         "selection";
+                string msg = $"Scope: {label} — {n} MEP element(s) in scope.";
+                if (n == 0 && FabricationOptions.ScopeSelection)
+                    msg += " (Generate package will fall back to active view automatically.)";
+                if (_txtScopeStatus != null) _txtScopeStatus.Text = msg;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"FabricationWorkspaceDialog.RefreshScopeStatus: {ex.Message}");
+                if (_txtScopeStatus != null) _txtScopeStatus.Text = "Scope: (refresh failed — see log)";
+            }
+        }
+
+        private int CountScopeElements()
+        {
+            if (_doc == null) return 0;
+            var cats = new[]
+            {
+                BuiltInCategory.OST_PipeCurves,    BuiltInCategory.OST_FlexPipeCurves,
+                BuiltInCategory.OST_PipeFitting,   BuiltInCategory.OST_PipeAccessory,
+                BuiltInCategory.OST_DuctCurves,    BuiltInCategory.OST_FlexDuctCurves,
+                BuiltInCategory.OST_DuctFitting,   BuiltInCategory.OST_DuctAccessory,
+                BuiltInCategory.OST_Conduit,       BuiltInCategory.OST_ConduitFitting,
+                BuiltInCategory.OST_CableTray,     BuiltInCategory.OST_CableTrayFitting,
+            };
+            try
+            {
+                if (FabricationOptions.ScopeProject)
+                {
+                    return new FilteredElementCollector(_doc)
+                        .WherePasses(new ElementMulticategoryFilter(cats))
+                        .WhereElementIsNotElementType()
+                        .GetElementCount();
+                }
+                if (FabricationOptions.ScopeActiveView)
+                {
+                    var view = _doc.ActiveView;
+                    if (view == null) return 0;
+                    return new FilteredElementCollector(_doc, view.Id)
+                        .WherePasses(new ElementMulticategoryFilter(cats))
+                        .WhereElementIsNotElementType()
+                        .GetElementCount();
+                }
+                // Selection scope — no UIDocument here; the count is approximated.
+                return 0;
+            }
+            catch { return 0; }
+        }
+
+        private void ConfigureShopDrawing()
+        {
+            if (_doc == null) return;
+            try
+            {
+                var dlg = new ShopDrawingOptionsDialog(_doc);
+                try { dlg.Owner = this; } catch { }
+                if (dlg.ShowDialog() == true)
+                {
+                    FabricationOptions.ShopDrawing = dlg.Result;
+                    RefreshShopDrawingStatus();
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("FabricationWorkspaceDialog.ConfigureShopDrawing", ex);
+            }
+        }
+
+        private void ClearShopDrawing()
+        {
+            FabricationOptions.ShopDrawing = null;
+            RefreshShopDrawingStatus();
+        }
+
+        private void RefreshShopDrawingStatus()
+        {
+            if (_txtShopDrawingStatus == null) return;
+            var opts = FabricationOptions.ShopDrawing;
+            if (opts == null)
+            {
+                _txtShopDrawingStatus.Text =
+                    "Auto-resolved per discipline (STING_TB_ASSEMBLY_*).\n" +
+                    "Falls back to first available title block when missing.";
+                return;
+            }
+            string tb = "Auto (per-discipline)";
+            if (_doc != null && opts.TitleBlockSymbolId != null
+                && opts.TitleBlockSymbolId != ElementId.InvalidElementId)
+            {
+                var fs = _doc.GetElement(opts.TitleBlockSymbolId) as FamilySymbol;
+                if (fs != null) tb = $"{fs.FamilyName} : {fs.Name}";
+            }
+            string vt = "None";
+            if (_doc != null && opts.ViewTemplateId != null
+                && opts.ViewTemplateId != ElementId.InvalidElementId)
+            {
+                var v = _doc.GetElement(opts.ViewTemplateId) as Autodesk.Revit.DB.View;
+                if (v != null) vt = v.Name;
+            }
+            string s = $"Title block: {tb}\nView template: {vt}";
+            if (!string.IsNullOrWhiteSpace(opts.SheetNumberPattern))
+                s += $"\nSheet #: {opts.SheetNumberPattern}";
+            if (!string.IsNullOrWhiteSpace(opts.SheetNamePattern))
+                s += $"\nSheet name: {opts.SheetNamePattern}";
+            _txtShopDrawingStatus.Text = s;
+        }
+
+        // ─── Preset persistence ─────────────────────────────────────────
+
+        private static string PresetPath()
+        {
+            string dir = StingToolsApp.DataPath ?? Path.GetTempPath();
+            return Path.Combine(dir, "FABRICATION_PRESETS.json");
+        }
+
+        private static Dictionary<string, FabricationPreset> LoadAllPresets()
+        {
+            try
+            {
+                string path = PresetPath();
+                if (!File.Exists(path)) return new Dictionary<string, FabricationPreset>(StringComparer.OrdinalIgnoreCase);
+                var json = File.ReadAllText(path);
+                var dict = JsonConvert.DeserializeObject<Dictionary<string, FabricationPreset>>(json);
+                return dict ?? new Dictionary<string, FabricationPreset>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"FabricationWorkspaceDialog.LoadAllPresets: {ex.Message}");
+                return new Dictionary<string, FabricationPreset>(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        private static void SaveAllPresets(Dictionary<string, FabricationPreset> presets)
+        {
+            try
+            {
+                string path = PresetPath();
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.WriteAllText(path, JsonConvert.SerializeObject(presets, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("FabricationWorkspaceDialog.SaveAllPresets", ex);
+            }
+        }
+
+        private static IEnumerable<string> ListPresetNames()
+            => LoadAllPresets().Keys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase);
+
+        private void LoadPreset()
+        {
+            string name = (_cmbPreset?.Text ?? "").Trim();
+            if (string.IsNullOrEmpty(name)) return;
+            var all = LoadAllPresets();
+            if (!all.TryGetValue(name, out var p))
+            {
+                MessageBox.Show($"Preset '{name}' not found.", Title, MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+            p.ApplyTo();
+            HydrateFromOptions();
+            RefreshScopeStatus();
+        }
+
+        private void SavePreset()
+        {
+            string name = (_cmbPreset?.Text ?? "").Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                MessageBox.Show("Type a preset name first.", Title, MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+            var all = LoadAllPresets();
+            all[name] = FabricationPreset.Capture();
+            SaveAllPresets(all);
+            RefreshPresetCombo(name);
+        }
+
+        private void DeletePreset()
+        {
+            string name = (_cmbPreset?.Text ?? "").Trim();
+            if (string.IsNullOrEmpty(name)) return;
+            var all = LoadAllPresets();
+            if (all.Remove(name))
+            {
+                SaveAllPresets(all);
+                RefreshPresetCombo(null);
+            }
+        }
+
+        private void RefreshPresetCombo(string select)
+        {
+            if (_cmbPreset == null) return;
+            _cmbPreset.Items.Clear();
+            foreach (var name in ListPresetNames()) _cmbPreset.Items.Add(name);
+            if (!string.IsNullOrEmpty(select)) _cmbPreset.Text = select; else _cmbPreset.Text = "";
+        }
+
+        // ─── Hydrate UI from FabricationOptions ─────────────────────────
+
+        private void HydrateFromOptions()
+        {
+            if (_rbScopeSel  != null) _rbScopeSel.IsChecked  = FabricationOptions.ScopeSelection;
+            if (_rbScopeView != null) _rbScopeView.IsChecked = FabricationOptions.ScopeActiveView;
+            if (_rbScopeProj != null) _rbScopeProj.IsChecked = FabricationOptions.ScopeProject;
+
+            if (_chkPipe     != null) _chkPipe.IsChecked     = FabricationOptions.RulePipe;
+            if (_chkPipeLB   != null) _chkPipeLB.IsChecked   = FabricationOptions.RulePipeLB;
+            if (_chkDuct     != null) _chkDuct.IsChecked     = FabricationOptions.RuleDuct;
+            if (_chkDuctPitt != null) _chkDuctPitt.IsChecked = FabricationOptions.RuleDuctPitt;
+            if (_chkConduit  != null) _chkConduit.IsChecked  = FabricationOptions.RuleConduit;
+
+            if (_chkAssy    != null) _chkAssy.IsChecked    = FabricationOptions.GenerateAssemblies;
+            if (_chkViews   != null) _chkViews.IsChecked   = FabricationOptions.GenerateViews;
+            if (_chkSheets  != null) _chkSheets.IsChecked  = FabricationOptions.GenerateSheets;
+            if (_chkSymbols != null) _chkSymbols.IsChecked = FabricationOptions.PlaceISO6412Symbols;
+            if (_chkCsv     != null) _chkCsv.IsChecked     = FabricationOptions.EmitPerDisciplineCsv;
+
+            if (_rbIso6412 != null) _rbIso6412.IsChecked =  FabricationOptions.ContentModeIso6412;
+            if (_rbGeneric != null) _rbGeneric.IsChecked = !FabricationOptions.ContentModeIso6412;
+        }
+
+        // ─── Dispatch to the dock-panel command handler ─────────────────
+
+        private void Dispatch(string tag)
+        {
+            try
+            {
+                if (!StingDockPanel.DispatchCommand(tag))
+                {
+                    MessageBox.Show("Could not dispatch command: " + tag +
+                        "\n(Open the STING dock panel once so the command pipeline initialises.)",
+                        Title, MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("FabricationWorkspaceDialog.Dispatch " + tag, ex);
+                MessageBox.Show("Could not dispatch command: " + tag,
+                    Title, MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        //  UI PRIMITIVES — Card / inputs / buttons
+        // ═══════════════════════════════════════════════════════════════
+
+        private UIElement Card(string title, UIElement body)
+        {
+            var outer = new Border
+            {
+                Background = new SolidColorBrush(CardBg),
+                BorderBrush = new SolidColorBrush(CardBorder),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(3),
+                Margin = new Thickness(0, 4, 0, 0),
+                Padding = new Thickness(10, 6, 10, 10),
+            };
+            var stack = new StackPanel();
+            stack.Children.Add(new TextBlock
+            {
+                Text = title,
+                FontWeight = FontWeights.SemiBold,
+                FontSize = 12,
+                Foreground = new SolidColorBrush(AccentColor),
+                Margin = new Thickness(0, 0, 0, 6),
+            });
+            stack.Children.Add(body);
+            outer.Child = stack;
+            return outer;
+        }
+
+        private CheckBox CheckRow(string label, bool value, Action<bool> setter)
+        {
+            var cb = new CheckBox
+            {
+                Content = label,
+                IsChecked = value,
+                Foreground = new SolidColorBrush(FgColor),
+                Margin = new Thickness(0, 2, 0, 2),
+                FontSize = 11,
+            };
+            cb.Checked   += (s, e) => setter?.Invoke(true);
+            cb.Unchecked += (s, e) => setter?.Invoke(false);
+            return cb;
+        }
+
+        private RadioButton MakeRadio(string label, string group, bool isChecked)
+        {
+            return new RadioButton
+            {
+                Content = label,
+                GroupName = group,
+                IsChecked = isChecked,
+                Foreground = new SolidColorBrush(FgColor),
+                Margin = new Thickness(0, 2, 12, 2),
+                FontSize = 11,
+            };
+        }
+
+        private TextBlock LabelInline(string text, double width)
+        {
+            return new TextBlock
+            {
+                Text = text,
+                Width = width,
+                Foreground = new SolidColorBrush(SubtleColor),
+                VerticalAlignment = VerticalAlignment.Center,
+                FontSize = 11,
+            };
+        }
+
+        private Button MakeSmallBtn(string label, Action onClick)
+        {
+            var b = new Button
+            {
+                Content = label,
+                Height = 22,
+                MinWidth = 60,
+                Margin = new Thickness(6, 0, 0, 0),
+                Background = new SolidColorBrush(NeutralBtn),
+                Foreground = new SolidColorBrush(FgColor),
+                BorderBrush = new SolidColorBrush(CardBorder),
+                BorderThickness = new Thickness(1),
+                Padding = new Thickness(8, 0, 8, 0),
+                FontSize = 11,
+            };
+            b.Click += (s, e) => onClick?.Invoke();
+            return b;
+        }
+
+        private Button MakeAccentBtn(string label, string commandTag)
+        {
+            var b = new Button
+            {
+                Content = label,
+                Height = 26,
+                MinWidth = 80,
+                Margin = new Thickness(0, 0, 6, 6),
+                Background = new SolidColorBrush(OrangeBtn),
+                Foreground = new SolidColorBrush(Color.FromRgb(0xFF, 0xFF, 0xFF)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0xF5, 0x7C, 0x00)),
+                BorderThickness = new Thickness(1),
+                Padding = new Thickness(10, 0, 10, 0),
+                FontSize = 11,
+                FontWeight = FontWeights.SemiBold,
+            };
+            b.Click += (s, e) => Dispatch(commandTag);
+            return b;
+        }
+
+        private Button MakeBigBtn(string label, Color bg, bool isDefault, Action onClick)
+        {
+            var fg = bg == NeutralBtn ? FgColor : Color.FromRgb(0xFF, 0xFF, 0xFF);
+            var b = new Button
+            {
+                Content = label,
+                Width = 140,
+                Height = 32,
+                Margin = new Thickness(8, 0, 0, 0),
+                Background = new SolidColorBrush(bg),
+                Foreground = new SolidColorBrush(fg),
+                BorderBrush = new SolidColorBrush(CardBorder),
+                BorderThickness = new Thickness(1),
+                FontWeight = isDefault ? FontWeights.Bold : FontWeights.Normal,
+                IsDefault = isDefault,
+                IsCancel = !isDefault,
+                FontSize = 12,
+            };
+            b.Click += (s, e) => onClick?.Invoke();
+            return b;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  PRESET DTO — captures + replays the FabricationOptions surface
+    // ═══════════════════════════════════════════════════════════════════
+
+    public sealed class FabricationPreset
+    {
+        public bool ScopeSelection  { get; set; }
+        public bool ScopeActiveView { get; set; }
+        public bool ScopeProject    { get; set; }
+
+        public bool RulePipe     { get; set; }
+        public bool RulePipeLB   { get; set; }
+        public bool RuleDuct     { get; set; }
+        public bool RuleDuctPitt { get; set; }
+        public bool RuleConduit  { get; set; }
+
+        public bool GenerateAssemblies   { get; set; }
+        public bool GenerateViews        { get; set; }
+        public bool GenerateSheets       { get; set; }
+        public bool PlaceISO6412Symbols  { get; set; }
+        public bool EmitPerDisciplineCsv { get; set; }
+
+        public bool ContentModeIso6412 { get; set; }
+
+        public static FabricationPreset Capture()
+        {
+            return new FabricationPreset
+            {
+                ScopeSelection       = FabricationOptions.ScopeSelection,
+                ScopeActiveView      = FabricationOptions.ScopeActiveView,
+                ScopeProject         = FabricationOptions.ScopeProject,
+                RulePipe             = FabricationOptions.RulePipe,
+                RulePipeLB           = FabricationOptions.RulePipeLB,
+                RuleDuct             = FabricationOptions.RuleDuct,
+                RuleDuctPitt         = FabricationOptions.RuleDuctPitt,
+                RuleConduit          = FabricationOptions.RuleConduit,
+                GenerateAssemblies   = FabricationOptions.GenerateAssemblies,
+                GenerateViews        = FabricationOptions.GenerateViews,
+                GenerateSheets       = FabricationOptions.GenerateSheets,
+                PlaceISO6412Symbols  = FabricationOptions.PlaceISO6412Symbols,
+                EmitPerDisciplineCsv = FabricationOptions.EmitPerDisciplineCsv,
+                ContentModeIso6412   = FabricationOptions.ContentModeIso6412,
+            };
+        }
+
+        public void ApplyTo()
+        {
+            FabricationOptions.ScopeSelection       = ScopeSelection;
+            FabricationOptions.ScopeActiveView      = ScopeActiveView;
+            FabricationOptions.ScopeProject         = ScopeProject;
+            FabricationOptions.RulePipe             = RulePipe;
+            FabricationOptions.RulePipeLB           = RulePipeLB;
+            FabricationOptions.RuleDuct             = RuleDuct;
+            FabricationOptions.RuleDuctPitt         = RuleDuctPitt;
+            FabricationOptions.RuleConduit          = RuleConduit;
+            FabricationOptions.GenerateAssemblies   = GenerateAssemblies;
+            FabricationOptions.GenerateViews        = GenerateViews;
+            FabricationOptions.GenerateSheets       = GenerateSheets;
+            FabricationOptions.PlaceISO6412Symbols  = PlaceISO6412Symbols;
+            FabricationOptions.EmitPerDisciplineCsv = EmitPerDisciplineCsv;
+            FabricationOptions.ContentModeIso6412   = ContentModeIso6412;
+        }
+    }
+}

--- a/StingTools/UI/FabricationWorkspaceDialog.cs
+++ b/StingTools/UI/FabricationWorkspaceDialog.cs
@@ -1,20 +1,17 @@
-// StingTools v4 MVP — Fabrication Workspace dialog.
+// StingTools v4 MVP — Fabrication Workspace dialog (light-themed, rich).
 //
-// Light-themed corporate workspace mirroring the DrawingTypeEditorDialog
-// pattern: 2-column grid (left = preset / scope / filter cards;
-// right = output / content-mode / title-block cards), plus a footer
-// row of action buttons (Generate package, Cut list, Weld map,
-// Isometrics, PCF, MAJ, BOM roll-up, Doc Register link, Close).
+// Replaces the old single-pane "Configure" dialog with the full
+// workspace from the spec: PRESET row, SCOPE row with live category
+// breakdown + per-discipline summary + system / level filters, a
+// tabbed body (Package / Cut list / Weld map / Isometrics / PCF /
+// MAJ) and a footer strip wiring every fabrication export.
 //
-// All state is funnelled through StingTools.Commands.Fabrication.
-// FabricationOptions before the underlying commands are dispatched
-// via the IExternalEventHandler / Cmd_Click pipeline. Pressing an
-// action button raises the matching Fabrication_* tag on the dock
-// panel command handler so the existing IExternalCommand wiring is
-// reused without duplication.
+// All state still flows through StingTools.Commands.Fabrication.
+// FabricationOptions; every action button raises the matching
+// Fabrication_* tag through StingDockPanel.DispatchCommand so the
+// existing IExternalCommand pipeline is reused without duplication.
 //
-// Palette is the same LightPalette used by DrawingTypeEditorDialog
-// — no dark mode anywhere.
+// Light palette only — DarkDialogTheme.LightPalette throughout.
 
 using System;
 using System.Collections.Generic;
@@ -39,48 +36,78 @@ namespace StingTools.UI
 {
     public sealed class FabricationWorkspaceDialog : Window
     {
-        // ── palette (light, contrast-safe — same as DrawingTypeEditorDialog) ──
-        private static readonly Color BgColor     = Color.FromRgb(0xFA, 0xFA, 0xFA);
-        private static readonly Color AccentColor = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color CardBg      = Color.FromRgb(0xFF, 0xFF, 0xFF);
-        private static readonly Color CardBorder  = Color.FromRgb(0xCF, 0xD8, 0xDC);
-        private static readonly Color FgColor     = Color.FromRgb(0x22, 0x22, 0x22);
-        private static readonly Color SubtleColor = Color.FromRgb(0x66, 0x66, 0x66);
-        private static readonly Color GreenBtn    = Color.FromRgb(0x4C, 0xAF, 0x50);
-        private static readonly Color OrangeBtn   = Color.FromRgb(0xFF, 0x98, 0x00);
-        private static readonly Color NeutralBtn  = Color.FromRgb(0xE8, 0xE8, 0xE8);
+        // ── palette (light, contrast-safe) ──
+        private static readonly Color BgColor      = Color.FromRgb(0xFA, 0xFA, 0xFA);
+        private static readonly Color AccentColor  = Color.FromRgb(0xE8, 0x91, 0x2D);
+        private static readonly Color CardBg       = Color.FromRgb(0xFF, 0xFF, 0xFF);
+        private static readonly Color CardBorder   = Color.FromRgb(0xCF, 0xD8, 0xDC);
+        private static readonly Color FgColor      = Color.FromRgb(0x22, 0x22, 0x22);
+        private static readonly Color SubtleColor  = Color.FromRgb(0x66, 0x66, 0x66);
+        private static readonly Color GreenBtn     = Color.FromRgb(0x4C, 0xAF, 0x50);
+        private static readonly Color OrangeBtn    = Color.FromRgb(0xFF, 0x98, 0x00);
+        private static readonly Color NeutralBtn   = Color.FromRgb(0xE8, 0xE8, 0xE8);
+        private static readonly Color AltRowBg     = Color.FromRgb(0xF5, 0xF7, 0xF9);
 
         // ── state ──
         private readonly Document _doc;
 
-        // Preset
-        private ComboBox  _cmbPreset;
+        // PRESET row
+        private ComboBox _cmbPreset;
 
-        // Scope
-        private RadioButton _rbScopeSel;
-        private RadioButton _rbScopeView;
-        private RadioButton _rbScopeProj;
+        // SCOPE row
+        private RadioButton _rbScopeSel, _rbScopeView, _rbScopeProj;
         private TextBlock   _txtScopeStatus;
 
-        // Filter (discipline rules)
+        // CATEGORY breakdown
+        private StackPanel _categoryListHost;
+        private TextBlock  _txtDisciplineSummary;
+        private readonly Dictionary<BuiltInCategory, CategoryRow> _catRows
+            = new Dictionary<BuiltInCategory, CategoryRow>();
+
+        // FILTER (system / level text)
+        private TextBox _txtSystemFilter, _txtLevelFilter;
+
+        // RULES card (collapsed into the filter strip)
         private CheckBox _chkPipe, _chkPipeLB, _chkDuct, _chkDuctPitt, _chkConduit;
 
-        // Output
+        // OUTPUT card
         private CheckBox _chkAssy, _chkViews, _chkSheets, _chkSymbols, _chkCsv;
 
-        // Content mode
+        // CONTENT MODE
         private RadioButton _rbIso6412, _rbGeneric;
 
-        // Title block / view template
+        // Tabs
+        private TabControl _tabs;
+        private StackPanel _packageGridHost;
+        private TextBlock  _packageHeader;
+
+        // Title block strip
         private TextBlock _txtShopDrawingStatus;
+
+        // ── MEP categories — single source of truth ──
+        private static readonly (BuiltInCategory bic, string label, string disc)[] MepCategories =
+        {
+            (BuiltInCategory.OST_PipeCurves,        "Pipes",              "Pipe"),
+            (BuiltInCategory.OST_FlexPipeCurves,    "Flex pipes",         "Pipe"),
+            (BuiltInCategory.OST_PipeFitting,       "Pipe fittings",      "Pipe"),
+            (BuiltInCategory.OST_PipeAccessory,     "Pipe accessories",   "Pipe"),
+            (BuiltInCategory.OST_DuctCurves,        "Ducts",              "Duct"),
+            (BuiltInCategory.OST_FlexDuctCurves,    "Flex ducts",         "Duct"),
+            (BuiltInCategory.OST_DuctFitting,       "Duct fittings",      "Duct"),
+            (BuiltInCategory.OST_DuctAccessory,     "Duct accessories",   "Duct"),
+            (BuiltInCategory.OST_Conduit,           "Conduit",            "Electrical"),
+            (BuiltInCategory.OST_ConduitFitting,    "Conduit fittings",   "Electrical"),
+            (BuiltInCategory.OST_CableTray,         "Cable trays",        "Electrical"),
+            (BuiltInCategory.OST_CableTrayFitting,  "Tray fittings",      "Electrical"),
+        };
 
         public FabricationWorkspaceDialog(Document doc)
         {
             _doc = doc;
 
             Title = "STING v4 — Fabrication Workspace";
-            Width = 1080; Height = 720;
-            MinWidth = 900; MinHeight = 560;
+            Width = 1100; Height = 760;
+            MinWidth = 920; MinHeight = 600;
             Background = new SolidColorBrush(BgColor);
             FontFamily = new FontFamily("Segoe UI");
             WindowStartupLocation = WindowStartupLocation.CenterOwner;
@@ -95,262 +122,420 @@ namespace StingTools.UI
 
             Content = BuildLayout();
             HydrateFromOptions();
-            RefreshScopeStatus();
+            RefreshScopeAndCategories();
             RefreshShopDrawingStatus();
+            RefreshPackagePreview();
         }
 
         // ═══════════════════════════════════════════════════════════════
-        //  LAYOUT — 2-column grid + footer
+        //  LAYOUT — top header strip + tab body + footer
         // ═══════════════════════════════════════════════════════════════
 
         private UIElement BuildLayout()
         {
-            var root = new Grid { Margin = new Thickness(12) };
-            root.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(360) });
-            root.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
-            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            var root = new DockPanel { Margin = new Thickness(12), LastChildFill = true };
 
-            var left = BuildLeftPanel();
-            Grid.SetColumn(left, 0); Grid.SetRow(left, 0);
-            root.Children.Add(left);
-
-            var right = BuildRightPanel();
-            Grid.SetColumn(right, 1); Grid.SetRow(right, 0);
-            root.Children.Add(right);
-
-            var footer = BuildFooter();
-            Grid.SetColumn(footer, 0); Grid.SetRow(footer, 1); Grid.SetColumnSpan(footer, 2);
-            root.Children.Add(footer);
+            var header   = BuildHeaderStrip();    DockPanel.SetDock(header,   Dock.Top);    root.Children.Add(header);
+            var scope    = BuildScopeStrip();     DockPanel.SetDock(scope,    Dock.Top);    root.Children.Add(scope);
+            var cats     = BuildCategoryCard();   DockPanel.SetDock(cats,     Dock.Top);    root.Children.Add(cats);
+            var filters  = BuildFiltersCard();    DockPanel.SetDock(filters,  Dock.Top);    root.Children.Add(filters);
+            var footer   = BuildFooter();         DockPanel.SetDock(footer,   Dock.Bottom); root.Children.Add(footer);
+            var shop     = BuildShopDrawingStrip();DockPanel.SetDock(shop,    Dock.Bottom); root.Children.Add(shop);
+            root.Children.Add(BuildTabBody()); // last child fills remainder
 
             return root;
         }
 
-        // ─── Left panel ─────────────────────────────────────────────────
+        // ─── Top: PRESET row ────────────────────────────────────────────
 
-        private UIElement BuildLeftPanel()
+        private UIElement BuildHeaderStrip()
         {
-            var scroll = new ScrollViewer
+            var grid = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(220) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            var lbl = new TextBlock
             {
-                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
-                Margin = new Thickness(0, 0, 8, 0),
+                Text = "PRESET",
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                VerticalAlignment = VerticalAlignment.Center,
             };
-            var stack = new StackPanel();
-            stack.Children.Add(BuildPresetCard());
-            stack.Children.Add(BuildScopeCard());
-            stack.Children.Add(BuildFilterCard());
-            scroll.Content = stack;
-            return scroll;
-        }
+            Grid.SetColumn(lbl, 0);
+            grid.Children.Add(lbl);
 
-        private UIElement BuildPresetCard()
-        {
-            var body = new StackPanel();
-
-            _cmbPreset = new ComboBox { Height = 24, IsEditable = true };
+            _cmbPreset = new ComboBox { Height = 24, IsEditable = true, Margin = new Thickness(0, 0, 8, 0) };
             DarkDialogTheme.StyleInput(_cmbPreset, CardBg, FgColor, CardBorder);
             foreach (var name in ListPresetNames()) _cmbPreset.Items.Add(name);
+            Grid.SetColumn(_cmbPreset, 1);
+            grid.Children.Add(_cmbPreset);
 
-            var row = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 4) };
-            row.Children.Add(LabelInline("Preset", 60));
-            _cmbPreset.Width = 180;
-            row.Children.Add(_cmbPreset);
-            row.Children.Add(MakeSmallBtn("Load",   () => LoadPreset()));
-            row.Children.Add(MakeSmallBtn("Save…",  () => SavePreset()));
-            row.Children.Add(MakeSmallBtn("Delete", () => DeletePreset()));
-            body.Children.Add(row);
+            var actions = new StackPanel { Orientation = Orientation.Horizontal };
+            actions.Children.Add(MakeSmallBtn("Load",   () => LoadPreset()));
+            actions.Children.Add(MakeSmallBtn("Save…",  () => SavePreset()));
+            actions.Children.Add(MakeSmallBtn("Delete", () => DeletePreset()));
+            Grid.SetColumn(actions, 2);
+            grid.Children.Add(actions);
 
-            return Card("Preset", body);
+            return grid;
         }
 
-        private UIElement BuildScopeCard()
-        {
-            var body = new StackPanel();
+        // ─── SCOPE row ──────────────────────────────────────────────────
 
+        private UIElement BuildScopeStrip()
+        {
+            var grid = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var lbl = new TextBlock
+            {
+                Text = "SCOPE",
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(lbl, 0); Grid.SetRow(lbl, 0);
+            grid.Children.Add(lbl);
+
+            var radios = new StackPanel { Orientation = Orientation.Horizontal };
             _rbScopeSel  = MakeRadio("Selection",   "FabScope", FabricationOptions.ScopeSelection);
             _rbScopeView = MakeRadio("Active view", "FabScope", FabricationOptions.ScopeActiveView);
             _rbScopeProj = MakeRadio("Project",     "FabScope", FabricationOptions.ScopeProject);
-            _rbScopeSel.Checked  += (s, e) => { CommitScope(); RefreshScopeStatus(); };
-            _rbScopeView.Checked += (s, e) => { CommitScope(); RefreshScopeStatus(); };
-            _rbScopeProj.Checked += (s, e) => { CommitScope(); RefreshScopeStatus(); };
+            _rbScopeSel.Checked  += (s, e) => { CommitScope(); RefreshScopeAndCategories(); RefreshPackagePreview(); };
+            _rbScopeView.Checked += (s, e) => { CommitScope(); RefreshScopeAndCategories(); RefreshPackagePreview(); };
+            _rbScopeProj.Checked += (s, e) => { CommitScope(); RefreshScopeAndCategories(); RefreshPackagePreview(); };
+            radios.Children.Add(_rbScopeSel);
+            radios.Children.Add(_rbScopeView);
+            radios.Children.Add(_rbScopeProj);
+            Grid.SetColumn(radios, 1); Grid.SetRow(radios, 0);
+            grid.Children.Add(radios);
 
-            var row = new StackPanel { Orientation = Orientation.Horizontal };
-            row.Children.Add(_rbScopeSel);
-            row.Children.Add(_rbScopeView);
-            row.Children.Add(_rbScopeProj);
-            row.Children.Add(MakeSmallBtn("Refresh", RefreshScopeStatus));
-            body.Children.Add(row);
+            var refresh = MakeSmallBtn("Refresh", () => { RefreshScopeAndCategories(); RefreshPackagePreview(); });
+            Grid.SetColumn(refresh, 2); Grid.SetRow(refresh, 0);
+            grid.Children.Add(refresh);
 
             _txtScopeStatus = new TextBlock
             {
                 Text = "Scope: …",
                 Foreground = new SolidColorBrush(SubtleColor),
                 FontSize = 11,
+                Margin = new Thickness(0, 4, 0, 0),
                 TextWrapping = TextWrapping.Wrap,
+            };
+            Grid.SetColumn(_txtScopeStatus, 0); Grid.SetRow(_txtScopeStatus, 1); Grid.SetColumnSpan(_txtScopeStatus, 4);
+            grid.Children.Add(_txtScopeStatus);
+
+            return grid;
+        }
+
+        // ─── CATEGORY breakdown card ────────────────────────────────────
+
+        private UIElement BuildCategoryCard()
+        {
+            var body = new StackPanel();
+
+            _categoryListHost = new StackPanel();
+            body.Children.Add(_categoryListHost);
+
+            _txtDisciplineSummary = new TextBlock
+            {
+                Text = "By discipline: …",
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                FontWeight = FontWeights.SemiBold,
                 Margin = new Thickness(0, 6, 0, 0),
             };
-            body.Children.Add(_txtScopeStatus);
+            body.Children.Add(_txtDisciplineSummary);
 
-            return Card("Scope", body);
+            // Build one row per category — populated/refreshed in
+            // RefreshScopeAndCategories.
+            foreach (var info in MepCategories)
+            {
+                var row = new CategoryRow(info.bic, info.label, info.disc, NeutralBtn, FgColor, AccentColor, AltRowBg, CardBorder);
+                _catRows[info.bic] = row;
+                _categoryListHost.Children.Add(row.RowElement);
+            }
+
+            return Card("Categories in scope", body);
         }
 
-        private UIElement BuildFilterCard()
+        // ─── FILTERS / RULES / OUTPUT / CONTENT ─────────────────────────
+
+        private UIElement BuildFiltersCard()
         {
-            var body = new StackPanel();
-            body.Children.Add(new TextBlock
+            var grid = new Grid { Margin = new Thickness(0, 0, 0, 0) };
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            // Filter (System / Level)
+            var filterBody = new StackPanel();
+            filterBody.Children.Add(new TextBlock
             {
-                Text = "Discipline rules from STING_FAB_RULES.json",
-                Foreground = new SolidColorBrush(SubtleColor),
-                FontSize = 11,
+                Text = "Free-text filters; blank = no filter.",
+                Foreground = new SolidColorBrush(SubtleColor), FontSize = 10,
                 Margin = new Thickness(0, 0, 0, 4),
             });
+            _txtSystemFilter = new TextBox { Height = 22 };
+            DarkDialogTheme.StyleInput(_txtSystemFilter, CardBg, FgColor, CardBorder);
+            _txtSystemFilter.LostFocus += (s, e) => RefreshPackagePreview();
+            filterBody.Children.Add(LabelInline("System", 70));
+            filterBody.Children.Add(_txtSystemFilter);
+            _txtLevelFilter = new TextBox { Height = 22, Margin = new Thickness(0, 4, 0, 0) };
+            DarkDialogTheme.StyleInput(_txtLevelFilter, CardBg, FgColor, CardBorder);
+            _txtLevelFilter.LostFocus += (s, e) => RefreshPackagePreview();
+            filterBody.Children.Add(LabelInline("Level", 70));
+            filterBody.Children.Add(_txtLevelFilter);
+            var filterCard = Card("Filter", filterBody);
+            Grid.SetColumn(filterCard, 0);
+            grid.Children.Add(filterCard);
 
-            _chkPipe     = CheckRow("Pipe (max 6 m / 4 bends)",                   FabricationOptions.RulePipe,     v => FabricationOptions.RulePipe     = v);
-            _chkPipeLB   = CheckRow("Pipe large bore (max 3 m)",                  FabricationOptions.RulePipeLB,   v => FabricationOptions.RulePipeLB   = v);
-            _chkDuct     = CheckRow("Duct TDF (max 3 m / 3 bends)",               FabricationOptions.RuleDuct,     v => FabricationOptions.RuleDuct     = v);
-            _chkDuctPitt = CheckRow("Duct Pittsburgh (max 2.4 m)",                FabricationOptions.RuleDuctPitt, v => FabricationOptions.RuleDuctPitt = v);
-            _chkConduit  = CheckRow("Conduit (max 6 m / 3 bends, BS 7671)",       FabricationOptions.RuleConduit,  v => FabricationOptions.RuleConduit  = v);
+            // Rules
+            var rulesBody = new StackPanel();
+            _chkPipe     = CheckRow("Pipe (max 6 m / 4 bends)",                FabricationOptions.RulePipe,     v => FabricationOptions.RulePipe     = v);
+            _chkPipeLB   = CheckRow("Pipe large bore (max 3 m)",               FabricationOptions.RulePipeLB,   v => FabricationOptions.RulePipeLB   = v);
+            _chkDuct     = CheckRow("Duct TDF (max 3 m / 3 bends)",            FabricationOptions.RuleDuct,     v => FabricationOptions.RuleDuct     = v);
+            _chkDuctPitt = CheckRow("Duct Pittsburgh (max 2.4 m)",             FabricationOptions.RuleDuctPitt, v => FabricationOptions.RuleDuctPitt = v);
+            _chkConduit  = CheckRow("Conduit (max 6 m / 3 bends, BS 7671)",    FabricationOptions.RuleConduit,  v => FabricationOptions.RuleConduit  = v);
+            rulesBody.Children.Add(_chkPipe);
+            rulesBody.Children.Add(_chkPipeLB);
+            rulesBody.Children.Add(_chkDuct);
+            rulesBody.Children.Add(_chkDuctPitt);
+            rulesBody.Children.Add(_chkConduit);
+            var rulesCard = Card("Rules", rulesBody);
+            Grid.SetColumn(rulesCard, 1);
+            grid.Children.Add(rulesCard);
 
-            body.Children.Add(_chkPipe);
-            body.Children.Add(_chkPipeLB);
-            body.Children.Add(_chkDuct);
-            body.Children.Add(_chkDuctPitt);
-            body.Children.Add(_chkConduit);
-
-            return Card("Filter", body);
-        }
-
-        // ─── Right panel ────────────────────────────────────────────────
-
-        private UIElement BuildRightPanel()
-        {
-            var scroll = new ScrollViewer
-            {
-                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
-                Margin = new Thickness(8, 0, 0, 0),
-            };
-            var stack = new StackPanel();
-            stack.Children.Add(BuildOutputCard());
-            stack.Children.Add(BuildContentModeCard());
-            stack.Children.Add(BuildShopDrawingCard());
-            stack.Children.Add(BuildExportsCard());
-            scroll.Content = stack;
-            return scroll;
-        }
-
-        private UIElement BuildOutputCard()
-        {
-            var body = new StackPanel();
+            // Output + Content mode (combined)
+            var outBody = new StackPanel();
             _chkAssy    = CheckRow("Generate AssemblyInstances",  FabricationOptions.GenerateAssemblies,  v => FabricationOptions.GenerateAssemblies  = v);
             _chkViews   = CheckRow("Generate views (5 + BOM)",    FabricationOptions.GenerateViews,       v => FabricationOptions.GenerateViews       = v);
             _chkSheets  = CheckRow("Generate shop drawing sheets",FabricationOptions.GenerateSheets,      v => FabricationOptions.GenerateSheets      = v);
             _chkSymbols = CheckRow("Place ISO 6412 symbols",      FabricationOptions.PlaceISO6412Symbols, v => FabricationOptions.PlaceISO6412Symbols = v);
             _chkCsv     = CheckRow("Emit per-discipline CSVs",    FabricationOptions.EmitPerDisciplineCsv,v => FabricationOptions.EmitPerDisciplineCsv= v);
-            body.Children.Add(_chkAssy);
-            body.Children.Add(_chkViews);
-            body.Children.Add(_chkSheets);
-            body.Children.Add(_chkSymbols);
-            body.Children.Add(_chkCsv);
-            return Card("Output", body);
-        }
-
-        private UIElement BuildContentModeCard()
-        {
-            var body = new StackPanel { Orientation = Orientation.Horizontal };
-            _rbIso6412 = MakeRadio("ISO 6412 (workshop)",     "FabContent", FabricationOptions.ContentModeIso6412);
+            outBody.Children.Add(_chkAssy);
+            outBody.Children.Add(_chkViews);
+            outBody.Children.Add(_chkSheets);
+            outBody.Children.Add(_chkSymbols);
+            outBody.Children.Add(_chkCsv);
+            outBody.Children.Add(new TextBlock { Text = "Content mode",
+                Foreground = new SolidColorBrush(SubtleColor), FontSize = 10,
+                Margin = new Thickness(0, 6, 0, 2) });
+            var contentRow = new StackPanel { Orientation = Orientation.Horizontal };
+            _rbIso6412 = MakeRadio("ISO 6412 (workshop)",     "FabContent",  FabricationOptions.ContentModeIso6412);
             _rbGeneric = MakeRadio("Generic (geometry only)", "FabContent", !FabricationOptions.ContentModeIso6412);
             _rbIso6412.Checked += (s, e) => FabricationOptions.ContentModeIso6412 = true;
             _rbGeneric.Checked += (s, e) => FabricationOptions.ContentModeIso6412 = false;
-            body.Children.Add(_rbIso6412);
-            body.Children.Add(_rbGeneric);
-            return Card("Content mode", body);
+            contentRow.Children.Add(_rbIso6412);
+            contentRow.Children.Add(_rbGeneric);
+            outBody.Children.Add(contentRow);
+            var outCard = Card("Output", outBody);
+            Grid.SetColumn(outCard, 2);
+            grid.Children.Add(outCard);
+
+            return grid;
         }
 
-        private UIElement BuildShopDrawingCard()
+        // ─── TAB body — Package / Cut list / Weld map / Iso / PCF / MAJ ─
+
+        private UIElement BuildTabBody()
         {
-            var body = new StackPanel();
+            var border = new Border
+            {
+                BorderBrush = new SolidColorBrush(CardBorder),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(3),
+                Background = new SolidColorBrush(CardBg),
+                Margin = new Thickness(0, 4, 0, 4),
+            };
+            _tabs = new TabControl
+            {
+                Background = new SolidColorBrush(CardBg),
+                BorderThickness = new Thickness(0),
+                Padding = new Thickness(6),
+            };
+            _tabs.Items.Add(BuildPackageTab());
+            _tabs.Items.Add(BuildExportTab("Cut list",   "Fabrication_ExportCutList",
+                "Re-emits STING_v4_pipe_cut_list.csv. Includes element id, system, size, length and material per pipe."));
+            _tabs.Items.Add(BuildExportTab("Weld map",   "Fabrication_ExportWeldMap",
+                "Re-emits STING_v4_weld_map.csv. Lists every weld with face id, joint type and discipline."));
+            _tabs.Items.Add(BuildExportTab("Isometrics", "Fabrication_ExportIsometrics",
+                "Indexes SP-… isometric sheets to STING_v4_isometric_index.csv for register intake."));
+            _tabs.Items.Add(BuildExportTab("PCF",        "Fabrication_ExportPcf",
+                "Exports SpoolGen-compatible PCF to STING_v4_export.pcf — pipe component file."));
+            _tabs.Items.Add(BuildExportTab("MAJ",        "Fabrication_ExportMaj",
+                "Exports MAJiC manufacturing-job XML for shop floor handover."));
+            border.Child = _tabs;
+            return border;
+        }
+
+        private TabItem BuildPackageTab()
+        {
+            var tab = new TabItem { Header = "Package" };
+
+            var dock = new DockPanel { LastChildFill = true };
+
+            // Toolbar — Tick all / Untick all / Smart group / Clash pre-flight / Undo
+            var toolbar = new WrapPanel { Margin = new Thickness(0, 0, 0, 6) };
+            DockPanel.SetDock(toolbar, Dock.Top);
+            _packageHeader = new TextBlock
+            {
+                Text = "0 assemblies will be created",
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(FgColor),
+                FontSize = 11,
+                Margin = new Thickness(0, 0, 12, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            toolbar.Children.Add(_packageHeader);
+            toolbar.Children.Add(MakeSmallBtn("Tick all",          () => TickAllAssemblies(true)));
+            toolbar.Children.Add(MakeSmallBtn("Untick all",        () => TickAllAssemblies(false)));
+            toolbar.Children.Add(MakeSmallBtn("Smart group",       () => Dispatch("Fabrication_SmartGroup")));
+            toolbar.Children.Add(MakeSmallBtn("Clash pre-flight",  () => Dispatch("Fabrication_ClashPreflight")));
+            toolbar.Children.Add(MakeSmallBtn("Undo last run",     () => Dispatch("Fabrication_UndoPackage")));
+            dock.Children.Add(toolbar);
+
+            // Assembly preview grid
+            var scroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Background = new SolidColorBrush(CardBg),
+            };
+            _packageGridHost = new StackPanel();
+
+            // Header row
+            var hdr = new Grid();
+            DefineAssemblyColumns(hdr);
+            AddCell(hdr, 0, "✓",          accent: true);
+            AddCell(hdr, 1, "DISC",       accent: true);
+            AddCell(hdr, 2, "SYS",        accent: true);
+            AddCell(hdr, 3, "LVL",        accent: true);
+            AddCell(hdr, 4, "Count",      accent: true, alignRight: true);
+            AddCell(hdr, 5, "Spool name", accent: true);
+            _packageGridHost.Children.Add(hdr);
+
+            scroll.Content = _packageGridHost;
+            dock.Children.Add(scroll);
+
+            tab.Content = dock;
+            return tab;
+        }
+
+        private TabItem BuildExportTab(string header, string commandTag, string description)
+        {
+            var tab = new TabItem { Header = header };
+            var stack = new StackPanel { Margin = new Thickness(8) };
+            stack.Children.Add(new TextBlock
+            {
+                Text = description,
+                TextWrapping = TextWrapping.Wrap,
+                Foreground = new SolidColorBrush(FgColor),
+                FontSize = 12,
+                Margin = new Thickness(0, 0, 0, 8),
+            });
+            stack.Children.Add(new TextBlock
+            {
+                Text = "Click Run to dispatch this export against the current scope.",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11,
+                Margin = new Thickness(0, 0, 0, 8),
+            });
+            var btn = MakeAccentBtn("Run " + header, commandTag);
+            btn.HorizontalAlignment = HorizontalAlignment.Left;
+            stack.Children.Add(btn);
+            tab.Content = stack;
+            return tab;
+        }
+
+        private void DefineAssemblyColumns(Grid g)
+        {
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(28) });
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(110) });
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        }
+
+        private void AddCell(Grid g, int col, string text, bool accent = false, bool alignRight = false)
+        {
+            var t = new TextBlock
+            {
+                Text = text ?? "",
+                Foreground = new SolidColorBrush(accent ? AccentColor : FgColor),
+                FontWeight = accent ? FontWeights.SemiBold : FontWeights.Normal,
+                FontSize = accent ? 11 : 11,
+                Margin = new Thickness(4, 4, 8, 4),
+                TextAlignment = alignRight ? TextAlignment.Right : TextAlignment.Left,
+            };
+            Grid.SetColumn(t, col);
+            g.Children.Add(t);
+        }
+
+        // ─── SHOP-DRAWING strip ─────────────────────────────────────────
+
+        private UIElement BuildShopDrawingStrip()
+        {
+            var dock = new DockPanel { LastChildFill = true, Margin = new Thickness(0, 4, 0, 4) };
+
+            var actions = new StackPanel { Orientation = Orientation.Horizontal };
+            DockPanel.SetDock(actions, Dock.Right);
+            actions.Children.Add(MakeSmallBtn("Configure…", ConfigureShopDrawing));
+            actions.Children.Add(MakeSmallBtn("Clear",      ClearShopDrawing));
+            dock.Children.Add(actions);
+
             _txtShopDrawingStatus = new TextBlock
             {
                 Foreground = new SolidColorBrush(FgColor),
                 FontSize = 11,
                 TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 0, 0, 6),
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 12, 0),
             };
-            body.Children.Add(_txtShopDrawingStatus);
+            dock.Children.Add(_txtShopDrawingStatus);
 
-            var row = new StackPanel { Orientation = Orientation.Horizontal };
-            row.Children.Add(MakeSmallBtn("Configure…", ConfigureShopDrawing));
-            row.Children.Add(MakeSmallBtn("Clear",      ClearShopDrawing));
-            body.Children.Add(row);
-
-            return Card("Title block & view template", body);
+            return Card("Title block & view template", dock);
         }
 
-        private UIElement BuildExportsCard()
-        {
-            var body = new StackPanel();
-            body.Children.Add(new TextBlock
-            {
-                Text = "Re-emit per-discipline sidecars without rebuilding the full package.",
-                Foreground = new SolidColorBrush(SubtleColor),
-                FontSize = 11,
-                TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 0, 0, 6),
-            });
-
-            var wrap = new WrapPanel();
-            wrap.Children.Add(MakeAccentBtn("Cut list",    "Fabrication_ExportCutList"));
-            wrap.Children.Add(MakeAccentBtn("Weld map",    "Fabrication_ExportWeldMap"));
-            wrap.Children.Add(MakeAccentBtn("Isometrics",  "Fabrication_ExportIsometrics"));
-            wrap.Children.Add(MakeAccentBtn("PCF",         "Fabrication_ExportPcf"));
-            wrap.Children.Add(MakeAccentBtn("MAJ",         "Fabrication_ExportMaj"));
-            wrap.Children.Add(MakeAccentBtn("ISO symbols", "Fabrication_PlaceISOSymbols"));
-            body.Children.Add(wrap);
-
-            return Card("Exports", body);
-        }
-
-        // ─── Footer ─────────────────────────────────────────────────────
+        // ─── FOOTER — every action surfaced ─────────────────────────────
 
         private UIElement BuildFooter()
         {
-            var row = new DockPanel
-            {
-                Margin = new Thickness(0, 10, 0, 0),
-                LastChildFill = false,
-            };
+            var outer = new StackPanel { Margin = new Thickness(0, 4, 0, 0) };
 
-            var hint = new TextBlock
-            {
-                Text = "Settings persist on FabricationOptions for the Revit session. " +
-                       "Generate package builds assemblies, views, sheets and (optionally) ISO 6412 symbols.",
-                Foreground = new SolidColorBrush(SubtleColor),
-                FontSize = 11,
-                VerticalAlignment = VerticalAlignment.Center,
-                TextWrapping = TextWrapping.Wrap,
-                MaxWidth = 520,
-            };
-            DockPanel.SetDock(hint, Dock.Left);
-            row.Children.Add(hint);
+            // Top row: Generate package (primary) + main exports
+            var row1 = new WrapPanel();
+            row1.Children.Add(MakeBigBtn("Generate package", GreenBtn,  true,  () => Dispatch("Fabrication_GeneratePackage")));
+            row1.Children.Add(MakeBigBtn("Export cut list",  NeutralBtn,false, () => Dispatch("Fabrication_ExportCutList")));
+            row1.Children.Add(MakeBigBtn("Export weld map",  OrangeBtn, false, () => Dispatch("Fabrication_ExportWeldMap")));
+            row1.Children.Add(MakeBigBtn("Export iso index", NeutralBtn,false, () => Dispatch("Fabrication_ExportIsometrics")));
+            outer.Children.Add(row1);
 
-            var right = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Right,
-            };
-            DockPanel.SetDock(right, Dock.Right);
+            // Bottom row: secondary actions
+            var row2 = new WrapPanel { Margin = new Thickness(0, 6, 0, 0) };
+            row2.Children.Add(MakeBigBtn("Incremental rebuild", NeutralBtn, false, () => Dispatch("Fabrication_IncrementalRebuild")));
+            row2.Children.Add(MakeBigBtn("BOM roll-up (XLSX)",  NeutralBtn, false, () => Dispatch("Fabrication_BomRollup")));
+            row2.Children.Add(MakeBigBtn("Export PCF",          NeutralBtn, false, () => Dispatch("Fabrication_ExportPcf")));
+            row2.Children.Add(MakeBigBtn("Export MAJ",          NeutralBtn, false, () => Dispatch("Fabrication_ExportMaj")));
+            row2.Children.Add(MakeBigBtn("Link → Doc Register", NeutralBtn, false, () => Dispatch("Fabrication_LinkDocRegister")));
+            row2.Children.Add(MakeBigBtn("Close",               NeutralBtn, false, () => { DialogResult = false; }));
+            outer.Children.Add(row2);
 
-            right.Children.Add(MakeBigBtn("Close",            NeutralBtn, false, () => { DialogResult = false; }));
-            right.Children.Add(MakeBigBtn("Generate package", GreenBtn,   true,  () => Dispatch("Fabrication_GeneratePackage")));
-            row.Children.Add(right);
-
-            return row;
+            return outer;
         }
 
         // ═══════════════════════════════════════════════════════════════
-        //  ACTIONS
+        //  SCOPE / CATEGORY refresh
         // ═══════════════════════════════════════════════════════════════
 
         private void CommitScope()
@@ -360,62 +545,304 @@ namespace StingTools.UI
             FabricationOptions.ScopeProject    = _rbScopeProj?.IsChecked == true;
         }
 
-        private void RefreshScopeStatus()
+        /// <summary>
+        /// Recompute element counts per category and per discipline,
+        /// honouring the selected scope (with auto-fallback hint).
+        /// </summary>
+        private void RefreshScopeAndCategories()
         {
             try
             {
-                int n = CountScopeElements();
-                string label =
-                    FabricationOptions.ScopeProject    ? "project"     :
-                    FabricationOptions.ScopeActiveView ? "active view" :
-                                                         "selection";
-                string msg = $"Scope: {label} — {n} MEP element(s) in scope.";
-                if (n == 0 && FabricationOptions.ScopeSelection)
-                    msg += " (Generate package will fall back to active view automatically.)";
-                if (_txtScopeStatus != null) _txtScopeStatus.Text = msg;
+                var ids = CollectScopeIds(out var scopeLabel, out var fellBack);
+
+                // Per-category counts (within the resolved id set).
+                var catCounts = new Dictionary<BuiltInCategory, int>();
+                foreach (var info in MepCategories) catCounts[info.bic] = 0;
+                if (_doc != null)
+                {
+                    foreach (var id in ids)
+                    {
+                        var el = _doc.GetElement(id);
+                        if (el?.Category == null) continue;
+                        var bic = (BuiltInCategory)(int)el.Category.Id.Value;
+                        if (catCounts.ContainsKey(bic)) catCounts[bic]++;
+                    }
+                }
+
+                // Apply to UI rows + collect discipline rollup.
+                var byDisc = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                foreach (var info in MepCategories)
+                {
+                    int n = catCounts[info.bic];
+                    if (_catRows.TryGetValue(info.bic, out var row)) row.SetCount(n);
+                    if (n == 0) continue;
+                    byDisc.TryGetValue(info.disc, out var sub);
+                    byDisc[info.disc] = sub + n;
+                }
+
+                int total = ids.Count;
+                if (_txtScopeStatus != null)
+                {
+                    _txtScopeStatus.Text = fellBack
+                        ? $"Scope: {scopeLabel} — {total} MEP element(s) in scope."
+                        : $"Scope: {scopeLabel} — {total} MEP element(s) in scope.";
+                }
+                if (_txtDisciplineSummary != null)
+                {
+                    _txtDisciplineSummary.Text = byDisc.Count == 0
+                        ? "By discipline: (none)"
+                        : "By discipline: " + string.Join(" · ",
+                            byDisc.OrderByDescending(kv => kv.Value).Select(kv => $"{kv.Key} = {kv.Value}"));
+                }
             }
             catch (Exception ex)
             {
-                StingLog.Warn($"FabricationWorkspaceDialog.RefreshScopeStatus: {ex.Message}");
-                if (_txtScopeStatus != null) _txtScopeStatus.Text = "Scope: (refresh failed — see log)";
+                StingLog.Warn($"FabricationWorkspaceDialog.RefreshScopeAndCategories: {ex.Message}");
             }
         }
 
-        private int CountScopeElements()
+        /// <summary>
+        /// Resolve element ids honouring scope with the same auto-fallback
+        /// chain used by GenerateFabPackageCommand. Returns a friendly
+        /// scope label and a flag indicating whether the dialog had to
+        /// fall through to the next scope tier.
+        /// </summary>
+        private List<ElementId> CollectScopeIds(out string scopeLabel, out bool fellBack)
         {
-            if (_doc == null) return 0;
-            var cats = new[]
-            {
-                BuiltInCategory.OST_PipeCurves,    BuiltInCategory.OST_FlexPipeCurves,
-                BuiltInCategory.OST_PipeFitting,   BuiltInCategory.OST_PipeAccessory,
-                BuiltInCategory.OST_DuctCurves,    BuiltInCategory.OST_FlexDuctCurves,
-                BuiltInCategory.OST_DuctFitting,   BuiltInCategory.OST_DuctAccessory,
-                BuiltInCategory.OST_Conduit,       BuiltInCategory.OST_ConduitFitting,
-                BuiltInCategory.OST_CableTray,     BuiltInCategory.OST_CableTrayFitting,
-            };
+            scopeLabel = "selection"; fellBack = false;
+            var ids = new List<ElementId>();
+            if (_doc == null) return ids;
+
+            var bics = MepCategories.Select(c => c.bic).ToArray();
+            var filter = new ElementMulticategoryFilter(bics);
+
             try
             {
                 if (FabricationOptions.ScopeProject)
                 {
-                    return new FilteredElementCollector(_doc)
-                        .WherePasses(new ElementMulticategoryFilter(cats))
-                        .WhereElementIsNotElementType()
-                        .GetElementCount();
+                    scopeLabel = "project";
+                    foreach (var e in new FilteredElementCollector(_doc)
+                        .WherePasses(filter).WhereElementIsNotElementType()) ids.Add(e.Id);
+                    return ids;
                 }
                 if (FabricationOptions.ScopeActiveView)
                 {
+                    scopeLabel = "active view";
                     var view = _doc.ActiveView;
-                    if (view == null) return 0;
-                    return new FilteredElementCollector(_doc, view.Id)
-                        .WherePasses(new ElementMulticategoryFilter(cats))
-                        .WhereElementIsNotElementType()
-                        .GetElementCount();
+                    if (view == null) return ids;
+                    foreach (var e in new FilteredElementCollector(_doc, view.Id)
+                        .WherePasses(filter).WhereElementIsNotElementType()) ids.Add(e.Id);
+                    return ids;
                 }
-                // Selection scope — no UIDocument here; the count is approximated.
-                return 0;
+
+                // Selection scope → mirror the dock-panel's current selection
+                // when accessible, otherwise fall back to active view.
+                var uidoc = StingTools.UI.StingCommandHandler.CurrentApp?.ActiveUIDocument;
+                if (uidoc != null)
+                {
+                    var sel = uidoc.Selection?.GetElementIds();
+                    if (sel != null)
+                    {
+                        foreach (var id in sel)
+                        {
+                            var el = _doc.GetElement(id);
+                            if (el?.Category == null) continue;
+                            var bic = (BuiltInCategory)(int)el.Category.Id.Value;
+                            if (bics.Contains(bic)) ids.Add(id);
+                        }
+                    }
+                }
+                if (ids.Count > 0) { scopeLabel = "selection"; return ids; }
+
+                // Auto-fallback: active view.
+                fellBack = true;
+                var v2 = _doc.ActiveView;
+                if (v2 != null)
+                {
+                    foreach (var e in new FilteredElementCollector(_doc, v2.Id)
+                        .WherePasses(filter).WhereElementIsNotElementType()) ids.Add(e.Id);
+                }
+                if (ids.Count > 0) { scopeLabel = "active view (auto-fallback from empty selection)"; return ids; }
+
+                // Auto-fallback: project.
+                foreach (var e in new FilteredElementCollector(_doc)
+                    .WherePasses(filter).WhereElementIsNotElementType()) ids.Add(e.Id);
+                scopeLabel = "project (auto-fallback from empty selection)";
             }
-            catch { return 0; }
+            catch (Exception ex) { StingLog.Warn($"FabricationWorkspaceDialog.CollectScopeIds: {ex.Message}"); }
+            return ids;
         }
+
+        // ═══════════════════════════════════════════════════════════════
+        //  PACKAGE preview — predicts the assemblies that will be created
+        // ═══════════════════════════════════════════════════════════════
+
+        private readonly List<AssemblyPreviewRow> _previewRows = new List<AssemblyPreviewRow>();
+
+        private void RefreshPackagePreview()
+        {
+            try
+            {
+                if (_packageGridHost == null) return;
+                _previewRows.Clear();
+
+                // Strip body rows (keep header).
+                while (_packageGridHost.Children.Count > 1)
+                    _packageGridHost.Children.RemoveAt(1);
+
+                if (_doc == null)
+                {
+                    _packageHeader.Text = "(no active document)";
+                    return;
+                }
+
+                var ids = CollectScopeIds(out _, out _);
+
+                // Build (DISC, SYS, LVL) groups using the engine's discipline
+                // mapping. Categories that are unticked in the rules card
+                // are excluded so the preview tracks what GeneratePackage
+                // would actually emit.
+                var groups = new Dictionary<(string disc, string sys, string lvl), int>();
+                string sysFilter = (_txtSystemFilter?.Text ?? "").Trim();
+                string lvlFilter = (_txtLevelFilter?.Text  ?? "").Trim();
+
+                foreach (var id in ids)
+                {
+                    var el = _doc.GetElement(id);
+                    if (el == null) continue;
+                    string disc = DisciplineFor(el);
+                    if (!RuleEnabledFor(disc)) continue;
+                    string sys = ParameterHelpers.GetString(el, "PLM_SYS_TXT");
+                    if (string.IsNullOrWhiteSpace(sys)) sys = ParameterHelpers.GetString(el, "HVC_SYS_TXT");
+                    if (string.IsNullOrWhiteSpace(sys)) sys = ParameterHelpers.GetString(el, "ELC_SYS_TXT");
+                    if (string.IsNullOrWhiteSpace(sys)) sys = "GEN";
+                    string lvl = ParameterHelpers.GetLevelCode(_doc, el);
+                    if (string.IsNullOrWhiteSpace(lvl)) lvl = "XX";
+                    if (!string.IsNullOrEmpty(sysFilter) && sys.IndexOf(sysFilter, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                    if (!string.IsNullOrEmpty(lvlFilter) && lvl.IndexOf(lvlFilter, StringComparison.OrdinalIgnoreCase) < 0) continue;
+
+                    var key = (disc, sys, lvl);
+                    groups.TryGetValue(key, out var n);
+                    groups[key] = n + 1;
+                }
+
+                int seq = 1;
+                foreach (var kv in groups.OrderBy(g => g.Key.disc).ThenBy(g => g.Key.sys).ThenBy(g => g.Key.lvl))
+                {
+                    var row = new AssemblyPreviewRow
+                    {
+                        Selected = true,
+                        Disc = ShortDiscCode(kv.Key.disc),
+                        System = kv.Key.sys,
+                        Level = kv.Key.lvl,
+                        Count = kv.Value,
+                        SpoolName = $"SP-{ShortDiscCode(kv.Key.disc)}-{kv.Key.sys}-{kv.Key.lvl}-{seq:D4}",
+                    };
+                    _previewRows.Add(row);
+                    _packageGridHost.Children.Add(BuildPreviewRow(row));
+                    seq++;
+                }
+
+                int active = _previewRows.Count(r => r.Selected);
+                _packageHeader.Text = $"{active} assembly(ies) will be created (of {_previewRows.Count} group(s))";
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"FabricationWorkspaceDialog.RefreshPackagePreview: {ex.Message}");
+            }
+        }
+
+        private UIElement BuildPreviewRow(AssemblyPreviewRow row)
+        {
+            var g = new Grid
+            {
+                Background = new SolidColorBrush((_packageGridHost.Children.Count % 2 == 0) ? AltRowBg : CardBg),
+            };
+            DefineAssemblyColumns(g);
+
+            var cb = new CheckBox
+            {
+                IsChecked = row.Selected,
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(2),
+            };
+            cb.Checked   += (s, e) => { row.Selected = true;  UpdatePackageHeader(); };
+            cb.Unchecked += (s, e) => { row.Selected = false; UpdatePackageHeader(); };
+            Grid.SetColumn(cb, 0); g.Children.Add(cb);
+            AddCell(g, 1, row.Disc);
+            AddCell(g, 2, row.System);
+            AddCell(g, 3, row.Level);
+            AddCell(g, 4, row.Count.ToString(), alignRight: true);
+            AddCell(g, 5, row.SpoolName);
+            return g;
+        }
+
+        private void TickAllAssemblies(bool selected)
+        {
+            foreach (var row in _previewRows) row.Selected = selected;
+            // Re-render so the checkboxes reflect the new state.
+            RefreshPackagePreview();
+        }
+
+        private void UpdatePackageHeader()
+        {
+            if (_packageHeader == null) return;
+            int active = _previewRows.Count(r => r.Selected);
+            _packageHeader.Text = $"{active} assembly(ies) will be created (of {_previewRows.Count} group(s))";
+        }
+
+        private static string DisciplineFor(Element el)
+        {
+            if (el?.Category == null) return "";
+            int bic = (int)el.Category.Id.Value;
+            switch ((BuiltInCategory)bic)
+            {
+                case BuiltInCategory.OST_PipeCurves:
+                case BuiltInCategory.OST_FlexPipeCurves:
+                case BuiltInCategory.OST_PipeFitting:
+                case BuiltInCategory.OST_PipeAccessory:
+                    return "Pipe";
+                case BuiltInCategory.OST_DuctCurves:
+                case BuiltInCategory.OST_FlexDuctCurves:
+                case BuiltInCategory.OST_DuctFitting:
+                case BuiltInCategory.OST_DuctAccessory:
+                    return "Duct";
+                case BuiltInCategory.OST_Conduit:
+                case BuiltInCategory.OST_ConduitFitting:
+                case BuiltInCategory.OST_CableTray:
+                case BuiltInCategory.OST_CableTrayFitting:
+                    return "Electrical";
+            }
+            return "";
+        }
+
+        private static string ShortDiscCode(string disc)
+        {
+            if (string.IsNullOrEmpty(disc)) return "X";
+            switch (disc)
+            {
+                case "Pipe":       return "P";
+                case "Duct":       return "D";
+                case "Electrical": return "E";
+            }
+            return disc.Substring(0, 1).ToUpperInvariant();
+        }
+
+        private static bool RuleEnabledFor(string disc)
+        {
+            switch (disc)
+            {
+                case "Pipe":       return FabricationOptions.RulePipe || FabricationOptions.RulePipeLB;
+                case "Duct":       return FabricationOptions.RuleDuct || FabricationOptions.RuleDuctPitt;
+                case "Electrical": return FabricationOptions.RuleConduit;
+            }
+            return true;
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+        //  SHOP-DRAWING actions
+        // ═══════════════════════════════════════════════════════════════
 
         private void ConfigureShopDrawing()
         {
@@ -449,7 +876,7 @@ namespace StingTools.UI
             if (opts == null)
             {
                 _txtShopDrawingStatus.Text =
-                    "Auto-resolved per discipline (STING_TB_ASSEMBLY_*).\n" +
+                    "Auto-resolved per discipline (STING_TB_ASSEMBLY_*). " +
                     "Falls back to first available title block when missing.";
                 return;
             }
@@ -467,15 +894,17 @@ namespace StingTools.UI
                 var v = _doc.GetElement(opts.ViewTemplateId) as Autodesk.Revit.DB.View;
                 if (v != null) vt = v.Name;
             }
-            string s = $"Title block: {tb}\nView template: {vt}";
+            string s = $"Title block: {tb}  ·  View template: {vt}";
             if (!string.IsNullOrWhiteSpace(opts.SheetNumberPattern))
-                s += $"\nSheet #: {opts.SheetNumberPattern}";
+                s += $"  ·  Sheet #: {opts.SheetNumberPattern}";
             if (!string.IsNullOrWhiteSpace(opts.SheetNamePattern))
-                s += $"\nSheet name: {opts.SheetNamePattern}";
+                s += $"  ·  Sheet name: {opts.SheetNamePattern}";
             _txtShopDrawingStatus.Text = s;
         }
 
-        // ─── Preset persistence ─────────────────────────────────────────
+        // ═══════════════════════════════════════════════════════════════
+        //  PRESET persistence
+        // ═══════════════════════════════════════════════════════════════
 
         private static string PresetPath()
         {
@@ -505,13 +934,11 @@ namespace StingTools.UI
             try
             {
                 string path = PresetPath();
-                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                var dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
                 File.WriteAllText(path, JsonConvert.SerializeObject(presets, Formatting.Indented));
             }
-            catch (Exception ex)
-            {
-                StingLog.Error("FabricationWorkspaceDialog.SaveAllPresets", ex);
-            }
+            catch (Exception ex) { StingLog.Error("FabricationWorkspaceDialog.SaveAllPresets", ex); }
         }
 
         private static IEnumerable<string> ListPresetNames()
@@ -529,7 +956,8 @@ namespace StingTools.UI
             }
             p.ApplyTo();
             HydrateFromOptions();
-            RefreshScopeStatus();
+            RefreshScopeAndCategories();
+            RefreshPackagePreview();
         }
 
         private void SavePreset()
@@ -563,10 +991,12 @@ namespace StingTools.UI
             if (_cmbPreset == null) return;
             _cmbPreset.Items.Clear();
             foreach (var name in ListPresetNames()) _cmbPreset.Items.Add(name);
-            if (!string.IsNullOrEmpty(select)) _cmbPreset.Text = select; else _cmbPreset.Text = "";
+            _cmbPreset.Text = string.IsNullOrEmpty(select) ? "" : select;
         }
 
-        // ─── Hydrate UI from FabricationOptions ─────────────────────────
+        // ═══════════════════════════════════════════════════════════════
+        //  Hydrate UI from FabricationOptions
+        // ═══════════════════════════════════════════════════════════════
 
         private void HydrateFromOptions()
         {
@@ -590,7 +1020,9 @@ namespace StingTools.UI
             if (_rbGeneric != null) _rbGeneric.IsChecked = !FabricationOptions.ContentModeIso6412;
         }
 
-        // ─── Dispatch to the dock-panel command handler ─────────────────
+        // ═══════════════════════════════════════════════════════════════
+        //  Dispatch
+        // ═══════════════════════════════════════════════════════════════
 
         private void Dispatch(string tag)
         {
@@ -612,7 +1044,7 @@ namespace StingTools.UI
         }
 
         // ═══════════════════════════════════════════════════════════════
-        //  UI PRIMITIVES — Card / inputs / buttons
+        //  UI primitives
         // ═══════════════════════════════════════════════════════════════
 
         private UIElement Card(string title, UIElement body)
@@ -705,7 +1137,7 @@ namespace StingTools.UI
             {
                 Content = label,
                 Height = 26,
-                MinWidth = 80,
+                MinWidth = 100,
                 Margin = new Thickness(0, 0, 6, 6),
                 Background = new SolidColorBrush(OrangeBtn),
                 Foreground = new SolidColorBrush(Color.FromRgb(0xFF, 0xFF, 0xFF)),
@@ -725,21 +1157,96 @@ namespace StingTools.UI
             var b = new Button
             {
                 Content = label,
-                Width = 140,
+                MinWidth = 130,
                 Height = 32,
-                Margin = new Thickness(8, 0, 0, 0),
+                Margin = new Thickness(0, 0, 6, 0),
                 Background = new SolidColorBrush(bg),
                 Foreground = new SolidColorBrush(fg),
                 BorderBrush = new SolidColorBrush(CardBorder),
                 BorderThickness = new Thickness(1),
                 FontWeight = isDefault ? FontWeights.Bold : FontWeights.Normal,
                 IsDefault = isDefault,
-                IsCancel = !isDefault,
                 FontSize = 12,
+                Padding = new Thickness(8, 0, 8, 0),
             };
             b.Click += (s, e) => onClick?.Invoke();
             return b;
         }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Helper types
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>One row in the live category-breakdown card. The row is
+    /// just a presentation surface — the underlying selection always
+    /// flows from the SCOPE radio buttons + free-text filters.</summary>
+    internal sealed class CategoryRow
+    {
+        private readonly TextBlock _txtCount;
+        public BuiltInCategory Category { get; }
+        public Grid RowElement { get; }
+
+        public CategoryRow(BuiltInCategory bic, string label, string disc,
+            Color rowBg, Color fg, Color accent, Color altRowBg, Color border)
+        {
+            Category = bic;
+
+            RowElement = new Grid { Margin = new Thickness(0, 1, 0, 1) };
+            RowElement.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(28) });
+            RowElement.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            RowElement.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+
+            var dot = new Border
+            {
+                Width = 10, Height = 10,
+                CornerRadius = new CornerRadius(5),
+                Background = new SolidColorBrush(accent),
+                Margin = new Thickness(2, 4, 8, 4),
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
+            Grid.SetColumn(dot, 0); RowElement.Children.Add(dot);
+
+            var lbl = new TextBlock
+            {
+                Text = $"{label}   ({disc})",
+                Foreground = new SolidColorBrush(fg),
+                FontSize = 11,
+                Margin = new Thickness(0, 4, 0, 4),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(lbl, 1); RowElement.Children.Add(lbl);
+
+            _txtCount = new TextBlock
+            {
+                Text = "0",
+                Foreground = new SolidColorBrush(fg),
+                FontWeight = FontWeights.SemiBold,
+                FontSize = 11,
+                Margin = new Thickness(0, 4, 4, 4),
+                TextAlignment = TextAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(_txtCount, 2); RowElement.Children.Add(_txtCount);
+        }
+
+        public void SetCount(int n)
+        {
+            if (_txtCount != null) _txtCount.Text = n.ToString();
+            RowElement.Opacity = n == 0 ? 0.45 : 1.0;
+        }
+    }
+
+    /// <summary>Single row in the Package preview grid.</summary>
+    internal sealed class AssemblyPreviewRow
+    {
+        public bool   Selected  { get; set; }
+        public string Disc      { get; set; }
+        public string System    { get; set; }
+        public string Level     { get; set; }
+        public int    Count     { get; set; }
+        public string SpoolName { get; set; }
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -275,6 +275,7 @@ namespace StingTools.UI
                     case "Mep_NamingAudit":     RunCommand<Commands.Mep.MepNamingAuditCommand>(app); break;
 
                     // ── v4 MVP: fabrication (Phase 5) ──
+                    case "Fabrication_OpenWorkspace":   RunCommand<Commands.Fabrication.FabricationWorkspaceCommand>(app); break;
                     case "Fabrication_GeneratePackage": RunCommand<Commands.Fabrication.GenerateFabPackageCommand>(app); break;
                     case "Fabrication_ExportCutList":   RunCommand<Commands.Fabrication.ExportCutListCommand>(app); break;
                     case "Fabrication_ExportIsometrics":RunCommand<Commands.Fabrication.ExportIsometricsCommand>(app); break;

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -275,13 +275,19 @@ namespace StingTools.UI
                     case "Mep_NamingAudit":     RunCommand<Commands.Mep.MepNamingAuditCommand>(app); break;
 
                     // ── v4 MVP: fabrication (Phase 5) ──
-                    case "Fabrication_OpenWorkspace":   RunCommand<Commands.Fabrication.FabricationWorkspaceCommand>(app); break;
-                    case "Fabrication_GeneratePackage": RunCommand<Commands.Fabrication.GenerateFabPackageCommand>(app); break;
-                    case "Fabrication_ExportCutList":   RunCommand<Commands.Fabrication.ExportCutListCommand>(app); break;
-                    case "Fabrication_ExportIsometrics":RunCommand<Commands.Fabrication.ExportIsometricsCommand>(app); break;
-                    case "Fabrication_ExportWeldMap":   RunCommand<Commands.Fabrication.ExportWeldMapCommand>(app); break;
-                    case "Fabrication_ExportMaj":       RunCommand<Commands.Fabrication.ExportMajCommand>(app); break;
-                    case "Fabrication_ExportPcf":       RunCommand<Commands.Fabrication.ExportPcfCommand>(app); break;
+                    case "Fabrication_OpenWorkspace":     RunCommand<Commands.Fabrication.FabricationWorkspaceCommand>(app); break;
+                    case "Fabrication_GeneratePackage":   RunCommand<Commands.Fabrication.GenerateFabPackageCommand>(app); break;
+                    case "Fabrication_ExportCutList":     RunCommand<Commands.Fabrication.ExportCutListCommand>(app); break;
+                    case "Fabrication_ExportIsometrics":  RunCommand<Commands.Fabrication.ExportIsometricsCommand>(app); break;
+                    case "Fabrication_ExportWeldMap":     RunCommand<Commands.Fabrication.ExportWeldMapCommand>(app); break;
+                    case "Fabrication_ExportMaj":         RunCommand<Commands.Fabrication.ExportMajCommand>(app); break;
+                    case "Fabrication_ExportPcf":         RunCommand<Commands.Fabrication.ExportPcfCommand>(app); break;
+                    case "Fabrication_UndoPackage":       RunCommand<Commands.Fabrication.UndoFabPackageCommand>(app); break;
+                    case "Fabrication_SmartGroup":        RunCommand<Commands.Fabrication.SmartGroupCommand>(app); break;
+                    case "Fabrication_ClashPreflight":    RunCommand<Commands.Fabrication.ClashPreflightCommand>(app); break;
+                    case "Fabrication_IncrementalRebuild":RunCommand<Commands.Fabrication.IncrementalRebuildCommand>(app); break;
+                    case "Fabrication_BomRollup":         RunCommand<Commands.Fabrication.BomRollupCommand>(app); break;
+                    case "Fabrication_LinkDocRegister":   RunCommand<Commands.Fabrication.LinkDocRegisterCommand>(app); break;
 
                     // ── v4 Phase C: calc engines ──
                     case "Calc_ConduitFill":  RunCommand<Commands.Routing.CalcConduitFillCommand>(app); break;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -4432,6 +4432,9 @@
                             <!-- ─── v4 MVP: Fabrication Tab ─── -->
                             <TabItem Header="Fabrication">
                                 <DockPanel>
+                                    <WrapPanel DockPanel.Dock="Top" Margin="4,4,4,2">
+                                        <Button Style="{StaticResource OrangeBtn}" Content="Open Workspace…" Tag="Fabrication_OpenWorkspace" Click="Cmd_Click" Width="140" Height="28" ToolTip="Open the full Fabrication Workspace dialog (light theme, Drawing-Type-Editor style: presets, scope counts, configure title block, dispatch any export)"/>
+                                    </WrapPanel>
                                     <WrapPanel DockPanel.Dock="Bottom" Margin="4,6,4,4">
                                         <Button Style="{StaticResource GreenBtn}"  Content="Generate package" Tag="Fabrication_GeneratePackage" Click="Cmd_Click" Width="110" Height="30" ToolTip="Build assemblies + views + sheets for selected MEP elements"/>
                                         <Button Style="{StaticResource ActionBtn}" Content="Cut list"         Tag="Fabrication_ExportCutList"   Click="Cmd_Click" Width="80"  Height="30" ToolTip="Re-emit pipe cut list CSV"/>
@@ -4441,7 +4444,7 @@
                                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                                         <StackPanel Margin="4">
 
-                                            <TextBlock Text="SCOPE" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,2,0,4"/>
+                                            <TextBlock Text="SCOPE" Style="{StaticResource SectionLabel}"/>
                                             <Border Style="{StaticResource GroupBorder}">
                                                 <StackPanel>
                                                     <RadioButton Content="Selection" GroupName="FabScope" x:Name="rbFabScopeSel"  IsChecked="True" Margin="2" FontSize="9"/>
@@ -4450,7 +4453,7 @@
                                                 </StackPanel>
                                             </Border>
 
-                                            <TextBlock Text="RULES" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,8,0,4"/>
+                                            <TextBlock Text="RULES" Style="{StaticResource SectionLabel}"/>
                                             <Border Style="{StaticResource GroupBorder}">
                                                 <StackPanel>
                                                     <TextBlock Text="Discipline rules from STING_FAB_RULES.json" FontSize="9" Margin="0,0,0,2"/>
@@ -4462,7 +4465,7 @@
                                                 </StackPanel>
                                             </Border>
 
-                                            <TextBlock Text="OUTPUT" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,8,0,4"/>
+                                            <TextBlock Text="OUTPUT" Style="{StaticResource SectionLabel}"/>
                                             <Border Style="{StaticResource GroupBorder}">
                                                 <StackPanel>
                                                     <CheckBox Content="Generate AssemblyInstances" x:Name="chkFabAssy" IsChecked="True" Margin="0,1" FontSize="9"/>
@@ -4473,7 +4476,7 @@
                                                 </StackPanel>
                                             </Border>
 
-                                            <TextBlock Text="CONTENT MODE" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,8,0,4"/>
+                                            <TextBlock Text="CONTENT MODE" Style="{StaticResource SectionLabel}"/>
                                             <Border Style="{StaticResource GroupBorder}">
                                                 <StackPanel>
                                                     <RadioButton Content="ISO 6412 (workshop)"      GroupName="FabContent" x:Name="rbFabIso6412"   IsChecked="True" Margin="2" FontSize="9"/>
@@ -4481,7 +4484,7 @@
                                                 </StackPanel>
                                             </Border>
 
-                                            <TextBlock Text="TITLE BLOCK &amp; VIEW TEMPLATE" FontWeight="Bold" FontSize="10" Foreground="#5D4037" Margin="0,8,0,4"/>
+                                            <TextBlock Text="TITLE BLOCK &amp; VIEW TEMPLATE" Style="{StaticResource SectionLabel}"/>
                                             <Border Style="{StaticResource GroupBorder}">
                                                 <StackPanel>
                                                     <TextBlock x:Name="txtFabShopDrawingStatus"


### PR DESCRIPTION
## Summary
Introduces a comprehensive light-themed Fabrication Workspace dialog that replaces the minimal "Configure" dialog with a full-featured workspace matching the v4 MVP specification. The dialog provides live MEP element counts, scope selection, category filtering, assembly preview, and centralized access to all fabrication export operations.

## Key Changes

- **New FabricationWorkspaceDialog** (`StingTools/UI/FabricationWorkspaceDialog.cs`)
  - Light-themed modal dialog with preset management, scope selection (Selection/Active view/Project), and live category breakdown
  - SCOPE row with radio buttons and auto-fallback logic matching GenerateFabPackageCommand behavior
  - CATEGORY card showing per-discipline element counts with per-category checkboxes
  - FILTERS card for System and Level text filtering
  - Tabbed body with Package preview grid + dedicated tabs for Cut list, Weld map, Isometrics, PCF, and MAJ exports
  - Title block & view template configuration strip
  - Footer with primary "Generate package" button and secondary export/utility buttons
  - Assembly preview grid predicting spool grouping (DISC/SYS/LVL/SEQ) with checkbox selection

- **Updated GenerateFabPackageCommand** (`StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs`)
  - Refactored scope collection into `CollectScopeWithFallback()` with auto-fallback chain: Selection → Active view → Project
  - When no elements found, now opens FabricationWorkspaceDialog instead of error dialog, allowing users to see available elements and select appropriate scope
  - Removed one-shot ShopDrawingOptionsDialog popup; shop drawing configuration now happens via workspace "Configure…" button or dock panel
  - Added logging of scope resolution for debugging

- **New FabricationWorkspaceCommand** (`StingTools/Commands/Fabrication/FabricationWorkspaceCommand.cs`)
  - IExternalCommand launcher for the workspace dialog
  - Handles null ExternalCommandData when called from dock panel

- **New FabricationStubCommands** (`StingTools/Commands/Fabrication/FabricationStubCommands.cs`)
  - Stub implementations for Smart Group, Clash Pre-flight, Incremental Rebuild, and BOM Roll-up commands
  - Provides clear roadmap messaging for v4 MVP phase features

- **Updated StingCommandHandler** (`StingTools/UI/StingCommandHandler.cs`)
  - Wired new command tags: `Fabrication_Workspace`, `Fabrication_SmartGroup`, `Fabrication_ClashPreflight`, `Fabrication_IncrementalRebuild`, `Fabrication_BomRollup`, `Fabrication_LinkDocRegister`, `Fabrication_UndoPackage`

- **Updated StingDockPanel** (`StingTools/UI/StingDockPanel.xaml`)
  - Added "Workspace…" button to Fabrication tab for quick access to the new dialog

## Implementation Details

- **Color palette**: Light theme only (DarkDialogTheme.LightPalette) with accent orange (#E8912D), green primary button (#4CAF50), neutral grays
- **MEP categories**: Single source of truth array covering Pipe, Duct, and Electrical disciplines with 12 category entries
- **Scope fallback logic**: Mirrors GenerateFabPackageCommand to ensure consistent behavior; Selection scope reads from current UIDocument selection with automatic fallback to active view then project
- **Assembly preview**: Groups elements by (Discipline, System, Level) and generates SP-{DISC}-{SYS}-{LVL}-{SEQ} spool names; respects category checkboxes and text filters
- **State management**: All fabrication options flow through FabricationOptions static class; dialog reads/writes this shared state
- **Command dispatch**: Action buttons use `StingDockPanel.DispatchCommand()` to route commands back through the dock panel's IExternalCommand pipeline, avoiding duplication

https://claude.ai/code/session_013hh6L98sQ1Lrvna7342ryJ