### PR TITLE
Phase 135: Add per-DrawingType token profile for tag depth, style & colour

### DIFF
--- a/StingTools/Core/Drawing/DrawingDriftDetector.cs
+++ b/StingTools/Core/Drawing/DrawingDriftDetector.cs
@@ -2,11 +2,13 @@
 //
 // DrawingDriftDetector scans every stamped view and reports where
 // the view's current state has drifted from its DrawingType profile.
-// Three drift kinds:
+// Drift kinds:
 //
-//   SCALE_DRIFT       view.Scale != profile.Scale
-//   DETAIL_DRIFT      view.DetailLevel != profile.DetailLevel
-//   TEMPLATE_DRIFT    view.ViewTemplateId.Name != profile.ViewTemplateName
+//   SCALE_DRIFT          view.Scale != profile.Scale
+//   DETAIL_DRIFT         view.DetailLevel != profile.DetailLevel
+//   TEMPLATE_DRIFT       view.ViewTemplateId.Name != profile.ViewTemplateName
+//   TOKEN_PROFILE_DRIFT  STING_VIEW_TAG_STYLE / TAG_SEG_MASK_TXT mismatch
+//                        (Phase 135)
 //
 // Consumed by the SyncStyles command (which re-applies the profile
 // on drifted views) and surfaced in the Inspect command output so
@@ -16,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
+using StingTools.Core;
 
 namespace StingTools.Core.Drawing
 {
@@ -71,9 +74,60 @@ namespace StingTools.Core.Drawing
                         report.Drifts.Add($"TEMPLATE: view '{tplName ?? "(none)"}' vs profile '{dt.ViewTemplateName}'");
                 }
 
+                // Phase 135 — token profile drift. Compares
+                // STING_VIEW_TAG_STYLE and TAG_SEG_MASK_TXT on the view
+                // to the resolved profile/pack defaults. SyncStyles
+                // re-runs DrawingTypePresentation.Apply which routes
+                // through TokenProfileApplier and heals the drift.
+                AppendTokenProfileDrift(doc, v, dt, report);
+
                 if (report.Any) reports.Add(report);
             }
             return reports;
+        }
+
+        private static void AppendTokenProfileDrift(Document doc, View v, DrawingType dt, DriftReport report)
+        {
+            try
+            {
+                // Resolve effective expected values (profile > pack).
+                var profile = dt.TokenProfile;
+                ViewStylePack pack = string.IsNullOrEmpty(dt.ViewStylePackId)
+                    ? null
+                    : ViewStylePackRegistry.Get(doc, dt.ViewStylePackId);
+
+                string expectedScheme = profile?.ColorScheme ?? pack?.TagColorScheme;
+                if (!string.IsNullOrEmpty(expectedScheme))
+                {
+                    string actual = ReadStringParam(v, ParamRegistry.VIEW_TAG_STYLE);
+                    if (!string.Equals(actual, expectedScheme, StringComparison.OrdinalIgnoreCase))
+                        report.Drifts.Add($"TOKEN_PROFILE: STING_VIEW_TAG_STYLE '{actual ?? "(empty)"}' vs profile '{expectedScheme}'");
+                }
+
+                string expectedMask = profile?.SegmentMask;
+                if (!string.IsNullOrEmpty(expectedMask)
+                    && expectedMask.Length == 8)
+                {
+                    string actual = ReadStringParam(v, ParamRegistry.TAG_SEG_MASK);
+                    if (!string.Equals(actual, expectedMask, StringComparison.Ordinal))
+                        report.Drifts.Add($"TOKEN_PROFILE: TAG_SEG_MASK '{actual ?? "(empty)"}' vs profile '{expectedMask}'");
+                }
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"AppendTokenProfileDrift({v.Id}): {ex.Message}");
+            }
+        }
+
+        private static string ReadStringParam(Element el, string paramName)
+        {
+            try
+            {
+                var p = el.LookupParameter(paramName);
+                if (p == null || p.StorageType != StorageType.String) return null;
+                return p.AsString();
+            }
+            catch { return null; }
         }
 
         private static string TemplateName(Document doc, ElementId id)

--- a/StingTools/Core/Drawing/DrawingType.cs
+++ b/StingTools/Core/Drawing/DrawingType.cs
@@ -142,6 +142,19 @@ namespace StingTools.Core.Drawing
         // Annotation rule pack
         [JsonProperty("annotation")] public AnnotationRulePack Annotation { get; set; } = new AnnotationRulePack();
 
+        /// <summary>
+        /// Phase 135 — token-level annotation profile. Controls TAG7
+        /// presentation mode, paragraph depth (global + per-category),
+        /// TAG7 section A–F visibility, tag size/style/colour preset,
+        /// per-view variable colour scheme, and 8-segment tag mask.
+        /// Null = inherit from <see cref="ViewStylePack"/> defaults
+        /// (tagColorScheme / defaultTagStyle / categoryTagStyles).
+        /// Applied between style-pack (step 7) and annotation (step 8)
+        /// via <c>TokenProfileApplier</c>.
+        /// </summary>
+        [JsonProperty("tokenProfile", NullValueHandling = NullValueHandling.Ignore)]
+        public AnnotationTokenProfile TokenProfile { get; set; }
+
         // Print / appearance overrides
         [JsonProperty("print")]      public PrintOverride Print { get; set; } = new PrintOverride();
 
@@ -351,6 +364,115 @@ namespace StingTools.Core.Drawing
         /// <summary>Optional per-rule TAG7 paragraph depth (1..10).</summary>
         [JsonProperty("depth", NullValueHandling = NullValueHandling.Ignore)]
         public int? Depth { get; set; }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    //  ANNOTATION TOKEN PROFILE — Phase 135
