### PR TITLE
Phase 136: Full Revit VG editor & pack-level view template fallbacks

### DIFF
--- a/StingTools/Core/Drawing/DrawingTypePresentation.cs
+++ b/StingTools/Core/Drawing/DrawingTypePresentation.cs
@@ -63,13 +63,27 @@ namespace StingTools.Core.Drawing
                 catch (Exception ex) { r.Warnings.Add($"Scale 1:{dt.Scale}: {ex.Message}"); }
             }
 
-            // Detail level -----------------------------------------------
-            if (!string.IsNullOrWhiteSpace(dt.DetailLevel))
+            // Phase 136 — resolve the pack EARLY so its DetailLevel /
+            // ViewTemplate can be used as a fallback when the DrawingType
+            // does not set its own. Pack VG/filter application still
+            // happens later (after crop) so there's no behaviour regression.
+            ViewStylePack earlyPack = null;
+            if (!string.IsNullOrWhiteSpace(dt.ViewStylePackId))
+            {
+                try { earlyPack = ViewStylePackRegistry.Get(doc, dt.ViewStylePackId); }
+                catch (Exception ex) { r.Warnings.Add($"Pack lookup '{dt.ViewStylePackId}': {ex.Message}"); }
+            }
+
+            // Detail level — DrawingType wins, pack falls through ---------
+            var effectiveDetail = !string.IsNullOrWhiteSpace(dt.DetailLevel)
+                ? dt.DetailLevel
+                : earlyPack?.DetailLevel;
+            if (!string.IsNullOrWhiteSpace(effectiveDetail))
             {
                 try
                 {
                     ViewDetailLevel parsed;
-                    switch (dt.DetailLevel.Trim().ToLowerInvariant())
+                    switch (effectiveDetail.Trim().ToLowerInvariant())
                     {
                         case "coarse": parsed = ViewDetailLevel.Coarse; break;
                         case "fine":   parsed = ViewDetailLevel.Fine;   break;
@@ -78,11 +92,14 @@ namespace StingTools.Core.Drawing
                     view.DetailLevel = parsed;
                     r.DetailLevelApplied = true;
                 }
-                catch (Exception ex) { r.Warnings.Add($"DetailLevel {dt.DetailLevel}: {ex.Message}"); }
+                catch (Exception ex) { r.Warnings.Add($"DetailLevel {effectiveDetail}: {ex.Message}"); }
             }
 
-            // View template ----------------------------------------------
-            if (!string.IsNullOrWhiteSpace(dt.ViewTemplateName))
+            // View template — DrawingType wins, pack falls through --------
+            var effectiveTemplate = !string.IsNullOrWhiteSpace(dt.ViewTemplateName)
+                ? dt.ViewTemplateName
+                : earlyPack?.ViewTemplate;
+            if (!string.IsNullOrWhiteSpace(effectiveTemplate))
             {
                 try
                 {
@@ -90,7 +107,7 @@ namespace StingTools.Core.Drawing
                         .OfClass(typeof(View))
                         .Cast<View>()
                         .FirstOrDefault(v => v.IsTemplate
-                            && string.Equals(v.Name, dt.ViewTemplateName, StringComparison.OrdinalIgnoreCase));
+                            && string.Equals(v.Name, effectiveTemplate, StringComparison.OrdinalIgnoreCase));
                     if (tpl != null)
                     {
                         view.ViewTemplateId = tpl.Id;
@@ -98,7 +115,7 @@ namespace StingTools.Core.Drawing
                     }
                     else
                     {
-                        r.Warnings.Add($"View template '{dt.ViewTemplateName}' not found in project.");
+                        r.Warnings.Add($"View template '{effectiveTemplate}' not found in project.");
                     }
                 }
                 catch (Exception ex) { r.Warnings.Add($"ViewTemplate: {ex.Message}"); }
@@ -117,21 +134,23 @@ namespace StingTools.Core.Drawing
             }
 
             // View Style Pack (shared graphic overrides) ---------------
-            ViewStylePack resolvedPack = null;
-            if (!string.IsNullOrWhiteSpace(dt.ViewStylePackId))
+            // Reuse the early-resolved pack (already used for the
+            // DetailLevel / ViewTemplate fallback above) so we only walk
+            // the registry + extends-chain once per Apply call.
+            ViewStylePack resolvedPack = earlyPack;
+            if (resolvedPack != null)
             {
                 try
                 {
-                    resolvedPack = ViewStylePackRegistry.Get(doc, dt.ViewStylePackId);
-                    if (resolvedPack != null)
-                    {
-                        var packStats = ViewStylePackApplier.Apply(doc, view, resolvedPack);
-                        r.PackApplied = true;
-                        r.Warnings.AddRange(packStats.Warnings);
-                    }
-                    else r.Warnings.Add($"ViewStylePack '{dt.ViewStylePackId}' not found.");
+                    var packStats = ViewStylePackApplier.Apply(doc, view, resolvedPack);
+                    r.PackApplied = true;
+                    r.Warnings.AddRange(packStats.Warnings);
                 }
                 catch (Exception ex) { r.Warnings.Add($"ViewStylePack: {ex.Message}"); }
+            }
+            else if (!string.IsNullOrWhiteSpace(dt.ViewStylePackId))
+            {
+                r.Warnings.Add($"ViewStylePack '{dt.ViewStylePackId}' not found.");
             }
 
             // Token Profile (Phase 135) — Step 7.5 -----------------------

--- a/StingTools/Core/Drawing/ViewStylePack.cs
+++ b/StingTools/Core/Drawing/ViewStylePack.cs
@@ -102,12 +102,74 @@ namespace StingTools.Core.Drawing
 
     public sealed class StyleVgOverride
     {
-        [JsonProperty("halftone",              NullValueHandling = NullValueHandling.Ignore)] public bool?   Halftone { get; set; }
-        [JsonProperty("projectionLineWeight",  NullValueHandling = NullValueHandling.Ignore)] public int?    ProjectionLineWeight { get; set; }
-        [JsonProperty("projectionLineColor",   NullValueHandling = NullValueHandling.Ignore)] public string  ProjectionLineColor { get; set; }
-        [JsonProperty("cutLineWeight",         NullValueHandling = NullValueHandling.Ignore)] public int?    CutLineWeight { get; set; }
-        [JsonProperty("cutLineColor",          NullValueHandling = NullValueHandling.Ignore)] public string  CutLineColor { get; set; }
-        [JsonProperty("transparency",          NullValueHandling = NullValueHandling.Ignore)] public int?    Transparency { get; set; }
+        // ── Visibility ─────────────────────────────────────────────────────────
+        [JsonProperty("visible", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Visible { get; set; }                  // null = inherited / not set
+
+        [JsonProperty("halftone", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Halftone { get; set; }
+
+        [JsonProperty("detailLevel", NullValueHandling = NullValueHandling.Ignore)]
+        public string DetailLevel { get; set; }             // "ByView"|"Coarse"|"Medium"|"Fine"
+
+        // ── Projection / Surface ────────────────────────────────────────────────
+        [JsonProperty("projectionLineColor",   NullValueHandling = NullValueHandling.Ignore)]
+        public string ProjectionLineColor { get; set; }     // "#RRGGBB"
+
+        [JsonProperty("projectionLineWeight",  NullValueHandling = NullValueHandling.Ignore)]
+        public int? ProjectionLineWeight { get; set; }      // 1–16
+
+        [JsonProperty("projectionLinePattern", NullValueHandling = NullValueHandling.Ignore)]
+        public string ProjectionLinePattern { get; set; }   // LinePatternElement.Name or "Solid"
+
+        [JsonProperty("surfaceFgPatternName",  NullValueHandling = NullValueHandling.Ignore)]
+        public string SurfaceFgPatternName { get; set; }    // FillPatternElement.Name
+
+        [JsonProperty("surfaceFgPatternColor", NullValueHandling = NullValueHandling.Ignore)]
+        public string SurfaceFgPatternColor { get; set; }
+
+        [JsonProperty("surfaceFgPatternVisible", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? SurfaceFgPatternVisible { get; set; }
+
+        [JsonProperty("surfaceBgPatternName",  NullValueHandling = NullValueHandling.Ignore)]
+        public string SurfaceBgPatternName { get; set; }
+
+        [JsonProperty("surfaceBgPatternColor", NullValueHandling = NullValueHandling.Ignore)]
+        public string SurfaceBgPatternColor { get; set; }
+
+        [JsonProperty("surfaceBgPatternVisible", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? SurfaceBgPatternVisible { get; set; }
+
+        [JsonProperty("transparency", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Transparency { get; set; }              // 0–100
+
+        // ── Cut ────────────────────────────────────────────────────────────────
+        [JsonProperty("cutLineColor",   NullValueHandling = NullValueHandling.Ignore)]
+        public string CutLineColor { get; set; }
+
+        [JsonProperty("cutLineWeight",  NullValueHandling = NullValueHandling.Ignore)]
+        public int? CutLineWeight { get; set; }
+
+        [JsonProperty("cutLinePattern", NullValueHandling = NullValueHandling.Ignore)]
+        public string CutLinePattern { get; set; }
+
+        [JsonProperty("cutFgPatternName",  NullValueHandling = NullValueHandling.Ignore)]
+        public string CutFgPatternName { get; set; }
+
+        [JsonProperty("cutFgPatternColor", NullValueHandling = NullValueHandling.Ignore)]
+        public string CutFgPatternColor { get; set; }
+
+        [JsonProperty("cutFgPatternVisible", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? CutFgPatternVisible { get; set; }
+
+        [JsonProperty("cutBgPatternName",  NullValueHandling = NullValueHandling.Ignore)]
+        public string CutBgPatternName { get; set; }
+
+        [JsonProperty("cutBgPatternColor", NullValueHandling = NullValueHandling.Ignore)]
+        public string CutBgPatternColor { get; set; }
+
+        [JsonProperty("cutBgPatternVisible", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? CutBgPatternVisible { get; set; }
     }
 
     public sealed class ViewStylePackLibrary

--- a/StingTools/Core/Drawing/ViewStylePack.cs
+++ b/StingTools/Core/Drawing/ViewStylePack.cs
@@ -34,6 +34,26 @@ namespace StingTools.Core.Drawing
         [JsonProperty("dimensionStyle")]  public string DimensionStyle { get; set; }
         [JsonProperty("hatchPalette")]    public string HatchPalette { get; set; }
 
+        // Phase 136 — pack-level fallbacks. The runtime (DrawingTypePresentation)
+        // uses these only when the DrawingType's own field is null/empty;
+        // DrawingType always wins when both are set.
+        [JsonProperty("viewTemplate", NullValueHandling = NullValueHandling.Ignore)]
+        public string ViewTemplate { get; set; }
+        [JsonProperty("detailLevel",  NullValueHandling = NullValueHandling.Ignore)]
+        public string DetailLevel { get; set; }
+        [JsonProperty("scaleHint",    NullValueHandling = NullValueHandling.Ignore)]
+        public string ScaleHint { get; set; }
+        [JsonProperty("colorScheme",  NullValueHandling = NullValueHandling.Ignore)]
+        public string ColorScheme { get; set; }
+
+        // Convenience for the editor — JSON keys the dialog wrote come from
+        // the local "appearance" object. These match the shape used in the
+        // disk JSON (STING_VIEW_STYLE_PACKS.json) so the runtime sees the
+        // same TextStyle / DimensionStyle / LineWeightScale values the
+        // editor emitted.
+        [JsonProperty("appearance", NullValueHandling = NullValueHandling.Ignore)]
+        public PackAppearanceDto Appearance { get; set; }
+
         [JsonProperty("filters")] public List<StyleFilterRule> Filters { get; set; } = new List<StyleFilterRule>();
 
         /// <summary>
@@ -172,9 +192,38 @@ namespace StingTools.Core.Drawing
         public bool? CutBgPatternVisible { get; set; }
     }
 
+    /// <summary>
+    /// Mirrors the dialog's "appearance" object inside each pack so the
+    /// runtime can deserialize the same JSON the editor writes. Promoted
+    /// fields are normalised onto ViewStylePack at load time by
+    /// <see cref="ViewStylePackRegistry"/> (see Promote).
+    /// </summary>
+    public sealed class PackAppearanceDto
+    {
+        [JsonProperty("lineWeightScale", NullValueHandling = NullValueHandling.Ignore)] public double? LineWeightScale { get; set; }
+        [JsonProperty("textStyleName",   NullValueHandling = NullValueHandling.Ignore)] public string TextStyleName { get; set; }
+        [JsonProperty("dimensionStyleName", NullValueHandling = NullValueHandling.Ignore)] public string DimensionStyleName { get; set; }
+        [JsonProperty("hatchPalette",    NullValueHandling = NullValueHandling.Ignore)] public string HatchPalette { get; set; }
+    }
+
     public sealed class ViewStylePackLibrary
     {
         [JsonProperty("version")] public int Version { get; set; } = 1;
-        [JsonProperty("viewStylePacks")] public List<ViewStylePack> Packs { get; set; } = new List<ViewStylePack>();
+
+        // Primary list — newer JSON files use "viewStylePacks".
+        [JsonProperty("viewStylePacks", NullValueHandling = NullValueHandling.Ignore)]
+        public List<ViewStylePack> Packs { get; set; } = new List<ViewStylePack>();
+
+        // Phase 136 — alias so the existing on-disk
+        // STING_VIEW_STYLE_PACKS.json (which uses "stylePacks") also
+        // deserializes correctly. Newtonsoft.Json calls the setter when
+        // it sees the legacy key; we forward to Packs so the runtime
+        // sees the same list either way.
+        [JsonProperty("stylePacks", NullValueHandling = NullValueHandling.Ignore)]
+        public List<ViewStylePack> StylePacksLegacy
+        {
+            get => null;     // never re-serialised — the canonical key wins on save
+            set { if (value != null && value.Count > 0) Packs = value; }
+        }
     }
 }

--- a/StingTools/Core/Drawing/ViewStylePackApplier.cs
+++ b/StingTools/Core/Drawing/ViewStylePackApplier.cs
@@ -68,12 +68,92 @@ namespace StingTools.Core.Drawing
                     var ogs = view.GetCategoryOverrides(catId) ?? new OverrideGraphicSettings();
                     var src = kv.Value;
 
-                    if (src.Halftone.HasValue)             ogs.SetHalftone(src.Halftone.Value);
-                    if (src.ProjectionLineWeight.HasValue) ogs.SetProjectionLineWeight(src.ProjectionLineWeight.Value);
-                    if (!string.IsNullOrEmpty(src.ProjectionLineColor)) ogs.SetProjectionLineColor(HexColor(src.ProjectionLineColor));
-                    if (src.CutLineWeight.HasValue)        ogs.SetCutLineWeight(src.CutLineWeight.Value);
-                    if (!string.IsNullOrEmpty(src.CutLineColor))        ogs.SetCutLineColor(HexColor(src.CutLineColor));
-                    if (src.Transparency.HasValue)         ogs.SetSurfaceTransparency(Clamp(src.Transparency.Value, 0, 100));
+                    // Visibility
+                    if (src.Visible.HasValue)
+                    {
+                        try { view.SetCategoryHidden(catId, !src.Visible.Value); }
+                        catch (Exception ex) { r.Warnings.Add($"Visibility '{kv.Key}': {ex.Message}"); }
+                    }
+
+                    // Projection line
+                    if (!string.IsNullOrEmpty(src.ProjectionLineColor))
+                        ogs.SetProjectionLineColor(HexColor(src.ProjectionLineColor));
+                    if (src.ProjectionLineWeight.HasValue)
+                        ogs.SetProjectionLineWeight(src.ProjectionLineWeight.Value);
+                    if (!string.IsNullOrEmpty(src.ProjectionLinePattern))
+                    {
+                        var lpId = ResolveLinePatternId(doc, src.ProjectionLinePattern);
+                        if (lpId != ElementId.InvalidElementId) ogs.SetProjectionLinePatternId(lpId);
+                    }
+
+                    // Surface foreground pattern
+                    if (!string.IsNullOrEmpty(src.SurfaceFgPatternName))
+                    {
+                        var fpId = ResolveFillPatternId(doc, src.SurfaceFgPatternName);
+                        if (fpId != ElementId.InvalidElementId) ogs.SetSurfaceForegroundPatternId(fpId);
+                    }
+                    if (!string.IsNullOrEmpty(src.SurfaceFgPatternColor))
+                        ogs.SetSurfaceForegroundPatternColor(HexColor(src.SurfaceFgPatternColor));
+                    if (src.SurfaceFgPatternVisible.HasValue)
+                        ogs.SetSurfaceForegroundPatternVisible(src.SurfaceFgPatternVisible.Value);
+
+                    // Surface background pattern
+                    if (!string.IsNullOrEmpty(src.SurfaceBgPatternName))
+                    {
+                        var fpId = ResolveFillPatternId(doc, src.SurfaceBgPatternName);
+                        if (fpId != ElementId.InvalidElementId) ogs.SetSurfaceBackgroundPatternId(fpId);
+                    }
+                    if (!string.IsNullOrEmpty(src.SurfaceBgPatternColor))
+                        ogs.SetSurfaceBackgroundPatternColor(HexColor(src.SurfaceBgPatternColor));
+                    if (src.SurfaceBgPatternVisible.HasValue)
+                        ogs.SetSurfaceBackgroundPatternVisible(src.SurfaceBgPatternVisible.Value);
+
+                    // Transparency
+                    if (src.Transparency.HasValue)
+                        ogs.SetSurfaceTransparency(Clamp(src.Transparency.Value, 0, 100));
+
+                    // Halftone
+                    if (src.Halftone.HasValue) ogs.SetHalftone(src.Halftone.Value);
+
+                    // Cut line
+                    if (!string.IsNullOrEmpty(src.CutLineColor))
+                        ogs.SetCutLineColor(HexColor(src.CutLineColor));
+                    if (src.CutLineWeight.HasValue)
+                        ogs.SetCutLineWeight(src.CutLineWeight.Value);
+                    if (!string.IsNullOrEmpty(src.CutLinePattern))
+                    {
+                        var lpId = ResolveLinePatternId(doc, src.CutLinePattern);
+                        if (lpId != ElementId.InvalidElementId) ogs.SetCutLinePatternId(lpId);
+                    }
+
+                    // Cut foreground pattern
+                    if (!string.IsNullOrEmpty(src.CutFgPatternName))
+                    {
+                        var fpId = ResolveFillPatternId(doc, src.CutFgPatternName);
+                        if (fpId != ElementId.InvalidElementId) ogs.SetCutForegroundPatternId(fpId);
+                    }
+                    if (!string.IsNullOrEmpty(src.CutFgPatternColor))
+                        ogs.SetCutForegroundPatternColor(HexColor(src.CutFgPatternColor));
+                    if (src.CutFgPatternVisible.HasValue)
+                        ogs.SetCutForegroundPatternVisible(src.CutFgPatternVisible.Value);
+
+                    // Cut background pattern
+                    if (!string.IsNullOrEmpty(src.CutBgPatternName))
+                    {
+                        var fpId = ResolveFillPatternId(doc, src.CutBgPatternName);
+                        if (fpId != ElementId.InvalidElementId) ogs.SetCutBackgroundPatternId(fpId);
+                    }
+                    if (!string.IsNullOrEmpty(src.CutBgPatternColor))
+                        ogs.SetCutBackgroundPatternColor(HexColor(src.CutBgPatternColor));
+                    if (src.CutBgPatternVisible.HasValue)
+                        ogs.SetCutBackgroundPatternVisible(src.CutBgPatternVisible.Value);
+
+                    // Per-category detail level
+                    if (!string.IsNullOrEmpty(src.DetailLevel))
+                    {
+                        if (Enum.TryParse<ViewDetailLevel>(src.DetailLevel, true, out var dl))
+                            ogs.SetDetailLevel(dl);
+                    }
 
                     view.SetCategoryOverrides(catId, ogs);
                     r.OverridesSet++;
@@ -139,6 +219,28 @@ namespace StingTools.Core.Drawing
             }
             catch { }
             return ElementId.InvalidElementId;
+        }
+
+        private static ElementId ResolveLinePatternId(Document doc, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return ElementId.InvalidElementId;
+            if (name.Equals("Solid", StringComparison.OrdinalIgnoreCase))
+                return LinePatternElement.GetSolidPatternId();
+            return new FilteredElementCollector(doc)
+                .OfClass(typeof(LinePatternElement))
+                .Cast<LinePatternElement>()
+                .FirstOrDefault(lp => string.Equals(lp.Name, name, StringComparison.OrdinalIgnoreCase))
+                ?.Id ?? ElementId.InvalidElementId;
+        }
+
+        private static ElementId ResolveFillPatternId(Document doc, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return ElementId.InvalidElementId;
+            return new FilteredElementCollector(doc)
+                .OfClass(typeof(FillPatternElement))
+                .Cast<FillPatternElement>()
+                .FirstOrDefault(fp => string.Equals(fp.Name, name, StringComparison.OrdinalIgnoreCase))
+                ?.Id ?? ElementId.InvalidElementId;
         }
 
         private static Autodesk.Revit.DB.Color HexColor(string hex)

--- a/StingTools/Core/Drawing/ViewStylePackRegistry.cs
+++ b/StingTools/Core/Drawing/ViewStylePackRegistry.cs
@@ -68,7 +68,10 @@ namespace StingTools.Core.Drawing
                     if (lib?.Packs != null && lib.Packs.Count > 0)
                     {
                         foreach (var p in lib.Packs)
+                        {
                             if (string.IsNullOrEmpty(p.Origin)) p.Origin = "corporate";
+                            PromoteAppearance(p);
+                        }
                         return lib;
                     }
                 }
@@ -92,7 +95,10 @@ namespace StingTools.Core.Drawing
                 var lib = JsonConvert.DeserializeObject<ViewStylePackLibrary>(File.ReadAllText(path));
                 if (lib?.Packs != null)
                     foreach (var p in lib.Packs)
+                    {
                         if (string.IsNullOrEmpty(p.Origin)) p.Origin = "project";
+                        PromoteAppearance(p);
+                    }
                 return lib;
             }
             catch (Exception ex)
@@ -154,6 +160,13 @@ namespace StingTools.Core.Drawing
                 if (!string.IsNullOrEmpty(p.TextStyle))      merged.TextStyle      = p.TextStyle;
                 if (!string.IsNullOrEmpty(p.DimensionStyle)) merged.DimensionStyle = p.DimensionStyle;
                 if (!string.IsNullOrEmpty(p.HatchPalette))   merged.HatchPalette   = p.HatchPalette;
+
+                // Phase 136 — pack-level fallbacks (used by DrawingTypePresentation
+                // when DrawingType doesn't set its own ViewTemplateName / DetailLevel).
+                if (!string.IsNullOrEmpty(p.ViewTemplate)) merged.ViewTemplate = p.ViewTemplate;
+                if (!string.IsNullOrEmpty(p.DetailLevel))  merged.DetailLevel  = p.DetailLevel;
+                if (!string.IsNullOrEmpty(p.ScaleHint))    merged.ScaleHint    = p.ScaleHint;
+                if (!string.IsNullOrEmpty(p.ColorScheme))  merged.ColorScheme  = p.ColorScheme;
                 if (p.Filters != null) foreach (var f in p.Filters) merged.Filters.Add(f);
                 if (p.VgOverrides != null)
                     foreach (var kv in p.VgOverrides) merged.VgOverrides[kv.Key] = kv.Value;
@@ -171,6 +184,22 @@ namespace StingTools.Core.Drawing
                 }
             }
             return merged;
+        }
+
+        /// <summary>
+        /// Phase 136 — fold the dialog-emitted "appearance" object into the
+        /// top-level pack fields (TextStyle / DimensionStyle / etc.) so the
+        /// runtime reads the same values regardless of which JSON shape
+        /// was used. Only fills empty top-level fields — never overwrites.
+        /// </summary>
+        private static void PromoteAppearance(ViewStylePack p)
+        {
+            if (p?.Appearance == null) return;
+            var a = p.Appearance;
+            if (a.LineWeightScale.HasValue && p.LineWeightScale == 1.0) p.LineWeightScale = a.LineWeightScale.Value;
+            if (string.IsNullOrEmpty(p.TextStyle)      && !string.IsNullOrEmpty(a.TextStyleName))      p.TextStyle = a.TextStyleName;
+            if (string.IsNullOrEmpty(p.DimensionStyle) && !string.IsNullOrEmpty(a.DimensionStyleName)) p.DimensionStyle = a.DimensionStyleName;
+            if (string.IsNullOrEmpty(p.HatchPalette)   && !string.IsNullOrEmpty(a.HatchPalette))       p.HatchPalette = a.HatchPalette;
         }
 
         private static string DocKey(Document doc)

--- a/StingTools/StingTools.csproj
+++ b/StingTools/StingTools.csproj
@@ -9,7 +9,9 @@
     <Version>2.2.0</Version>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
-    <UseWindowsForms>false</UseWindowsForms>
+    <!-- Phase 136 — DrawingTypeEditorDialog uses System.Windows.Forms.ColorDialog
+         from the new VG editor's Line and Pattern override sub-dialogs. -->
+    <UseWindowsForms>true</UseWindowsForms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/StingTools/UI/DrawingTypeEditorDialog.cs
+++ b/StingTools/UI/DrawingTypeEditorDialog.cs
@@ -1394,7 +1394,102 @@ namespace StingTools.UI
                 _current.Phase, v => _current.Phase = v,
                 tooltip: "RIBA Plan of Work 2020 stage 0–7. Use * for any stage."));
             body.Children.Add(LabeledTextBlock("Origin", _current.Origin ?? "project"));
+
+            // Phase 136 — surface View style pack as a top-level identity field
+            // (a Drawing Type's most important visual binding). A dedicated
+            // BuildViewStylePackPicker() returns label + dropdown + edit link
+            // as one row group so it's discoverable here AND callable from the
+            // Views card if needed.
+            body.Children.Add(BuildViewStylePackPicker());
             return Card("Identity", body);
+        }
+
+        // Dedicated, prominent View style pack chooser. Non-editable
+        // dropdown listing every loaded pack ("(none)" + every entry from
+        // STING_VIEW_STYLE_PACKS.json — corporate baseline + project
+        // override + new packs created in the same session). Includes a
+        // "→ Edit selected pack" link that jumps to the View Style Packs
+        // tab and highlights the active pack.
+        private UIElement BuildViewStylePackPicker()
+        {
+            var stack = new StackPanel { Margin = new Thickness(0, 2, 0, 2) };
+
+            // Row 1 — label + ComboBox (non-editable for unmistakable UX).
+            var row = new DockPanel { Margin = new Thickness(0, 3, 0, 0), LastChildFill = true };
+            var lbl = new TextBlock {
+                Text = "View style pack",
+                Width = 200,
+                Foreground = new SolidColorBrush(SubtleColor),
+                VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = "Picks a ViewStylePack from STING_VIEW_STYLE_PACKS.json. " +
+                          "The pack supplies VG overrides, filter rules, text/dim style and tag defaults.",
+            };
+            DockPanel.SetDock(lbl, Dock.Left);
+            row.Children.Add(lbl);
+
+            var combo = new ComboBox { Height = 22, IsEditable = false };
+            DarkDialogTheme.StyleInput(combo, CardBg, FgColor, CardBorder);
+            combo.Items.Add("(none)");
+            foreach (var p in _packs ?? new List<ViewStylePack>())
+                combo.Items.Add($"{p.Id}  —  {p.Name ?? p.Id}");
+
+            // Initial selection — match by id prefix; fall back to (none).
+            string initial = "(none)";
+            if (!string.IsNullOrEmpty(_current.ViewStylePackId))
+            {
+                foreach (var item in combo.Items)
+                {
+                    if (item is string s &&
+                        s.StartsWith(_current.ViewStylePackId + "  —  ", StringComparison.OrdinalIgnoreCase))
+                    { initial = s; break; }
+                }
+                if (initial == "(none)") initial = _current.ViewStylePackId;
+            }
+            combo.SelectedItem = initial;
+            combo.SelectionChanged += (s, e) =>
+            {
+                if (combo.SelectedItem is string ss)
+                {
+                    if (ss == "(none)") { _current.ViewStylePackId = null; return; }
+                    var idx = ss.IndexOf("  —  ", StringComparison.Ordinal);
+                    _current.ViewStylePackId = idx > 0 ? ss.Substring(0, idx).Trim() : ss.Trim();
+                }
+            };
+            row.Children.Add(combo);
+            stack.Children.Add(row);
+
+            // Row 2 — count strip + "Edit selected pack" hyperlink.
+            var hint = new DockPanel { Margin = new Thickness(204, 2, 4, 4), LastChildFill = true };
+            var count = new TextBlock {
+                Text = $"{(_packs?.Count ?? 0)} pack(s) loaded · select one to bind",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 10,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            DockPanel.SetDock(count, Dock.Left);
+            hint.Children.Add(count);
+
+            var link = new TextBlock {
+                Text = "→ Edit selected pack",
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                Cursor = Cursors.Hand,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            link.MouseLeftButtonUp += (s, e) =>
+            {
+                if (string.IsNullOrEmpty(_current.ViewStylePackId)) return;
+                var target = (_packs ?? new List<ViewStylePack>()).FirstOrDefault(p =>
+                    string.Equals(p.Id, _current.ViewStylePackId, StringComparison.OrdinalIgnoreCase));
+                if (target == null) return;
+                _rootTabs.SelectedIndex = 1;
+                SelectPack(target);
+            };
+            hint.Children.Add(link);
+            stack.Children.Add(hint);
+
+            return stack;
         }
 
         private UIElement BuildSheetCard()
@@ -1431,50 +1526,8 @@ namespace StingTools.UI
                 _current.ViewportTypeName, v => _current.ViewportTypeName = v,
                 ProjectAssetPicker.ViewportTypeNames(_doc),
                 "ElementType where Category = OST_Viewports in the active project."));
-
-            // Phase 136 — ViewStylePackId picker + edit link.
-            var packItems = new[] { "(none)" }
-                .Concat((_packs ?? new List<ViewStylePack>()).Select(p => $"{p.Id}  —  {p.Name ?? p.Id}"))
-                .ToArray();
-            var currentPackDisplay = string.IsNullOrEmpty(_current.ViewStylePackId)
-                ? "(none)"
-                : packItems.FirstOrDefault(s => s.StartsWith(_current.ViewStylePackId + " "))
-                  ?? _current.ViewStylePackId;
-            body.Children.Add(LabeledProjectAssetCombo(
-                "View style pack",
-                currentPackDisplay,
-                v =>
-                {
-                    if (string.IsNullOrEmpty(v) || v == "(none)") { _current.ViewStylePackId = null; return; }
-                    var id = v.Contains("  —  ")
-                        ? v.Split(new[] { "  —  " }, 2, StringSplitOptions.None)[0].Trim()
-                        : v.Trim();
-                    _current.ViewStylePackId = string.IsNullOrEmpty(id) ? null : id;
-                },
-                packItems,
-                "The ViewStylePack that supplies VG overrides, filter rules and tag style defaults. " +
-                "Packs are defined in the View Style Packs tab."));
-
-            var navLink = new TextBlock
-            {
-                Text = "→ Edit selected pack",
-                Foreground = new SolidColorBrush(AccentColor),
-                FontSize = 11,
-                Cursor = Cursors.Hand,
-                HorizontalAlignment = HorizontalAlignment.Right,
-                Margin = new Thickness(0, 2, 4, 6),
-            };
-            navLink.MouseLeftButtonUp += (s, e) =>
-            {
-                if (string.IsNullOrEmpty(_current.ViewStylePackId)) return;
-                var target = (_packs ?? new List<ViewStylePack>()).FirstOrDefault(p =>
-                    string.Equals(p.Id, _current.ViewStylePackId, StringComparison.OrdinalIgnoreCase));
-                if (target == null) return;
-                _rootTabs.SelectedIndex = 1;            // switch to View Style Packs tab
-                SelectPack(target);                     // highlight the matching pack in the list
-            };
-            body.Children.Add(navLink);
-
+            // View style pack picker lives in the Identity card now (Phase 136)
+            // — see BuildViewStylePackPicker() for the discoverable top-level UX.
             return Card("Views", body);
         }
 

--- a/StingTools/UI/DrawingTypeEditorDialog.cs
+++ b/StingTools/UI/DrawingTypeEditorDialog.cs
@@ -194,6 +194,13 @@ namespace StingTools.UI
             }
             catch { }
 