+    //
+    //  Per-DrawingType token-level presentation knobs. Distinct from the
+    //  rule-pack (which decides WHAT to tag) — this one decides HOW the
+    //  resulting tags read on the sheet: how many paragraph tiers are
+    //  visible, which TAG7 sub-sections show, what size/style/colour the
+    //  tag text is, and which 8-segment tokens the displayed tag carries.
+    //
+    //  Every field is optional. Null means "inherit / don't override":
+    //    * Pack-level defaults on the resolved ViewStylePack apply when
+    //      this profile leaves a slot empty.
+    //    * Where neither profile nor pack sets a value, the engine
+    //      leaves the underlying parameter alone.
+    //
+    //  Applied by <c>TokenProfileApplier</c> in step 7.5 of the pipeline,
+    //  between ViewStylePack (step 7) and Annotation (step 8).
+    // ─────────────────────────────────────────────────────────────────────
+
+    public sealed class AnnotationTokenProfile
+    {
+        /// <summary>
+        /// Presentation mode preset — Compact / Technical / FullSpec /
+        /// Presentation / BOQ. Drives the global TAG_PARA_STATE_*
+        /// pattern and TAG_WARN_VISIBLE flag through the same engine
+        /// the existing SetPresentationModeCommand uses. Null = leave
+        /// preset alone, write the explicit fields below instead.
+        /// </summary>
+        [JsonProperty("presentationMode", NullValueHandling = NullValueHandling.Ignore)]
+        public string PresentationMode { get; set; }
+
+        /// <summary>
+        /// Global TAG7 paragraph depth (1..10). Sets PARA_STATE_1..N to
+        /// Yes and the rest to No. Null = leave as-is. Per-category
+        /// overrides (<see cref="CategoryDepths"/>) win over this when
+        /// present.
+        /// </summary>
+        [JsonProperty("paraDepth", NullValueHandling = NullValueHandling.Ignore)]
+        public int? ParaDepth { get; set; }
+
+        /// <summary>
+        /// Per-category TAG7 paragraph depth override (1..10). Lookup
+        /// by category display name. Empty / missing key falls back to
+        /// <see cref="ParaDepth"/>.
+        /// </summary>
+        [JsonProperty("categoryDepths", NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, int> CategoryDepths { get; set; }
+
+        /// <summary>
+        /// TAG7 sub-section visibility map. Keys: "A".."F" (case-
+        /// insensitive). Values: true = visible, false = hidden. Writes
+        /// TAG_7_SECTION_VISIBLE_{A..F}_BOOL on every element in scope.
+        /// Missing key = leave as-is.
+        /// </summary>
+        [JsonProperty("sectionVisibility", NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, bool> SectionVisibility { get; set; }
+
+        /// <summary>
+        /// Tag size preset — "2", "2.5", "3", "3.5". Combined with
+        /// <see cref="TagStyle"/> + <see cref="TagColor"/> to pick the
+        /// active TAG_{size}{style}_{color}_BOOL. Null = leave as-is.
+        /// </summary>
+        [JsonProperty("tagSize", NullValueHandling = NullValueHandling.Ignore)]
+        public string TagSize { get; set; }
+
+        /// <summary>
+        /// Tag style preset — "NOM" / "BOLD" / "ITALIC" / "BOLDITALIC".
+        /// Null = leave as-is.
+        /// </summary>
+        [JsonProperty("tagStyle", NullValueHandling = NullValueHandling.Ignore)]
+        public string TagStyle { get; set; }
+
+        /// <summary>
+        /// Tag colour preset — "BLACK" / "BLUE" / "GREEN" / "RED" /
+        /// "ORANGE" / "GREY" / "PURPLE" / "YELLOW". Null = leave as-is.
+        /// </summary>
+        [JsonProperty("tagColor", NullValueHandling = NullValueHandling.Ignore)]
+        public string TagColor { get; set; }
+
+        /// <summary>
+        /// Per-view variable colour scheme to write into
+        /// STING_VIEW_TAG_STYLE — picks up TagStyleEngine's
+        /// VariableSchemes (System / Status / Zone / Level / Location
+        /// / Function) or BuiltInSchemes (Discipline / Warm / Cool /
+        /// Red / Yellow / Blue / Mono / Dark). Null = leave the view
+        /// param alone.
+        /// </summary>
+        [JsonProperty("colorScheme", NullValueHandling = NullValueHandling.Ignore)]
+        public string ColorScheme { get; set; }
+
+        /// <summary>
+        /// 8-segment tag mask string of 1/0 chars selecting which
+        /// DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ tokens render in the
+        /// displayed tag. Example "10000001" = DISC + SEQ only. Writes
+        /// <c>TAG_SEG_MASK_TXT</c>. Null = leave as-is. Length must be
+        /// 8; shorter / longer values are ignored with a warning.
+        /// </summary>
+        [JsonProperty("segmentMask", NullValueHandling = NullValueHandling.Ignore)]
+        public string SegmentMask { get; set; }
+
+        /// <summary>
+        /// Display mode integer (1..5) written to
+        /// <c>STING_DISPLAY_MODE</c>. 1=SEQ, 2=PROD-SEQ, 3=DISC-SYS-SEQ,
+        /// 4=DISC-PROD-SEQ, 5=Full 8-segment. Null = leave as-is.
+        /// </summary>
+        [JsonProperty("displayMode", NullValueHandling = NullValueHandling.Ignore)]
+        public int? DisplayMode { get; set; }
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/StingTools/Core/Drawing/DrawingTypePresentation.cs
+++ b/StingTools/Core/Drawing/DrawingTypePresentation.cs
@@ -26,6 +26,7 @@ namespace StingTools.Core.Drawing
             public bool TemplateApplied    { get; set; }
             public bool PackApplied        { get; set; }
             public bool CropApplied        { get; set; }
+            public bool TokenProfileApplied { get; set; }   // Phase 135 — Step 7.5
             public AnnotationRunStats Annotation { get; set; }
             public System.Collections.Generic.List<string> Warnings { get; } = new System.Collections.Generic.List<string>();
         }
@@ -116,20 +117,42 @@ namespace StingTools.Core.Drawing
             }
 
             // View Style Pack (shared graphic overrides) ---------------
+            ViewStylePack resolvedPack = null;
             if (!string.IsNullOrWhiteSpace(dt.ViewStylePackId))
             {
                 try
                 {
-                    var pack = ViewStylePackRegistry.Get(doc, dt.ViewStylePackId);
-                    if (pack != null)
+                    resolvedPack = ViewStylePackRegistry.Get(doc, dt.ViewStylePackId);
+                    if (resolvedPack != null)
                     {
-                        var packStats = ViewStylePackApplier.Apply(doc, view, pack);
+                        var packStats = ViewStylePackApplier.Apply(doc, view, resolvedPack);
                         r.PackApplied = true;
                         r.Warnings.AddRange(packStats.Warnings);
                     }
                     else r.Warnings.Add($"ViewStylePack '{dt.ViewStylePackId}' not found.");
                 }
                 catch (Exception ex) { r.Warnings.Add($"ViewStylePack: {ex.Message}"); }
+            }
+
+            // Token Profile (Phase 135) — Step 7.5 -----------------------
+            // Runs between the pack apply and the annotation pass so any
+            // auto-tags AnnotationRunner emits inherit the active style
+            // preset, paragraph depth, section visibility, and segment
+            // mask. No-op when neither the profile nor the pack supplies
+            // any tag-appearance value.
+            if (dt.TokenProfile != null
+                || resolvedPack?.TagColorScheme != null
+                || resolvedPack?.DefaultTagStyle != null
+                || (resolvedPack?.CategoryTagStyles != null && resolvedPack.CategoryTagStyles.Count > 0))
+            {
+                try
+                {
+                    var tpRes = TokenProfileApplier.Apply(doc, view, dt, resolvedPack);
+                    r.TokenProfileApplied = tpRes.ViewParamWrites + tpRes.ElementWrites
+                                          + tpRes.TypeWrites > 0 || tpRes.PresentationApplied;
+                    r.Warnings.AddRange(tpRes.Warnings);
+                }
+                catch (Exception ex) { r.Warnings.Add($"TokenProfileApplier: {ex.Message}"); }
             }
 
             // Annotation pass --------------------------------------------

--- a/StingTools/Core/Drawing/DrawingTypeRegistry.cs
+++ b/StingTools/Core/Drawing/DrawingTypeRegistry.cs
@@ -91,6 +91,7 @@ namespace StingTools.Core.Drawing
                 if (p.SectionMarker != null) m.SectionMarker = p.SectionMarker;
                 if (p.Slots != null && p.Slots.Count > 0) m.Slots = p.Slots;
                 if (p.Annotation != null)    m.Annotation = p.Annotation;
+                if (p.TokenProfile != null)  m.TokenProfile = p.TokenProfile;
                 if (p.Print != null)         m.Print = p.Print;
             }
             return m;

--- a/StingTools/Core/Drawing/TokenProfileApplier.cs
+++ b/StingTools/Core/Drawing/TokenProfileApplier.cs
@@ -1,0 +1,457 @@
+// StingTools — Drawing Template Manager · Phase 135
+//
+// TokenProfileApplier translates an AnnotationTokenProfile (per
+// DrawingType) and the resolved ViewStylePack's tag-appearance
+// defaults into Revit parameter writes on the view, the elements
+// in the view, and the corresponding family types.
+//
+// Pipeline ordering: this runs as Step 7.5 in
+// DrawingTypePresentation.Apply — between the ViewStylePack apply
+// (step 7) and the AnnotationRunner (step 8). Running before the
+// annotation pass means any auto-tags it creates inherit the
+// already-active style preset and depth tier.
+//
+// Step layout:
+//   A. STING_VIEW_TAG_STYLE — view-level colour scheme route
+//   B. PARA_STATE_1..10 + per-category depth — paragraph tiers
+//   C. TAG_7_SECTION_VISIBLE_A..F — TAG7 sub-section visibility
+//   D. TAG_{size}{style}_{color}_BOOL — tag style preset matrix
+//   E. TAG_SEG_MASK_TXT — 8-segment mask
+//   F. STING_DISPLAY_MODE — display mode integer
+//   G. Presentation-mode preset — global PARA_STATE_* + WARN_VISIBLE
+//
+// Inheritance: profile fields on the DrawingType always win over
+// pack fields, and pack fields win over the no-op default.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+using StingTools.Tags;
+
+namespace StingTools.Core.Drawing
+{
+    public static class TokenProfileApplier
+    {
+        public sealed class ApplyResult
+        {
+            public int  ViewParamWrites    { get; set; }
+            public int  ElementWrites      { get; set; }
+            public int  TypeWrites         { get; set; }
+            public bool PresentationApplied { get; set; }
+            public List<string> Warnings    { get; } = new List<string>();
+        }
+
+        /// <summary>
+        /// Apply the merged AnnotationTokenProfile (DrawingType) +
+        /// ViewStylePack tag-appearance defaults to the given view.
+        /// All Revit writes happen inside the caller's transaction.
+        /// Returns the number of writes per scope.
+        /// </summary>
+        public static ApplyResult Apply(Document doc, View view, DrawingType dt, ViewStylePack pack)
+        {
+            var r = new ApplyResult();
+            if (doc == null || view == null || dt == null) return r;
+            if (view.IsTemplate) return r;
+
+            // Resolve effective values: profile > pack > null
+            var profile  = dt.TokenProfile;
+            string scheme   = profile?.ColorScheme ?? pack?.TagColorScheme;
+            string size     = profile?.TagSize;
+            string style    = profile?.TagStyle;
+            string colour   = profile?.TagColor;
+            int?   depth    = profile?.ParaDepth;
+            string preset   = profile?.PresentationMode;
+            string segMask  = profile?.SegmentMask;
+            int?   dispMode = profile?.DisplayMode;
+            var    sectVis  = profile?.SectionVisibility;
+            var    catDeps  = profile?.CategoryDepths;
+
+            try
+            {
+                // ── Step A. View-level colour scheme route ─────────────
+                if (!string.IsNullOrWhiteSpace(scheme))
+                {
+                    if (TryWriteViewParam(view, ParamRegistry.VIEW_TAG_STYLE, scheme))
+                        r.ViewParamWrites++;
+                }
+
+                // ── Step E. Segment mask (view-level) ──────────────────
+                if (!string.IsNullOrWhiteSpace(segMask))
+                {
+                    if (segMask.Length == 8 && segMask.All(c => c == '0' || c == '1'))
+                    {
+                        if (TryWriteViewParam(view, ParamRegistry.TAG_SEG_MASK, segMask))
+                            r.ViewParamWrites++;
+                    }
+                    else
+                    {
+                        r.Warnings.Add($"SegmentMask '{segMask}' must be 8 chars of 0/1; ignored.");
+                    }
+                }
+
+                // ── Step F. Display mode (per element in view) ─────────
+                if (dispMode.HasValue && dispMode.Value >= 1 && dispMode.Value <= 5)
+                    r.ElementWrites += WriteElementInts(doc, view, ParamRegistry.DISPLAY_MODE, dispMode.Value);
+
+                // ── Step C. TAG7 section visibility (per element) ──────
+                if (sectVis != null && sectVis.Count > 0)
+                    r.ElementWrites += WriteSectionVisibility(doc, view, sectVis);
+
+                // ── Step G. Presentation-mode preset (global tier set) ─
+                if (!string.IsNullOrWhiteSpace(preset))
+                {
+                    bool ok = ApplyPresentationPreset(doc, preset);
+                    if (ok)
+                    {
+                        r.PresentationApplied = true;
+                        r.TypeWrites += 1;
+                    }
+                    else r.Warnings.Add($"Unknown presentation mode '{preset}'.");
+                }
+
+                // ── Step B. Global paragraph depth (project types) ─────
+                // Only fire when no preset specified — preset already
+                // sets PARA_STATE_*, so doing both would race.
+                if (string.IsNullOrWhiteSpace(preset) && depth.HasValue
+                    && depth.Value >= 1 && depth.Value <= 10)
+                {
+                    int n = TagStyleEngine.SetParagraphDepth(doc, depth.Value, warnVisible: true);
+                    r.TypeWrites += n;
+                }
+
+                // ── Step B. Per-category depth override ────────────────
+                if (catDeps != null && catDeps.Count > 0)
+                    r.TypeWrites += WriteCategoryDepths(doc, view, catDeps);
+
+                // ── Step D. Tag style preset (size/style/colour) ───────
+                // Profile triple wins; otherwise fall back to pack
+                // DefaultTagStyle. CategoryTagStyles loop runs after
+                // the global preset so per-category values win.
+                StylePresetTriple effective = ResolveStyleTriple(size, style, colour, pack?.DefaultTagStyle);
+                if (effective != null)
+                    r.TypeWrites += ApplyTagStylePreset(doc, effective);
+
+                if (pack?.CategoryTagStyles != null && pack.CategoryTagStyles.Count > 0)
+                    r.TypeWrites += ApplyCategoryTagStyles(doc, view, pack.CategoryTagStyles);
+            }
+            catch (Exception ex)
+            {
+                r.Warnings.Add($"TokenProfileApplier: {ex.Message}");
+                StingLog.Warn($"TokenProfileApplier.Apply: {ex.Message}");
+            }
+
+            StingLog.Info(
+                $"TokenProfileApplier: view='{view.Name}' viewWrites={r.ViewParamWrites} " +
+                $"elemWrites={r.ElementWrites} typeWrites={r.TypeWrites} " +
+                $"warnings={r.Warnings.Count}");
+            return r;
+        }
+
+        // ── View-level parameter writer (string only) ───────────────────
+
+        private static bool TryWriteViewParam(View view, string paramName, string value)
+        {
+            try
+            {
+                Parameter p = view.LookupParameter(paramName);
+                if (p == null || p.IsReadOnly) return false;
+                if (p.StorageType != StorageType.String) return false;
+                string cur = p.AsString() ?? "";
+                if (string.Equals(cur, value, StringComparison.Ordinal)) return false;
+                p.Set(value ?? "");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TokenProfileApplier view param '{paramName}': {ex.Message}");
+                return false;
+            }
+        }
+
+        // ── Per-element integer write (e.g. STING_DISPLAY_MODE) ─────────
+
+        private static int WriteElementInts(Document doc, View view, string paramName, int value)
+        {
+            int n = 0;
+            try
+            {
+                var ids = new FilteredElementCollector(doc, view.Id)
+                    .WhereElementIsNotElementType()
+                    .ToElementIds();
+                foreach (var id in ids)
+                {
+                    var el = doc.GetElement(id);
+                    if (el == null) continue;
+                    Parameter p = el.LookupParameter(paramName);
+                    if (p == null || p.IsReadOnly) continue;
+                    if (p.StorageType != StorageType.Integer) continue;
+                    if (p.AsInteger() == value) continue;
+                    try { p.Set(value); n++; }
+                    catch { /* element-specific failure — keep going */ }
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"WriteElementInts({paramName}): {ex.Message}");
+            }
+            return n;
+        }
+
+        // ── TAG7 section visibility (per element) ───────────────────────
+
+        private static int WriteSectionVisibility(Document doc, View view, Dictionary<string, bool> map)
+        {
+            int n = 0;
+            // Only A..F are valid keys.
+            var canonical = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in map)
+            {
+                string k = (kv.Key ?? "").Trim().ToUpperInvariant();
+                if (k.Length == 1 && k[0] >= 'A' && k[0] <= 'F')
+                    canonical[k] = kv.Value;
+            }
+            if (canonical.Count == 0) return 0;
+
+            var ids = new FilteredElementCollector(doc, view.Id)
+                .WhereElementIsNotElementType()
+                .ToElementIds();
+            foreach (var id in ids)
+            {
+                var el = doc.GetElement(id);
+                if (el == null) continue;
+                foreach (var kv in canonical)
+                {
+                    string pname = $"TAG_7_SECTION_VISIBLE_{kv.Key}_BOOL";
+                    Parameter p = el.LookupParameter(pname);
+                    if (p == null) continue;   // family doesn't carry this section flag
+                    if (ParameterHelpers.SetYesNo(el, pname, kv.Value, overwrite: true)) n++;
+                }
+            }
+            return n;
+        }
+
+        // ── Per-category depth override ─────────────────────────────────
+
+        private static int WriteCategoryDepths(Document doc, View view, Dictionary<string, int> map)
+        {
+            int n = 0;
+            var byCat = new Dictionary<string, List<ElementId>>(StringComparer.OrdinalIgnoreCase);
+            var ids = new FilteredElementCollector(doc, view.Id)
+                .WhereElementIsNotElementType()
+                .ToElementIds();
+            foreach (var id in ids)
+            {
+                var el = doc.GetElement(id);
+                if (el?.Category == null) continue;
+                string cat = el.Category.Name ?? "";
+                if (string.IsNullOrEmpty(cat)) continue;
+                if (!byCat.TryGetValue(cat, out var list))
+                    byCat[cat] = list = new List<ElementId>();
+                list.Add(id);
+            }
+
+            string[] states = ParamRegistry.AllParaStates;
+            foreach (var kv in map)
+            {
+                int d = Math.Max(1, Math.Min(10, kv.Value));
+                if (!byCat.TryGetValue(kv.Key ?? "", out var list)) continue;
+
+                // Apply depth on the TYPE of each instance; one type
+                // serves many instances so dedupe.
+                var typeIds = new HashSet<ElementId>();
+                foreach (var id in list)
+                {
+                    var el = doc.GetElement(id);
+                    var tid = el?.GetTypeId();
+                    if (tid != null && tid != ElementId.InvalidElementId)
+                        typeIds.Add(tid);
+                }
+
+                foreach (var tid in typeIds)
+                {
+                    var typeEl = doc.GetElement(tid);
+                    if (typeEl == null) continue;
+                    bool any = false;
+                    for (int i = 0; i < states.Length; i++)
+                    {
+                        bool want = (i + 1) <= d;
+                        if (ParameterHelpers.SetYesNo(typeEl, states[i], want, overwrite: true))
+                            any = true;
+                    }
+                    if (any) n++;
+                }
+            }
+            return n;
+        }
+
+        // ── Style preset matrix ─────────────────────────────────────────
+
+        private sealed class StylePresetTriple
+        {
+            public string Size;
+            public string Style;
+            public string Color;
+            public string ParamName => $"TAG_{Size}{Style}_{Color}_BOOL";
+        }
+
+        private static StylePresetTriple ResolveStyleTriple(
+            string size, string style, string colour, string packDefault)
+        {
+            // Profile triple — accept partial values, fill from pack default.
+            if (string.IsNullOrWhiteSpace(size) && string.IsNullOrWhiteSpace(style)
+                && string.IsNullOrWhiteSpace(colour))
+            {
+                if (string.IsNullOrWhiteSpace(packDefault)) return null;
+                return ParseCanonicalStyleName(packDefault);
+            }
+
+            var fallback = string.IsNullOrWhiteSpace(packDefault)
+                ? null : ParseCanonicalStyleName(packDefault);
+
+            return new StylePresetTriple
+            {
+                Size  = !string.IsNullOrWhiteSpace(size)   ? size.Trim()
+                          : fallback?.Size  ?? "2.5",
+                Style = !string.IsNullOrWhiteSpace(style)  ? style.Trim().ToUpperInvariant()
+                          : fallback?.Style ?? "NOM",
+                Color = !string.IsNullOrWhiteSpace(colour) ? colour.Trim().ToUpperInvariant()
+                          : fallback?.Color ?? "BLACK",
+            };
+        }
+
+        /// <summary>
+        /// Canonical style name format is "{size}{style}_{color}", e.g.
+        /// "2.5BOLD_RED" or "2NOM_BLACK". Returns null on unparsable
+        /// input.
+        /// </summary>
+        private static StylePresetTriple ParseCanonicalStyleName(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return null;
+            int u = s.IndexOf('_');
+            if (u <= 0 || u >= s.Length - 1) return null;
+            string head = s.Substring(0, u);
+            string color = s.Substring(u + 1).ToUpperInvariant();
+
+            // Pull style suffix off head — match longest known style.
+            string[] styles = { "BOLDITALIC", "BOLD", "ITALIC", "NOM" };
+            foreach (var st in styles)
+            {
+                if (head.EndsWith(st, StringComparison.OrdinalIgnoreCase))
+                {
+                    string size = head.Substring(0, head.Length - st.Length);
+                    return new StylePresetTriple { Size = size, Style = st, Color = color };
+                }
+            }
+            return null;
+        }
+
+        private static int ApplyTagStylePreset(Document doc, StylePresetTriple t)
+        {
+            string activeParam = t.ParamName;
+            string[] all = ParamRegistry.AllTagStyleParams;
+
+            int updated = 0;
+            var allTypes = new FilteredElementCollector(doc).WhereElementIsElementType();
+            foreach (Element typeEl in allTypes)
+            {
+                bool any = false;
+                foreach (string pname in all)
+                {
+                    Parameter p = typeEl.LookupParameter(pname);
+                    if (p == null || p.IsReadOnly) continue;
+                    bool want = string.Equals(pname, activeParam, StringComparison.OrdinalIgnoreCase);
+                    if (ParameterHelpers.SetYesNo(typeEl, pname, want, overwrite: true))
+                        any = true;
+                }
+                if (any) updated++;
+            }
+            return updated;
+        }
+
+        private static int ApplyCategoryTagStyles(Document doc, View view, Dictionary<string, string> map)
+        {
+            int updated = 0;
+            // Collect type ids per category from instances in view.
+            var byCat = new Dictionary<string, HashSet<ElementId>>(StringComparer.OrdinalIgnoreCase);
+            var ids = new FilteredElementCollector(doc, view.Id)
+                .WhereElementIsNotElementType()
+                .ToElementIds();
+            foreach (var id in ids)
+            {
+                var el = doc.GetElement(id);
+                var cat = el?.Category?.Name;
+                if (string.IsNullOrEmpty(cat)) continue;
+                var tid = el.GetTypeId();
+                if (tid == null || tid == ElementId.InvalidElementId) continue;
+                if (!byCat.TryGetValue(cat, out var set))
+                    byCat[cat] = set = new HashSet<ElementId>();
+                set.Add(tid);
+            }
+
+            string[] all = ParamRegistry.AllTagStyleParams;
+            foreach (var kv in map)
+            {
+                if (string.IsNullOrWhiteSpace(kv.Value)) continue;
+                var triple = ParseCanonicalStyleName(kv.Value);
+                if (triple == null) continue;
+                if (!byCat.TryGetValue(kv.Key ?? "", out var typeIds)) continue;
+
+                string activeParam = triple.ParamName;
+                foreach (var tid in typeIds)
+                {
+                    var typeEl = doc.GetElement(tid);
+                    if (typeEl == null) continue;
+                    bool any = false;
+                    foreach (string pname in all)
+                    {
+                        Parameter p = typeEl.LookupParameter(pname);
+                        if (p == null || p.IsReadOnly) continue;
+                        bool want = string.Equals(pname, activeParam, StringComparison.OrdinalIgnoreCase);
+                        if (ParameterHelpers.SetYesNo(typeEl, pname, want, overwrite: true))
+                            any = true;
+                    }
+                    if (any) updated++;
+                }
+            }
+            return updated;
+        }
+
+        // ── Presentation-mode preset (matches the existing modes) ───────
+
+        private static bool ApplyPresentationPreset(Document doc, string mode)
+        {
+            bool s1, s2, s3, warn;
+            switch ((mode ?? "").Trim().ToUpperInvariant())
+            {
+                case "COMPACT":
+                    s1 = true;  s2 = false; s3 = false; warn = false; break;
+                case "TECHNICAL":
+                    s1 = true;  s2 = true;  s3 = false; warn = true;  break;
+                case "FULLSPEC":
+                case "FULL_SPECIFICATION":
+                case "FULL SPECIFICATION":
+                    s1 = true;  s2 = true;  s3 = true;  warn = true;  break;
+                case "PRESENTATION":
+                    s1 = true;  s2 = true;  s3 = false; warn = false; break;
+                case "BOQ":
+                    s1 = true;  s2 = true;  s3 = false; warn = false; break;
+                default:
+                    return false;
+            }
+
+            var allTypes = new FilteredElementCollector(doc)
+                .WhereElementIsElementType()
+                .ToList();
+            foreach (Element typeEl in allTypes)
+            {
+                ParameterHelpers.SetYesNo(typeEl, ParamRegistry.PARA_STATE_1, s1, overwrite: true);
+                ParameterHelpers.SetYesNo(typeEl, ParamRegistry.PARA_STATE_2, s2, overwrite: true);
+                ParameterHelpers.SetYesNo(typeEl, ParamRegistry.PARA_STATE_3, s3, overwrite: true);
+                ParameterHelpers.SetYesNo(typeEl, ParamRegistry.WARN_VISIBLE, warn, overwrite: true);
+            }
+            return true;
+        }
+    }
+}

--- a/StingTools/Core/Drawing/ViewStylePack.cs
+++ b/StingTools/Core/Drawing/ViewStylePack.cs
@@ -52,6 +52,38 @@ namespace StingTools.Core.Drawing
         [JsonProperty("tagFamilies")] public Dictionary<string, string> TagFamilies { get; set; }
             = new Dictionary<string, string>();
 
+        // ── Phase 135 — Tag Appearance pack-level defaults ──
+        // Resolved by TokenProfileApplier whenever the per-DrawingType
+        // AnnotationTokenProfile leaves a slot empty. DrawingType always
+        // wins when both set the same field.
+
+        /// <summary>
+        /// Pack-level default colour scheme. Variable-driven scheme
+        /// name (e.g. "System", "Status", "Discipline") written into
+        /// STING_VIEW_TAG_STYLE for every view this pack is applied to.
+        /// Null = no pack default.
+        /// </summary>
+        [JsonProperty("tagColorScheme", NullValueHandling = NullValueHandling.Ignore)]
+        public string TagColorScheme { get; set; }
+
+        /// <summary>
+        /// Pack-level default tag style preset — "{size}{style}_{colour}"
+        /// canonical name (e.g. "2.5BOLD_RED"). Used when the
+        /// DrawingType profile's TagSize / TagStyle / TagColor are all
+        /// null. Null = no pack default.
+        /// </summary>
+        [JsonProperty("defaultTagStyle", NullValueHandling = NullValueHandling.Ignore)]
+        public string DefaultTagStyle { get; set; }
+
+        /// <summary>
+        /// Per-category tag style override (canonical preset name).
+        /// Loosely wins over DefaultTagStyle, loses to the
+        /// DrawingType.TokenProfile.TagSize/Style/Color triple.
+        /// </summary>
+        [JsonProperty("categoryTagStyles", NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, string> CategoryTagStyles { get; set; }
+            = new Dictionary<string, string>();
+
         [JsonProperty("checksum", NullValueHandling = NullValueHandling.Ignore)]
         public string Checksum { get; set; }
     }

--- a/StingTools/Core/Drawing/ViewStylePackRegistry.cs
+++ b/StingTools/Core/Drawing/ViewStylePackRegistry.cs
@@ -159,6 +159,16 @@ namespace StingTools.Core.Drawing
                     foreach (var kv in p.VgOverrides) merged.VgOverrides[kv.Key] = kv.Value;
                 if (p.TagFamilies != null)
                     foreach (var kv in p.TagFamilies) merged.TagFamilies[kv.Key] = kv.Value;
+
+                // Phase 135 — Tag Appearance pack-level defaults
+                if (!string.IsNullOrEmpty(p.TagColorScheme))   merged.TagColorScheme = p.TagColorScheme;
+                if (!string.IsNullOrEmpty(p.DefaultTagStyle))  merged.DefaultTagStyle = p.DefaultTagStyle;
+                if (p.CategoryTagStyles != null)
+                {
+                    if (merged.CategoryTagStyles == null)
+                        merged.CategoryTagStyles = new Dictionary<string, string>();
+                    foreach (var kv in p.CategoryTagStyles) merged.CategoryTagStyles[kv.Key] = kv.Value;
+                }
             }
             return merged;
         }

--- a/StingTools/Data/STING_DRAWING_TYPES.json
+++ b/StingTools/Data/STING_DRAWING_TYPES.json
@@ -3337,9 +3337,166 @@
         "halftoneLinks": false,
         "lineWeightScale": 0.8
       }
+    },
+    {
+      "id": "mep-plan-presentation",
+      "name": "MEP Plan — Presentation (Phase 135)",
+      "description": "Client-facing MEP plan. Shallow paragraph depth, only TAG7 sections A+B visible, soft Discipline colour scheme, segment mask hides LVL/ZONE for visual cleanliness.",
+      "origin": "corporate",
+      "purpose": "Plan",
+      "discipline": "M",
+      "phase": "PRESENTATION",
+      "paperSize": "A1",
+      "titleBlockFamily": "STING_TB_SHEET_A1",
+      "scale": 100,
+      "detailLevel": "Medium",
+      "viewTemplateName": "STING - MEP Plan",
+      "viewStylePackId": "corp-presentation-rich",
+      "sheetNumberPattern": "{project}-{originator}-{vol}-{lvl}-{type}-{role}-{seq:D4}-{suit}-{rev}",
+      "sheetNamePattern": "MEP PRESENTATION — {lvl}",
+      "crop": { "kind": "ScopeBoxOrBbox", "marginMm": 200 },
+      "slots": [
+        { "label": "Main Plan", "viewType": "Plan", "normX": 0.03, "normY": 0.05, "normW": 0.75, "normH": 0.9, "required": true },
+        { "label": "Legend",    "viewType": "Legend", "normX": 0.8, "normY": 0.05, "normW": 0.18, "normH": 0.9 }
+      ],
+      "annotation": {
+        "dimensionStrategy": "Linear",
+        "tagFamilies": { "Mechanical Equipment": "STING_TAG_MECH" },
+        "denseUntilScale": 100,
+        "rules": [
+          { "category": "Mechanical Equipment", "ruleType": "AutoTag", "enabled": true },
+          { "category": "Air Terminals",        "ruleType": "AutoTag", "enabled": true }
+        ]
+      },
+      "tokenProfile": {
+        "presentationMode": "Presentation",
+        "paraDepth": 2,
+        "sectionVisibility": { "A": true, "B": true, "C": false, "D": false, "E": false, "F": false },
+        "tagSize": "2.5",
+        "tagStyle": "NOM",
+        "tagColor": "BLUE",
+        "colorScheme": "Discipline",
+        "segmentMask": "10010101",
+        "displayMode": 4
+      },
+      "print": { "colourScheme": "PresentationRich", "halftoneLinks": true, "lineWeightScale": 0.8 }
+    },
+    {
+      "id": "mep-plan-technical",
+      "name": "MEP Plan — Technical (Phase 135)",
+      "description": "Engineering-issue MEP plan. Full paragraph tier 5, all TAG7 sections visible, System variable colour scheme, BOLD tags, full 8-segment tag mask.",
+      "origin": "corporate",
+      "purpose": "Plan",
+      "discipline": "M",
+      "phase": "TECHNICAL",
+      "paperSize": "A1",
+      "titleBlockFamily": "STING_TB_SHEET_A1",
+      "scale": 100,
+      "detailLevel": "Fine",
+      "viewTemplateName": "STING - MEP Plan",
+      "viewStylePackId": "corp-coordination",
+      "sheetNumberPattern": "{project}-{originator}-{vol}-{lvl}-{type}-{role}-{seq:D4}-{suit}-{rev}",
+      "sheetNamePattern": "MEP TECHNICAL — {lvl}",
+      "crop": { "kind": "ScopeBoxOrBbox", "marginMm": 100 },
+      "slots": [
+        { "label": "Main Plan", "viewType": "Plan", "normX": 0.03, "normY": 0.05, "normW": 0.75, "normH": 0.9, "required": true },
+        { "label": "Legend",    "viewType": "Legend", "normX": 0.8, "normY": 0.05, "normW": 0.18, "normH": 0.9 }
+      ],
+      "annotation": {
+        "dimensionStrategy": "Linear",
+        "tagFamilies": {
+          "Mechanical Equipment": "STING_TAG_MECH",
+          "Air Terminals":        "STING_TAG_AIR_TERMINAL",
+          "Pipe Fittings":        "STING_TAG_PIPE",
+          "Duct Fittings":        "STING_TAG_DUCT"
+        },
+        "denseUntilScale": 100,
+        "rules": [
+          { "category": "Grids",                "ruleType": "AutoDim", "enabled": true },
+          { "category": "Mechanical Equipment", "ruleType": "AutoTag", "enabled": true },
+          { "category": "Air Terminals",        "ruleType": "AutoTag", "enabled": true },
+          { "category": "Pipe Fittings",        "ruleType": "AutoTag", "enabled": true },
+          { "category": "Duct Fittings",        "ruleType": "AutoTag", "enabled": true }
+        ]
+      },
+      "tokenProfile": {
+        "presentationMode": "Technical",
+        "paraDepth": 5,
+        "categoryDepths": {
+          "Mechanical Equipment": 7,
+          "Air Terminals":        4,
+          "Pipe Fittings":        6,
+          "Duct Fittings":        6
+        },
+        "sectionVisibility": { "A": true, "B": true, "C": true, "D": true, "E": true, "F": true },
+        "tagSize": "2",
+        "tagStyle": "BOLD",
+        "tagColor": "BLACK",
+        "colorScheme": "System",
+        "segmentMask": "11111111",
+        "displayMode": 5
+      },
+      "print": { "colourScheme": "Monochrome", "halftoneLinks": false, "lineWeightScale": 1.0 }
+    },
+    {
+      "id": "mep-plan-fabrication",
+      "name": "MEP Plan — Fabrication (Phase 135)",
+      "description": "Workshop-floor MEP plan. Tier 10 audit-trail TAG7, all sections, System variable colours, BOLD-RED tags, mask shows DISC-SYS-PROD-SEQ for spool-pack readability.",
+      "origin": "corporate",
+      "purpose": "Plan",
+      "discipline": "M",
+      "phase": "FABRICATION",
+      "paperSize": "A1",
+      "titleBlockFamily": "STING_TB_SHEET_A1",
+      "scale": 50,
+      "detailLevel": "Fine",
+      "viewTemplateName": "STING - Fabrication Shop",
+      "viewStylePackId": "corp-fabrication-shop",
+      "sheetNumberPattern": "{project}-{originator}-{vol}-{lvl}-{type}-{role}-{seq:D4}-{suit}-{rev}",
+      "sheetNamePattern": "MEP FABRICATION — {lvl}",
+      "crop": { "kind": "ScopeBoxOrBbox", "marginMm": 80 },
+      "slots": [
+        { "label": "Main Plan",   "viewType": "Plan",     "normX": 0.03, "normY": 0.30, "normW": 0.75, "normH": 0.65, "required": true },
+        { "label": "Cut List",    "viewType": "Schedule", "normX": 0.03, "normY": 0.05, "normW": 0.75, "normH": 0.22 },
+        { "label": "Spool Refs",  "viewType": "Legend",   "normX": 0.80, "normY": 0.05, "normW": 0.18, "normH": 0.9 }
+      ],
+      "annotation": {
+        "dimensionStrategy": "Ordinate",
+        "dimensionStyle": "STING - Ordinate",
+        "tagFamilies": {
+          "Pipe Fittings": "STING_TAG_PIPE_SHOP",
+          "Duct Fittings": "STING_TAG_DUCT_SHOP"
+        },
+        "denseUntilScale": 50,
+        "rules": [
+          { "category": "Pipe Fittings",        "ruleType": "AutoTag", "enabled": true },
+          { "category": "Duct Fittings",        "ruleType": "AutoTag", "enabled": true },
+          { "category": "Mechanical Equipment", "ruleType": "AutoTag", "enabled": true }
+        ]
+      },
+      "tokenProfile": {
+        "presentationMode": "FullSpec",
+        "paraDepth": 10,
+        "categoryDepths": {
+          "Pipe Fittings":        10,
+          "Duct Fittings":        10,
+          "Mechanical Equipment": 8
+        },
+        "sectionVisibility": { "A": true, "B": true, "C": true, "D": true, "E": true, "F": true },
+        "tagSize": "2",
+        "tagStyle": "BOLD",
+        "tagColor": "RED",
+        "colorScheme": "System",
+        "segmentMask": "10001011",
+        "displayMode": 5
+      },
+      "print": { "colourScheme": "Monochrome", "halftoneLinks": false, "lineWeightScale": 1.1 }
     }
   ],
   "routing": [
+    { "discipline": "M", "phase": "PRESENTATION", "docType": "PLAN", "drawingTypeId": "mep-plan-presentation" },
+    { "discipline": "M", "phase": "TECHNICAL",   "docType": "PLAN", "drawingTypeId": "mep-plan-technical" },
+    { "discipline": "M", "phase": "FABRICATION", "docType": "PLAN", "drawingTypeId": "mep-plan-fabrication" },
     {
       "discipline": "P",
       "phase": "*",

--- a/StingTools/Data/STING_VIEW_STYLE_PACKS.json
+++ b/StingTools/Data/STING_VIEW_STYLE_PACKS.json
@@ -204,6 +204,16 @@
         "Structural Columns":     { "projColor": "#4A148C", "projWeight": 4, "halftone": true },
         "Structural Framing":     { "projColor": "#4A148C", "projWeight": 3, "halftone": true },
         "Walls":                  { "halftone": true, "projColor": "#808080", "projWeight": 2 }
+      },
+      "tagColorScheme": "System",
+      "defaultTagStyle": "2BOLD_BLACK",
+      "categoryTagStyles": {
+        "Mechanical Equipment": "2BOLD_BLUE",
+        "Pipe Fittings":        "2NOM_GREEN",
+        "Duct Fittings":        "2NOM_BLUE",
+        "Electrical Equipment": "2BOLD_ORANGE",
+        "Fire Alarm Devices":   "2BOLD_RED",
+        "Sprinklers":           "2BOLD_RED"
       }
     },
     {
@@ -229,6 +239,13 @@
         "Walls":              { "visible": false },
         "Structural Framing": { "visible": false },
         "Dimensions":         { "projColor": "#000000", "projWeight": 2 }
+      },
+      "tagColorScheme": "System",
+      "defaultTagStyle": "2BOLD_RED",
+      "categoryTagStyles": {
+        "Pipe Fittings":        "2BOLD_RED",
+        "Duct Fittings":        "2BOLD_RED",
+        "Mechanical Equipment": "2BOLD_BLACK"
       }
     },
     {
@@ -255,6 +272,13 @@
         "Grids":               { "visible": false },
         "Dimensions":          { "visible": false },
         "Text Notes":          { "projColor": "#263238" }
+      },
+      "tagColorScheme": "Discipline",
+      "defaultTagStyle": "2.5NOM_BLUE",
+      "categoryTagStyles": {
+        "Rooms":   "3NOM_BLACK",
+        "Doors":   "2.5NOM_BLACK",
+        "Windows": "2.5NOM_BLACK"
       }
     },
     {
@@ -274,6 +298,13 @@
         "Rooms":              { "projColor": "#BDBDBD" },
         "Furniture":          { "projColor": "#9E9E9E" },
         "Topography":         { "projColor": "#BDBDBD" }
+      },
+      "tagColorScheme": "Mono",
+      "defaultTagStyle": "2.5NOM_BLACK",
+      "categoryTagStyles": {
+        "Rooms":   "2.5NOM_BLACK",
+        "Doors":   "2NOM_BLACK",
+        "Windows": "2NOM_BLACK"
       }
     }
   ],