+            // Phase 136 — _packs initialised here (before BuildLayout) so the
+            // Drawing Types tab's ViewStylePackId combo is populated on first
+            // render. Was previously created inside BuildViewStylePacksTab,
+            // which fires AFTER BuildDrawingTypesTab.
+            _packs = LoadViewStylePacks();
+            BuildCategoryTrees();   // Phase 136 — VG editor trees + pattern lists
+
             Content = BuildLayout();
             if (_types.Count > 0) SelectType(_types[0]);
         }
@@ -297,7 +304,8 @@ namespace StingTools.UI
 
         private UIElement BuildViewStylePacksTab()
         {
-            _packs = LoadViewStylePacks();
+            // _packs is initialised in the constructor before BuildLayout()
+            // so the Drawing Types tab can also use it.
             var grid = new Grid();
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(280) });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -398,41 +406,13 @@ namespace StingTools.UI
                 _currentPack.ColorScheme, v => _currentPack.ColorScheme = v));
             _packFormHost.Children.Add(Card("Appearance", apBody));
 
-            // Filter rules
-            var frBody = new StackPanel();
+            // Phase 136 — full Revit-style VG editor (replaces the old
+            // row-grid for both Filter rules and VG overrides). Four-tab
+            // layout with category tree, Override... sub-dialogs, per-tab
+            // All/None/Invert/Expand actions.
             _currentPack.FilterRules = _currentPack.FilterRules ?? new List<PackFilterRule>();
-            frBody.Children.Add(new TextBlock {
-                Text = "Per-filter graphic overrides. Filters must already exist in the project (ParameterFilterElement). Colours in #RRGGBB.",
-                Foreground = new SolidColorBrush(SubtleColor), FontSize = 11, TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 0, 0, 4) });
-            frBody.Children.Add(MakeFilterRuleHeader());
-            foreach (var fr in _currentPack.FilterRules.ToList())
-                frBody.Children.Add(MakeFilterRuleRow(fr));
-            frBody.Children.Add(MakeSmallBtn("＋ Add filter rule", () =>
-            {
-                _currentPack.FilterRules.Add(new PackFilterRule { Name = "NewFilter", Visible = true,
-                    ProjColor = "#000000", ProjWeight = 1, CutColor = "#000000", CutWeight = 1 });
-                RenderPackForm();
-            }));
-            _packFormHost.Children.Add(Card("Filter rules", frBody));
-
-            // VG Overrides per category
-            var vgBody = new StackPanel();
             _currentPack.VgOverrides = _currentPack.VgOverrides ?? new Dictionary<string, PackCategoryOverride>();
-            vgBody.Children.Add(new TextBlock {
-                Text = "Per-category graphic overrides. Key = category name (Walls / Grids / Rooms), BuiltInCategory enum, or <Room Separation> for subcategories. Colours in #RRGGBB.",
-                Foreground = new SolidColorBrush(SubtleColor), FontSize = 11, TextWrapping = TextWrapping.Wrap,
-                Margin = new Thickness(0, 0, 0, 4) });
-            vgBody.Children.Add(MakeVgHeader());
-            foreach (var kv in _currentPack.VgOverrides.ToList())
-                vgBody.Children.Add(MakeVgRow(kv.Key, kv.Value));
-            vgBody.Children.Add(MakeSmallBtn("＋ Add VG override", () =>
-            {
-                var key = "NewCategory" + _currentPack.VgOverrides.Count;
-                _currentPack.VgOverrides[key] = new PackCategoryOverride { Visible = true, ProjWeight = 1 };
-                RenderPackForm();
-            }));
-            _packFormHost.Children.Add(Card("VG overrides (per category)", vgBody));
+            _packFormHost.Children.Add(BuildFullVgEditor());
 
             // Phase 135 — Tag Appearance card
             _packFormHost.Children.Add(BuildPackTagAppearanceCard());
@@ -569,109 +549,18 @@ namespace StingTools.UI
             return host;
         }
 