--- a/StingTools/UI/DrawingTypeEditorDialog.cs
+++ b/StingTools/UI/DrawingTypeEditorDialog.cs
@@ -434,6 +434,9 @@ namespace StingTools.UI
             }));
             _packFormHost.Children.Add(Card("VG overrides (per category)", vgBody));
 
+            // Phase 135 — Tag Appearance card
+            _packFormHost.Children.Add(BuildPackTagAppearanceCard());
+
             // Validation strip
             _packFormHost.Children.Add(new TextBlock
             {
@@ -442,6 +445,128 @@ namespace StingTools.UI
                 FontSize = 11, Margin = new Thickness(4, 10, 4, 4),
                 TextWrapping = TextWrapping.Wrap,
             });
+        }
+
+        // Phase 135 — pack-level tag appearance defaults. Per-DrawingType
+        // AnnotationTokenProfile fields override these; the pack supplies
+        // a sensible default for every profile that bound to it but didn't
+        // set every tag knob explicitly.
+        private UIElement BuildPackTagAppearanceCard()
+        {
+            var p = _currentPack;
+            var body = new StackPanel();
+
+            string[] schemes = new[] { "", "Discipline", "System", "Status", "Zone", "Level", "Location", "Function",
+                                        "Warm", "Cool", "Red", "Yellow", "Blue", "Mono", "Dark" };
+            body.Children.Add(LabeledCombo("Default colour scheme",
+                schemes, p.TagColorScheme ?? "",
+                v => p.TagColorScheme = string.IsNullOrWhiteSpace(v) ? null : v.Trim(),
+                tooltip: "Variable-driven scheme written to STING_VIEW_TAG_STYLE on every view this pack applies to. Profile-level scheme wins."));
+
+            string[] commonStyles = new[] { "",
+                "2NOM_BLACK", "2BOLD_BLACK", "2.5NOM_BLACK", "2.5BOLD_BLACK",
+                "2NOM_BLUE", "2BOLD_BLUE", "2.5NOM_BLUE",
+                "2NOM_GREEN", "2BOLD_GREEN",
+                "2NOM_RED", "2BOLD_RED", "2.5BOLD_RED",
+                "2NOM_ORANGE", "2BOLD_ORANGE",
+                "2.5BOLDITALIC_PURPLE",
+                "3NOM_BLACK", "3BOLD_BLACK", "3.5BOLD_BLACK",
+            };
+            body.Children.Add(LabeledCombo("Default tag style preset",
+                commonStyles, p.DefaultTagStyle ?? "",
+                v => p.DefaultTagStyle = string.IsNullOrWhiteSpace(v) ? null : v.Trim(),
+                tooltip: "Canonical name '{size}{style}_{color}' (e.g. '2.5BOLD_RED'). Profile-level Size/Style/Color triple wins."));
+
+            body.Children.Add(BuildPackCategoryTagStylesGrid(p));
+            return Card("Tag appearance (Phase 135)", body);
+        }
+
+        private static readonly GridLength[] _packCatStyleCols =
+        {
+            new GridLength(180),
+            new GridLength(1, GridUnitType.Star),
+            new GridLength(24),
+        };
+
+        private UIElement BuildPackCategoryTagStylesGrid(ViewStylePack p)
+        {
+            p.CategoryTagStyles = p.CategoryTagStyles ?? new Dictionary<string, string>();
+
+            var host = new StackPanel { Margin = new Thickness(0, 8, 0, 0) };
+            host.Children.Add(new TextBlock {
+                Text = "Per-category tag style — overrides Default tag style above for that category.",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11, Margin = new Thickness(0, 0, 0, 2) });
+
+            // Header
+            var header = new Grid { Margin = new Thickness(0, 4, 0, 2) };
+            for (int i = 0; i < _packCatStyleCols.Length; i++)
+                header.ColumnDefinitions.Add(new ColumnDefinition { Width = _packCatStyleCols[i] });
+            string[] hd = { "Category", "Style preset", "" };
+            for (int i = 0; i < hd.Length; i++)
+            {
+                var t = new TextBlock { Text = hd[i], FontSize = 10,
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0) };
+                Grid.SetColumn(t, i); header.Children.Add(t);
+            }
+            host.Children.Add(header);
+
+            var cats = Merge(ProjectAssetPicker.TaggableCategoryNames(_doc),
+                             KnownTaggableCategories).ToArray();
+            string[] commonStyles = new[] {
+                "2NOM_BLACK", "2BOLD_BLACK", "2.5NOM_BLACK", "2.5BOLD_BLACK",
+                "2NOM_BLUE", "2BOLD_BLUE",
+                "2NOM_GREEN", "2BOLD_GREEN",
+                "2NOM_RED", "2BOLD_RED", "2.5BOLD_RED",
+                "2NOM_ORANGE", "2BOLD_ORANGE",
+                "3NOM_BLACK", "3BOLD_BLACK",
+            };
+
+            foreach (var kv in p.CategoryTagStyles.ToList())
+            {
+                var g = new Grid { Margin = new Thickness(0, 1, 0, 1) };
+                for (int i = 0; i < _packCatStyleCols.Length; i++)
+                    g.ColumnDefinitions.Add(new ColumnDefinition { Width = _packCatStyleCols[i] });
+
+                string catKey = kv.Key;
+                var keyBox = SmallCombo(catKey, newKey =>
+                {
+                    newKey = (newKey ?? "").Trim();
+                    if (string.IsNullOrEmpty(newKey) || newKey == catKey) return;
+                    if (!p.CategoryTagStyles.ContainsKey(catKey)) return;
+                    var existing = p.CategoryTagStyles[catKey];
+                    p.CategoryTagStyles.Remove(catKey);
+                    p.CategoryTagStyles[newKey] = existing;
+                }, cats);
+
+                var styleBox = SmallCombo(kv.Value ?? "", v =>
+                {
+                    if (p.CategoryTagStyles.ContainsKey(catKey))
+                        p.CategoryTagStyles[catKey] = (v ?? "").Trim();
+                }, commonStyles);
+
+                var rm = MakeSmallBtn("×", () => { p.CategoryTagStyles.Remove(catKey); RenderPackForm(); });
+                rm.Width = 22;
+
+                var ctrls = new UIElement[] { keyBox, styleBox, rm };
+                for (int i = 0; i < ctrls.Length; i++)
+                {
+                    Grid.SetColumn(ctrls[i], i);
+                    if (ctrls[i] is FrameworkElement fe)
+                        fe.Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0);
+                    g.Children.Add(ctrls[i]);
+                }
+                host.Children.Add(g);
+            }
+
+            host.Children.Add(MakeSmallBtn("＋ Add category style", () =>
+            {
+                var key = "NewCategory" + p.CategoryTagStyles.Count;
+                p.CategoryTagStyles[key] = "2NOM_BLACK";
+                RenderPackForm();
+            }));
+            return host;
         }
 
         // ── Filter rule row ──
@@ -655,6 +780,15 @@ namespace StingTools.UI
             [JsonProperty("appearance")]  public PackAppearance Appearance { get; set; }
             [JsonProperty("filterRules")] public List<PackFilterRule> FilterRules { get; set; }
             [JsonProperty("vgOverrides")] public Dictionary<string, PackCategoryOverride> VgOverrides { get; set; }
+
+            // Phase 135 — Tag Appearance pack-level defaults
+            [JsonProperty("tagColorScheme",   NullValueHandling = NullValueHandling.Ignore)]
+            public string TagColorScheme { get; set; }
+            [JsonProperty("defaultTagStyle",  NullValueHandling = NullValueHandling.Ignore)]
+            public string DefaultTagStyle { get; set; }
+            [JsonProperty("categoryTagStyles", NullValueHandling = NullValueHandling.Ignore)]
+            public Dictionary<string, string> CategoryTagStyles { get; set; }
+
             public override string ToString()
             {
                 var ext = string.IsNullOrEmpty(Extends) ? "" : $"  ←  {Extends}";
@@ -1144,6 +1278,7 @@ namespace StingTools.UI
             _formHost.Children.Add(BuildCropCard());
             _formHost.Children.Add(BuildSectionMarkerCard());
             _formHost.Children.Add(BuildAnnotationCard());
+            _formHost.Children.Add(BuildTokenProfileCard());   // Phase 135
             _formHost.Children.Add(BuildSlotsCard());
 
             // Validation strip
@@ -1300,6 +1435,202 @@ namespace StingTools.UI
             body.Children.Add(BuildTagFamiliesGrid(pack));
 
             return Card("Annotation rule pack", body);
+        }
+
+        // Phase 135 — Token Depth & Style card.
+        // Drives the AnnotationTokenProfile fields: presentation mode,
+        // global + per-category paragraph depth, TAG7 section visibility,
+        // tag size/style/colour preset, view-level colour scheme, segment
+        // mask, display mode. Empty ⇒ inherit from ViewStylePack pack-level
+        // defaults (defaultTagStyle / categoryTagStyles / tagColorScheme).
+        private UIElement BuildTokenProfileCard()
+        {
+            var tp = _current.TokenProfile = _current.TokenProfile ?? new AnnotationTokenProfile();
+            var body = new StackPanel();
+
+            string[] presetModes = new[] { "", "Compact", "Technical", "FullSpec", "Presentation", "BOQ" };
+            body.Children.Add(LabeledCombo("Presentation mode preset",
+                presetModes, tp.PresentationMode ?? "",
+                v => tp.PresentationMode = string.IsNullOrWhiteSpace(v) ? null : v.Trim(),
+                tooltip: "Sets PARA_STATE_1/2/3 + WARN_VISIBLE in one shot. Empty = use Para-depth slider below."));
+
+            body.Children.Add(LabeledNullableNumber("Global paragraph depth (1-10)",
+                tp.ParaDepth, v => tp.ParaDepth = v,
+                tooltip: "Tier 1 = compact, 10 = full audit. Empty = inherit from preset / leave alone."));
+
+            string[] sizes  = new[] { "", "2", "2.5", "3", "3.5" };
+            string[] styles = new[] { "", "NOM", "BOLD", "ITALIC", "BOLDITALIC" };
+            string[] colors = new[] { "", "BLACK", "BLUE", "GREEN", "RED", "ORANGE", "GREY", "PURPLE", "YELLOW" };
+
+            body.Children.Add(LabeledCombo("Tag size",
+                sizes, tp.TagSize ?? "",
+                v => tp.TagSize = string.IsNullOrWhiteSpace(v) ? null : v.Trim(),
+                tooltip: "Empty = inherit from pack DefaultTagStyle. mm text height."));
+            body.Children.Add(LabeledCombo("Tag style",
+                styles, tp.TagStyle ?? "",
+                v => tp.TagStyle = string.IsNullOrWhiteSpace(v) ? null : v.Trim().ToUpperInvariant()));
+            body.Children.Add(LabeledCombo("Tag colour",
+                colors, tp.TagColor ?? "",
+                v => tp.TagColor = string.IsNullOrWhiteSpace(v) ? null : v.Trim().ToUpperInvariant()));
+
+            string[] schemes = new[] { "", "Discipline", "System", "Status", "Zone", "Level", "Location", "Function",
+                                        "Warm", "Cool", "Red", "Yellow", "Blue", "Mono", "Dark" };
+            body.Children.Add(LabeledCombo("View colour scheme (STING_VIEW_TAG_STYLE)",
+                schemes, tp.ColorScheme ?? "",
+                v => tp.ColorScheme = string.IsNullOrWhiteSpace(v) ? null : v.Trim(),
+                tooltip: "Variable-driven colour map written to STING_VIEW_TAG_STYLE on the view."));
+
+            body.Children.Add(LabeledTextBox("Segment mask (8 chars 0/1)",
+                tp.SegmentMask, v => tp.SegmentMask = string.IsNullOrWhiteSpace(v) ? null : v.Trim(),
+                tooltip: "DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ. Example '10000001' = DISC + SEQ only."));
+
+            body.Children.Add(LabeledNullableNumber("Display mode (1-5)",
+                tp.DisplayMode, v => tp.DisplayMode = v,
+                tooltip: "1=SEQ, 2=PROD-SEQ, 3=DISC-SYS-SEQ, 4=DISC-PROD-SEQ, 5=Full 8-segment."));
+
+            body.Children.Add(BuildSectionVisibilityGrid(tp));
+            body.Children.Add(BuildCategoryDepthsGrid(tp));
+
+            // Summary / collapse line
+            var summary = new TextBlock {
+                Text = SummariseTokenProfile(tp),
+                FontSize = 11, TextWrapping = TextWrapping.Wrap,
+                Foreground = new SolidColorBrush(SubtleColor),
+                Margin = new Thickness(0, 6, 0, 0),
+            };
+            body.Children.Add(summary);
+
+            return Card("Token Depth & Style (Phase 135)", body);
+        }
+
+        private UIElement BuildSectionVisibilityGrid(AnnotationTokenProfile tp)
+        {
+            tp.SectionVisibility = tp.SectionVisibility ?? new Dictionary<string, bool>();
+            var host = new StackPanel { Margin = new Thickness(0, 6, 0, 0) };
+            host.Children.Add(new TextBlock {
+                Text = "TAG7 section visibility — A: Identity · B: System · C: Spatial · D: Lifecycle · E: Technical · F: Classification",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 4) });
+
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            string[] keys = { "A", "B", "C", "D", "E", "F" };
+            foreach (var k in keys)
+            {
+                bool cur = tp.SectionVisibility.TryGetValue(k, out var b) && b;
+                var cb = new CheckBox {
+                    Content = k, IsChecked = cur, Margin = new Thickness(0, 0, 12, 0),
+                    Foreground = new SolidColorBrush(FgColor),
+                };
+                cb.Checked   += (s, e) => tp.SectionVisibility[k] = true;
+                cb.Unchecked += (s, e) => tp.SectionVisibility[k] = false;
+                row.Children.Add(cb);
+            }
+            host.Children.Add(row);
+            return host;
+        }
+
+        private static readonly GridLength[] _catDepthCols =
+        {
+            new GridLength(220),
+            new GridLength(60),
+            new GridLength(24),
+        };
+
+        private UIElement BuildCategoryDepthsGrid(AnnotationTokenProfile tp)
+        {
+            tp.CategoryDepths = tp.CategoryDepths ?? new Dictionary<string, int>();
+            var host = new StackPanel { Margin = new Thickness(0, 6, 0, 0) };
+            host.Children.Add(new TextBlock {
+                Text = "Per-category paragraph depth (overrides global ParaDepth above for that category only).",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 11, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 4) });
+
+            // Header
+            var header = new Grid { Margin = new Thickness(0, 4, 0, 2) };
+            for (int i = 0; i < _catDepthCols.Length; i++)
+                header.ColumnDefinitions.Add(new ColumnDefinition { Width = _catDepthCols[i] });
+            string[] hd = { "Category", "Depth", "" };
+            for (int i = 0; i < hd.Length; i++)
+            {
+                var t = new TextBlock { Text = hd[i], FontSize = 10,
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0) };
+                Grid.SetColumn(t, i); header.Children.Add(t);
+            }
+            host.Children.Add(header);
+
+            var cats = Merge(ProjectAssetPicker.TaggableCategoryNames(_doc),
+                             KnownTaggableCategories).ToArray();
+
+            foreach (var kv in tp.CategoryDepths.ToList())
+            {
+                var g = new Grid { Margin = new Thickness(0, 1, 0, 1) };
+                for (int i = 0; i < _catDepthCols.Length; i++)
+                    g.ColumnDefinitions.Add(new ColumnDefinition { Width = _catDepthCols[i] });
+
+                string catKey = kv.Key;
+                var keyBox = SmallCombo(catKey, newKey =>
+                {
+                    newKey = (newKey ?? "").Trim();
+                    if (string.IsNullOrEmpty(newKey) || newKey == catKey) return;
+                    if (!tp.CategoryDepths.ContainsKey(catKey)) return;
+                    var existing = tp.CategoryDepths[catKey];
+                    tp.CategoryDepths.Remove(catKey);
+                    tp.CategoryDepths[newKey] = existing;
+                }, cats);
+
+                int curDepth = kv.Value;
+                var depth = SmallCombo(curDepth.ToString(), v =>
+                {
+                    if (int.TryParse(v, out var n) && tp.CategoryDepths.ContainsKey(catKey))
+                        tp.CategoryDepths[catKey] = n;
+                }, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+                depth.IsEditable = false;
+
+                var rm = MakeSmallBtn("×", () => { tp.CategoryDepths.Remove(catKey); RenderForm(); });
+                rm.Width = 22;
+
+                var ctrls = new UIElement[] { keyBox, depth, rm };
+                for (int i = 0; i < ctrls.Length; i++)
+                {
+                    Grid.SetColumn(ctrls[i], i);
+                    if (ctrls[i] is FrameworkElement fe)
+                        fe.Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0);
+                    g.Children.Add(ctrls[i]);
+                }
+                host.Children.Add(g);
+            }
+
+            host.Children.Add(MakeSmallBtn("＋ Add category depth", () =>
+            {
+                var key = "NewCategory" + tp.CategoryDepths.Count;
+                tp.CategoryDepths[key] = 5;
+                RenderForm();
+            }));
+            return host;
+        }
+
+        private static string SummariseTokenProfile(AnnotationTokenProfile tp)
+        {
+            var bits = new List<string>();
+            if (!string.IsNullOrWhiteSpace(tp.PresentationMode)) bits.Add($"mode:{tp.PresentationMode}");
+            if (tp.ParaDepth.HasValue) bits.Add($"depth:{tp.ParaDepth.Value}");
+            if (!string.IsNullOrWhiteSpace(tp.TagSize) || !string.IsNullOrWhiteSpace(tp.TagStyle) || !string.IsNullOrWhiteSpace(tp.TagColor))
+                bits.Add($"tag:{tp.TagSize ?? "·"}{tp.TagStyle ?? "·"}_{tp.TagColor ?? "·"}");
+            if (!string.IsNullOrWhiteSpace(tp.ColorScheme)) bits.Add($"scheme:{tp.ColorScheme}");
+            if (!string.IsNullOrWhiteSpace(tp.SegmentMask)) bits.Add($"mask:{tp.SegmentMask}");
+            if (tp.DisplayMode.HasValue) bits.Add($"disp:{tp.DisplayMode.Value}");
+            if (tp.SectionVisibility != null && tp.SectionVisibility.Count > 0)
+                bits.Add("sect:" + string.Join("",
+                    tp.SectionVisibility.OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase)
+                        .Select(k => k.Value ? k.Key : k.Key.ToLower())));
+            if (tp.CategoryDepths != null && tp.CategoryDepths.Count > 0)
+                bits.Add($"cats:{tp.CategoryDepths.Count}");
+            return bits.Count == 0
+                ? "Inherits all values from ViewStylePack pack-level defaults."
+                : "Active: " + string.Join(" · ", bits);
         }
 
         // Compact grid editor for AnnotationRulePack.Rules (Change 6c).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3125,3 +3125,50 @@ button continues to invoke the Centre as a modeless window.
      parameter rows that are intentionally unbound. A future
      `BINDING_COVERAGE_REPORT` job could flag the small subset of
      instance parameters that still lack a category binding.