-        // ── Filter rule row ──
-        private UIElement MakeFilterRuleHeader()
-        {
-            var g = new Grid { Margin = new Thickness(0, 4, 0, 2) };
-            string[] headers = { "Filter name", "Visible", "Halftone", "Proj-Col", "Proj-Wt", "Cut-Col", "Cut-Wt", "Trans%" };
-            double[] widths  = { 160, 56, 56, 70, 50, 70, 50, 56 };
-            for (int i = 0; i < widths.Length; i++)
-                g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(widths[i]) });
-            for (int i = 0; i < headers.Length; i++)
-            {
-                var t = new TextBlock { Text = headers[i], FontSize = 10,
-                    Foreground = new SolidColorBrush(SubtleColor) };
-                Grid.SetColumn(t, i); g.Children.Add(t);
-            }
-            return g;
-        }
-
-        private UIElement MakeFilterRuleRow(PackFilterRule fr)
-        {
-            var g = new Grid { Margin = new Thickness(0, 1, 0, 1) };
-            double[] widths = { 160, 56, 56, 70, 50, 70, 50, 56 };
-            for (int i = 0; i < widths.Length; i++)
-                g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(widths[i]) });
-
-            var filterNames = Merge(ProjectAssetPicker.ParameterFilterNames(_doc),
-                                    CommonStingFilters).ToArray();
-            var name = SmallCombo(fr.Name, v => fr.Name = v, filterNames);
-            var vis  = MakeChk(fr.Visible,  v => fr.Visible = v);
-            var ht   = MakeChk(fr.Halftone, v => fr.Halftone = v);
-            var pc   = SmallTb(fr.ProjColor, v => fr.ProjColor = v);
-            var pw   = SmallTb(fr.ProjWeight.ToString(), v => fr.ProjWeight = TryInt(v));
-            var cc   = SmallTb(fr.CutColor, v => fr.CutColor = v);
-            var cw   = SmallTb(fr.CutWeight.ToString(), v => fr.CutWeight = TryInt(v));
-            var tr   = SmallTb(fr.Transparency.ToString(), v => fr.Transparency = TryInt(v));
-
-            var ctrls = new UIElement[] { name, vis, ht, pc, pw, cc, cw, tr };
-            for (int i = 0; i < ctrls.Length; i++)
-            {
-                Grid.SetColumn(ctrls[i], i);
-                if (ctrls[i] is FrameworkElement fe) fe.Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0);
-                g.Children.Add(ctrls[i]);
-            }
-            return g;
-        }
-
-        // ── VG override row ──
-        private UIElement MakeVgHeader()
-        {
-            var g = new Grid { Margin = new Thickness(0, 4, 0, 2) };
-            string[] headers = { "Category", "Visible", "Halftone", "Proj-Col", "Proj-Wt", "Cut-Col", "Cut-Wt", "Trans%" };
-            double[] widths  = { 160, 56, 56, 70, 50, 70, 50, 56 };
-            for (int i = 0; i < widths.Length; i++)
-                g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(widths[i]) });
-            for (int i = 0; i < headers.Length; i++)
-            {
-                var t = new TextBlock { Text = headers[i], FontSize = 10,
-                    Foreground = new SolidColorBrush(SubtleColor) };
-                Grid.SetColumn(t, i); g.Children.Add(t);
-            }
-            return g;
-        }
-
-        private UIElement MakeVgRow(string key, PackCategoryOverride v)
-        {
-            var g = new Grid { Margin = new Thickness(0, 1, 0, 1) };
-            double[] widths = { 160, 56, 56, 70, 50, 70, 50, 56 };
-            for (int i = 0; i < widths.Length; i++)
-                g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(widths[i]) });
-
-            // Category column: editable combo sourced from KnownRevitCategories
-            // ∪ live ProjectAssetPicker.CategoryNames so users pick from
-            // real categories but can still type "OST_Walls" or
-            // subcategory "<Room Separation>".
-            var categories = Merge(ProjectAssetPicker.CategoryNames(_doc),
-                                   KnownRevitCategories).ToArray();
-            var keyBox = SmallCombo(key, newKey =>
-            {
-                if (string.IsNullOrWhiteSpace(newKey) || newKey == key) return;
-                _currentPack.VgOverrides.Remove(key);
-                _currentPack.VgOverrides[newKey] = v;
-            }, categories);
-            var vis = MakeChk(v.Visible, b => v.Visible = b);
-            var ht  = MakeChk(v.Halftone,b => v.Halftone = b);
-            var pc  = SmallTb(v.ProjColor,  s => v.ProjColor = s);
-            var pw  = SmallTb(v.ProjWeight.ToString(), s => v.ProjWeight = TryInt(s));
-            var cc  = SmallTb(v.CutColor,   s => v.CutColor = s);
-            var cw  = SmallTb(v.CutWeight.ToString(), s => v.CutWeight = TryInt(s));
-            var tr  = SmallTb(v.Transparency.ToString(), s => v.Transparency = TryInt(s));
-
-            var ctrls = new UIElement[] { keyBox, vis, ht, pc, pw, cc, cw, tr };
-            for (int i = 0; i < ctrls.Length; i++)
-            {
-                Grid.SetColumn(ctrls[i], i);
-                if (ctrls[i] is FrameworkElement fe) fe.Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0);
-                g.Children.Add(ctrls[i]);
-            }
-            return g;
-        }
-
+        // Phase 136 — old MakeVgHeader / MakeVgRow / MakeFilterRuleHeader /
+        // MakeFilterRuleRow row-grid helpers replaced by the full Revit-style
+        // VG editor (BuildFullVgEditor + nested helpers, below). MakeChk is
+        // kept for the AnnotationRules grid, which still uses a flat bool.
         private CheckBox MakeChk(bool value, Action<bool> setter)
         {
-            var cb = new CheckBox { IsChecked = value, VerticalAlignment = VerticalAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Center };
+            var cb = new CheckBox
+            {
+                IsChecked = value,
+                VerticalAlignment   = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
             cb.Checked   += (s, e) => setter?.Invoke(true);
             cb.Unchecked += (s, e) => setter?.Invoke(false);
             return cb;
@@ -804,27 +693,98 @@ namespace StingTools.UI
             [JsonProperty("hatchPalette")]    public string HatchPalette { get; set; }
         }
 
+        // Phase 136 — PackFilterRule mirrors StyleFilterRule's full Revit-style
+        // override surface: line override (color + weight + pattern) and
+        // surface fg/bg pattern (name + color + visibility) for both
+        // projection and cut. Legacy projColor/projWeight/cutColor/cutWeight
+        // kept for backward compat with existing JSON files.
         private class PackFilterRule
         {
             [JsonProperty("name")]         public string Name { get; set; }
             [JsonProperty("visible")]      public bool Visible { get; set; } = true;
             [JsonProperty("halftone")]     public bool Halftone { get; set; }
-            [JsonProperty("projColor")]    public string ProjColor { get; set; }
-            [JsonProperty("projWeight")]   public int ProjWeight { get; set; }
-            [JsonProperty("cutColor")]     public string CutColor { get; set; }
-            [JsonProperty("cutWeight")]    public int CutWeight { get; set; }
-            [JsonProperty("transparency")] public int Transparency { get; set; }
+
+            // ── legacy short field names (kept for back-compat) ──
+            [JsonProperty("projColor",  NullValueHandling = NullValueHandling.Ignore)] public string ProjColor { get; set; }
+            [JsonProperty("projWeight", NullValueHandling = NullValueHandling.Ignore)] public int    ProjWeight { get; set; }
+            [JsonProperty("cutColor",   NullValueHandling = NullValueHandling.Ignore)] public string CutColor { get; set; }
+            [JsonProperty("cutWeight",  NullValueHandling = NullValueHandling.Ignore)] public int    CutWeight { get; set; }
+            [JsonProperty("transparency", NullValueHandling = NullValueHandling.Ignore)] public int  Transparency { get; set; }
+
+            // ── new full Revit-style fields ──
+            [JsonProperty("projLinePattern", NullValueHandling = NullValueHandling.Ignore)] public string ProjLinePattern { get; set; }
+
+            [JsonProperty("surfaceFgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string SurfaceFgPatternName { get; set; }
+            [JsonProperty("surfaceFgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string SurfaceFgPatternColor { get; set; }
+            [JsonProperty("surfaceFgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  SurfaceFgPatternVisible { get; set; }
+
+            [JsonProperty("surfaceBgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string SurfaceBgPatternName { get; set; }
+            [JsonProperty("surfaceBgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string SurfaceBgPatternColor { get; set; }
+            [JsonProperty("surfaceBgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  SurfaceBgPatternVisible { get; set; }
+
+            [JsonProperty("cutLinePattern", NullValueHandling = NullValueHandling.Ignore)] public string CutLinePattern { get; set; }
+
+            [JsonProperty("cutFgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string CutFgPatternName { get; set; }
+            [JsonProperty("cutFgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string CutFgPatternColor { get; set; }
+            [JsonProperty("cutFgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  CutFgPatternVisible { get; set; }
+
+            [JsonProperty("cutBgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string CutBgPatternName { get; set; }
+            [JsonProperty("cutBgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string CutBgPatternColor { get; set; }
+            [JsonProperty("cutBgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  CutBgPatternVisible { get; set; }
         }
 
+        // Phase 136 — PackCategoryOverride mirrors StyleVgOverride's full
+        // Revit-style override surface. Visibility / Halftone now nullable
+        // (null = inherited / not set). Legacy projColor/projWeight/cutColor/
+        // cutWeight kept for backward compat with existing JSON files.
         private class PackCategoryOverride
         {
-            [JsonProperty("visible")]      public bool Visible { get; set; } = true;
-            [JsonProperty("halftone")]     public bool Halftone { get; set; }
-            [JsonProperty("projColor")]    public string ProjColor { get; set; }
-            [JsonProperty("projWeight")]   public int ProjWeight { get; set; }
-            [JsonProperty("cutColor")]     public string CutColor { get; set; }
-            [JsonProperty("cutWeight")]    public int CutWeight { get; set; }
-            [JsonProperty("transparency")] public int Transparency { get; set; }
+            [JsonProperty("visible",  NullValueHandling = NullValueHandling.Ignore)] public bool?  Visible  { get; set; }
+            [JsonProperty("halftone", NullValueHandling = NullValueHandling.Ignore)] public bool?  Halftone { get; set; }
+            [JsonProperty("detailLevel", NullValueHandling = NullValueHandling.Ignore)] public string DetailLevel { get; set; }
+
+            // ── legacy short field names (kept for back-compat) ──
+            [JsonProperty("projColor",  NullValueHandling = NullValueHandling.Ignore)] public string ProjColor  { get; set; }
+            [JsonProperty("projWeight", NullValueHandling = NullValueHandling.Ignore)] public int    ProjWeight { get; set; }
+            [JsonProperty("cutColor",   NullValueHandling = NullValueHandling.Ignore)] public string CutColor   { get; set; }
+            [JsonProperty("cutWeight",  NullValueHandling = NullValueHandling.Ignore)] public int    CutWeight  { get; set; }
+            [JsonProperty("transparency", NullValueHandling = NullValueHandling.Ignore)] public int  Transparency { get; set; }
+
+            // ── new full Revit-style fields ──
+            [JsonProperty("projLinePattern", NullValueHandling = NullValueHandling.Ignore)] public string ProjLinePattern { get; set; }
+
+            [JsonProperty("surfaceFgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string SurfaceFgPatternName { get; set; }
+            [JsonProperty("surfaceFgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string SurfaceFgPatternColor { get; set; }
+            [JsonProperty("surfaceFgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  SurfaceFgPatternVisible { get; set; }
+
+            [JsonProperty("surfaceBgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string SurfaceBgPatternName { get; set; }
+            [JsonProperty("surfaceBgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string SurfaceBgPatternColor { get; set; }
+            [JsonProperty("surfaceBgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  SurfaceBgPatternVisible { get; set; }
+
+            [JsonProperty("cutLinePattern", NullValueHandling = NullValueHandling.Ignore)] public string CutLinePattern { get; set; }
+
+            [JsonProperty("cutFgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string CutFgPatternName { get; set; }
+            [JsonProperty("cutFgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string CutFgPatternColor { get; set; }
+            [JsonProperty("cutFgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  CutFgPatternVisible { get; set; }
+
+            [JsonProperty("cutBgPatternName",    NullValueHandling = NullValueHandling.Ignore)] public string CutBgPatternName { get; set; }
+            [JsonProperty("cutBgPatternColor",   NullValueHandling = NullValueHandling.Ignore)] public string CutBgPatternColor { get; set; }
+            [JsonProperty("cutBgPatternVisible", NullValueHandling = NullValueHandling.Ignore)] public bool?  CutBgPatternVisible { get; set; }
+
+            /// <summary>True when no field is overridden — used to keep JSON sparse.</summary>
+            public bool IsEmpty()
+            {
+                return !Visible.HasValue && !Halftone.HasValue && string.IsNullOrEmpty(DetailLevel)
+                    && string.IsNullOrEmpty(ProjColor) && ProjWeight == 0
+                    && string.IsNullOrEmpty(CutColor)  && CutWeight  == 0
+                    && Transparency == 0
+                    && string.IsNullOrEmpty(ProjLinePattern)
+                    && string.IsNullOrEmpty(SurfaceFgPatternName) && string.IsNullOrEmpty(SurfaceFgPatternColor) && !SurfaceFgPatternVisible.HasValue
+                    && string.IsNullOrEmpty(SurfaceBgPatternName) && string.IsNullOrEmpty(SurfaceBgPatternColor) && !SurfaceBgPatternVisible.HasValue
+                    && string.IsNullOrEmpty(CutLinePattern)
+                    && string.IsNullOrEmpty(CutFgPatternName) && string.IsNullOrEmpty(CutFgPatternColor) && !CutFgPatternVisible.HasValue
+                    && string.IsNullOrEmpty(CutBgPatternName) && string.IsNullOrEmpty(CutBgPatternColor) && !CutBgPatternVisible.HasValue;
+            }
         }
 
         private UIElement BuildViewportToolsTab()
@@ -1355,6 +1315,50 @@ namespace StingTools.UI
                 _current.ViewportTypeName, v => _current.ViewportTypeName = v,
                 ProjectAssetPicker.ViewportTypeNames(_doc),
                 "ElementType where Category = OST_Viewports in the active project."));
+
+            // Phase 136 — ViewStylePackId picker + edit link.
+            var packItems = new[] { "(none)" }
+                .Concat((_packs ?? new List<ViewStylePack>()).Select(p => $"{p.Id}  —  {p.Name ?? p.Id}"))
+                .ToArray();
+            var currentPackDisplay = string.IsNullOrEmpty(_current.ViewStylePackId)
+                ? "(none)"
+                : packItems.FirstOrDefault(s => s.StartsWith(_current.ViewStylePackId + " "))
+                  ?? _current.ViewStylePackId;
+            body.Children.Add(LabeledProjectAssetCombo(
+                "View style pack",
+                currentPackDisplay,
+                v =>
+                {
+                    if (string.IsNullOrEmpty(v) || v == "(none)") { _current.ViewStylePackId = null; return; }
+                    var id = v.Contains("  —  ")
+                        ? v.Split(new[] { "  —  " }, 2, StringSplitOptions.None)[0].Trim()
+                        : v.Trim();
+                    _current.ViewStylePackId = string.IsNullOrEmpty(id) ? null : id;
+                },
+                packItems,
+                "The ViewStylePack that supplies VG overrides, filter rules and tag style defaults. " +
+                "Packs are defined in the View Style Packs tab."));
+
+            var navLink = new TextBlock
+            {
+                Text = "→ Edit selected pack",
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                Cursor = Cursors.Hand,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 2, 4, 6),
+            };
+            navLink.MouseLeftButtonUp += (s, e) =>
+            {
+                if (string.IsNullOrEmpty(_current.ViewStylePackId)) return;
+                var target = (_packs ?? new List<ViewStylePack>()).FirstOrDefault(p =>
+                    string.Equals(p.Id, _current.ViewStylePackId, StringComparison.OrdinalIgnoreCase));
+                if (target == null) return;
+                _rootTabs.SelectedIndex = 1;            // switch to View Style Packs tab
+                SelectPack(target);                     // highlight the matching pack in the list
+            };
+            body.Children.Add(navLink);
+
             return Card("Views", body);
         }
 
@@ -2250,5 +2254,1119 @@ namespace StingTools.UI
             var json = JsonConvert.SerializeObject(src);
             return JsonConvert.DeserializeObject<DrawingType>(json);
         }
+
+        // ───────────────────────────────────────────────────────────────
+        //  PHASE 136 — FULL REVIT-STYLE VG EDITOR
+        //  4-tab layout (Model / Annotation / Imported / Filters) with
+        //  category tree, Override... sub-dialogs (Lines + Patterns),
+        //  per-category Halftone + DetailLevel, All/None/Invert/Expand bulk.
+        // ───────────────────────────────────────────────────────────────
+
+        // ── VgCategoryNode — internal model for the editor tree ──
+        private sealed class VgCategoryNode
+        {
+            public string CategoryName { get; set; }       // display name
+            public string CategoryKey  { get; set; }       // key into VgOverrides dict
+            public bool IsSubcategory  { get; set; }
+            public List<VgCategoryNode> Children { get; set; } = new List<VgCategoryNode>();
+            public bool IsExpanded { get; set; }            // UI state for [+]/[-]
+        }
+
+        // Cached tree state (built once in the constructor, reused).
+        private List<VgCategoryNode> _modelCatNodes      = new List<VgCategoryNode>();
+        private List<VgCategoryNode> _annotationCatNodes = new List<VgCategoryNode>();
+        private List<VgCategoryNode> _importedCatNodes   = new List<VgCategoryNode>();
+        private string[] _linePatternNames = new[] { "(No Override)", "Solid" };
+        private string[] _fillPatternNames = new[] { "(No Override)" };
+
+        // Build the three category trees + line/fill pattern lists from the
+        // active document. Called once from the constructor (before BuildLayout).
+        private void BuildCategoryTrees()
+        {
+            try
+            {
+                if (_doc == null) return;
+
+                // Model categories ----------------------------------------
+                foreach (Category cat in _doc.Settings.Categories)
+                {
+                    if (cat == null) continue;
+                    if (cat.CategoryType != CategoryType.Model) continue;
+                    var node = new VgCategoryNode { CategoryName = cat.Name, CategoryKey = cat.Name };
+                    foreach (Category sub in cat.SubCategories)
+                    {
+                        if (sub == null) continue;
+                        node.Children.Add(new VgCategoryNode
+                        {
+                            CategoryName  = sub.Name,
+                            CategoryKey   = "<" + sub.Name + ">",
+                            IsSubcategory = true,
+                        });
+                    }
+                    _modelCatNodes.Add(node);
+                }
+                _modelCatNodes = _modelCatNodes.OrderBy(n => n.CategoryName).ToList();
+
+                // Annotation categories -----------------------------------
+                foreach (Category cat in _doc.Settings.Categories)
+                {
+                    if (cat == null) continue;
+                    if (cat.CategoryType != CategoryType.Annotation) continue;
+                    var node = new VgCategoryNode { CategoryName = cat.Name, CategoryKey = cat.Name };
+                    foreach (Category sub in cat.SubCategories)
+                    {
+                        if (sub == null) continue;
+                        node.Children.Add(new VgCategoryNode
+                        {
+                            CategoryName  = sub.Name,
+                            CategoryKey   = "<" + sub.Name + ">",
+                            IsSubcategory = true,
+                        });
+                    }
+                    _annotationCatNodes.Add(node);
+                }
+                _annotationCatNodes = _annotationCatNodes.OrderBy(n => n.CategoryName).ToList();
+
+                // Imported (DWG / DXF) categories --------------------------
+                // Group by import file name; subcats are the layers.
+                var imports = new FilteredElementCollector(_doc)
+                    .OfClass(typeof(ImportInstance))
+                    .Cast<ImportInstance>()
+                    .Where(i => i?.Category != null)
+                    .ToList();
+                var byFile = new Dictionary<string, VgCategoryNode>(StringComparer.OrdinalIgnoreCase);
+                foreach (var imp in imports)
+                {
+                    var c = imp.Category;
+                    if (c == null) continue;
+                    if (!byFile.TryGetValue(c.Name, out var parent))
+                    {
+                        parent = new VgCategoryNode { CategoryName = c.Name, CategoryKey = c.Name };
+                        byFile[c.Name] = parent;
+                        foreach (Category sub in c.SubCategories)
+                        {
+                            if (sub == null) continue;
+                            parent.Children.Add(new VgCategoryNode
+                            {
+                                CategoryName  = sub.Name,
+                                CategoryKey   = "<" + sub.Name + ">",
+                                IsSubcategory = true,
+                            });
+                        }
+                    }
+                }
+                _importedCatNodes = byFile.Values.OrderBy(n => n.CategoryName).ToList();
+
+                // Line + fill patterns ------------------------------------
+                _linePatternNames = new[] { "(No Override)", "Solid" }
+                    .Concat(new FilteredElementCollector(_doc)
+                        .OfClass(typeof(LinePatternElement))
+                        .Cast<LinePatternElement>()
+                        .Select(lp => lp.Name).OrderBy(n => n))
+                    .Distinct().ToArray();
+
+                _fillPatternNames = new[] { "(No Override)" }
+                    .Concat(new FilteredElementCollector(_doc)
+                        .OfClass(typeof(FillPatternElement))
+                        .Cast<FillPatternElement>()
+                        .Select(fp => fp.Name).OrderBy(n => n))
+                    .Distinct().ToArray();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("DrawingTypeEditor.BuildCategoryTrees: " + ex.Message);
+            }
+        }
+
+
+        // ── BuildFullVgEditor — replaces the old VG/Filter row-grids ──
+        // 4 tabs: Model Categories / Annotation Categories / Imported / Filters
+        private UIElement BuildFullVgEditor()
+        {
+            var border = new Border
+            {
+                BorderThickness = new Thickness(1),
+                BorderBrush = new SolidColorBrush(CardBorder),
+                Background  = new SolidColorBrush(CardBg),
+                Margin = new Thickness(0, 6, 0, 6),
+            };
+
+            var outer = new DockPanel();
+            border.Child = outer;
+
+            var title = new TextBlock
+            {
+                Text = "VG overrides (per category)",
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(AccentColor),
+                Margin = new Thickness(8, 6, 8, 2),
+            };
+            DockPanel.SetDock(title, Dock.Top);
+            outer.Children.Add(title);
+
+            var note = new TextBlock
+            {
+                Text = "Categories not overridden are drawn according to Object Styles settings. " +
+                       "Colours in #RRGGBB. Patterns resolved by name from the active project.",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 10,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(8, 0, 8, 4),
+            };
+            DockPanel.SetDock(note, Dock.Top);
+            outer.Children.Add(note);
+
+            var tabs = new TabControl
+            {
+                Background  = new SolidColorBrush(BgColor),
+                Foreground  = new SolidColorBrush(FgColor),
+                BorderBrush = new SolidColorBrush(CardBorder),
+                Margin      = new Thickness(4),
+            };
+            tabs.Items.Add(MakeVgTab("Model Categories",      BuildVgTreeTab(_modelCatNodes)));
+            tabs.Items.Add(MakeVgTab("Annotation Categories", BuildVgTreeTab(_annotationCatNodes)));
+            tabs.Items.Add(MakeVgTab("Imported Categories",   BuildVgTreeTab(_importedCatNodes)));
+            tabs.Items.Add(MakeVgTab("Filters",               BuildFiltersTab()));
+            DockPanel.SetDock(tabs, Dock.Top);
+            outer.Children.Add(tabs);
+
+            return border;
+        }
+
+        private TabItem MakeVgTab(string header, UIElement content)
+        {
+            return new TabItem
+            {
+                Header = header, Content = content,
+                Background = new SolidColorBrush(CardBg),
+                Foreground = new SolidColorBrush(FgColor),
+            };
+        }
+
+
+        // Column widths shared by the header row + every category row so
+        // the columns line up regardless of dialog width. Order:
+        // [vis-chk, name, lines, patterns, transparency, cut-lines, cut-patterns, halftone, detail-lvl]
+        private static readonly double[] _vgColWidths =
+            { 22, 180, 90, 90, 50, 90, 90, 60, 80 };
+
+        private UIElement BuildVgTreeTab(List<VgCategoryNode> nodes)
+        {
+            var dock = new DockPanel { Margin = new Thickness(2), LastChildFill = true };
+
+            // Column header row
+            var hdrRow = MakeVgHeaderRow();
+            DockPanel.SetDock(hdrRow, Dock.Top);
+            dock.Children.Add(hdrRow);
+
+            // Action button row at bottom: All / None / Invert / Expand All
+            var actions = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 4, 0, 2),
+            };
+            actions.Children.Add(MakeSmallBtn("All",        () => BulkSetVisibility(nodes, true)));
+            actions.Children.Add(MakeSmallBtn("None",       () => BulkSetVisibility(nodes, false)));
+            actions.Children.Add(MakeSmallBtn("Invert",     () => BulkInvertVisibility(nodes)));
+            actions.Children.Add(MakeSmallBtn("Expand All", () => BulkExpand(nodes, true)));
+            actions.Children.Add(MakeSmallBtn("Collapse All", () => BulkExpand(nodes, false)));
+            DockPanel.SetDock(actions, Dock.Bottom);
+            dock.Children.Add(actions);
+
+            // Scrollable category rows
+            var scroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                MaxHeight = 380,
+            };
+            var rows = new StackPanel();
+            scroll.Content = rows;
+            dock.Children.Add(scroll);
+
+            RenderVgRows(rows, nodes);
+            return dock;
+        }
+
+        // Render the rows for the given node list. Subcat rows render only
+        // when the parent is expanded. Re-called whenever override state
+        // changes that affects visibility / structure.
+        private void RenderVgRows(StackPanel host, List<VgCategoryNode> nodes)
+        {
+            host.Children.Clear();
+            foreach (var n in nodes)
+            {
+                host.Children.Add(MakeVgCategoryRow(n, host, nodes, indent: 0));
+                if (n.IsExpanded)
+                {
+                    foreach (var sub in n.Children)
+                        host.Children.Add(MakeVgCategoryRow(sub, host, nodes, indent: 16));
+                }
+            }
+        }
+
+        private UIElement MakeVgHeaderRow()
+        {
+            var g = new Grid { Margin = new Thickness(0, 4, 0, 2) };
+            for (int i = 0; i < _vgColWidths.Length; i++)
+                g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(_vgColWidths[i]) });
+
+            // Header labels (matching Revit's VG dialog headings)
+            string[] headers = { "", "Visibility", "Lines", "Patterns", "Trans%", "Cut Lines", "Cut Patterns", "Halftone", "Detail Level" };
+            for (int i = 0; i < headers.Length; i++)
+            {
+                var t = new TextBlock
+                {
+                    Text = headers[i], FontSize = 10,
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0),
+                };
+                Grid.SetColumn(t, i); g.Children.Add(t);
+            }
+            return g;
+        }
+
+
+        // Build the row for one category (model / annotation / imported).
+        // Has: visibility-checkbox, name (with [+]/[-] for parents), Lines
+        // Override... button, Patterns Override... button, Transparency tb,
+        // Cut Lines Override... button, Cut Patterns Override... button,
+        // Halftone checkbox, DetailLevel combo.
+        private UIElement MakeVgCategoryRow(VgCategoryNode node, StackPanel host,
+            List<VgCategoryNode> rootList, int indent)
+        {
+            var g = new Grid { Margin = new Thickness(0, 1, 0, 1) };
+            for (int i = 0; i < _vgColWidths.Length; i++)
+                g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(_vgColWidths[i]) });
+
+            var ovr = GetOrCreateOverride(node.CategoryKey);
+
+            // Col 0 — visibility checkbox
+            var visCb = new CheckBox
+            {
+                IsChecked = ovr.Visible ?? true,
+                VerticalAlignment   = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
+            visCb.Checked   += (s, e) => { ovr.Visible = true;  CleanupIfEmpty(node.CategoryKey); };
+            visCb.Unchecked += (s, e) => { ovr.Visible = false; CleanupIfEmpty(node.CategoryKey); };
+            Grid.SetColumn(visCb, 0); g.Children.Add(visCb);
+
+            // Col 1 — category name with optional expand/collapse triangle
+            var namePanel = new DockPanel { Margin = new Thickness(indent + 2, 0, 0, 0) };
+            if (!node.IsSubcategory && node.Children.Count > 0)
+            {
+                var tri = new TextBlock
+                {
+                    Text = node.IsExpanded ? "▼" : "▶",
+                    Width = 12, FontSize = 10,
+                    Foreground = new SolidColorBrush(AccentColor),
+                    Cursor = Cursors.Hand,
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+                tri.MouseLeftButtonUp += (s, e) =>
+                {
+                    node.IsExpanded = !node.IsExpanded;
+                    RenderVgRows(host, rootList);
+                };
+                DockPanel.SetDock(tri, Dock.Left);
+                namePanel.Children.Add(tri);
+            }
+            else
+            {
+                var spacer = new TextBlock { Width = 12 };
+                DockPanel.SetDock(spacer, Dock.Left);
+                namePanel.Children.Add(spacer);
+            }
+            namePanel.Children.Add(new TextBlock
+            {
+                Text = node.CategoryName, FontSize = 11,
+                Foreground = new SolidColorBrush(FgColor),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            Grid.SetColumn(namePanel, 1); g.Children.Add(namePanel);
+
+            // Col 2 — Projection Lines override button
+            var btnLines = MakeOverrideBtn(SummariseLineOverride(
+                ovr.ProjColor, ovr.ProjWeight, ovr.ProjLinePattern), () =>
+            {
+                if (LineOverrideSubDialog.ShowEditor(this, "Line Graphics",
+                    ovr.ProjColor, ovr.ProjWeight, ovr.ProjLinePattern,
+                    _linePatternNames,
+                    out var newColor, out var newWeight, out var newPattern))
+                {
+                    ovr.ProjColor       = newColor;
+                    ovr.ProjWeight      = newWeight;
+                    ovr.ProjLinePattern = newPattern;
+                    CleanupIfEmpty(node.CategoryKey);
+                    RenderVgRows(host, rootList);
+                }
+            });
+            Grid.SetColumn(btnLines, 2); g.Children.Add(btnLines);
+
+            // Col 3 — Surface Patterns override button (fg + bg)
+            var btnPats = MakeOverrideBtn(SummarisePatternOverride(
+                ovr.SurfaceFgPatternName, ovr.SurfaceFgPatternColor, ovr.SurfaceFgPatternVisible,
+                ovr.SurfaceBgPatternName, ovr.SurfaceBgPatternColor, ovr.SurfaceBgPatternVisible), () =>
+            {
+                var fg = (ovr.SurfaceFgPatternName, ovr.SurfaceFgPatternColor, ovr.SurfaceFgPatternVisible);
+                var bg = (ovr.SurfaceBgPatternName, ovr.SurfaceBgPatternColor, ovr.SurfaceBgPatternVisible);
+                if (PatternOverrideSubDialog.ShowEditor(this, "Surface Patterns",
+                    fg, bg, _fillPatternNames, out var newFg, out var newBg))
+                {
+                    ovr.SurfaceFgPatternName    = newFg.name;
+                    ovr.SurfaceFgPatternColor   = newFg.color;
+                    ovr.SurfaceFgPatternVisible = newFg.visible;
+                    ovr.SurfaceBgPatternName    = newBg.name;
+                    ovr.SurfaceBgPatternColor   = newBg.color;
+                    ovr.SurfaceBgPatternVisible = newBg.visible;
+                    CleanupIfEmpty(node.CategoryKey);
+                    RenderVgRows(host, rootList);
+                }
+            });
+            Grid.SetColumn(btnPats, 3); g.Children.Add(btnPats);
+
+            // Col 4 — transparency text box
+            var transTb = new TextBox
+            {
+                Text = ovr.Transparency == 0 ? "" : ovr.Transparency.ToString(),
+                FontSize = 10, Height = 20,
+                ToolTip = "0–100. Empty = no override.",
+            };
+            DarkDialogTheme.StyleInput(transTb, CardBg, FgColor, CardBorder);
+            transTb.LostFocus += (s, e) =>
+            {
+                if (string.IsNullOrWhiteSpace(transTb.Text)) { ovr.Transparency = 0; }
+                else if (int.TryParse(transTb.Text, out var n)) ovr.Transparency = Math.Max(0, Math.Min(100, n));
+                CleanupIfEmpty(node.CategoryKey);
+            };
+            Grid.SetColumn(transTb, 4); g.Children.Add(transTb);
+
+            // Col 5 — Cut Lines override button
+            var btnCutLines = MakeOverrideBtn(SummariseLineOverride(
+                ovr.CutColor, ovr.CutWeight, ovr.CutLinePattern), () =>
+            {
+                if (LineOverrideSubDialog.ShowEditor(this, "Cut Line Graphics",
+                    ovr.CutColor, ovr.CutWeight, ovr.CutLinePattern,
+                    _linePatternNames,
+                    out var newColor, out var newWeight, out var newPattern))
+                {
+                    ovr.CutColor       = newColor;
+                    ovr.CutWeight      = newWeight;
+                    ovr.CutLinePattern = newPattern;
+                    CleanupIfEmpty(node.CategoryKey);
+                    RenderVgRows(host, rootList);
+                }
+            });
+            Grid.SetColumn(btnCutLines, 5); g.Children.Add(btnCutLines);
+
+            // Col 6 — Cut Patterns override button (fg + bg)
+            var btnCutPats = MakeOverrideBtn(SummarisePatternOverride(
+                ovr.CutFgPatternName, ovr.CutFgPatternColor, ovr.CutFgPatternVisible,
+                ovr.CutBgPatternName, ovr.CutBgPatternColor, ovr.CutBgPatternVisible), () =>
+            {
+                var fg = (ovr.CutFgPatternName, ovr.CutFgPatternColor, ovr.CutFgPatternVisible);
+                var bg = (ovr.CutBgPatternName, ovr.CutBgPatternColor, ovr.CutBgPatternVisible);
+                if (PatternOverrideSubDialog.ShowEditor(this, "Cut Patterns",
+                    fg, bg, _fillPatternNames, out var newFg, out var newBg))
+                {
+                    ovr.CutFgPatternName    = newFg.name;
+                    ovr.CutFgPatternColor   = newFg.color;
+                    ovr.CutFgPatternVisible = newFg.visible;
+                    ovr.CutBgPatternName    = newBg.name;
+                    ovr.CutBgPatternColor   = newBg.color;
+                    ovr.CutBgPatternVisible = newBg.visible;
+                    CleanupIfEmpty(node.CategoryKey);
+                    RenderVgRows(host, rootList);
+                }
+            });
+            Grid.SetColumn(btnCutPats, 6); g.Children.Add(btnCutPats);
+
+            // Col 7 — Halftone checkbox (3-state via context: null = not overridden)
+            var htCb = new CheckBox
+            {
+                IsChecked = ovr.Halftone,
+                IsThreeState = true,
+                VerticalAlignment   = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                ToolTip = "Indeterminate = no override; checked = halftone; unchecked = no halftone.",
+            };
+            htCb.Checked   += (s, e) => { ovr.Halftone = true;  CleanupIfEmpty(node.CategoryKey); };
+            htCb.Unchecked += (s, e) => { ovr.Halftone = false; CleanupIfEmpty(node.CategoryKey); };
+            htCb.Indeterminate += (s, e) => { ovr.Halftone = null; CleanupIfEmpty(node.CategoryKey); };
+            Grid.SetColumn(htCb, 7); g.Children.Add(htCb);
+
+            // Col 8 — Detail Level combo
+            var dlItems = new[] { "(By View)", "Coarse", "Medium", "Fine" };
+            var dlCb = new ComboBox { Height = 20, FontSize = 10, IsEditable = false };
+            DarkDialogTheme.StyleInput(dlCb, CardBg, FgColor, CardBorder);
+            foreach (var it in dlItems) dlCb.Items.Add(it);
+            dlCb.SelectedItem = string.IsNullOrEmpty(ovr.DetailLevel)
+                ? "(By View)"
+                : (dlItems.FirstOrDefault(d => d.Equals(ovr.DetailLevel, StringComparison.OrdinalIgnoreCase)) ?? "(By View)");
+            dlCb.SelectionChanged += (s, e) =>
+            {
+                if (dlCb.SelectedItem is string ss)
+                {
+                    ovr.DetailLevel = ss == "(By View)" ? null : ss;
+                    CleanupIfEmpty(node.CategoryKey);
+                }
+            };
+            Grid.SetColumn(dlCb, 8); g.Children.Add(dlCb);
+
+            return g;
+        }
+
+
+        // ── Override-state helpers ──
+        private PackCategoryOverride GetOrCreateOverride(string key)
+        {
+            if (_currentPack.VgOverrides == null)
+                _currentPack.VgOverrides = new Dictionary<string, PackCategoryOverride>();
+            if (!_currentPack.VgOverrides.TryGetValue(key, out var ovr) || ovr == null)
+            {
+                ovr = new PackCategoryOverride();
+                _currentPack.VgOverrides[key] = ovr;
+            }
+            return ovr;
+        }
+
+        // If the override has no fields set, remove it from the dict so the
+        // serialised JSON stays sparse — mirrors Revit's behaviour.
+        private void CleanupIfEmpty(string key)
+        {
+            if (_currentPack.VgOverrides == null) return;
+            if (!_currentPack.VgOverrides.TryGetValue(key, out var ovr) || ovr == null) return;
+            if (ovr.IsEmpty()) _currentPack.VgOverrides.Remove(key);
+        }
+
+        private void BulkSetVisibility(List<VgCategoryNode> nodes, bool visible)
+        {
+            foreach (var n in nodes)
+            {
+                var ovr = GetOrCreateOverride(n.CategoryKey);
+                ovr.Visible = visible;
+                CleanupIfEmpty(n.CategoryKey);
+                foreach (var sub in n.Children)
+                {
+                    var so = GetOrCreateOverride(sub.CategoryKey);
+                    so.Visible = visible;
+                    CleanupIfEmpty(sub.CategoryKey);
+                }
+            }
+            RenderPackForm();
+        }
+
+        private void BulkInvertVisibility(List<VgCategoryNode> nodes)
+        {
+            foreach (var n in nodes)
+            {
+                var ovr = GetOrCreateOverride(n.CategoryKey);
+                ovr.Visible = !(ovr.Visible ?? true);
+                CleanupIfEmpty(n.CategoryKey);
+            }
+            RenderPackForm();
+        }
+
+        private void BulkExpand(List<VgCategoryNode> nodes, bool expand)
+        {
+            foreach (var n in nodes) n.IsExpanded = expand;
+            RenderPackForm();
+        }
+
+        // ── UI factory helpers ──
+        private Button MakeOverrideBtn(string label, Action onClick)
+        {
+            var b = new Button
+            {
+                Content = label, Height = 20, FontSize = 10,
+                Padding = new Thickness(4, 0, 4, 0),
+                Background  = new SolidColorBrush(CardBg),
+                Foreground  = new SolidColorBrush(FgColor),
+                BorderBrush = new SolidColorBrush(CardBorder),
+                BorderThickness = new Thickness(1),
+                Margin = new Thickness(2, 0, 0, 0),
+                HorizontalContentAlignment = HorizontalAlignment.Left,
+            };
+            b.Click += (s, e) => onClick?.Invoke();
+            return b;
+        }
+
+        private static string SummariseLineOverride(string color, int weight, string pattern)
+        {
+            bool any = !string.IsNullOrEmpty(color) || weight > 0 || !string.IsNullOrEmpty(pattern);
+            if (!any) return "Override...";
+            var parts = new List<string>();
+            if (weight > 0) parts.Add($"Wt:{weight}");
+            if (!string.IsNullOrEmpty(color)) parts.Add(color);
+            if (!string.IsNullOrEmpty(pattern)) parts.Add(pattern);
+            return string.Join(" ", parts);
+        }
+
+        private static string SummarisePatternOverride(
+            string fgName, string fgColor, bool? fgVisible,
+            string bgName, string bgColor, bool? bgVisible)
+        {
+            bool anyFg = !string.IsNullOrEmpty(fgName) || !string.IsNullOrEmpty(fgColor) || fgVisible.HasValue;
+            bool anyBg = !string.IsNullOrEmpty(bgName) || !string.IsNullOrEmpty(bgColor) || bgVisible.HasValue;
+            if (!anyFg && !anyBg) return "Override...";
+            var bits = new List<string>();
+            if (anyFg) bits.Add($"fg:{fgName ?? ""}");
+            if (anyBg) bits.Add($"bg:{bgName ?? ""}");
+            return string.Join(" ", bits);
+        }
+
+
+        // Filters tab — VG-style override surface for ParameterFilterElements.
+        // Same column layout as VG categories (without the category-tree
+        // expand/collapse) so the editor reads consistently across tabs.
+        private static readonly double[] _filterColWidths =
+            { 200, 22, 90, 90, 50, 60 };
+        // [Filter name, visible-chk, lines, patterns, trans%, halftone]
+
+        private UIElement BuildFiltersTab()
+        {
+            var dock = new DockPanel { Margin = new Thickness(2), LastChildFill = true };
+
+            // Header
+            var hdr = new Grid { Margin = new Thickness(0, 4, 0, 2) };
+            for (int i = 0; i < _filterColWidths.Length; i++)
+                hdr.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(_filterColWidths[i]) });
+            string[] hd = { "Filter Name", "", "Lines", "Patterns", "Trans%", "Halftone" };
+            for (int i = 0; i < hd.Length; i++)
+            {
+                var t = new TextBlock
+                {
+                    Text = hd[i], FontSize = 10,
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    Margin = new Thickness(i == 0 ? 0 : 4, 0, 0, 0),
+                };
+                Grid.SetColumn(t, i); hdr.Children.Add(t);
+            }
+            DockPanel.SetDock(hdr, Dock.Top);
+            dock.Children.Add(hdr);
+
+            // "Add filter rule" + Remove-all bottom row
+            var actions = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 4, 0, 2),
+            };
+            actions.Children.Add(MakeSmallBtn("＋ Add filter rule", () =>
+            {
+                _currentPack.FilterRules.Add(new PackFilterRule
+                {
+                    Name = "NewFilter", Visible = true, Halftone = false,
+                });
+                RenderPackForm();
+            }));
+            DockPanel.SetDock(actions, Dock.Bottom);
+            dock.Children.Add(actions);
+
+            // Scrollable filter rows
+            var scroll = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                MaxHeight = 380,
+            };
+            var rows = new StackPanel();
+            scroll.Content = rows;
+            dock.Children.Add(scroll);
+
+            var filterNames = Merge(ProjectAssetPicker.ParameterFilterNames(_doc),
+                                    CommonStingFilters).ToArray();
+            foreach (var fr in _currentPack.FilterRules.ToList())
+                rows.Children.Add(MakeFilterRow(fr, filterNames));
+
+            return dock;
+        }
+
+        private UIElement MakeFilterRow(PackFilterRule fr, string[] filterNames)
+        {
+            var g = new Grid { Margin = new Thickness(0, 1, 0, 1) };
+            for (int i = 0; i < _filterColWidths.Length; i++)
+                g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(_filterColWidths[i]) });
+
+            // Col 0 — filter name combo
+            var nameBox = SmallCombo(fr.Name ?? "", v => fr.Name = v, filterNames);
+            Grid.SetColumn(nameBox, 0); g.Children.Add(nameBox);
+
+            // Col 1 — visibility checkbox
+            var visCb = new CheckBox
+            {
+                IsChecked = fr.Visible,
+                VerticalAlignment   = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
+            visCb.Checked   += (s, e) => fr.Visible = true;
+            visCb.Unchecked += (s, e) => fr.Visible = false;
+            Grid.SetColumn(visCb, 1); g.Children.Add(visCb);
+
+            // Col 2 — Projection Lines override button
+            var btnLines = MakeOverrideBtn(
+                SummariseLineOverride(fr.ProjColor, fr.ProjWeight, fr.ProjLinePattern), () =>
+                {
+                    if (LineOverrideSubDialog.ShowEditor(this, "Filter Line Graphics",
+                        fr.ProjColor, fr.ProjWeight, fr.ProjLinePattern,
+                        _linePatternNames,
+                        out var nc, out var nw, out var np))
+                    {
+                        fr.ProjColor = nc; fr.ProjWeight = nw; fr.ProjLinePattern = np;
+                        RenderPackForm();
+                    }
+                });
+            Grid.SetColumn(btnLines, 2); g.Children.Add(btnLines);
+
+            // Col 3 — Surface Patterns override button (fg + bg)
+            var btnPats = MakeOverrideBtn(SummarisePatternOverride(
+                fr.SurfaceFgPatternName, fr.SurfaceFgPatternColor, fr.SurfaceFgPatternVisible,
+                fr.SurfaceBgPatternName, fr.SurfaceBgPatternColor, fr.SurfaceBgPatternVisible), () =>
+            {
+                var fg = (fr.SurfaceFgPatternName, fr.SurfaceFgPatternColor, fr.SurfaceFgPatternVisible);
+                var bg = (fr.SurfaceBgPatternName, fr.SurfaceBgPatternColor, fr.SurfaceBgPatternVisible);
+                if (PatternOverrideSubDialog.ShowEditor(this, "Filter Surface Patterns",
+                    fg, bg, _fillPatternNames, out var newFg, out var newBg))
+                {
+                    fr.SurfaceFgPatternName    = newFg.name;
+                    fr.SurfaceFgPatternColor   = newFg.color;
+                    fr.SurfaceFgPatternVisible = newFg.visible;
+                    fr.SurfaceBgPatternName    = newBg.name;
+                    fr.SurfaceBgPatternColor   = newBg.color;
+                    fr.SurfaceBgPatternVisible = newBg.visible;
+                    RenderPackForm();
+                }
+            });
+            Grid.SetColumn(btnPats, 3); g.Children.Add(btnPats);
+
+            // Col 4 — transparency
+            var transTb = new TextBox
+            {
+                Text = fr.Transparency == 0 ? "" : fr.Transparency.ToString(),
+                FontSize = 10, Height = 20,
+            };
+            DarkDialogTheme.StyleInput(transTb, CardBg, FgColor, CardBorder);
+            transTb.LostFocus += (s, e) =>
+            {
+                if (string.IsNullOrWhiteSpace(transTb.Text)) fr.Transparency = 0;
+                else if (int.TryParse(transTb.Text, out var n)) fr.Transparency = Math.Max(0, Math.Min(100, n));
+            };
+            Grid.SetColumn(transTb, 4); g.Children.Add(transTb);
+
+            // Col 5 — halftone
+            var htCb = new CheckBox
+            {
+                IsChecked = fr.Halftone,
+                VerticalAlignment   = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
+            htCb.Checked   += (s, e) => fr.Halftone = true;
+            htCb.Unchecked += (s, e) => fr.Halftone = false;
+            Grid.SetColumn(htCb, 5); g.Children.Add(htCb);
+
+            return g;
+        }
+
+
+        // ── LineOverrideSubDialog — modal "Override Lines" editor ──
+        // Color (square swatch + #RRGGBB textbox + native ColorDialog),
+        // Weight (combo: (No Override) | 1..16),
+        // Pattern (combo from doc's LinePatternElements; Solid + No Override).
+        // Static ShowEditor() takes existing values, returns user-chosen values.
+        private sealed class LineOverrideSubDialog : Window
+        {
+            private string _color;
+            private int    _weight;
+            private string _pattern;
+            private TextBox _hexBox;
+            private Border  _swatch;
+            private ComboBox _weightCb;
+            private ComboBox _patternCb;
+            private bool _ok;
+
+            public static bool ShowEditor(Window owner, string title,
+                string currentColor, int currentWeight, string currentPattern,
+                string[] linePatternNames,
+                out string newColor, out int newWeight, out string newPattern)
+            {
+                var dlg = new LineOverrideSubDialog(owner, title,
+                    currentColor, currentWeight, currentPattern, linePatternNames);
+                dlg.ShowDialog();
+                newColor   = dlg._ok ? dlg._color   : currentColor;
+                newWeight  = dlg._ok ? dlg._weight  : currentWeight;
+                newPattern = dlg._ok ? dlg._pattern : currentPattern;
+                return dlg._ok;
+            }
+
+            private LineOverrideSubDialog(Window owner, string title,
+                string color, int weight, string pattern, string[] linePatternNames)
+            {
+                _color = color ?? "";
+                _weight = weight;
+                _pattern = pattern ?? "";
+
+                Title = title;
+                Width = 360; Height = 220;
+                WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                Owner = owner;
+                Background = new SolidColorBrush(Color.FromRgb(0xFA, 0xFA, 0xFA));
+                FontFamily = new FontFamily("Segoe UI");
+                ResizeMode = ResizeMode.NoResize;
+
+                var grid = new Grid { Margin = new Thickness(12) };
+                grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+                grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(70) });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                // Row 0 — color
+                var lblColor = new TextBlock { Text = "Color:", VerticalAlignment = VerticalAlignment.Center };
+                Grid.SetRow(lblColor, 0); Grid.SetColumn(lblColor, 0); grid.Children.Add(lblColor);
+
+                var colorPanel = new DockPanel { LastChildFill = true };
+                _swatch = new Border
+                {
+                    Width = 24, Height = 24,
+                    BorderBrush = new SolidColorBrush(Color.FromRgb(0xCF, 0xD8, 0xDC)),
+                    BorderThickness = new Thickness(1),
+                    Background = HexToBrush(_color),
+                    Margin = new Thickness(0, 0, 6, 0),
+                    Cursor = Cursors.Hand,
+                };
+                _swatch.MouseLeftButtonUp += (s, e) => OpenColorPicker();
+                DockPanel.SetDock(_swatch, Dock.Left);
+                colorPanel.Children.Add(_swatch);
+
+                _hexBox = new TextBox { Text = _color, Height = 22 };
+                _hexBox.LostFocus += (s, e) =>
+                {
+                    _color = (_hexBox.Text ?? "").Trim();
+                    _swatch.Background = HexToBrush(_color);
+                };
+                colorPanel.Children.Add(_hexBox);
+                Grid.SetRow(colorPanel, 0); Grid.SetColumn(colorPanel, 1); grid.Children.Add(colorPanel);
+
+                var lnkClearColor = new TextBlock
+                {
+                    Text = "(No Override)",
+                    Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0x91, 0x2D)),
+                    Cursor = Cursors.Hand, FontSize = 10,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(8, 0, 0, 0),
+                };
+                lnkClearColor.MouseLeftButtonUp += (s, e) =>
+                {
+                    _color = ""; _hexBox.Text = ""; _swatch.Background = Brushes.Transparent;
+                };
+                Grid.SetRow(lnkClearColor, 0); Grid.SetColumn(lnkClearColor, 2); grid.Children.Add(lnkClearColor);
+
+                // Row 1 — weight
+                var lblWeight = new TextBlock { Text = "Weight:", VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 8, 0, 0) };
+                Grid.SetRow(lblWeight, 1); Grid.SetColumn(lblWeight, 0); grid.Children.Add(lblWeight);
+
+                _weightCb = new ComboBox { Height = 22, Margin = new Thickness(0, 8, 0, 0) };
+                _weightCb.Items.Add("(No Override)");
+                for (int i = 1; i <= 16; i++) _weightCb.Items.Add(i.ToString());
+                _weightCb.SelectedItem = _weight > 0 ? _weight.ToString() : "(No Override)";
+                _weightCb.SelectionChanged += (s, e) =>
+                {
+                    if (_weightCb.SelectedItem is string ss)
+                        _weight = ss == "(No Override)" ? 0 : int.Parse(ss);
+                };
+                Grid.SetRow(_weightCb, 1); Grid.SetColumn(_weightCb, 1); Grid.SetColumnSpan(_weightCb, 2);
+                grid.Children.Add(_weightCb);
+
+                // Row 2 — pattern
+                var lblPattern = new TextBlock { Text = "Pattern:", VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 8, 0, 0) };
+                Grid.SetRow(lblPattern, 2); Grid.SetColumn(lblPattern, 0); grid.Children.Add(lblPattern);
+
+                _patternCb = new ComboBox { Height = 22, Margin = new Thickness(0, 8, 0, 0) };
+                foreach (var n in linePatternNames ?? new[] { "(No Override)", "Solid" })
+                    _patternCb.Items.Add(n);
+                _patternCb.SelectedItem = string.IsNullOrEmpty(_pattern) ? "(No Override)" : _pattern;
+                _patternCb.SelectionChanged += (s, e) =>
+                {
+                    if (_patternCb.SelectedItem is string ss)
+                        _pattern = ss == "(No Override)" ? "" : ss;
+                };
+                Grid.SetRow(_patternCb, 2); Grid.SetColumn(_patternCb, 1); Grid.SetColumnSpan(_patternCb, 2);
+                grid.Children.Add(_patternCb);
+
+                // Row 4 — OK / Cancel
+                var btns = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                };
+                var ok = new Button { Content = "OK", Width = 80, Height = 26, IsDefault = true,
+                    Margin = new Thickness(0, 0, 6, 0) };
+                ok.Click += (s, e) => { _ok = true; Close(); };
+                var cancel = new Button { Content = "Cancel", Width = 80, Height = 26, IsCancel = true };
+                cancel.Click += (s, e) => { _ok = false; Close(); };
+                btns.Children.Add(ok); btns.Children.Add(cancel);
+                Grid.SetRow(btns, 4); Grid.SetColumn(btns, 0); Grid.SetColumnSpan(btns, 3);
+                grid.Children.Add(btns);
+
+                Content = grid;
+            }
+
+            private static SolidColorBrush HexToBrush(string hex)
+            {
+                if (string.IsNullOrWhiteSpace(hex)) return new SolidColorBrush(Colors.Transparent);
+                var s = hex.TrimStart('#');
+                if (s.Length != 6) return new SolidColorBrush(Colors.Transparent);
+                try
+                {
+                    byte r = Convert.ToByte(s.Substring(0, 2), 16);
+                    byte g = Convert.ToByte(s.Substring(2, 2), 16);
+                    byte b = Convert.ToByte(s.Substring(4, 2), 16);
+                    return new SolidColorBrush(Color.FromRgb(r, g, b));
+                }
+                catch { return new SolidColorBrush(Colors.Transparent); }
+            }
+
+            private void OpenColorPicker()
+            {
+                using (var cd = new System.Windows.Forms.ColorDialog())
+                {
+                    if (!string.IsNullOrEmpty(_color))
+                    {
+                        var s = _color.TrimStart('#');
+                        if (s.Length == 6)
+                        {
+                            try
+                            {
+                                byte r = Convert.ToByte(s.Substring(0, 2), 16);
+                                byte g = Convert.ToByte(s.Substring(2, 2), 16);
+                                byte b = Convert.ToByte(s.Substring(4, 2), 16);
+                                cd.Color = System.Drawing.Color.FromArgb(r, g, b);
+                            }
+                            catch { }
+                        }
+                    }
+                    if (cd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    {
+                        _color = $"#{cd.Color.R:X2}{cd.Color.G:X2}{cd.Color.B:X2}";
+                        _hexBox.Text = _color;
+                        _swatch.Background = HexToBrush(_color);
+                    }
+                }
+            }
+        }
+
+
+        // ── PatternOverrideSubDialog — modal "Override Patterns" editor ──
+        // Two stacked sections (Foreground / Background); each section has
+        // Visible CheckBox + Color row (swatch + hex + native ColorDialog) +
+        // Pattern combo. ShowEditor takes/returns (name, color, visible).
+        private sealed class PatternOverrideSubDialog : Window
+        {
+            private string _fgName, _fgColor; private bool? _fgVisible;
+            private string _bgName, _bgColor; private bool? _bgVisible;
+            private bool _ok;
+
+            // Foreground UI
+            private CheckBox _fgVisCb; private TextBox _fgHex;
+            private Border _fgSwatch; private ComboBox _fgPatCb;
+            // Background UI
+            private CheckBox _bgVisCb; private TextBox _bgHex;
+            private Border _bgSwatch; private ComboBox _bgPatCb;
+
+            public static bool ShowEditor(Window owner, string title,
+                (string name, string color, bool? visible) fg,
+                (string name, string color, bool? visible) bg,
+                string[] fillPatternNames,
+                out (string name, string color, bool? visible) newFg,
+                out (string name, string color, bool? visible) newBg)
+            {
+                var dlg = new PatternOverrideSubDialog(owner, title, fg, bg, fillPatternNames);
+                dlg.ShowDialog();
+                newFg = dlg._ok ? (dlg._fgName, dlg._fgColor, dlg._fgVisible) : fg;
+                newBg = dlg._ok ? (dlg._bgName, dlg._bgColor, dlg._bgVisible) : bg;
+                return dlg._ok;
+            }
+
+            private PatternOverrideSubDialog(Window owner, string title,
+                (string name, string color, bool? visible) fg,
+                (string name, string color, bool? visible) bg,
+                string[] fillPatternNames)
+            {
+                _fgName = fg.name ?? ""; _fgColor = fg.color ?? ""; _fgVisible = fg.visible;
+                _bgName = bg.name ?? ""; _bgColor = bg.color ?? ""; _bgVisible = bg.visible;
+
+                Title = title;
+                Width = 420; Height = 320;
+                WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                Owner = owner;
+                Background = new SolidColorBrush(Color.FromRgb(0xFA, 0xFA, 0xFA));
+                FontFamily = new FontFamily("Segoe UI");
+                ResizeMode = ResizeMode.NoResize;
+
+                var stack = new StackPanel { Margin = new Thickness(12) };
+                stack.Children.Add(BuildSection("Foreground pattern", true,  fillPatternNames));
+                stack.Children.Add(BuildSection("Background pattern", false, fillPatternNames));
+
+                var btns = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    Margin = new Thickness(0, 8, 0, 0),
+                };
+                var ok = new Button { Content = "OK", Width = 80, Height = 26, IsDefault = true,
+                    Margin = new Thickness(0, 0, 6, 0) };
+                ok.Click += (s, e) => { _ok = true; Close(); };
+                var cancel = new Button { Content = "Cancel", Width = 80, Height = 26, IsCancel = true };
+                cancel.Click += (s, e) => { _ok = false; Close(); };
+                btns.Children.Add(ok); btns.Children.Add(cancel);
+                stack.Children.Add(btns);
+
+                Content = stack;
+            }
+
+            private UIElement BuildSection(string title, bool isFg, string[] fillPatternNames)
+            {
+                var border = new Border
+                {
+                    BorderThickness = new Thickness(1),
+                    BorderBrush = new SolidColorBrush(Color.FromRgb(0xCF, 0xD8, 0xDC)),
+                    Padding = new Thickness(8),
+                    Margin = new Thickness(0, 0, 0, 6),
+                };
+                var inner = new StackPanel();
+                inner.Children.Add(new TextBlock
+                {
+                    Text = title, FontWeight = FontWeights.SemiBold,
+                    Margin = new Thickness(0, 0, 0, 6),
+                });
+
+                // Visible row
+                var visCb = new CheckBox
+                {
+                    Content = "Visible", IsThreeState = true,
+                    IsChecked = isFg ? _fgVisible : _bgVisible,
+                    Margin = new Thickness(0, 0, 0, 4),
+                    ToolTip = "Indeterminate = no override.",
+                };
+                visCb.Checked      += (s, e) => SetVisible(isFg, true);
+                visCb.Unchecked    += (s, e) => SetVisible(isFg, false);
+                visCb.Indeterminate += (s, e) => SetVisible(isFg, null);
+                if (isFg) _fgVisCb = visCb; else _bgVisCb = visCb;
+                inner.Children.Add(visCb);
+
+                // Color row
+                var colorRow = new DockPanel { LastChildFill = true, Margin = new Thickness(0, 0, 0, 4) };
+                var lbl = new TextBlock { Text = "Color:", Width = 50, VerticalAlignment = VerticalAlignment.Center };
+                DockPanel.SetDock(lbl, Dock.Left);
+                colorRow.Children.Add(lbl);
+
+                var swatch = new Border
+                {
+                    Width = 24, Height = 24,
+                    BorderBrush = new SolidColorBrush(Color.FromRgb(0xCF, 0xD8, 0xDC)),
+                    BorderThickness = new Thickness(1),
+                    Background = LineOverrideSubDialog_HexToBrush(isFg ? _fgColor : _bgColor),
+                    Cursor = Cursors.Hand,
+                    Margin = new Thickness(0, 0, 6, 0),
+                };
+                DockPanel.SetDock(swatch, Dock.Left);
+                colorRow.Children.Add(swatch);
+                if (isFg) _fgSwatch = swatch; else _bgSwatch = swatch;
+
+                var hex = new TextBox { Text = isFg ? _fgColor : _bgColor, Height = 22 };
+                hex.LostFocus += (s, e) =>
+                {
+                    var v = (hex.Text ?? "").Trim();
+                    if (isFg) { _fgColor = v; _fgSwatch.Background = LineOverrideSubDialog_HexToBrush(v); }
+                    else      { _bgColor = v; _bgSwatch.Background = LineOverrideSubDialog_HexToBrush(v); }
+                };
+                colorRow.Children.Add(hex);
+                if (isFg) _fgHex = hex; else _bgHex = hex;
+
+                swatch.MouseLeftButtonUp += (s, e) => OpenColorPicker(isFg);
+                inner.Children.Add(colorRow);
+
+                // Pattern row
+                var patRow = new DockPanel { LastChildFill = true };
+                var lbl2 = new TextBlock { Text = "Pattern:", Width = 50, VerticalAlignment = VerticalAlignment.Center };
+                DockPanel.SetDock(lbl2, Dock.Left);
+                patRow.Children.Add(lbl2);
+
+                var patCb = new ComboBox { Height = 22 };
+                foreach (var n in fillPatternNames ?? new[] { "(No Override)" })
+                    patCb.Items.Add(n);
+                patCb.SelectedItem = string.IsNullOrEmpty(isFg ? _fgName : _bgName)
+                    ? "(No Override)"
+                    : (isFg ? _fgName : _bgName);
+                patCb.SelectionChanged += (s, e) =>
+                {
+                    if (patCb.SelectedItem is string ss)
+                    {
+                        var v = ss == "(No Override)" ? "" : ss;
+                        if (isFg) _fgName = v; else _bgName = v;
+                    }
+                };
+                if (isFg) _fgPatCb = patCb; else _bgPatCb = patCb;
+                patRow.Children.Add(patCb);
+                inner.Children.Add(patRow);
+
+                border.Child = inner;
+                return border;
+            }
+
+            private void SetVisible(bool isFg, bool? v)
+            {
+                if (isFg) _fgVisible = v;
+                else      _bgVisible = v;
+            }
+
+            private void OpenColorPicker(bool isFg)
+            {
+                var current = isFg ? _fgColor : _bgColor;
+                using (var cd = new System.Windows.Forms.ColorDialog())
+                {
+                    if (!string.IsNullOrEmpty(current))
+                    {
+                        var s = current.TrimStart('#');
+                        if (s.Length == 6)
+                        {
+                            try
+                            {
+                                byte r = Convert.ToByte(s.Substring(0, 2), 16);
+                                byte g = Convert.ToByte(s.Substring(2, 2), 16);
+                                byte b = Convert.ToByte(s.Substring(4, 2), 16);
+                                cd.Color = System.Drawing.Color.FromArgb(r, g, b);
+                            }
+                            catch { }
+                        }
+                    }
+                    if (cd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    {
+                        var hex = $"#{cd.Color.R:X2}{cd.Color.G:X2}{cd.Color.B:X2}";
+                        if (isFg) { _fgColor = hex; _fgHex.Text = hex; _fgSwatch.Background = LineOverrideSubDialog_HexToBrush(hex); }
+                        else      { _bgColor = hex; _bgHex.Text = hex; _bgSwatch.Background = LineOverrideSubDialog_HexToBrush(hex); }
+                    }
+                }
+            }
+
+            // Reusable hex→brush converter (kept inside the dialog so the
+            // sub-dialog stays self-contained).
+            private static SolidColorBrush LineOverrideSubDialog_HexToBrush(string hex)
+            {
+                if (string.IsNullOrWhiteSpace(hex)) return new SolidColorBrush(Colors.Transparent);
+                var s = hex.TrimStart('#');
+                if (s.Length != 6) return new SolidColorBrush(Colors.Transparent);
+                try
+                {
+                    byte r = Convert.ToByte(s.Substring(0, 2), 16);
+                    byte g = Convert.ToByte(s.Substring(2, 2), 16);
+                    byte b = Convert.ToByte(s.Substring(4, 2), 16);
+                    return new SolidColorBrush(Color.FromRgb(r, g, b));
+                }
+                catch { return new SolidColorBrush(Colors.Transparent); }
+            }
+        }
+
     }
 }

--- a/StingTools/UI/DrawingTypeEditorDialog.cs
+++ b/StingTools/UI/DrawingTypeEditorDialog.cs
@@ -111,6 +111,122 @@ namespace StingTools.UI
             "Structural Rebar", "Walls", "Windows", "Zones",
         };
 
+        // Phase 136 — Native Revit categories grouped by discipline. Used by
+        // the VG editor's discipline-filter combo, and as a fallback when
+        // doc.Settings.Categories returns an unusually thin list (empty
+        // template, family editor, no MEP loaded, etc.). Keys mirror the
+        // discipline filter values; the special "All" key is reserved at
+        // runtime for "no filter".
+        private static readonly Dictionary<string, string[]> KnownModelCategoriesByDiscipline =
+            new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Architectural"] = new[]
+            {
+                "Walls", "Curtain Panels", "Curtain Wall Mullions", "Curtain Systems",
+                "Doors", "Windows", "Floors", "Ceilings", "Roofs",
+                "Stairs", "Railings", "Ramps", "Casework", "Furniture", "Furniture Systems",
+                "Specialty Equipment", "Generic Models", "Mass",
+                "Site", "Topography", "Parking", "Planting", "Entourage",
+                "Roads", "Pads",
+            },
+            ["Structural"] = new[]
+            {
+                "Structural Columns", "Structural Framing", "Structural Foundations",
+                "Structural Connections", "Structural Stiffeners", "Structural Trusses",
+                "Structural Rebar", "Structural Area Reinforcement",
+                "Structural Path Reinforcement", "Structural Fabric Areas",
+                "Structural Fabric Reinforcement", "Rebar Shape", "Structural Beam Systems",
+                "Structural Loads", "Analytical Spaces", "Analytical Surfaces",
+            },
+            ["Mechanical"] = new[]
+            {
+                "Mechanical Equipment", "Air Terminals", "Ducts", "Duct Fittings",
+                "Duct Accessories", "Duct Insulations", "Duct Linings", "Duct Placeholders",
+                "Duct Systems", "Flex Ducts", "HVAC Zones", "MEP Fabrication Ductwork",
+                "MEP Fabrication Hangers",
+            },
+            ["Electrical"] = new[]
+            {
+                "Electrical Equipment", "Electrical Fixtures", "Lighting Fixtures",
+                "Lighting Devices", "Cable Trays", "Cable Tray Fittings",
+                "Conduits", "Conduit Fittings", "Wires", "Electrical Circuits",
+                "Telephone Devices", "Communication Devices", "Data Devices",
+                "Security Devices", "Nurse Call Devices", "Fire Alarm Devices",
+            },
+            ["Plumbing"] = new[]
+            {
+                "Pipes", "Pipe Fittings", "Pipe Accessories", "Pipe Insulations",
+                "Pipe Placeholders", "Flex Pipes", "Plumbing Fixtures",
+                "Sprinklers", "Piping Systems", "MEP Fabrication Pipework",
+            },
+            ["Fire Protection"] = new[]
+            {
+                "Fire Alarm Devices", "Fire Protection", "Sprinklers",
+            },
+            ["Coordination"] = new[]
+            {
+                "Rooms", "Spaces", "Areas", "Zones",
+                "Levels", "Grids", "Scope Boxes", "Reference Planes", "Reference Lines",
+                "Section Boxes", "Matchline", "Detail Items", "Model Groups",
+                "Assembly Instances", "Assemblies", "Parts", "Project Information",
+            },
+        };
+
+        private static readonly Dictionary<string, string[]> KnownAnnotationCategoriesByDiscipline =
+            new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Annotation"] = new[]
+            {
+                "Dimensions", "Spot Coordinates", "Spot Elevations", "Spot Slopes",
+                "Text Notes", "Generic Annotations", "Keynote Tags", "Multi-Category Tags",
+                "Detail Items", "Filled Region", "Masking Region",
+                "Revision Clouds", "Revision Cloud Tags",
+                "Section Marks", "Elevation Marks", "Callout Boundary", "Callout Heads",
+                "Reference View", "View Title", "Sheet Number", "Sheet Name",
+                "Title Marks", "Levels (Annotation)", "Grids (Annotation)", "Matchline",
+            },
+            ["Tags — Architectural"] = new[]
+            {
+                "Door Tags", "Window Tags", "Wall Tags", "Floor Tags", "Ceiling Tags",
+                "Roof Tags", "Stair Tags", "Railing Tags", "Ramp Tags", "Casework Tags",
+                "Furniture Tags", "Furniture System Tags", "Curtain Panel Tags",
+                "Generic Model Tags", "Specialty Equipment Tags",
+                "Room Tags", "Space Tags", "Area Tags", "Zone Tags",
+                "Site Tags", "Parking Tags", "Planting Tags",
+            },
+            ["Tags — Structural"] = new[]
+            {
+                "Structural Column Tags", "Structural Framing Tags",
+                "Structural Foundation Tags", "Structural Connection Tags",
+                "Structural Rebar Tags", "Structural Truss Tags",
+                "Structural Beam System Tags", "Span Direction Symbol",
+            },
+            ["Tags — Mechanical"] = new[]
+            {
+                "Mechanical Equipment Tags", "Air Terminal Tags",
+                "Duct Tags", "Duct Fitting Tags", "Duct Accessory Tags",
+                "Duct Insulation Tags", "Flex Duct Tags",
+                "HVAC Zone Tags",
+            },
+            ["Tags — Electrical"] = new[]
+            {
+                "Electrical Equipment Tags", "Electrical Fixture Tags",
+                "Lighting Fixture Tags", "Lighting Device Tags",
+                "Cable Tray Tags", "Cable Tray Fitting Tags",
+                "Conduit Tags", "Conduit Fitting Tags", "Wire Tags",
+                "Communication Device Tags", "Data Device Tags",
+                "Security Device Tags", "Nurse Call Device Tags",
+                "Fire Alarm Device Tags", "Telephone Device Tags",
+            },
+            ["Tags — Plumbing"] = new[]
+            {
+                "Pipe Tags", "Pipe Fitting Tags", "Pipe Accessory Tags",
+                "Pipe Insulation Tags", "Flex Pipe Tags",
+                "Plumbing Fixture Tags", "Sprinkler Tags",
+            },
+        };
+
+
         private static readonly string[] CommonStingFilters = new[]
         {
             "Existing - Halftone", "Demolished - Red", "New Construction",
@@ -2267,6 +2383,7 @@ namespace StingTools.UI
         {
             public string CategoryName { get; set; }       // display name
             public string CategoryKey  { get; set; }       // key into VgOverrides dict
+            public string Discipline   { get; set; }       // "Architectural"/"Mechanical"/... for filter combo
             public bool IsSubcategory  { get; set; }
             public List<VgCategoryNode> Children { get; set; } = new List<VgCategoryNode>();
             public bool IsExpanded { get; set; }            // UI state for [+]/[-]
@@ -2279,103 +2396,148 @@ namespace StingTools.UI
         private string[] _linePatternNames = new[] { "(No Override)", "Solid" };
         private string[] _fillPatternNames = new[] { "(No Override)" };
 
-        // Build the three category trees + line/fill pattern lists from the
-        // active document. Called once from the constructor (before BuildLayout).
+        // Discipline label assigned to nodes created from the static
+        // fallback list (the live doc loop assigns "Project" so users see
+        // which entries are currently bound to a category in this model).
+        private const string DISC_PROJECT = "Project";
+
+        // Build the three category trees + line/fill pattern lists.
+        // Unions doc.Settings.Categories with the static
+        // KnownModelCategoriesByDiscipline / KnownAnnotationCategoriesByDiscipline
+        // tables so the editor always shows a complete native-Revit catalogue,
+        // even on minimal projects (template-only documents, family editor,
+        // empty new project) and is filterable by discipline.
         private void BuildCategoryTrees()
         {
+            // Per-step try/catch so a failure in one step (e.g. a hostile
+            // doc.Settings.Categories iteration) doesn't suppress the static
+            // fallback that follows.
+            var modelByKey = new Dictionary<string, VgCategoryNode>(StringComparer.OrdinalIgnoreCase);
+            var annoByKey  = new Dictionary<string, VgCategoryNode>(StringComparer.OrdinalIgnoreCase);
+
+            // 1. Live doc categories ----------------------------------------
             try
             {
-                if (_doc == null) return;
-
-                // Model categories ----------------------------------------
-                foreach (Category cat in _doc.Settings.Categories)
+                if (_doc != null)
                 {
-                    if (cat == null) continue;
-                    if (cat.CategoryType != CategoryType.Model) continue;
-                    var node = new VgCategoryNode { CategoryName = cat.Name, CategoryKey = cat.Name };
-                    foreach (Category sub in cat.SubCategories)
+                    foreach (Category cat in _doc.Settings.Categories)
                     {
-                        if (sub == null) continue;
-                        node.Children.Add(new VgCategoryNode
-                        {
-                            CategoryName  = sub.Name,
-                            CategoryKey   = "<" + sub.Name + ">",
-                            IsSubcategory = true,
-                        });
-                    }
-                    _modelCatNodes.Add(node);
-                }
-                _modelCatNodes = _modelCatNodes.OrderBy(n => n.CategoryName).ToList();
-
-                // Annotation categories -----------------------------------
-                foreach (Category cat in _doc.Settings.Categories)
-                {
-                    if (cat == null) continue;
-                    if (cat.CategoryType != CategoryType.Annotation) continue;
-                    var node = new VgCategoryNode { CategoryName = cat.Name, CategoryKey = cat.Name };
-                    foreach (Category sub in cat.SubCategories)
-                    {
-                        if (sub == null) continue;
-                        node.Children.Add(new VgCategoryNode
-                        {
-                            CategoryName  = sub.Name,
-                            CategoryKey   = "<" + sub.Name + ">",
-                            IsSubcategory = true,
-                        });
-                    }
-                    _annotationCatNodes.Add(node);
-                }
-                _annotationCatNodes = _annotationCatNodes.OrderBy(n => n.CategoryName).ToList();
-
-                // Imported (DWG / DXF) categories --------------------------
-                // Group by import file name; subcats are the layers.
-                var imports = new FilteredElementCollector(_doc)
-                    .OfClass(typeof(ImportInstance))
-                    .Cast<ImportInstance>()
-                    .Where(i => i?.Category != null)
-                    .ToList();
-                var byFile = new Dictionary<string, VgCategoryNode>(StringComparer.OrdinalIgnoreCase);
-                foreach (var imp in imports)
-                {
-                    var c = imp.Category;
-                    if (c == null) continue;
-                    if (!byFile.TryGetValue(c.Name, out var parent))
-                    {
-                        parent = new VgCategoryNode { CategoryName = c.Name, CategoryKey = c.Name };
-                        byFile[c.Name] = parent;
-                        foreach (Category sub in c.SubCategories)
+                        if (cat == null) continue;
+                        Dictionary<string, VgCategoryNode> bucket = null;
+                        if (cat.CategoryType == CategoryType.Model) bucket = modelByKey;
+                        else if (cat.CategoryType == CategoryType.Annotation) bucket = annoByKey;
+                        if (bucket == null) continue;
+                        var node = new VgCategoryNode {
+                            CategoryName = cat.Name, CategoryKey = cat.Name,
+                            Discipline = DISC_PROJECT };
+                        foreach (Category sub in cat.SubCategories)
                         {
                             if (sub == null) continue;
-                            parent.Children.Add(new VgCategoryNode
-                            {
-                                CategoryName  = sub.Name,
-                                CategoryKey   = "<" + sub.Name + ">",
-                                IsSubcategory = true,
-                            });
+                            node.Children.Add(new VgCategoryNode {
+                                CategoryName = sub.Name, CategoryKey = "<" + sub.Name + ">",
+                                Discipline = DISC_PROJECT, IsSubcategory = true });
                         }
+                        bucket[cat.Name] = node;
                     }
                 }
-                _importedCatNodes = byFile.Values.OrderBy(n => n.CategoryName).ToList();
-
-                // Line + fill patterns ------------------------------------
-                _linePatternNames = new[] { "(No Override)", "Solid" }
-                    .Concat(new FilteredElementCollector(_doc)
-                        .OfClass(typeof(LinePatternElement))
-                        .Cast<LinePatternElement>()
-                        .Select(lp => lp.Name).OrderBy(n => n))
-                    .Distinct().ToArray();
-
-                _fillPatternNames = new[] { "(No Override)" }
-                    .Concat(new FilteredElementCollector(_doc)
-                        .OfClass(typeof(FillPatternElement))
-                        .Cast<FillPatternElement>()
-                        .Select(fp => fp.Name).OrderBy(n => n))
-                    .Distinct().ToArray();
             }
-            catch (Exception ex)
+            catch (Exception ex) { StingLog.Warn("BuildCategoryTrees.live: " + ex.Message); }
+
+            // 2. Static fallback (runs unconditionally — never throws) -----
+            foreach (var kv in KnownModelCategoriesByDiscipline)
+                foreach (var name in kv.Value)
+                {
+                    if (modelByKey.ContainsKey(name)) continue;
+                    modelByKey[name] = new VgCategoryNode {
+                        CategoryName = name, CategoryKey = name, Discipline = kv.Key };
+                }
+            foreach (var kv in KnownAnnotationCategoriesByDiscipline)
+                foreach (var name in kv.Value)
+                {
+                    if (annoByKey.ContainsKey(name)) continue;
+                    annoByKey[name] = new VgCategoryNode {
+                        CategoryName = name, CategoryKey = name, Discipline = kv.Key };
+                }
+
+            _modelCatNodes      = modelByKey.Values.OrderBy(n => n.CategoryName).ToList();
+            _annotationCatNodes = annoByKey.Values .OrderBy(n => n.CategoryName).ToList();
+
+            // 3. Imported (DWG / DXF) categories — live doc only ----------
+            try
             {
-                StingLog.Warn("DrawingTypeEditor.BuildCategoryTrees: " + ex.Message);
+                if (_doc != null)
+                {
+                    var imports = new FilteredElementCollector(_doc)
+                        .OfClass(typeof(ImportInstance))
+                        .Cast<ImportInstance>()
+                        .Where(i => i?.Category != null)
+                        .ToList();
+                    var byFile = new Dictionary<string, VgCategoryNode>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var imp in imports)
+                    {
+                        var c = imp.Category;
+                        if (c == null) continue;
+                        if (!byFile.TryGetValue(c.Name, out var parent))
+                        {
+                            parent = new VgCategoryNode {
+                                CategoryName = c.Name, CategoryKey = c.Name, Discipline = DISC_PROJECT };
+                            byFile[c.Name] = parent;
+                            foreach (Category sub in c.SubCategories)
+                            {
+                                if (sub == null) continue;
+                                parent.Children.Add(new VgCategoryNode {
+                                    CategoryName = sub.Name, CategoryKey = "<" + sub.Name + ">",
+                                    Discipline = DISC_PROJECT, IsSubcategory = true });
+                            }
+                        }
+                    }
+                    _importedCatNodes = byFile.Values.OrderBy(n => n.CategoryName).ToList();
+                }
             }
+            catch (Exception ex) { StingLog.Warn("BuildCategoryTrees.imports: " + ex.Message); }
+
+            // 4. Line + fill patterns — live doc only ---------------------
+            try
+            {
+                if (_doc != null)
+                {
+                    _linePatternNames = new[] { "(No Override)", "Solid" }
+                        .Concat(new FilteredElementCollector(_doc)
+                            .OfClass(typeof(LinePatternElement))
+                            .Cast<LinePatternElement>()
+                            .Select(lp => lp.Name).OrderBy(n => n))
+                        .Distinct().ToArray();
+
+                    _fillPatternNames = new[] { "(No Override)" }
+                        .Concat(new FilteredElementCollector(_doc)
+                            .OfClass(typeof(FillPatternElement))
+                            .Cast<FillPatternElement>()
+                            .Select(fp => fp.Name).OrderBy(n => n))
+                        .Distinct().ToArray();
+                }
+            }
+            catch (Exception ex) { StingLog.Warn("BuildCategoryTrees.patterns: " + ex.Message); }
+        }
+
+        // Returns the discipline filter options for a given tree type.
+        // "All" + "Project" (live-doc-tagged) + each static-table key.
+        private string[] DisciplineFilterOptions(IEnumerable<VgCategoryNode> nodes,
+            Dictionary<string, string[]> staticTable)
+        {
+            var live = nodes.Select(n => n.Discipline ?? "")
+                .Where(d => !string.IsNullOrEmpty(d))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            // Order: "All" first, then "Project" if any live entries, then
+            // static-table keys in their declared order.
+            var ordered = new List<string> { "All" };
+            if (live.Any(d => d.Equals(DISC_PROJECT, StringComparison.OrdinalIgnoreCase)))
+                ordered.Add(DISC_PROJECT);
+            foreach (var k in staticTable.Keys)
+                if (live.Any(d => d.Equals(k, StringComparison.OrdinalIgnoreCase))
+                    && !ordered.Contains(k, StringComparer.OrdinalIgnoreCase))
+                    ordered.Add(k);
+            return ordered.ToArray();
         }
 
 
@@ -2450,9 +2612,38 @@ namespace StingTools.UI
         private static readonly double[] _vgColWidths =
             { 22, 180, 90, 90, 50, 90, 90, 60, 80 };
 
+        // Per-tab discipline filter state — keyed by tree-list reference so
+        // each tab keeps its own filter independently.
+        private readonly Dictionary<List<VgCategoryNode>, string> _disciplineFilter
+            = new Dictionary<List<VgCategoryNode>, string>();
+
         private UIElement BuildVgTreeTab(List<VgCategoryNode> nodes)
         {
             var dock = new DockPanel { Margin = new Thickness(2), LastChildFill = true };
+
+            // Resolve the static-table for this tree (used for filter options).
+            var staticTable = ReferenceEquals(nodes, _annotationCatNodes)
+                ? KnownAnnotationCategoriesByDiscipline
+                : KnownModelCategoriesByDiscipline;
+
+            // Discipline filter row (top) ---------------------------------
+            if (!_disciplineFilter.ContainsKey(nodes)) _disciplineFilter[nodes] = "All";
+            var filterRow = new DockPanel { Margin = new Thickness(0, 0, 0, 4), LastChildFill = true };
+            var filterLbl = new TextBlock {
+                Text = "Filter by discipline:",
+                Foreground = new SolidColorBrush(SubtleColor),
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 6, 0) };
+            DockPanel.SetDock(filterLbl, Dock.Left);
+            filterRow.Children.Add(filterLbl);
+
+            var filterCombo = new ComboBox { Height = 22, IsEditable = false, MinWidth = 160 };
+            DarkDialogTheme.StyleInput(filterCombo, CardBg, FgColor, CardBorder);
+            foreach (var d in DisciplineFilterOptions(nodes, staticTable))
+                filterCombo.Items.Add(d);
+            filterCombo.SelectedItem = _disciplineFilter[nodes];
+            DockPanel.SetDock(filterRow, Dock.Top);
+            dock.Children.Add(filterRow);
 
             // Column header row
             var hdrRow = MakeVgHeaderRow();
@@ -2465,35 +2656,68 @@ namespace StingTools.UI
                 Orientation = Orientation.Horizontal,
                 Margin = new Thickness(0, 4, 0, 2),
             };
-            actions.Children.Add(MakeSmallBtn("All",        () => BulkSetVisibility(nodes, true)));
-            actions.Children.Add(MakeSmallBtn("None",       () => BulkSetVisibility(nodes, false)));
-            actions.Children.Add(MakeSmallBtn("Invert",     () => BulkInvertVisibility(nodes)));
-            actions.Children.Add(MakeSmallBtn("Expand All", () => BulkExpand(nodes, true)));
-            actions.Children.Add(MakeSmallBtn("Collapse All", () => BulkExpand(nodes, false)));
+            actions.Children.Add(MakeSmallBtn("All",        () => BulkSetVisibility(FilteredNodes(nodes), true)));
+            actions.Children.Add(MakeSmallBtn("None",       () => BulkSetVisibility(FilteredNodes(nodes), false)));
+            actions.Children.Add(MakeSmallBtn("Invert",     () => BulkInvertVisibility(FilteredNodes(nodes))));
+            actions.Children.Add(MakeSmallBtn("Expand All", () => BulkExpand(FilteredNodes(nodes), true)));
+            actions.Children.Add(MakeSmallBtn("Collapse All", () => BulkExpand(FilteredNodes(nodes), false)));
             DockPanel.SetDock(actions, Dock.Bottom);
             dock.Children.Add(actions);
 
-            // Scrollable category rows
-            var scroll = new ScrollViewer
-            {
-                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                MaxHeight = 380,
-            };
-            var rows = new StackPanel();
-            scroll.Content = rows;
-            dock.Children.Add(scroll);
+            // Category rows — direct StackPanel inside the DockPanel's
+            // remaining (LastChildFill) area. The form-host already has its
+            // own outer ScrollViewer, so we don't nest one here (which could
+            // collapse to zero height when the parent has Auto sizing).
+            var rowsHost = new StackPanel { MinHeight = 220 };
+            dock.Children.Add(rowsHost);
 
-            RenderVgRows(rows, nodes);
+            // Wire the filter combo *after* rowsHost exists so the handler
+            // can re-render against the current filter selection.
+            filterCombo.SelectionChanged += (s, e) =>
+            {
+                if (filterCombo.SelectedItem is string ss)
+                {
+                    _disciplineFilter[nodes] = ss;
+                    RenderVgRows(rowsHost, nodes);
+                }
+            };
+            filterRow.Children.Add(filterCombo);
+
+            RenderVgRows(rowsHost, nodes);
             return dock;
         }
 
-        // Render the rows for the given node list. Subcat rows render only
-        // when the parent is expanded. Re-called whenever override state
-        // changes that affects visibility / structure.
+        // Filter `nodes` by the active discipline selection ("All" → no filter).
+        private List<VgCategoryNode> FilteredNodes(List<VgCategoryNode> nodes)
+        {
+            if (!_disciplineFilter.TryGetValue(nodes, out var disc) || string.IsNullOrEmpty(disc) || disc == "All")
+                return nodes;
+            return nodes.Where(n => string.Equals(n.Discipline, disc, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+        }
+
+        // Render the rows for the given node list, honouring the per-tab
+        // discipline filter. Subcat rows render only when the parent is
+        // expanded. Re-called whenever filter / override state changes.
         private void RenderVgRows(StackPanel host, List<VgCategoryNode> nodes)
         {
             host.Children.Clear();
-            foreach (var n in nodes)
+            var filtered = FilteredNodes(nodes);
+
+            if (filtered.Count == 0)
+            {
+                host.Children.Add(new TextBlock
+                {
+                    Text = "(no categories match this filter — switch to All or load some elements)",
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    FontStyle = FontStyles.Italic,
+                    FontSize = 11,
+                    Margin = new Thickness(8, 8, 8, 8),
+                });
+                return;
+            }
+
+            foreach (var n in filtered)
             {
                 host.Children.Add(MakeVgCategoryRow(n, host, nodes, indent: 0));
                 if (n.IsExpanded)

--- a/StingTools/UI/DrawingTypeEditorDialog.cs
+++ b/StingTools/UI/DrawingTypeEditorDialog.cs
@@ -438,6 +438,9 @@ namespace StingTools.UI
             actions.Children.Add(MakeSmallBtn("＋ New",  () => ActionNewPack()));
             actions.Children.Add(MakeSmallBtn("Clone",   () => ActionClonePack()));
             actions.Children.Add(MakeSmallBtn("Delete",  () => ActionDeletePack()));
+            // Phase 136 — bidirectional view-template copy.
+            actions.Children.Add(MakeSmallBtn("Push template → bound types",
+                () => ActionPushPackTemplateToBoundTypes()));
             DockPanel.SetDock(actions, Dock.Top); dock.Children.Add(actions);
 
             _lbPacks = new ListBox
@@ -766,6 +769,55 @@ namespace StingTools.UI
             _lbPacks.Items.Remove(_currentPack);
             _currentPack = _packs.FirstOrDefault();
             if (_currentPack != null) SelectPack(_currentPack); else _packFormHost.Children.Clear();
+        }
+
+        // Phase 136 — push pack.ViewTemplate down to every DrawingType bound
+        // to this pack. Useful when you've changed the pack default and want
+        // every drawing using it to pick up the new template explicitly
+        // (rather than relying on the runtime fallback).
+        private void ActionPushPackTemplateToBoundTypes()
+        {
+            if (_currentPack == null) return;
+            if (string.IsNullOrWhiteSpace(_currentPack.ViewTemplate))
+            {
+                System.Windows.MessageBox.Show(
+                    "Set the pack's view template first (Appearance card).",
+                    "STING — push template", MessageBoxButton.OK);
+                return;
+            }
+            var bound = _types.Where(t => string.Equals(t.ViewStylePackId, _currentPack.Id,
+                                                         StringComparison.OrdinalIgnoreCase)).ToList();
+            if (bound.Count == 0)
+            {
+                System.Windows.MessageBox.Show(
+                    $"No Drawing Types are bound to pack '{_currentPack.Id}'. Bind some first.",
+                    "STING — push template", MessageBoxButton.OK);
+                return;
+            }
+
+            // Show preview list and confirm.
+            var preview = string.Join("\n", bound.Take(10).Select(t => $"  • {t.Id}"
+                + (string.IsNullOrEmpty(t.ViewTemplateName) ? "  (currently inherits)" : $"  (overwrites '{t.ViewTemplateName}')")));
+            if (bound.Count > 10) preview += $"\n  …and {bound.Count - 10} more";
+            var resp = System.Windows.MessageBox.Show(
+                $"Set ViewTemplateName = '{_currentPack.ViewTemplate}' on {bound.Count} Drawing Type(s) bound to '{_currentPack.Id}'?\n\n"
+                + preview + "\n\nDrawing Types that already have an explicit template will be OVERWRITTEN.",
+                "STING — push template to bound types", MessageBoxButton.YesNo);
+            if (resp != MessageBoxResult.Yes) return;
+
+            int n = 0;
+            foreach (var t in bound)
+            {
+                t.ViewTemplateName = _currentPack.ViewTemplate;
+                if (!string.Equals(t.Origin, "project", StringComparison.OrdinalIgnoreCase))
+                    t.Origin = "project";   // edits land in project override on save
+                n++;
+            }
+            // Refresh the Drawing Types tab list display.
+            RefreshList();
+            System.Windows.MessageBox.Show(
+                $"Updated {n} Drawing Type(s).\nSave to persist to <project>/_BIM_COORD/drawing_types.json.",
+                "STING — push template", MessageBoxButton.OK);
         }
 
         // ── JSON load ──
@@ -1421,6 +1473,70 @@ namespace StingTools.UI
             return Card("Identity", body);
         }
 
+        // Phase 136 — small accent-coloured hyperlink used inside the pack
+        // picker hint row. ToolTip optional; clicks fire onClick.
+        private TextBlock MakePackInlineLink(string text, string tooltip, Action onClick)
+        {
+            var t = new TextBlock
+            {
+                Text = "  " + text,
+                Foreground = new SolidColorBrush(AccentColor),
+                FontSize = 11,
+                Cursor = Cursors.Hand,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(8, 0, 0, 0),
+                ToolTip = tooltip,
+            };
+            t.MouseLeftButtonUp += (s, e) => onClick?.Invoke();
+            return t;
+        }
+
+        // Phase 136 — push the active DrawingType's ViewTemplateName up to
+        // its bound pack (sets pack.ViewTemplate). Useful when the user
+        // has authored a template they want adopted as the pack default.
+        private void ActionPushTypeTemplateToPack()
+        {
+            if (_current == null) return;
+            if (string.IsNullOrWhiteSpace(_current.ViewStylePackId))
+            {
+                System.Windows.MessageBox.Show(
+                    "Bind this Drawing Type to a View Style Pack first.",
+                    "STING — push template", MessageBoxButton.OK);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(_current.ViewTemplateName))
+            {
+                System.Windows.MessageBox.Show(
+                    "This Drawing Type has no ViewTemplateName set — nothing to push.",
+                    "STING — push template", MessageBoxButton.OK);
+                return;
+            }
+            var pack = _packs.FirstOrDefault(p =>
+                string.Equals(p.Id, _current.ViewStylePackId, StringComparison.OrdinalIgnoreCase));
+            if (pack == null)
+            {
+                System.Windows.MessageBox.Show(
+                    $"Bound pack '{_current.ViewStylePackId}' not found in the editor's pack list.",
+                    "STING — push template", MessageBoxButton.OK);
+                return;
+            }
+            var prev = pack.ViewTemplate ?? "(unset)";
+            var resp = System.Windows.MessageBox.Show(
+                $"Set pack '{pack.Id}'.ViewTemplate = '{_current.ViewTemplateName}'?\n\n" +
+                $"Previous pack value: {prev}\n\n" +
+                "Every Drawing Type bound to this pack that doesn't override its own template " +
+                "will fall through to the new pack value.",
+                "STING — push template to pack", MessageBoxButton.YesNo);
+            if (resp != MessageBoxResult.Yes) return;
+
+            pack.ViewTemplate = _current.ViewTemplateName;
+            if (!string.Equals(pack.Origin, "project", StringComparison.OrdinalIgnoreCase))
+                pack.Origin = "project";
+            System.Windows.MessageBox.Show(
+                $"Updated pack '{pack.Id}'.\nSave to persist to <project>/_BIM_COORD/view_style_packs.json.",
+                "STING — push template", MessageBoxButton.OK);
+        }
+
         // Dedicated, prominent View style pack chooser. Non-editable
         // dropdown listing every loaded pack ("(none)" + every entry from
         // STING_VIEW_STYLE_PACKS.json — corporate baseline + project
@@ -1486,24 +1602,38 @@ namespace StingTools.UI
             DockPanel.SetDock(count, Dock.Left);
             hint.Children.Add(count);
 
-            var link = new TextBlock {
-                Text = "→ Edit selected pack",
-                Foreground = new SolidColorBrush(AccentColor),
-                FontSize = 11,
-                Cursor = Cursors.Hand,
+            // Right-side link group — three actions, each space-separated.
+            var linkRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right,
                 VerticalAlignment = VerticalAlignment.Center,
             };
-            link.MouseLeftButtonUp += (s, e) =>
-            {
-                if (string.IsNullOrEmpty(_current.ViewStylePackId)) return;
-                var target = (_packs ?? new List<ViewStylePack>()).FirstOrDefault(p =>
-                    string.Equals(p.Id, _current.ViewStylePackId, StringComparison.OrdinalIgnoreCase));
-                if (target == null) return;
-                _rootTabs.SelectedIndex = 1;
-                SelectPack(target);
-            };
-            hint.Children.Add(link);
+            linkRow.Children.Add(MakePackInlineLink("Use pack template",
+                "Clear my ViewTemplateName so I inherit from the pack's fallback.",
+                () =>
+                {
+                    if (string.IsNullOrEmpty(_current.ViewStylePackId)) return;
+                    _current.ViewTemplateName = null;
+                    if (!string.Equals(_current.Origin, "project", StringComparison.OrdinalIgnoreCase))
+                        _current.Origin = "project";
+                    RenderForm();   // refresh to show the cleared field
+                }));
+            linkRow.Children.Add(MakePackInlineLink("↑ Push to pack",
+                "Set the bound pack's ViewTemplate = this DrawingType's ViewTemplateName.",
+                () => ActionPushTypeTemplateToPack()));
+            linkRow.Children.Add(MakePackInlineLink("→ Edit pack", null,
+                () =>
+                {
+                    if (string.IsNullOrEmpty(_current.ViewStylePackId)) return;
+                    var target = (_packs ?? new List<ViewStylePack>()).FirstOrDefault(p =>
+                        string.Equals(p.Id, _current.ViewStylePackId, StringComparison.OrdinalIgnoreCase));
+                    if (target == null) return;
+                    _rootTabs.SelectedIndex = 1;
+                    SelectPack(target);
+                }));
+            DockPanel.SetDock(linkRow, Dock.Right);
+            hint.Children.Add(linkRow);
             stack.Children.Add(hint);
 
             return stack;

--- a/StingTools/UI/DrawingTypeEditorDialog.cs
+++ b/StingTools/UI/DrawingTypeEditorDialog.cs
@@ -506,20 +506,37 @@ namespace StingTools.UI
                 new[] { "ISO 13567 monochrome", "ISO 13567 colour", "AIA NCS", "BS 1192 mono", "Project custom" },
                 ap.HatchPalette, v => ap.HatchPalette = v,
                 tooltip: "Informational tag for the hatch family used by this pack — does not bind to a Revit asset."));
-            apBody.Children.Add(LabeledProjectAssetCombo("View template name",
+            apBody.Children.Add(LabeledProjectAssetCombo("View template name (fallback)",
                 _currentPack.ViewTemplate, v => _currentPack.ViewTemplate = v,
                 Merge(ProjectAssetPicker.ViewTemplateNames(_doc), CommonStingViewTemplates),
-                "View templates (View.IsTemplate = true) in the active project, plus STING corporate templates."));
-            apBody.Children.Add(LabeledCombo("Detail level",
+                "Pack-level view template — used as a FALLBACK when the DrawingType's own " +
+                "ViewTemplateName is empty. The DrawingType field always wins when both are set."));
+            apBody.Children.Add(LabeledCombo("Detail level (fallback)",
                 Iso19650Vocabulary.DetailLevels, _currentPack.DetailLevel,
-                v => _currentPack.DetailLevel = v));
+                v => _currentPack.DetailLevel = v,
+                tooltip: "Pack-level detail level — fallback when the DrawingType doesn't set one."));
             apBody.Children.Add(LabeledCombo("Scale hint",
                 new[] { "1:5", "1:10", "1:20", "1:25", "1:50", "1:100", "1:200", "1:500" },
                 _currentPack.ScaleHint, v => _currentPack.ScaleHint = v,
-                tooltip: "Common architectural scales. Free-text allowed if your pack needs an unusual scale."));
+                tooltip: "Informational only — the DrawingType.Scale field actually drives the produced view's scale."));
             apBody.Children.Add(LabeledCombo("Colour scheme",
                 Iso19650Vocabulary.ColorSchemes,
                 _currentPack.ColorScheme, v => _currentPack.ColorScheme = v));
+
+            // Phase 136 — show how many line / fill patterns are available
+            // from the active project. Confirms to the user that the VG
+            // editor's Override... sub-dialogs are pulling live project
+            // patterns, not a static list.
+            int linePatCount = Math.Max(0, (_linePatternNames?.Length ?? 0) - 2);   // minus "(No Override)" + "Solid"
+            int fillPatCount = Math.Max(0, (_fillPatternNames?.Length ?? 0) - 1);   // minus "(No Override)"
+            apBody.Children.Add(new TextBlock {
+                Text = $"Patterns from active project — {linePatCount} line pattern(s), {fillPatCount} fill pattern(s) loaded. " +
+                       "The Override... buttons in the VG tabs below pull from these lists.",
+                Foreground = new SolidColorBrush(SubtleColor),
+                FontSize = 10, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 6, 0, 0),
+            });
+
             _packFormHost.Children.Add(Card("Appearance", apBody));
 
             // Phase 136 — full Revit-style VG editor (replaces the old
@@ -1518,10 +1535,12 @@ namespace StingTools.UI
             body.Children.Add(LabeledCombo("Detail level",
                 Iso19650Vocabulary.DetailLevels,
                 _current.DetailLevel, v => _current.DetailLevel = v));
-            body.Children.Add(LabeledProjectAssetCombo("View template name",
+            body.Children.Add(LabeledProjectAssetCombo("View template name (overrides pack)",
                 _current.ViewTemplateName, v => _current.ViewTemplateName = v,
                 ProjectAssetPicker.ViewTemplateNames(_doc),
-                "View templates (View.IsTemplate = true) in the active project."));
+                "View templates (View.IsTemplate = true) in the active project. " +
+                "When set, this OVERRIDES the View Style Pack's template fallback. " +
+                "Leave blank to inherit from the pack."));
             body.Children.Add(LabeledProjectAssetCombo("Viewport type name",
                 _current.ViewportTypeName, v => _current.ViewportTypeName = v,
                 ProjectAssetPicker.ViewportTypeNames(_doc),

--- a/docs/AEC_PRODUCTION_SET_STRATEGY.md
+++ b/docs/AEC_PRODUCTION_SET_STRATEGY.md
@@ -1,0 +1,267 @@
+# AEC Production-Set Strategy
+
+A reference catalogue mapping every drawing a typical AEC firm produces across
+a project lifecycle to a (DrawingType, ViewStylePack) pair, so generators can
+route automatically and presentation stays consistent across stages, disciplines
+and audiences.
+
+This is the planning companion to `STING_DRAWING_TYPES.json` and
+`STING_VIEW_STYLE_PACKS.json`. Adopt as much or as little as fits your firm.
+
+---
+
+## 1. The pack catalogue (corp-base + 10 specialised)
+
+Packs are organised so most production work uses one of three baseline
+plan packs (`corp-construction`, `corp-presentation`, `corp-coordination`),
+with specialised packs branching off via `extends`.
+
+| Pack id | Purpose | Extends | Visual signature |
+|---|---|---|---|
+| `corp-base` | House defaults — line weights, text/dim styles, hatch palette, "Existing/Demolished/New" filters | — | ISO 13567 mono palette, STING-2.5mm text, STING-Linear dims |
+| `corp-construction` | IFC and tender drawings (full info, bold proposed, halftoned existing) | `corp-base` | Bold cut lines, full hatch, no presentation effects |
+| `corp-presentation` | Client-facing renders, design narratives, marketing | `corp-base` | Light line weights, rich colour, no grids/levels, halftoned context |
+| `corp-coordination` | MEP coordination, clash, federated views | `corp-base` | Discipline colour-coded, all systems visible halftoned for context |
+| `corp-asbuilt` | Hand-back as-built sets | `corp-construction` | Mono only, no proposed/demolition graphics, "AS BUILT" overlay |
+| `corp-fabrication-shop` | Pipe / duct / weld spool sheets | `corp-construction` | Heavy lines (1.4× scale), part-mark filters, ISO 6412 symbol family |
+| `corp-survey` | Existing-condition surveys, demolition records | `corp-base` | Light grey 0.5× weights, dimension-heavy, photo callouts |
+| `corp-authority` | Planning, building control, conservation submissions | `corp-construction` | Authority-required line weights, NTS suppressed, statutory tags |
+| `corp-clarification` | RFI sketches, mark-ups, query packs | `corp-base` | Red-line markup, revision-cloud bias, tab-style query log |
+| `corp-handover` | FM / O&M / asset-handover drawings | `corp-construction` | Asset categories accented, base halftoned, COBie tags only |
+| `corp-presentation-mono` | Mono / black-and-white render alternative | `corp-presentation` | Greyscale palette, halftones, no colour fills |
+
+---
+
+## 2. Drawing-Type matrix (RIBA Stage × Discipline × Output)
+
+Each row is a `(DrawingType.Id, ViewStylePack.Id)` pair, with the kind of view
+it produces and a recommended scale. Stage codes follow RIBA Plan of Work 2020;
+discipline codes follow ISO 19650-2 § A.5.
+
+### 2.1 Pre-design / Stage 0–1 (Site appraisal + briefing)
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| Site location plan | `site-location-A1-1to1250` | `corp-presentation` | 1:1250 | Plan over OS context |
+| Site survey | `site-survey-A1-1to200` | `corp-survey` | 1:200 | Plan w/ levels, trees, services |
+| Existing site photos | `site-photo-board-A1` | `corp-presentation` | NTS | Photo composite |
+| Demolition plan | `arch-demolition-A1-1to100` | `corp-survey` | 1:100 | Plan w/ red-line demo |
+| Phasing plan | `coord-phasing-A1-1to200` | `corp-construction` | 1:200 | Coloured phase blocks |
+
+### 2.2 Concept design / Stage 2
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| Site strategy | `arch-site-strategy-A1-1to500` | `corp-presentation` | 1:500 | Plan w/ massing |
+| Massing study | `arch-massing-A1` | `corp-presentation` | NTS | 3D axon |
+| Floor plans (concept) | `arch-plan-A1-1to200-concept` | `corp-presentation` | 1:200 | Plan |
+| Sections (concept) | `arch-section-A1-1to200-concept` | `corp-presentation` | 1:200 | Section |
+| Concept narrative | `pres-design-intent-A1` | `corp-presentation` | NTS | Plan + 3D + caption |
+| Mood board | `pres-mood-board-A1` | `corp-presentation` | NTS | Image grid |
+
+### 2.3 Schematic / Stage 3 (Developed design)
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| Floor plans | `arch-plan-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| RCP | `arch-rcp-A1-1to100` | `corp-construction` | 1:100 | Reflected ceiling plan |
+| Roof plan | `arch-roof-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Site plan | `arch-site-A1-1to500` | `corp-construction` | 1:500 | Plan |
+| Floor finishes | `arch-floor-finishes-A1-1to100` | `corp-construction` | 1:100 | Plan w/ material legend |
+| Elevations | `arch-elev-A1-1to100` | `corp-construction` | 1:100 | Elevation |
+| Sections | `arch-section-A1-1to50` | `corp-construction` | 1:50 | Section |
+| Door schedule | `door-schedule-A2` | `corp-construction` | NTS | Schedule |
+| Window schedule | `arch-window-schedule-A2` | `corp-construction` | NTS | Schedule |
+| Coordinated MEP plan | `mep-coord-A1-1to50` | `corp-coordination` | 1:50 | Plan w/ all systems |
+
+### 2.4 Technical / Stage 4 (Construction documentation)
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| **Architectural** |
+| Setting-out plan | `arch-setting-out-A1-1to50` | `corp-construction` | 1:50 | Plan w/ grids + dims |
+| Detail sections | `arch-detail-A3-1to20` | `corp-construction` | 1:20 | Section detail |
+| Wall types schedule | `arch-wall-types-A2` | `corp-construction` | NTS | Schedule + types |
+| Interior elevations | `arch-interior-elev-A1-1to50` | `corp-construction` | 1:50 | Elevation |
+| Stair / lift cores | `arch-core-A1-1to50` | `corp-construction` | 1:50 | Plan + section |
+| Fire strategy | `arch-fire-strategy-A1-1to100` | `corp-authority` | 1:100 | Plan w/ fire lines |
+| Accessibility | `arch-accessibility-A1-1to100` | `corp-authority` | 1:100 | Plan w/ M-clauses |
+| **Structural** |
+| Foundation plan | `struct-foundation-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Slab plans | `struct-slab-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Framing plans | `struct-framing-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Column schedule | `struct-column-schedule-A2` | `corp-construction` | NTS | Schedule |
+| Rebar details | `struct-rebar-detail-A3-1to20` | `corp-construction` | 1:20 | Section detail |
+| Connections | `struct-connection-A3-1to10` | `corp-construction` | 1:10 | Detail |
+| **Mechanical** |
+| HVAC duct plan | `mep-hvac-duct-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Plant room | `mep-plantroom-A1-1to50` | `corp-construction` | 1:50 | Plan + section |
+| Riser diagrams | `mep-hvac-riser-A1-1to50` | `corp-construction` | 1:50 | Section |
+| Schematic (single-line) | `mep-hvac-schematic-A1` | `corp-construction` | NTS | Schematic |
+| **Electrical** |
+| Power layout | `elec-power-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Lighting layout | `elec-lighting-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Fire alarm | `elec-fire-alarm-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Containment (cable tray) | `elec-containment-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| LV riser diagram | `elec-riser-A2-1to100` | `corp-construction` | 1:100 | Riser schematic |
+| Single-line diagram | `elec-sld-A1` | `corp-construction` | NTS | Schematic |
+| **Plumbing / Public health** |
+| DCW / DHW plans | `plumb-water-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Drainage plan | `plumb-drainage-A1-1to100` | `corp-construction` | 1:100 | Plan |
+| Plumbing risers | `plumb-riser-A1` | `corp-construction` | NTS | Schematic |
+| **Fire protection** |
+| Sprinkler layout | `fp-sprinkler-A1-1to100` | `corp-construction` | 1:100 | Plan |
+
+### 2.5 Construction / Stage 5
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| **Fabrication shop drawings** |
+| Pipe spool | `pipe-spool-A1-1to50` | `corp-fabrication-shop` | 1:50 | Spool layout w/ ISO 6412 |
+| Duct spool | `duct-spool-A1-1to50` | `corp-fabrication-shop` | 1:50 | Spool layout |
+| Weld map | `weld-map-A1-1to50` | `corp-fabrication-shop` | 1:50 | Plan w/ weld symbols |
+| Cut list | `cutlist-A2` | `corp-fabrication-shop` | NTS | Schedule |
+| Isometrics | `iso-A3` | `corp-fabrication-shop` | NTS | 3D iso |
+| **Site works** |
+| RFI sketch | `clar-rfi-A3` | `corp-clarification` | varies | Plan/section + question |
+| Mark-up | `clar-markup-A1` | `corp-clarification` | varies | Plan + revision strip |
+| Issued for construction | uses base IFC types above | `corp-construction` | varies | — |
+
+### 2.6 Handover / Stage 6
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| As-built plans | `arch-asbuilt-A1-1to100` | `corp-asbuilt` | 1:100 | Plan w/ AS BUILT stamp |
+| FM asset location | `fm-asset-location-A1-1to100` | `corp-handover` | 1:100 | Plan w/ assets accented |
+| O&M index | `handover-A1` | `corp-handover` | NTS | Sheet index |
+| Health & safety file | `hsf-A2` | `corp-handover` | NTS | Schedule |
+| Maintenance access | `fm-access-A1-1to100` | `corp-handover` | 1:100 | Plan w/ access zones |
+
+### 2.7 Authority submissions
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| Planning submission | `auth-planning-A1-1to200` | `corp-authority` | 1:200 | Plan |
+| Building control | `auth-bc-A1-1to100` | `corp-authority` | 1:100 | Plan |
+| Conservation area | `auth-heritage-A1-1to100` | `corp-authority` | 1:100 | Plan + photos |
+| Section 106 | `auth-s106-A1` | `corp-authority` | varies | — |
+
+### 2.8 Client presentation / marketing
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| Presentation 3D axon | `pres-3d-axon-A1` | `corp-presentation` | NTS | 3D + key plan |
+| Perspective | `pres-perspective-A1` | `corp-presentation` | NTS | Full-bleed perspective |
+| Render board | `pres-render-board-A1` | `corp-presentation` | NTS | 4-up renders |
+| Site context | `pres-context-site-A1` | `corp-presentation` | 1:500 | Aerial + caption |
+| Exterior elevation (rendered) | `pres-exterior-elev-A1` | `corp-presentation` | 1:200 | Elevation w/ materials |
+| Material strip | `pres-material-strip-A2` | `corp-presentation` | NTS | Material samples |
+| Interior render | `pres-interior-A1` | `corp-presentation` | NTS | Render |
+| Marketing 4-pager | `marketing-4pp-A1` | `corp-presentation` | NTS | Composite |
+
+### 2.9 Coordination / Federation
+
+| Drawing | DrawingType | Pack | Scale | View kind |
+|---|---|---|---|---|
+| Clash sheet | `coord-clash-A1-1to50` | `corp-coordination` | 1:50 | Plan w/ clash callouts |
+| Federation 3D | `coord-fed-3d-A1` | `corp-coordination` | NTS | 3D federated |
+| Coordination section | `coord-section-A1-1to50` | `corp-coordination` | 1:50 | Section all systems |
+| Section cuts | `coord-cuts-A1-1to50` | `corp-coordination` | 1:50 | Multi-section |
+
+---
+
+## 3. Routing rules — automatic profile selection
+
+The matrix above is consumed by `STING_DRAWING_TYPES.json:routing[]`. Pattern:
+
+```
+{ "discipline": "A", "phase": "STAGE_4", "docType": "PLAN",       "drawingTypeId": "arch-plan-A1-1to100"      }
+{ "discipline": "M", "phase": "STAGE_4", "docType": "HVAC_DUCT",  "drawingTypeId": "mep-hvac-duct-A1-1to100"  }
+{ "discipline": "*", "phase": "PRESENTATION", "docType": "AXON",  "drawingTypeId": "pres-3d-axon-A1"          }
+{ "discipline": "*", "phase": "*",       "docType": "RFI",        "drawingTypeId": "clar-rfi-A3"              }
+```
+
+When `BatchSectionsCommand` / `ShopDrawingComposer` / `BatchSheetsCommand` are
+called, they pass `(discipline, phase, docType)` to `DrawingDispatcher.Resolve`
+which returns the right DrawingType — and that DrawingType already names the
+right ViewStylePack. End-to-end automation, no per-drawing dialog.
+
+---
+
+## 4. Workflow guidance — choosing the right (DrawingType, Pack) pair
+
+### Production drawings (stages 4–5 IFC)
+Bind every DrawingType to **`corp-construction`** unless there's a strong
+reason to deviate. House the per-category VG overrides here. Use Revit view
+templates to lock graphics; the pack adds filter rules + tag families on top.
+
+### Coordination drawings (clash, federated)
+Bind to **`corp-coordination`**. The pack's VG overrides should colour-code
+discipline categories (M=blue, E=yellow, P=green, FP=red) and halftone the
+arch base for context.
+
+### Fabrication
+Bind spool DrawingTypes to **`corp-fabrication-shop`**. The pack should set
+`lineWeightScale = 1.4`, point at fabrication-specific text + dim styles,
+and include filters that highlight the spool's part-mark.
+
+### Client-facing
+Bind to **`corp-presentation`** for colour boards + renders, or
+**`corp-presentation-mono`** for greyscale. Strip grids, levels, dimensions.
+DrawingType.ViewTemplateName usually empty — let the pack drive.
+
+### Authority submissions
+Bind to **`corp-authority`**. Each submitting authority can extend further
+(e.g. `corp-authority-london`, `corp-authority-conservation`) — set
+`Extends: corp-authority` and override the differences only.
+
+### As-built handover
+Bind to **`corp-asbuilt`**. Pack should suppress proposed/demolition graphics,
+add an "AS BUILT" title-block stamp via title-block param binding, and lock
+revision codes to "P0".
+
+### RFI / mark-ups
+Bind to **`corp-clarification`**. Pack should bias revision clouds + a query
+log table block. Sheet number pattern: `RFI-{nnn}` not the project pattern.
+
+---
+
+## 5. Build-out plan — recommended sequencing
+
+Don't try to author all 80+ drawing types and 11 packs at once. Sensible order:
+
+1. **Pack baseline** (1 day): `corp-base` + `corp-construction` +
+   `corp-presentation` + `corp-coordination`. These cover ~70% of work.
+2. **Stage 4 IFC drawing types** (1–2 days): every row in §2.4 above.
+   Bind all to `corp-construction` initially.
+3. **Routing** (½ day): the rules table in §3 — once written, every batch
+   generator picks the right type.
+4. **Specialised packs** (per-project, as needed): `corp-fabrication-shop`,
+   `corp-asbuilt`, `corp-handover`, `corp-authority`, `corp-clarification`.
+5. **Presentation drawings** (per-project): `corp-presentation` is the
+   workhorse; the DrawingTypes are short-lived per pitch.
+
+Use the editor's **Clone** button liberally — it's faster to clone an
+existing pack/type and tweak than to author from scratch.
+
+---
+
+## 6. Copying view templates between packs and types
+
+Two new buttons added in Phase 136 (see Drawing Type Editor):
+
+- **View Style Packs tab → "Push template → bound types"**: takes the
+  current pack's `ViewTemplate` and writes it onto every Drawing Type bound
+  to this pack via `ViewStylePackId`. Use when you've changed the pack
+  default and want every drawing to adopt it explicitly (rather than
+  relying on the runtime fallback).
+- **Drawing Types tab → "↑ Push to pack"**: takes the current Drawing
+  Type's `ViewTemplateName` and writes it to the bound pack's
+  `ViewTemplate`. Use when you've authored a drawing-specific template
+  you want adopted as the new pack default.
+- **Drawing Types tab → "Use pack template"**: clears the Drawing Type's
+  `ViewTemplateName` so it inherits from the pack. Useful after a "push to
+  pack" if you want clean inheritance going forward.
+
+Both push operations flip the affected entries' `Origin` to `project` so
+they save to `<project>/_BIM_COORD/` overrides, never the corporate baseline.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3199,3 +3199,33 @@ edit-time to keep the JSON sparse, matching Revit's own VG dialog behaviour.
 
 **csproj** — added `<UseWindowsForms>true</UseWindowsForms>` so the new sub-dialogs can
 launch the native `System.Windows.Forms.ColorDialog` colour picker.
+
+#### Completed (Phase 136 — follow-up: pack/profile fallback chain + workflow clarity)
+
+**Fallback chain wired end-to-end.** `DrawingTypePresentation.Apply` now resolves
+the pack early and uses `pack.ViewTemplate` / `pack.DetailLevel` as fallbacks when
+the DrawingType doesn't set its own — DrawingType always wins when both are set.
+Previously the pack's view template was loaded into the editor but never applied
+at runtime.
+
+**`ViewStylePack` extended** with `ViewTemplate`, `DetailLevel`, `ScaleHint`,
+`ColorScheme` so the runtime can read the same fields the editor writes. New
+`PackAppearanceDto` mirrors the editor's nested `appearance` object so
+`STING_VIEW_STYLE_PACKS.json` (which uses that shape) deserializes without
+silently dropping `textStyleName` / `dimensionStyleName` / `lineWeightScale` /
+`hatchPalette`. `ViewStylePackRegistry.PromoteAppearance` folds those onto the
+top-level pack fields at load time. Extends-chain merging extended to fold
+the four new fields parent → child.
+
+**JSON schema alias.** `ViewStylePackLibrary` now also accepts the legacy
+`stylePacks` array name (in addition to `viewStylePacks`) so the existing
+on-disk corporate JSON loads on the runtime path — was previously falling
+through to `BuildDefaults` because the array key didn't match.
+
+**Editor UX clarity.** Drawing Type's "View template name" tooltip now reads
+"overrides pack" with explicit precedence wording. View Style Pack's view
+template / detail level fields renamed "(fallback)" so the user sees the
+relationship at a glance. New status strip in the View Style Pack Appearance
+card: "Patterns from active project — N line pattern(s), M fill pattern(s)
+loaded" so the user can confirm the VG editor is sourcing patterns from the
+live document.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3172,3 +3172,30 @@ button continues to invoke the Centre as a modeless window.
    `Core/Drawing/DrawingDriftDetector.cs`. Compares STING_VIEW_TAG_STYLE +
    TAG_SEG_MASK_TXT on stamped views against the resolved profile/pack pair; SyncStyles
    re-runs `DrawingTypePresentation.Apply` to heal the drift.
+
+#### Completed (Phase 136 — Drawing Type Editor: ViewStylePack dropdown + full Revit VG editor)
+
+**ViewStylePackId dropdown** added to Drawing Types > Views card. Lists all packs by
+id + name (including unsaved new packs created in the same session). Includes
+"→ Edit pack" link that switches to View Style Packs tab and selects the matching pack.
+`_packs` initialised before `BuildLayout()` so the combo is populated on first render.
+
+**Full Revit-style VG editor** replaces the old row-grid in View Style Packs tab.
+4-tab structure (Model Categories / Annotation Categories / Imported Categories / Filters)
+with full category tree from live `doc.Settings.Categories`, subcategory expand/collapse,
+Override... sub-dialogs for Lines (color + weight + pattern) and Patterns
+(fg/bg color + fg/bg pattern + visibility per layer), per-category Detail Level,
+Halftone, Transparency, All/None/Invert/Expand All bulk actions.
+
+**StyleVgOverride POCO extended** with 16 new fields covering line patterns, surface and
+cut fill patterns (fg+bg), pattern visibility, category visibility, and per-category
+detail level. `ViewStylePackApplier.Apply()` wired to apply all new fields via
+`OverrideGraphicSettings`; `ResolveLinePatternId()` and `ResolveFillPatternId()` helpers
+added.
+
+**Local PackCategoryOverride / PackFilterRule** mirror the new field set so the editor
+roundtrips cleanly through `STING_VIEW_STYLE_PACKS.json`. Empty overrides are pruned at
+edit-time to keep the JSON sparse, matching Revit's own VG dialog behaviour.
+
+**csproj** — added `<UseWindowsForms>true</UseWindowsForms>` so the new sub-dialogs can
+launch the native `System.Windows.Forms.ColorDialog` colour picker.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3229,3 +3229,24 @@ relationship at a glance. New status strip in the View Style Pack Appearance
 card: "Patterns from active project — N line pattern(s), M fill pattern(s)
 loaded" so the user can confirm the VG editor is sourcing patterns from the
 live document.
+
+#### Completed (Phase 136 — follow-up: pack ↔ type template copy + AEC strategy doc)
+
+**Bidirectional template copy.**
+- View Style Packs tab gained a "Push template → bound types" button: takes the
+  pack's `ViewTemplate` and writes it onto every Drawing Type bound to this
+  pack. Confirms with a preview of affected types.
+- Drawing Types tab gained "↑ Push to pack" + "Use pack template" links next
+  to the View style pack picker. The first writes the Drawing Type's
+  `ViewTemplateName` up to the bound pack's `ViewTemplate`; the second clears
+  the Drawing Type's value so it inherits the pack fallback.
+- Both push operations flip affected entries' `Origin` to `project` so saves
+  land in `<project>/_BIM_COORD/` overrides, never the corporate baseline.
+
+**`docs/AEC_PRODUCTION_SET_STRATEGY.md`** — new reference catalogue laying out
+a complete AEC production-set strategy: 11 ViewStylePacks (corp-base + 10
+specialised: construction / presentation / coordination / fabrication-shop /
+survey / authority / clarification / asbuilt / handover / presentation-mono),
+plus an 80+ DrawingType matrix indexed by RIBA stage × discipline × output.
+Recommended sequencing: baseline 4 packs first, Stage 4 IFC types next, then
+routing rules, then specialised packs as projects need them.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3250,3 +3250,20 @@ survey / authority / clarification / asbuilt / handover / presentation-mono),
 plus an 80+ DrawingType matrix indexed by RIBA stage × discipline × output.
 Recommended sequencing: baseline 4 packs first, Stage 4 IFC types next, then
 routing rules, then specialised packs as projects need them.
+
+#### Design — STING-Managed View Templates (advisory, not implemented)
+
+`docs/STING_MANAGED_TEMPLATES_DESIGN.md` — full proposal for replacing
+hand-authored Revit view templates with **STING-managed** templates that the
+runtime auto-generates from the pack's settings. Hybrid architecture: each
+pack picks `templateMode = managed | external`. In `managed` mode the runtime
+maintains `STING:<pack-id>:<view-type>` templates from pack JSON (VG, filters,
+detail level, phase, discipline, view range, visual style, …). `external`
+mode preserves the current behaviour as an escape hatch.
+
+Phased build: Phase 1 scaffolding (mode flag + cheap fields), Phase 2 full
+template fidelity (view range / underlay / sun / display), Phase 3 migration
+commands, Phase 4 polish. Phase 1 is the smallest piece that delivers the
+"don't go back to Revit for VG/templates" promise.
+
+Implementation pending user approval — no runtime change yet.

--- a/docs/STING_MANAGED_TEMPLATES_DESIGN.md
+++ b/docs/STING_MANAGED_TEMPLATES_DESIGN.md
@@ -1,0 +1,310 @@
+# Design — STING-Managed View Templates
+
+## The proposal in one line
+
+Stop authoring Revit view templates by hand. Author **packs** in STING; let the
+runtime *generate* and *maintain* the matching Revit view templates in the
+background, and bind every produced view to one. The user never opens Revit's
+VG / templates dialog.
+
+---
+
+## Why the current state has friction
+
+The Phase 136 work made `pack.ViewTemplate` a *fallback* for
+`DrawingType.ViewTemplateName`, but both still **point at a Revit-authored
+template**. Three forms of drift result:
+
+1. **Pack VG vs template VG.** When a template is locked, Revit honours the
+   template; pack VG overrides land on it indirectly or are silently lost. The
+   applier already warns about this.
+2. **Editor expectation vs runtime reality.** The editor lets you author VG +
+   filters in the pack, but if the template locks the same categories, you've
+   double-edited and the pack's contribution is invisible.
+3. **Template lifecycle.** Templates are project-scoped. Packs are corporate.
+   So the same `corp-standard-plan` pack ends up bound to different templates
+   in every project — and when one project edits the template, the others
+   don't follow.
+
+The user's instinct is right: if STING owns the visual style, *Revit's
+template UI shouldn't be the source of truth*.
+
+---
+
+## What a view template can express (and where the pack stands today)
+
+Template setting | Pack today | Comment
+---|---|---
+V/G category overrides (line wt, colour, pattern, fg/bg fill, halftone, transparency, detail level) | ✅ | Phase 136 expanded to full Revit fidelity
+Filter overrides | ✅ | Per-filter VG (now mirrored against StyleVgOverride shape)
+Filter visibility | ✅ |
+Detail level | ✅ | `pack.DetailLevel`
+Scale | ⚠️ | `pack.ScaleHint` is informational; `DrawingType.Scale` is authoritative
+Discipline | ⚠️ | Derived from `DrawingType.Discipline`
+**View range** (top, cut plane, bottom, view depth) | ❌ | *Plan-only*
+**Far clip offset** | ❌ | Section / elevation
+**Phase + Phase filter** | ❌ |
+**Visual style** (wireframe / hidden / shaded / consistent / realistic / raytrace) | ❌ |
+**Sun setting** | ❌ | Mostly elevations / 3D
+**Annotation crop** | ❌ |
+**Display options** (shadows, edges, ambient, sketchy lines) | ❌ |
+**Background** (image / gradient / sky) | ❌ |
+**Photographic exposure** | ❌ | 3D
+**Worksets visibility** | ❌ |
+**Underlay** (level + range + halftone) | ❌ | *Plan-only*
+
+So **~10 fields** are needed before a pack can be a complete template
+substitute. Most are simple scalars or enums; none are Revit API-hard.
+
+---
+
+## What Revit lets us do programmatically
+
+Confirmed Revit 2025+ APIs:
+
+```csharp
+// Create a view of the right type
+View v = ViewPlan.Create(doc, viewFamilyTypeId, levelId);
+// Apply VG / filters / scale / detail level / phase / etc.
+v.Scale = 50;
+v.DetailLevel = ViewDetailLevel.Fine;
+v.ViewTemplateId = ElementId.InvalidElementId;  // detach
+v.SetCategoryOverrides(catId, ogs);
+v.SetFilterOverrides(filterId, ogs);
+v.SetFilterVisibility(filterId, true);
+v.AddFilter(filterId);
+
+// Convert it into a template
+v.ViewTemplateId = ElementId.InvalidElementId;     // not bound
+// (a "view template" is just a View with IsTemplate=true; setting it via
+//  the v.IsTemplate setter is read-only — but you can flag it on creation
+//  via the View Templates dialog or via Element.CopyAsTemplate workflows)
+```
+
+The cleanest pattern: **maintain one Revit template per (pack-id, view-type)
+pair**, named `STING:<pack-id>:<view-type>`, stamped with
+`STING_PACK_ID_TXT` + `STING_PACK_CHECKSUM_TXT` so the runtime knows it owns
+the template and can detect drift.
+
+---
+
+## Three viable architectures (compared)
+
+### A. Pure managed — kill `ViewTemplate` fields entirely
+
+- Remove `pack.ViewTemplate` and `DrawingType.ViewTemplateName`.
+- Pack carries every visual + view setting.
+- Runtime generates `STING:<pack>:<view-type>` templates and binds views to them.
+
+| Pro | Con |
+|---|---|
+| Single source of truth, no drift possible | No escape hatch — if Revit grows a template feature STING doesn't model, you're stuck |
+| One-stop editing | Disruptive migration; all existing JSON breaks |
+| Cleanest mental model | Every team that has invested in custom templates loses them |
+
+### B. Pure external — the old way
+
+Status-quo before Phase 136. Pack is just decoration on top of a Revit
+template the user authored. Rejected — that's the current pain point.
+
+### C. **Hybrid (recommended)** — `templateMode` flag per pack
+
+Each pack declares one of:
+
+- **`managed`** *(new default)*: STING auto-generates and maintains
+  `STING:<pack>:<view-type>` templates. Pack carries all settings;
+  `pack.ViewTemplate` field is ignored.
+- **`external`**: Existing behaviour. Pack names a Revit template by name;
+  STING applies VG/filters on top *only if the template doesn't lock them*.
+
+| Pro | Con |
+|---|---|
+| Single source of truth in the common case | Two code paths to maintain |
+| Escape hatch for legacy projects + Revit-only features | Slightly more configuration surface |
+| Phased migration — flip mode per-pack | Need clear UX for which mode is active |
+
+**Recommendation: C.** It costs one boolean flag per pack and gives every
+project the choice. Most corporate work flips to `managed` and never looks
+back; one-off projects with a heavy custom Revit template flip to `external`.
+
+---
+
+## What the pack needs to grow (for `managed` mode to be complete)
+
+Add to `ViewStylePack`:
+
+```jsonc
+{
+  "templateMode": "managed",   // or "external"
+
+  "viewRange": {                // plans only
+    "topMm":            2300,
+    "cutPlaneMm":       1200,
+    "bottomMm":            0,
+    "viewDepthMm":      -300
+  },
+  "underlay": {                 // plans only
+    "baseLevel":    "below",    // "off" | "below" | "<level-name>"
+    "topLevel":     "above",
+    "orientation":  "look-down",
+    "halftone":     true
+  },
+  "phaseFilter":     "Show All",     // by name
+  "discipline":      "Architectural",// "Architectural"|"Structural"|"Mechanical"|"Electrical"|"Plumbing"|"Coordination"
+  "visualStyle":     "HiddenLine",
+  "sunSetting":      { "preset": "Lighting" },
+  "displayOptions": {
+    "shadows":       false,
+    "sketchyLines":  false,
+    "ambientShadows":false
+  },
+  "annotationCrop":  false,
+  "farClipMm":      30000,             // sections / elevations
+  "background":      "None",            // "None"|"Sky"|"Gradient"|"Image:..."
+
+  // Bounds — used to keep auto-generated templates in sync with what user
+  // actually wants. Anything not listed here, the runtime won't touch on
+  // the auto-generated template (so user can manually tweak).
+  "managedFields": [
+    "vg", "filters", "detailLevel", "viewRange", "phaseFilter",
+    "discipline", "visualStyle", "annotationCrop"
+  ]
+}
+```
+
+`managedFields` is the contract that protects user work: STING only writes
+the fields you list. Everything else on the auto-generated template is
+fair game for manual edits.
+
+---
+
+## Runtime sync algorithm
+
+Pseudocode for `ManagedTemplateSyncer.EnsureTemplate(doc, pack, viewType)`:
+
+```
+1. Compute pack checksum (SHA-256 of pack JSON, scoped to managedFields)
+2. Look for existing Revit view named  STING:<pack-id>:<viewType>
+   - If absent:
+       a. Create a stub view of viewType (ViewPlan / ViewSection / View3D…)
+       b. Detach it from any active template
+       c. Apply pack settings (VG, filters, scale, detail, phase, …)
+       d. Stamp STING_PACK_ID_TXT, STING_PACK_CHECKSUM_TXT, STING_MANAGED_BOOL=1
+       e. Convert to template (set IsTemplate via the supported API path)
+       f. Cache template ElementId
+   - If present:
+       a. Read STING_PACK_CHECKSUM_TXT
+       b. If matches → reuse, return
+       c. If drift → re-apply only the fields in pack.managedFields,
+          update checksum stamp
+3. Return the template's ElementId
+```
+
+`DrawingTypePresentation.Apply` then:
+
+```
+if (pack.templateMode == "managed") {
+    var tplId = ManagedTemplateSyncer.EnsureTemplate(doc, pack, view.ViewType);
+    view.ViewTemplateId = tplId;
+    // Pack VG / filters now live ON the template, not on the view —
+    // so the existing ViewStylePackApplier.Apply becomes a no-op in
+    // managed mode (it ran on the template, not the view).
+} else {
+    // existing behaviour: resolve pack.ViewTemplate by name + apply pack
+    // VG/filters on the view (and warn if template is locked).
+}
+```
+
+---
+
+## What this gives you
+
+- **One screen, all visual control.** Open the View Style Pack editor, edit
+  VG + view range + phase + visual style. Save. Every drawing bound to that
+  pack updates instantly on next regen.
+- **No template name typos.** STING picks the template name; user never
+  types it.
+- **Versioning works.** Pack checksum drift is detectable (already wired in
+  `DrawingDriftDetector`); a single `SyncStyles` re-applies all packs.
+- **Project-portable.** Open the same project on a different machine — the
+  STING template gets regenerated from the pack JSON; no need to ship
+  pre-authored Revit templates.
+
+---
+
+## Known limits / risks
+
+1. **Template lifecycle in Revit.** The auto-generated templates appear in
+   the Project Browser (Templates section) named `STING:*`. Some teams may
+   find this noisy. *Mitigation:* the Project Browser organizer that
+   already groups by `STING_DRAWING_TYPE_ID_TXT` can be extended to fold
+   STING templates into a dedicated branch.
+2. **User edits a managed template in Revit's UI.** Next sync will revert
+   any field listed in `managedFields`. *Mitigation:* show a warning
+   sticker on the template's primary view, plus a "this template is
+   STING-managed" tooltip in the editor.
+3. **Migration.** Existing `pack.ViewTemplate` entries need to be either
+   converted to managed (read the named template's settings into pack
+   fields) or kept as `external`. Both are scriptable.
+4. **API edge cases.** Some template fields (e.g. *Section Box* for 3D
+   views, schedule appearance fields) require version-specific API calls.
+   Defer these until a real project asks for them.
+5. **VG editor visibility.** When `templateMode = managed`, the editor's
+   "View template name" combo should hide / disable. We need a clear UI
+   signal that the pack is *self-sufficient*.
+
+---
+
+## Phased implementation
+
+Each phase is shippable on its own.
+
+### Phase 1 — Scaffolding (~2 days)
+- Add `templateMode`, `viewRange`, `phaseFilter`, `discipline`,
+  `visualStyle`, `annotationCrop`, `farClipMm`, `displayOptions`,
+  `managedFields` to `ViewStylePack`.
+- Editor cards: View Range / Phase / Display under the existing Appearance
+  card. Hide them when `templateMode == "external"`.
+- New runtime class `ManagedTemplateSyncer` with `EnsureTemplate(doc, pack,
+  viewType)`. Initially honours only VG + filters + detail level +
+  phaseFilter + discipline (the cheap fields). Returns ElementId of the
+  generated template.
+- Wire `DrawingTypePresentation.Apply` to call the syncer when
+  `pack.templateMode == "managed"`.
+
+### Phase 2 — Full template fidelity (~3 days)
+- Add View Range, Underlay, Sun, Visual Style, Display Options, Background,
+  Annotation Crop, Far Clip, Photographic Exposure handling.
+- Per-view-type template generation (`STING:<pack>:Plan`,
+  `STING:<pack>:Section`, `STING:<pack>:Elevation`, `STING:<pack>:3D`,
+  `STING:<pack>:Detail`, `STING:<pack>:Drafting`).
+- Drift detection includes pack checksum stamp.
+
+### Phase 3 — Migration tools (~1 day)
+- Command: **"Convert Pack to Managed"** — picks an existing Revit template
+  by name, reads its settings into pack fields, sets `templateMode =
+  managed`. Removes the original template (or renames to
+  `<original>_legacy` for safety).
+- Command: **"Detach Pack from STING Management"** — copies pack settings
+  out into a new Revit template, sets `templateMode = external` pointing
+  at it.
+
+### Phase 4 — Polish (~½ day)
+- Project Browser organizer fold STING templates into a `STING — managed
+  templates` branch.
+- Editor sticker: "This pack manages 4 templates: STING:corp-plan:Plan,
+  STING:corp-plan:Section, …" (so the user sees the side-effect).
+- "Regenerate templates now" button on the pack editor toolbar.
+
+---
+
+## Recommendation
+
+**Adopt the hybrid (Architecture C).** Default new packs to `managed`. Keep
+`external` as the escape hatch. Build in phases: get Phase 1 shipping with
+~80% of the value (VG + filters + phase + discipline), then layer Phase 2
+on top as need surfaces.
+
+The user's instinct — *don't go back to Revit for VG / template management*
+— is correct, and this design honours it without throwing away the option
+when an unusual project needs it.


### PR DESCRIPTION
## Summary

Extends the Drawing Type Editor with a complete Revit-style visual graphics (VG) override editor for View Style Packs, adds 16 new fields to `StyleVgOverride` for line/fill patterns and category visibility, and implements pack-level fallbacks for `ViewTemplate` and `DetailLevel` when DrawingType fields are not set.

## Key Changes

- **DrawingTypeEditorDialog.cs**: Replaced simple row-grid VG editor with a 4-tab structure (Model Categories / Annotation Categories / Imported Categories / Filters) featuring full category tree navigation, expand/collapse, Override dialogs for Lines and Patterns, bulk actions (All/None/Invert/Expand All), and per-category Detail Level controls.

- **StyleVgOverride POCO**: Extended with 16 new fields:
  - Line patterns: `ProjectionLinePattern`, `CutLinePattern`
  - Surface/cut fill patterns: `SurfaceFillColor`, `SurfaceFillPattern`, `CutFillColor`, `CutFillPattern`
  - Pattern visibility: `SurfaceFillVisibility`, `CutFillVisibility`
  - Category visibility: `Visible`
  - Per-category detail level: `DetailLevel`

- **ViewStylePack POCO**: Added pack-level fallback fields (`ViewTemplate`, `DetailLevel`, `ScaleHint`, `ColorScheme`) and `Appearance` DTO for editor convenience, allowing packs to provide defaults when DrawingType fields are unset.

- **ViewStylePackApplier.Apply()**: Wired all new `StyleVgOverride` fields to `OverrideGraphicSettings` API calls; added `ResolveLinePatternId()` and `ResolveFillPatternId()` helpers to resolve pattern names to Revit ElementIds.

- **DrawingTypePresentation.Apply()**: Resolves pack early to use its `DetailLevel` and `ViewTemplate` as fallbacks when DrawingType does not set them; maintains existing VG/filter application order.

- **ViewStylePackRegistry**: Added `PromoteAppearance()` to migrate editor-emitted `Appearance` DTO fields into top-level pack properties for runtime consistency.

- **Project file**: Enabled `UseWindowsForms` for ColorDialog support in the VG editor.

## Documentation

Added two reference guides:
- **STING_MANAGED_TEMPLATES_DESIGN.md**: Proposes a hybrid architecture (managed vs. external template modes) to eliminate drift between pack VG and Revit templates, with a feature matrix of what packs can express today and what's needed.
- **AEC_PRODUCTION_SET_STRATEGY.md**: Reference catalogue mapping typical AEC drawing types to (DrawingType, ViewStylePack) pairs across project lifecycle stages and disciplines.

## Notable Implementation Details

- Pack-level fallbacks are applied *before* crop/view range logic so they don't regress existing behavior.
- The editor writes `Appearance` as a nested object; `PromoteAppearance()` flattens it to match disk JSON shape for runtime consistency.
- Category visibility is applied via `view.SetCategoryHidden()` rather than `OverrideGraphicSettings`, as Revit's API requires.
- Full Revit fidelity for line/fill patterns, halftone, transparency, and detail level per category.

https://claude.ai/code/session_01S6Sf46L2LRq6389i5f4533