+
+---
+
+#### Completed (Phase 135 — DrawingType Token Profile: per-profile tag depth, style & colour control)
+
+1. **`AnnotationTokenProfile` POCO** added to `Core/Drawing/DrawingType.cs` with 9 optional
+   fields: `presentationMode`, `paraDepth`, `categoryDepths`, `sectionVisibility`,
+   `tagSize`, `tagStyle`, `tagColor`, `colorScheme`, `segmentMask`, `displayMode`.
+   Null on every field means "inherit / don't override". Wired into
+   `DrawingTypeRegistry.ResolveExtends` so the merged snapshot carries the profile.
+
+2. **`TokenProfileApplier`** added at `Core/Drawing/TokenProfileApplier.cs` (~430 lines).
+   Steps A–G translate the merged profile + `ViewStylePack` defaults into Revit writes:
+   STING_VIEW_TAG_STYLE param, paragraph depth, TAG7 section visibility, tag style preset
+   matrix, segment mask, display mode, presentation-mode preset. All writes are
+   idempotent and inside the caller's transaction.
+
+3. **Pipeline addition (Step 7.5)** wired into `DrawingTypePresentation.Apply()` between
+   `ViewStylePack` apply (step 7) and `AnnotationRunner` (step 8). No-op when neither the
+   profile nor the pack supplies any tag-appearance value.
+
+4. **`ViewStylePack` extended** with three pack-level defaults:
+   `TagColorScheme`, `DefaultTagStyle`, `CategoryTagStyles` (in
+   `Core/Drawing/ViewStylePack.cs`). DrawingType profile fields override pack fields.
+   `ViewStylePackRegistry.ResolveExtends` folds them through the inheritance chain.
+
+5. **3 new drawing types** in `Data/STING_DRAWING_TYPES.json`:
+   `mep-plan-presentation` (depth 2, scheme Discipline, BLUE NOM, mask 10010101),
+   `mep-plan-technical` (depth 5 + per-cat overrides, scheme System, BOLD BLACK, full mask),
+   `mep-plan-fabrication` (depth 10, scheme System, BOLD RED, mask 10001011).
+   Each picks up routing rules (M discipline, PRESENTATION/TECHNICAL/FABRICATION phases).
+
+6. **4 packs updated** in `Data/STING_VIEW_STYLE_PACKS.json`:
+   `corp-coordination` / `corp-fabrication-shop` / `corp-presentation-rich` /
+   `corp-presentation-mono` now seed `tagColorScheme` + `defaultTagStyle` +
+   `categoryTagStyles` so projects bound to those packs without an explicit profile still
+   get coherent tag colours.
+
+7. **Drawing Type editor** — added "Token Depth & Style" card to Tab 1 (presentation mode,
+   global + per-category depth, TAG7 A–F section checkboxes, size/style/colour combos,
+   colour-scheme combo, segment mask, display mode, summary collapse line). Tab 2 grew a
+   "Tag appearance" card (default scheme / default style / per-category style grid).
+
+8. **Drift detection** — `TOKEN_PROFILE_DRIFT` kind added to
+   `Core/Drawing/DrawingDriftDetector.cs`. Compares STING_VIEW_TAG_STYLE +
+   TAG_SEG_MASK_TXT on stamped views against the resolved profile/pack pair; SyncStyles
+   re-runs `DrawingTypePresentation.Apply` to heal the drift.


### PR DESCRIPTION
## Summary

Introduces a new `AnnotationTokenProfile` system that allows DrawingType definitions to control tag appearance (paragraph depth, style, colour, visibility) independently of the annotation rule pack. This enables different drawing types to present the same tagged elements with different visual emphasis and detail levels.

## Key Changes

- **New `AnnotationTokenProfile` POCO** (`DrawingType.cs`): 9 optional fields controlling presentation mode, paragraph depth (global + per-category), TAG7 section visibility (A–F), tag size/style/colour preset, view colour scheme, segment mask, and display mode. All fields are nullable; null means "inherit from pack defaults or leave alone."

- **New `TokenProfileApplier` class** (`TokenProfileApplier.cs`, ~430 lines): Standalone applier that translates merged profile + `ViewStylePack` defaults into Revit parameter writes across 7 steps:
  - View-level colour scheme (STING_VIEW_TAG_STYLE)
  - Paragraph depth tiers (PARA_STATE_1..10) with per-category overrides
  - TAG7 section visibility (TAG_7_SECTION_VISIBLE_A..F_BOOL)
  - Tag style preset matrix (TAG_{size}{style}_{color}_BOOL)
  - Segment mask (TAG_SEG_MASK_TXT)
  - Display mode (STING_DISPLAY_MODE)
  - Presentation-mode preset (global tier set)

- **Pipeline integration** (`DrawingTypePresentation.cs`): Added Step 7.5 between ViewStylePack apply (step 7) and AnnotationRunner (step 8), ensuring auto-tags inherit the active style preset and depth tier.

- **`ViewStylePack` extended** (`ViewStylePack.cs`): Three new pack-level defaults:
  - `TagColorScheme`: Variable-driven colour scheme name
  - `DefaultTagStyle`: Canonical "{size}{style}_{color}" preset
  - `CategoryTagStyles`: Per-category style overrides
  
  DrawingType profile fields always win over pack fields.

- **Registry inheritance** (`DrawingTypeRegistry.cs`, `ViewStylePackRegistry.cs`): Both registries now fold `TokenProfile` and tag-appearance fields through their `ResolveExtends` chains.

- **Drift detection** (`DrawingDriftDetector.cs`): Added TOKEN_PROFILE_DRIFT kind to detect mismatches in STING_VIEW_TAG_STYLE and TAG_SEG_MASK_TXT; SyncStyles re-applies the profile to heal drift.

- **UI support** (`DrawingTypeEditorDialog.cs`): New "Token Depth & Style" card in DrawingType editor with controls for presentation mode, paragraph depth, tag size/style/colour, colour scheme, segment mask, display mode, TAG7 section visibility, and per-category depth overrides. Pack-level "Tag appearance" card added for defaults.

- **3 new example drawing types** (`STING_DRAWING_TYPES.json`): MEP Plan variants (Presentation, Technical, Fabrication) demonstrating the profile in use with different depth tiers, section visibility, and colour schemes.

- **Pack defaults populated** (`STING_VIEW_STYLE_PACKS.json`): Existing packs (corp-coordination, corp-fabrication-shop) now carry tag appearance defaults.

## Implementation Details

- All parameter writes are idempotent and occur within the caller's transaction.
- Inheritance model: profile > pack > no-op default (leave parameter alone).
- Presentation-mode preset and explicit paragraph depth are mutually exclusive (preset already sets PARA_STATE_*).
- Per-category depth overrides apply to element types, deduped across instances in the view.
- Style preset matrix uses canonical "{size}{style}_{color}" naming (e.g., "2.5BOLD_RED") with fallback parsing from pack defaults.
- Segment mask validated as 8 characters of 0/1; invalid masks logged as warnings.
- No-op when neither profile nor pack supplies any tag-appearance value.

https://claude.ai/code/session_015MkdJPzJvwoSeaypVcYekf