### PR TITLE
Performance & correctness: caching, discipline filtering, and queue batching

### DIFF
--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -1974,6 +1974,44 @@ namespace StingTools.BIMManager
             var doc = app.ActiveUIDocument?.Document;
             if (doc == null) { TaskDialog.Show("Planscape", "No document open."); return; }
 
+            // D-2: warn the user when this sync would push from a non-central
+            // or unsynced local copy. We block only on user choice — once
+            // accepted, the sync proceeds with whatever payload the local
+            // model carries.
+            try
+            {
+                if (!doc.IsWorkshared)
+                {
+                    StingLog.Info("Planscape sync: document is not workshared — local model is the source of truth");
+                    var nonShared = new TaskDialog("Planscape Sync — Confirm")
+                    {
+                        MainInstruction = "Document is not workshared",
+                        MainContent = "The current document is not workshared. The sync will include only elements visible in this local copy. Continue?",
+                        CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.Cancel,
+                        DefaultButton = TaskDialogResult.Cancel,
+                    };
+                    if (nonShared.Show() != TaskDialogResult.Yes) return;
+                }
+                else
+                {
+                    bool isModified = false;
+                    try { isModified = doc.IsModified; } catch { }
+                    StingLog.Info($"Planscape sync: workshared (IsModified={isModified})");
+                    if (isModified)
+                    {
+                        var unsynced = new TaskDialog("Planscape Sync — Confirm")
+                        {
+                            MainInstruction = "Local changes have not been synced to central",
+                            MainContent = "Document has unsaved local changes. Sync to central before pushing tags to Planscape so the server reflects authoritative state. Continue with the local snapshot anyway?",
+                            CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.Cancel,
+                            DefaultButton = TaskDialogResult.Cancel,
+                        };
+                        if (unsynced.Show() != TaskDialogResult.Yes) return;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"Planscape sync worksharing pre-check: {ex.Message}"); }
+
             // Load project ID from connection config
             string bimDir = BIMManagerEngine.GetBIMManagerDir(doc);
             string cfgPath = Path.Combine(bimDir, "planscape_connection.json");

--- a/StingTools/Commands/Drawing/DrawingSyncStylesCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingSyncStylesCommand.cs
@@ -34,11 +34,18 @@ namespace StingTools.Commands.Drawing
                 var doc = data?.Application?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
-                var reports = DrawingDriftDetector.Scan(doc);
+                var allReports = DrawingDriftDetector.Scan(doc);
+                // C-8 / E-2: skip reports whose only entries are suppressed by
+                // a controlling view template — re-applying does nothing for
+                // those, and they would otherwise resurface every Sync run.
+                var reports = allReports.Where(r => r.AnyActionable).ToList();
+                int suppressedOnly = allReports.Count - reports.Count;
                 if (reports.Count == 0)
                 {
-                    TaskDialog.Show("STING — Sync Styles",
-                        "Every stamped view is already in sync with its Drawing Type.");
+                    string msg2 = suppressedOnly > 0
+                        ? $"Every actionable view is already in sync with its Drawing Type.\n{suppressedOnly} view(s) have fields controlled by a view template — those are informational only."
+                        : "Every stamped view is already in sync with its Drawing Type.";
+                    TaskDialog.Show("STING — Sync Styles", msg2);
                     return Result.Succeeded;
                 }
 

--- a/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
@@ -69,10 +69,30 @@ namespace StingTools.Commands.Drawing
                 try
                 {
                     var drifts = DrawingDriftDetector.Scan(doc);
-                    if (drifts.Count == 0)
+                    int actionable = drifts.Count(r => r.AnyActionable);
+                    int suppressed = drifts.Count(r => r.AnySuppressed);
+                    if (actionable == 0 && suppressed == 0)
                         sb.AppendLine("Drift:      0 view(s) out of sync with their profile");
+                    else if (actionable == 0)
+                        sb.AppendLine($"Drift:      0 actionable; {suppressed} view(s) have template-controlled fields (informational, no action required)");
                     else
-                        sb.AppendLine($"Drift:      {drifts.Count} view(s) drifted — run 'Sync Styles' to resync");
+                        sb.AppendLine($"Drift:      {actionable} view(s) drifted — run 'Sync Styles' to resync"
+                            + (suppressed > 0 ? $"; {suppressed} additional view(s) have template-controlled fields (informational only)" : ""));
+
+                    // E-2: list any DRIFT_SUPPRESSED_BY_TEMPLATE entries in a
+                    // separate "Informational — no action required" section so
+                    // users understand why SyncStyles will not touch them.
+                    if (suppressed > 0)
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine("Informational — no action required (view template controls these fields):");
+                        foreach (var r in drifts.Where(rr => rr.AnySuppressed).Take(10))
+                        {
+                            sb.AppendLine($"  {r.ViewName}  [{r.DrawingTypeId}]");
+                            foreach (var s in r.Suppressed.Take(3))
+                                sb.AppendLine($"     · {s}");
+                        }
+                    }
                 }
                 catch (Exception dex) { sb.AppendLine($"Drift scan failed: {dex.Message}"); }
 

--- a/StingTools/Core/Drawing/DrawingDriftDetector.cs
+++ b/StingTools/Core/Drawing/DrawingDriftDetector.cs
@@ -29,7 +29,18 @@ namespace StingTools.Core.Drawing
         public string    DrawingTypeId { get; set; }
         public List<string> Drifts { get; } = new List<string>();
 
+        /// <summary>
+        /// C-8 / E-2: drift items that the running view template suppresses
+        /// (the parameter cannot be written by the profile because the
+        /// template controls it). SyncStyles must skip these — re-applying
+        /// will fail silently and the report will resurface forever. Inspect
+        /// surfaces them as informational ("template controls this field").
+        /// </summary>
+        public List<string> Suppressed { get; } = new List<string>();
+
         public bool Any => Drifts.Count > 0;
+        public bool AnyActionable => Drifts.Count > 0;
+        public bool AnySuppressed => Suppressed.Count > 0;
     }
 
     public static class DrawingDriftDetector
@@ -39,6 +50,19 @@ namespace StingTools.Core.Drawing
             var reports = new List<DriftReport>();
             if (doc == null) return reports;
 
+            // C-4: build a single id → DrawingType dictionary up front so we
+            // don't walk DrawingTypeLibrary.DrawingTypes once per stamped view.
+            // ListAll(doc) returns the cached library; the per-id resolved
+            // value is memoized inside DrawingTypeRegistry.Get (C-5).
+            var resolvedById = new Dictionary<string, DrawingType>(StringComparer.OrdinalIgnoreCase);
+            foreach (var raw in DrawingTypeRegistry.ListAll(doc))
+            {
+                if (string.IsNullOrWhiteSpace(raw.Id)) continue;
+                if (resolvedById.ContainsKey(raw.Id)) continue;
+                var resolved = DrawingTypeRegistry.Get(doc, raw.Id);
+                if (resolved != null) resolvedById[raw.Id] = resolved;
+            }
+
             foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(View)))
             {
                 if (!(el is View v) || v.IsTemplate) continue;
@@ -46,7 +70,7 @@ namespace StingTools.Core.Drawing
                 if (string.IsNullOrWhiteSpace(dtId)) continue;   // not a STING view
                 if (DrawingTypeStamper.IsLocked(v)) continue;    // user-frozen
 
-                var dt = DrawingTypeRegistry.Get(doc, dtId);
+                resolvedById.TryGetValue(dtId, out var dt);
                 if (dt == null)
                 {
                     var r = new DriftReport { ViewId = v.Id, ViewName = v.Name, DrawingTypeId = dtId };
@@ -88,9 +112,29 @@ namespace StingTools.Core.Drawing
                 // through TokenProfileApplier and heals the drift.
                 AppendTokenProfileDrift(doc, v, dt, report);
 
-                if (report.Any) reports.Add(report);
+                if (report.Drifts.Count > 0 || report.Suppressed.Count > 0) reports.Add(report);
             }
             return reports;
+        }
+
+        /// <summary>
+        /// C-8: returns true when the view's currently applied view template
+        /// controls the named parameter — meaning a profile re-apply cannot
+        /// write to it. Used to demote TOKEN_PROFILE drift into
+        /// <see cref="DriftReport.Suppressed"/> so SyncStyles doesn't loop.
+        /// </summary>
+        private static bool TemplateControlsParameter(Document doc, View v, string paramName)
+        {
+            try
+            {
+                if (v?.ViewTemplateId == null || v.ViewTemplateId == ElementId.InvalidElementId) return false;
+                if (!(doc.GetElement(v.ViewTemplateId) is View tpl)) return false;
+                var p = tpl.LookupParameter(paramName);
+                if (p == null) return false;
+                var nonControlled = tpl.GetNonControlledTemplateParameterIds();
+                return nonControlled == null || !nonControlled.Contains(p.Id);
+            }
+            catch { return false; }
         }
 
         private static void AppendManagedTemplateDrift(Document doc, View v, DrawingType dt, DriftReport report)
@@ -138,7 +182,15 @@ namespace StingTools.Core.Drawing
                 {
                     string actual = ReadStringParam(v, ParamRegistry.VIEW_TAG_STYLE);
                     if (!string.Equals(actual, expectedScheme, StringComparison.OrdinalIgnoreCase))
-                        report.Drifts.Add($"TOKEN_PROFILE: STING_VIEW_TAG_STYLE '{actual ?? "(empty)"}' vs profile '{expectedScheme}'");
+                    {
+                        // C-8: if the running view template controls this
+                        // parameter, demote the entry to Suppressed so
+                        // SyncStyles doesn't retry forever.
+                        if (TemplateControlsParameter(doc, v, ParamRegistry.VIEW_TAG_STYLE))
+                            report.Suppressed.Add($"DRIFT_SUPPRESSED_BY_TEMPLATE: STING_VIEW_TAG_STYLE controlled by view template ('{actual ?? "(empty)"}' vs profile '{expectedScheme}')");
+                        else
+                            report.Drifts.Add($"TOKEN_PROFILE: STING_VIEW_TAG_STYLE '{actual ?? "(empty)"}' vs profile '{expectedScheme}'");
+                    }
                 }
 
                 string expectedMask = profile?.SegmentMask;
@@ -147,7 +199,12 @@ namespace StingTools.Core.Drawing
                 {
                     string actual = ReadStringParam(v, ParamRegistry.TAG_SEG_MASK);
                     if (!string.Equals(actual, expectedMask, StringComparison.Ordinal))
-                        report.Drifts.Add($"TOKEN_PROFILE: TAG_SEG_MASK '{actual ?? "(empty)"}' vs profile '{expectedMask}'");
+                    {
+                        if (TemplateControlsParameter(doc, v, ParamRegistry.TAG_SEG_MASK))
+                            report.Suppressed.Add($"DRIFT_SUPPRESSED_BY_TEMPLATE: TAG_SEG_MASK controlled by view template ('{actual ?? "(empty)"}' vs profile '{expectedMask}')");
+                        else
+                            report.Drifts.Add($"TOKEN_PROFILE: TAG_SEG_MASK '{actual ?? "(empty)"}' vs profile '{expectedMask}'");
+                    }
                 }
             }
             catch (Exception ex)

--- a/StingTools/Core/Drawing/DrawingTypePresentation.cs
+++ b/StingTools/Core/Drawing/DrawingTypePresentation.cs
@@ -12,6 +12,7 @@
 // Null drawingType is a no-op so adding the call is zero-regression.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
 
@@ -19,6 +20,162 @@ namespace StingTools.Core.Drawing
 {
     public static class DrawingTypePresentation
     {
+        // ── C-1 view-template cache ────────────────────────────────────────
+        // Per-document map of (templateName → ElementId) so batch producers
+        // (BatchSections, BatchElevations, BatchSheets) skip the
+        // FilteredElementCollector<View> scan for every view they create.
+        // Invalidated on document close and on DrawingTypeRegistry.Reload(doc).
+        private static readonly object _viewTemplateCacheLock = new object();
+        private static readonly Dictionary<string, Dictionary<string, ElementId>> _viewTemplateCache
+            = new Dictionary<string, Dictionary<string, ElementId>>(StringComparer.OrdinalIgnoreCase);
+
+        // ── C-2 pack-resolution cache ─────────────────────────────────────
+        // Per-document map of (packId → ViewStylePack) so batch producers
+        // resolve each pack only once. Invalidated by the same triggers as
+        // the view-template cache.
+        private static readonly object _packCacheLock = new object();
+        private static readonly Dictionary<string, Dictionary<string, ViewStylePack>> _packCache
+            = new Dictionary<string, Dictionary<string, ViewStylePack>>(StringComparer.OrdinalIgnoreCase);
+
+        private static string DocKey(Document doc)
+        {
+            if (doc == null) return "__null__";
+            try { return string.IsNullOrEmpty(doc.PathName) ? doc.Title : doc.PathName; }
+            catch { return "__unknown__"; }
+        }
+
+        private static ElementId ResolveViewTemplate(Document doc, string name)
+        {
+            if (doc == null || string.IsNullOrWhiteSpace(name)) return ElementId.InvalidElementId;
+            string docKey = DocKey(doc);
+            Dictionary<string, ElementId> docMap;
+            lock (_viewTemplateCacheLock)
+            {
+                if (!_viewTemplateCache.TryGetValue(docKey, out docMap))
+                {
+                    docMap = new Dictionary<string, ElementId>(StringComparer.OrdinalIgnoreCase);
+                    _viewTemplateCache[docKey] = docMap;
+                }
+                if (docMap.TryGetValue(name, out ElementId cached))
+                {
+                    if (cached != ElementId.InvalidElementId)
+                    {
+                        var elem = doc.GetElement(cached);
+                        if (elem is View vTpl && vTpl.IsValidObject && vTpl.IsTemplate)
+                            return cached;
+                    }
+                    docMap.Remove(name);
+                }
+            }
+
+            var tpl = new FilteredElementCollector(doc)
+                .OfClass(typeof(View))
+                .Cast<View>()
+                .FirstOrDefault(v => v.IsTemplate
+                    && string.Equals(v.Name, name, StringComparison.OrdinalIgnoreCase));
+            ElementId resolved = tpl?.Id ?? ElementId.InvalidElementId;
+
+            lock (_viewTemplateCacheLock)
+            {
+                if (_viewTemplateCache.TryGetValue(docKey, out var live))
+                    live[name] = resolved;
+            }
+            return resolved;
+        }
+
+        private static ViewStylePack ResolvePackCached(Document doc, string packId)
+        {
+            if (doc == null || string.IsNullOrWhiteSpace(packId)) return null;
+            string docKey = DocKey(doc);
+            lock (_packCacheLock)
+            {
+                if (_packCache.TryGetValue(docKey, out var docMap)
+                    && docMap.TryGetValue(packId, out var cached))
+                    return cached;
+            }
+
+            ViewStylePack resolved = null;
+            try { resolved = ViewStylePackRegistry.Get(doc, packId); }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"ResolvePackCached '{packId}': {ex.Message}");
+            }
+
+            lock (_packCacheLock)
+            {
+                if (!_packCache.TryGetValue(docKey, out var docMap))
+                {
+                    docMap = new Dictionary<string, ViewStylePack>(StringComparer.OrdinalIgnoreCase);
+                    _packCache[docKey] = docMap;
+                }
+                docMap[packId] = resolved;
+            }
+            return resolved;
+        }
+
+        /// <summary>
+        /// C-1 / D-3: clear the cached view-template ElementIds for a given
+        /// document. Wired to <see cref="DrawingTypeRegistry.Reload"/> and the
+        /// document-closed handler so a stale ElementId from a previous
+        /// session never resolves to a deleted template.
+        /// </summary>
+        public static void InvalidateViewTemplateCache(Document doc)
+        {
+            string docKey = DocKey(doc);
+            lock (_viewTemplateCacheLock)
+            {
+                if (_viewTemplateCache.ContainsKey(docKey))
+                    _viewTemplateCache.Remove(docKey);
+            }
+        }
+
+        /// <summary>
+        /// C-2 / D-3: clear the cached <see cref="ViewStylePack"/> entries for a
+        /// given document. Same triggers as
+        /// <see cref="InvalidateViewTemplateCache"/>.
+        /// </summary>
+        public static void InvalidatePackCache(Document doc)
+        {
+            string docKey = DocKey(doc);
+            lock (_packCacheLock)
+            {
+                if (_packCache.ContainsKey(docKey))
+                    _packCache.Remove(docKey);
+            }
+        }
+
+        /// <summary>
+        /// D-1: pre-warm the per-document caches for a batch run.
+        /// Builds the (template name → ElementId) and (packId → pack) maps in
+        /// one pass so subsequent <see cref="Apply"/> calls all hit the cache
+        /// regardless of which DrawingType they request. Safe to call outside
+        /// any Transaction. Idempotent — re-runs are a no-op once warm.
+        /// </summary>
+        public static void Prewarm(Document doc)
+        {
+            if (doc == null) return;
+            try
+            {
+                var lib = DrawingTypeRegistry.GetLibrary(doc);
+                if (lib?.DrawingTypes == null) return;
+
+                // Pre-resolve every drawing type once so the C-5 memo is hot
+                // (which in turn means every (template name, pack id) referenced
+                // by the catalogue gets warmed below).
+                foreach (var raw in lib.DrawingTypes)
+                {
+                    if (string.IsNullOrWhiteSpace(raw.Id)) continue;
+                    var dt = DrawingTypeRegistry.Get(doc, raw.Id);
+                    if (dt == null) continue;
+                    if (!string.IsNullOrWhiteSpace(dt.ViewTemplateName))
+                        ResolveViewTemplate(doc, dt.ViewTemplateName);
+                    if (!string.IsNullOrWhiteSpace(dt.ViewStylePackId))
+                        ResolvePackCached(doc, dt.ViewStylePackId);
+                }
+            }
+            catch (Exception ex) { StingTools.Core.StingLog.Warn($"DrawingTypePresentation.Prewarm: {ex.Message}"); }
+        }
+
         public sealed class ApplyOptions
         {
             /// <summary>
@@ -109,18 +266,16 @@ namespace StingTools.Core.Drawing
             }
 
             // View template ----------------------------------------------
+            // C-1: cached lookup; FilteredElementCollector<View> only runs
+            // on first miss per (docKey, templateName).
             if (!string.IsNullOrWhiteSpace(dt.ViewTemplateName))
             {
                 try
                 {
-                    var tpl = new FilteredElementCollector(doc)
-                        .OfClass(typeof(View))
-                        .Cast<View>()
-                        .FirstOrDefault(v => v.IsTemplate
-                            && string.Equals(v.Name, dt.ViewTemplateName, StringComparison.OrdinalIgnoreCase));
-                    if (tpl != null)
+                    ElementId tplId = ResolveViewTemplate(doc, dt.ViewTemplateName);
+                    if (tplId != ElementId.InvalidElementId)
                     {
-                        view.ViewTemplateId = tpl.Id;
+                        view.ViewTemplateId = tplId;
                         r.TemplateApplied = true;
                     }
                     else
@@ -153,7 +308,9 @@ namespace StingTools.Core.Drawing
             {
                 try
                 {
-                    resolvedPack = ViewStylePackRegistry.Get(doc, dt.ViewStylePackId);
+                    // C-2: cached lookup so batch producers resolve a given
+                    // pack only once per session.
+                    resolvedPack = ResolvePackCached(doc, dt.ViewStylePackId);
                     if (resolvedPack == null)
                     {
                         r.Warnings.Add($"ViewStylePack '{dt.ViewStylePackId}' not found.");

--- a/StingTools/Core/Drawing/DrawingTypeRegistry.cs
+++ b/StingTools/Core/Drawing/DrawingTypeRegistry.cs
@@ -33,15 +33,48 @@ namespace StingTools.Core.Drawing
         private static readonly Dictionary<string, DrawingTypeLibrary> _cache
             = new Dictionary<string, DrawingTypeLibrary>(StringComparer.OrdinalIgnoreCase);
 
+        // C-5: per-document memoization of ResolveExtends results so callers
+        // (DrawingDriftDetector.Scan, DrawingTypePresentation.Apply, the
+        // auto-tagger discipline filter) don't recompute the merged inheritance
+        // chain on every Get() call. Cleared by Reload(doc).
+        private static readonly Dictionary<string, Dictionary<string, DrawingType>> _resolvedCache
+            = new Dictionary<string, Dictionary<string, DrawingType>>(StringComparer.OrdinalIgnoreCase);
+
         // Public surface -------------------------------------------------
 
         public static DrawingType Get(Document doc, string id)
         {
             if (string.IsNullOrWhiteSpace(id)) return null;
             var lib = GetLibrary(doc);
+
+            // C-5: cached resolved DrawingType. Lookup is O(1); first-call
+            // miss runs ResolveExtends once and stores the result.
+            string docKey = DocKey(doc);
+            lock (_lock)
+            {
+                if (_resolvedCache.TryGetValue(docKey, out var docMap)
+                    && docMap.TryGetValue(id, out var memo))
+                {
+                    StingTools.Core.StingLog.RecordHit(StingTools.Core.StingLog.CacheKind.DrawingTypeRegistry); // E-1
+                    return memo;
+                }
+            }
+            StingTools.Core.StingLog.RecordMiss(StingTools.Core.StingLog.CacheKind.DrawingTypeRegistry); // E-1
+
             var raw = lib.DrawingTypes.FirstOrDefault(
                 t => string.Equals(t.Id, id, StringComparison.OrdinalIgnoreCase));
-            return raw == null ? null : ResolveExtends(lib, raw);
+            var resolved = raw == null ? null : ResolveExtends(lib, raw);
+
+            lock (_lock)
+            {
+                if (!_resolvedCache.TryGetValue(docKey, out var docMap))
+                {
+                    docMap = new Dictionary<string, DrawingType>(StringComparer.OrdinalIgnoreCase);
+                    _resolvedCache[docKey] = docMap;
+                }
+                docMap[id] = resolved;
+            }
+            return resolved;
         }
 
         /// <summary>
@@ -123,7 +156,20 @@ namespace StingTools.Core.Drawing
             {
                 var key = DocKey(doc);
                 if (_cache.ContainsKey(key)) _cache.Remove(key);
+                if (_resolvedCache.ContainsKey(key)) _resolvedCache.Remove(key);
             }
+
+            // D-3: cascade the reload through every dependent cache so a JSON
+            // edit (drawing_types.json or view_style_packs.json) doesn't leave
+            // a stale view-template / pack / managed-template id behind.
+            try { DrawingTypePresentation.InvalidateViewTemplateCache(doc); }
+            catch (Exception ex) { StingTools.Core.StingLog.Warn($"Reload InvalidateViewTemplateCache: {ex.Message}"); }
+
+            try { DrawingTypePresentation.InvalidatePackCache(doc); }
+            catch (Exception ex) { StingTools.Core.StingLog.Warn($"Reload InvalidatePackCache: {ex.Message}"); }
+
+            try { ManagedTemplateSyncer.InvalidateCache(doc); }
+            catch (Exception ex) { StingTools.Core.StingLog.Warn($"Reload InvalidateManagedTemplateCache: {ex.Message}"); }
         }
 
         public static DrawingTypeLibrary GetLibrary(Document doc)

--- a/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
+++ b/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
@@ -26,8 +26,19 @@ namespace StingTools.Core.Drawing
 {
     internal static class ManagedTemplateSyncer
     {
-        private static readonly Dictionary<(string packId, ViewType vt), ElementId> _cache
-            = new Dictionary<(string, ViewType), ElementId>();
+        // C-6: keyed by document so a stale ElementId from a previously
+        // open document is never returned to a different document.
+        private static readonly object _cacheLock = new object();
+        private static readonly Dictionary<string, Dictionary<(string packId, ViewType vt), ElementId>> _cache
+            = new Dictionary<string, Dictionary<(string, ViewType), ElementId>>(StringComparer.OrdinalIgnoreCase);
+
+        // C-3: per-document seed-view cache so EnsureTemplate doesn't run
+        // two FilteredElementCollector<View> scans for every (pack, viewType)
+        // pair on first use. Built lazily on first EnsureTemplate call per
+        // document and invalidated on Reload / DocumentClosed.
+        private static readonly object _seedCacheLock = new object();
+        private static readonly Dictionary<string, Dictionary<ViewType, ElementId>> _seedViewCache
+            = new Dictionary<string, Dictionary<ViewType, ElementId>>(StringComparer.OrdinalIgnoreCase);
 
         // Default field set when ManagedFields is not specified.
         private static readonly List<string> DefaultManagedFields = new List<string>
@@ -35,9 +46,107 @@ namespace StingTools.Core.Drawing
             "scale", "detailLevel", "discipline", "visualStyle", "phaseFilter"
         };
 
+        private static string DocKey(Document doc)
+        {
+            if (doc == null) return "__null__";
+            try { return string.IsNullOrEmpty(doc.PathName) ? doc.Title : doc.PathName; }
+            catch { return "__unknown__"; }
+        }
+
+        /// <summary>
+        /// Clear all cached managed-template ElementIds and seed views.
+        /// Use sparingly — prefer the document-scoped overload.
+        /// </summary>
         public static void InvalidateCache()
         {
-            _cache.Clear();
+            lock (_cacheLock) { _cache.Clear(); }
+            lock (_seedCacheLock) { _seedViewCache.Clear(); }
+        }
+
+        /// <summary>
+        /// C-6 / D-3: invalidate the cached managed-template + seed-view
+        /// entries for a specific document. Wired to
+        /// <see cref="DrawingTypeRegistry.Reload"/> and the document-closed
+        /// handler in <c>StingToolsApp</c>.
+        /// </summary>
+        public static void InvalidateCache(Document doc)
+        {
+            string key = DocKey(doc);
+            lock (_cacheLock)
+            {
+                if (_cache.ContainsKey(key)) _cache.Remove(key);
+            }
+            lock (_seedCacheLock)
+            {
+                if (_seedViewCache.ContainsKey(key)) _seedViewCache.Remove(key);
+            }
+        }
+
+        private static Dictionary<(string, ViewType), ElementId> GetOrCreateCacheBucket(string docKey)
+        {
+            lock (_cacheLock)
+            {
+                if (!_cache.TryGetValue(docKey, out var bucket))
+                {
+                    bucket = new Dictionary<(string, ViewType), ElementId>();
+                    _cache[docKey] = bucket;
+                }
+                return bucket;
+            }
+        }
+
+        /// <summary>
+        /// C-3: resolve a seed view of the requested type. Prefers existing
+        /// "STING - " prefixed templates; falls back to any non-template view
+        /// of that type. Result is cached per (docKey, viewType) so repeated
+        /// calls during a batch only run the FilteredElementCollector twice
+        /// once.
+        /// </summary>
+        private static View ResolveSeed(Document doc, ViewType viewType)
+        {
+            if (doc == null) return null;
+            string docKey = DocKey(doc);
+            ElementId cachedId;
+            lock (_seedCacheLock)
+            {
+                if (_seedViewCache.TryGetValue(docKey, out var docMap)
+                    && docMap.TryGetValue(viewType, out cachedId)
+                    && cachedId != ElementId.InvalidElementId)
+                {
+                    if (doc.GetElement(cachedId) is View cached
+                        && cached.IsValidObject
+                        && cached.ViewType == viewType)
+                    {
+                        return cached;
+                    }
+                    docMap.Remove(viewType);
+                }
+            }
+
+            View seed = new FilteredElementCollector(doc)
+                .OfClass(typeof(View))
+                .Cast<View>()
+                .FirstOrDefault(t => t.IsTemplate
+                                     && t.ViewType == viewType
+                                     && (t.Name ?? "").StartsWith("STING - ", StringComparison.Ordinal));
+            if (seed == null)
+            {
+                seed = new FilteredElementCollector(doc)
+                    .OfClass(typeof(View))
+                    .Cast<View>()
+                    .FirstOrDefault(t => !t.IsTemplate && t.ViewType == viewType);
+            }
+
+            lock (_seedCacheLock)
+            {
+                if (!_seedViewCache.TryGetValue(docKey, out var docMap))
+                {
+                    docMap = new Dictionary<ViewType, ElementId>();
+                    _seedViewCache[docKey] = docMap;
+                }
+                docMap[viewType] = seed?.Id ?? ElementId.InvalidElementId;
+            }
+            return seed;
         }
 
         internal static string GetManagedTemplateName(string packId, ViewType vt)
@@ -117,13 +226,22 @@ namespace StingTools.Core.Drawing
                 return ElementId.InvalidElementId;
             if (result == null) result = new PackApplyResult();
 
-            // 1. Cache hit
+            // 1. Cache hit (C-6 — per-document bucket; IsValidObject guard
+            // catches a stale id from a copied / save-as'd document).
+            string docKey = DocKey(doc);
+            var bucket = GetOrCreateCacheBucket(docKey);
             var key = (pack.Id, viewType);
-            if (_cache.TryGetValue(key, out var cachedId))
+            ElementId cachedId;
+            lock (_cacheLock)
             {
-                if (doc.GetElement(cachedId) is View v && v.IsTemplate)
+                bucket.TryGetValue(key, out cachedId);
+            }
+            if (cachedId != ElementId.InvalidElementId)
+            {
+                if (doc.GetElement(cachedId) is View v && v.IsValidObject && v.IsTemplate)
                     return cachedId;
-                _cache.Remove(key);
+                StingTools.Core.StingLog.Warn($"ManagedTemplateSyncer: stale cache id evicted for pack '{pack.Id}' / {viewType}");
+                lock (_cacheLock) { bucket.Remove(key); }
             }
 
             var templateName = GetManagedTemplateName(pack.Id, viewType);
@@ -147,24 +265,13 @@ namespace StingTools.Core.Drawing
                         DrawingTypeStamper.PARAM_DRAWING_TYPE_ID,
                         $"pack:{pack.Id};cs={current}", overwrite: true);
                 }
-                _cache[key] = existing.Id;
+                lock (_cacheLock) { bucket[key] = existing.Id; }
                 return existing.Id;
             }
 
-            // 3. Find a seed template / view
-            View seed = new FilteredElementCollector(doc)
-                .OfClass(typeof(View))
-                .Cast<View>()
-                .FirstOrDefault(t => t.IsTemplate &&
-                                     t.ViewType == viewType &&
-                                     (t.Name ?? "").StartsWith("STING - ", StringComparison.Ordinal));
-            if (seed == null)
-            {
-                seed = new FilteredElementCollector(doc)
-                    .OfClass(typeof(View))
-                    .Cast<View>()
-                    .FirstOrDefault(t => !t.IsTemplate && t.ViewType == viewType);
-            }
+            // 3. Find a seed template / view (C-3 — cached per
+            // (docKey, viewType) so repeated calls in a batch don't re-scan).
+            View seed = ResolveSeed(doc, viewType);
             if (seed == null)
             {
                 result.Warnings.Add($"ManagedTemplateSyncer: no seed view of type {viewType} found for pack '{pack.Id}'.");
@@ -215,7 +322,7 @@ namespace StingTools.Core.Drawing
                 DrawingTypeStamper.PARAM_DRAWING_TYPE_ID,
                 $"pack:{pack.Id};cs={checksum}", overwrite: true);
 
-            _cache[key] = newView.Id;
+            lock (_cacheLock) { bucket[key] = newView.Id; }
             return newView.Id;
         }
 

--- a/StingTools/Core/ParameterHelpers.cs
+++ b/StingTools/Core/ParameterHelpers.cs
@@ -133,6 +133,12 @@ namespace StingTools.Core
             return doc.PathName ?? doc.Title ?? "Untitled";
         }
 
+        // A-7: hard cap to prevent unbounded growth across many documents
+        // opened/closed in one session. 50_000 is generous (a typical project
+        // has far fewer unique (typeId, paramName) pairs); a clear is logged
+        // at Warn so unexpected growth is visible.
+        private const int _paramCacheCap = 50_000;
+
         /// <summary>Cached parameter lookup. Uses stable document key + element's TypeId + paramName as cache key.
         /// Falls back to LookupParameter on first access per type, then O(1) thereafter.
         /// Exposed as `internal` so sibling classes in this file (NativeParamMapper,
@@ -145,12 +151,23 @@ namespace StingTools.Core
 
             if (!_paramCache.TryGetValue(key, out Definition cachedDef))
             {
+                StingLog.RecordMiss(StingLog.CacheKind.ParamCache); // E-1
                 Parameter found = el.LookupParameter(paramName);
+                // A-7: bounded — clear when the cache exceeds 50K entries
+                // (this should not happen in practice; the clear is logged
+                // so unexpected growth is visible in diagnostics).
+                if (_paramCache.Count >= _paramCacheCap)
+                {
+                    int original = _paramCache.Count;
+                    _paramCache.Clear();
+                    StingLog.Warn($"_paramCache reached {original} entries; cleared to enforce cap of {_paramCacheCap}.");
+                }
                 // Cache the Definition (not Parameter — that's per-element)
                 _paramCache[key] = found?.Definition;
                 return found;
             }
 
+            StingLog.RecordHit(StingLog.CacheKind.ParamCache); // E-1
             if (cachedDef == null) return null; // Known miss
             return el.get_Parameter(cachedDef);
         }
@@ -684,9 +701,11 @@ namespace StingTools.Core
                     && string.Equals(_roomCacheDocKey, key, StringComparison.Ordinal)
                     && (DateTime.UtcNow - _roomCacheStamp) < _roomCacheTtl)
                 {
+                    StingLog.RecordHit(StingLog.CacheKind.RoomIndex); // E-1
                     return _roomCacheIndex;
                 }
             }
+            StingLog.RecordMiss(StingLog.CacheKind.RoomIndex); // E-1
 
             var index = new Dictionary<ElementId, Room>();
             try

--- a/StingTools/Core/StingAutoTagger.cs
+++ b/StingTools/Core/StingAutoTagger.cs
@@ -58,6 +58,48 @@ namespace StingTools.Core
         private static readonly System.Collections.Concurrent.ConcurrentDictionary<long, string>
             _tag7HashCache = new System.Collections.Concurrent.ConcurrentDictionary<long, string>();
 
+        // A-6: bounded LRU eviction for _tag7HashCache to prevent unbounded
+        // memory growth in long sessions. Mirrors the _elementVersionHash
+        // 20%-eviction pattern (~lines 790-802) — once the cache exceeds
+        // _tag7CacheCap entries, the oldest 20% are dropped.
+        private const int _tag7CacheCap = 10000;
+
+        /// <summary>
+        /// A-6: store a TAG7 hash for an element id. Performs the same
+        /// 20%-eviction-at-cap dance used elsewhere so callers don't have to.
+        /// </summary>
+        public static void StoreTag7Hash(long elementId, string hash)
+        {
+            if (string.IsNullOrEmpty(hash)) return;
+            _tag7HashCache[elementId] = hash;
+
+            if (_tag7HashCache.Count > _tag7CacheCap)
+            {
+                int original = _tag7HashCache.Count;
+                int target = original / 5;
+                int evicted = 0;
+                foreach (var kvp in _tag7HashCache)
+                {
+                    if (evicted >= target) break;
+                    _tag7HashCache.TryRemove(kvp.Key, out _);
+                    evicted++;
+                }
+                StingLog.Info($"_tag7HashCache: evicted {evicted} of {original} entries (cap {_tag7CacheCap}).");
+            }
+        }
+
+        /// <summary>A-6: read a previously cached TAG7 hash; returns null when absent.</summary>
+        public static string TryGetTag7Hash(long elementId)
+        {
+            if (_tag7HashCache.TryGetValue(elementId, out var h))
+            {
+                StingLog.RecordHit(StingLog.CacheKind.Tag7Hash); // E-1
+                return h;
+            }
+            StingLog.RecordMiss(StingLog.CacheKind.Tag7Hash); // E-1
+            return null;
+        }
+
         // BUG-04: ExternalEvent queue for deferred tag processing
         private static readonly ConcurrentQueue<ElementId> _pendingQueue = new ConcurrentQueue<ElementId>();
         private static ExternalEvent _autoTagEvent;
@@ -522,15 +564,72 @@ namespace StingTools.Core
                     var existingTags = _cachedExistingTags;
                     var seqCounters = _cachedSeqCounters;
 
-                    // Dequeue up to MaxPerBatch elements
-                    var batch = new List<ElementId>();
-                    while (batch.Count < MaxPerBatch && _pendingQueue.TryDequeue(out ElementId eid))
-                        batch.Add(eid);
+                    // C-7: resolve the active view's DrawingType discipline (if
+                    // any) once for this drain pass so per-element decisions in
+                    // ProcessBatch are an O(1) string compare.
+                    string activeViewDtDiscipline = ResolveActiveViewDrawingTypeDiscipline(app, doc);
 
-                    if (batch.Count == 0) return;
+                    // A-3: Drain the entire pending queue inside a single TransactionGroup
+                    // so the user sees one undo entry for a full bulk-paste session.
+                    // Each MaxPerBatch chunk still commits its own child Transaction (preserves
+                    // IUpdater safety + per-chunk rollback on failure), but they assimilate into
+                    // one parent group for a clean undo stack and one journal entry.
+                    int totalProcessed = 0;
+                    int totalAttempted = 0;
+                    using (var txGroup = new TransactionGroup(doc, "STING Auto-Tag"))
+                    {
+                        txGroup.Start();
 
-                    int processed = 0;
-                    using (var trans = new Transaction(doc, "STING Auto-Tag"))
+                        while (!_pendingQueue.IsEmpty)
+                        {
+                            var batch = new List<ElementId>();
+                            while (batch.Count < MaxPerBatch && _pendingQueue.TryDequeue(out ElementId eid))
+                                batch.Add(eid);
+                            if (batch.Count == 0) break;
+                            totalAttempted += batch.Count;
+
+                            int processed = ProcessBatch(doc, batch, ctx, existingTags, seqCounters, activeViewDtDiscipline);
+                            totalProcessed += processed;
+                        }
+
+                        txGroup.Assimilate();
+                    }
+
+                    // A-3 / A-8: Save SEQ sidecar once after the group assimilates,
+                    // not per child batch. Guarantees the sidecar always reflects a committed state.
+                    try { TagConfig.SaveSeqSidecar(doc, seqCounters); }
+                    catch (Exception ssEx) { StingLog.Warn($"AutoTagger SaveSeqSidecar: {ssEx.Message}"); }
+
+                    ComplianceScan.InvalidateCache();
+                    _consecutiveFailures = 0;
+
+                    if (totalProcessed > 0)
+                        StingLog.Info($"AutoTagger queue: processed {totalProcessed}/{totalAttempted} elements (single undo entry)");
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Error("AutoTagQueueHandler.Execute", ex);
+                }
+            }
+
+            /// <summary>
+            /// A-3: Per-chunk processing wrapped in one Transaction. Returns the
+            /// number of elements successfully tagged in this chunk. Failure of an
+            /// individual element is swallowed and logged; chunk-level Transaction
+            /// failure is logged and the chunk's contribution is zero.
+            /// </summary>
+            private int ProcessBatch(
+                Document doc,
+                List<ElementId> batch,
+                TokenAutoPopulator.PopulationContext ctx,
+                HashSet<string> existingTags,
+                Dictionary<string, int> seqCounters,
+                string activeViewDtDiscipline)
+            {
+                int processed = 0;
+                try
+                {
+                    using (var trans = new Transaction(doc, "STING Auto-Tag (chunk)"))
                     {
                         trans.Start();
                         foreach (ElementId id in batch)
@@ -545,6 +644,17 @@ namespace StingTools.Core
 
                             string catName = ParameterHelpers.GetCategoryName(el);
                             if (string.IsNullOrEmpty(catName)) continue;
+
+                            // C-7: when the active view is stamped with a
+                            // DrawingType whose discipline is not "*", defer
+                            // off-discipline elements rather than tag them
+                            // and clutter the view.
+                            if (!string.IsNullOrEmpty(activeViewDtDiscipline)
+                                && !DoesElementMatchDiscipline(el, catName, activeViewDtDiscipline))
+                            {
+                                EnqueueDeferred(id);
+                                continue;
+                            }
 
                             try
                             {
@@ -628,25 +738,13 @@ namespace StingTools.Core
                             }
                         }
                         trans.Commit();
-
-                        // FIX-02: Save SEQ sidecar after commit for session continuity
-                        try { TagConfig.SaveSeqSidecar(doc, seqCounters); }
-                        catch (Exception ssEx) { StingLog.Warn($"AutoTagger SaveSeqSidecar: {ssEx.Message}"); }
                     }
-
-                    ComplianceScan.InvalidateCache();
-                    _consecutiveFailures = 0;
-
-                    if (processed > 0)
-                        StingLog.Info($"AutoTagger queue: processed {processed}/{batch.Count} elements");
-
-                    // If more items remain in queue, raise event again
-                    if (!_pendingQueue.IsEmpty && _autoTagEvent != null)
-                        _autoTagEvent.Raise();
                 }
-                catch (Exception ex)
+                catch (Exception batchEx)
                 {
-                    StingLog.Error("AutoTagQueueHandler.Execute", ex);
+                    StingLog.Error($"AutoTagQueueHandler.ProcessBatch ({batch.Count} elements)", batchEx);
+                    // A-3: chunk-level failure rolls back this chunk only; outer
+                    // TransactionGroup continues with the next chunk.
                     _consecutiveFailures++;
 
                     if (_consecutiveFailures >= MaxFailuresBeforeAutoDisable)
@@ -664,6 +762,51 @@ namespace StingTools.Core
                         catch (Exception uiEx) { StingLog.Warn($"Auto-tagger status bar update failed: {uiEx.Message}"); }
                     }
                 }
+                return processed;
+            }
+
+            /// <summary>
+            /// C-7: returns the discipline string of the active view's stamped
+            /// DrawingType, or null when the view is not stamped, the type
+            /// can't be resolved, or its discipline is "*" / empty (all
+            /// disciplines welcome). The caller treats null as "no filter".
+            /// </summary>
+            private static string ResolveActiveViewDrawingTypeDiscipline(UIApplication app, Document doc)
+            {
+                try
+                {
+                    View view = doc?.ActiveView ?? app?.ActiveUIDocument?.ActiveView;
+                    if (view == null || view is ViewSheet) return null;
+                    string dtId = ParameterHelpers.GetString(view, "STING_DRAWING_TYPE_ID_TXT");
+                    if (string.IsNullOrWhiteSpace(dtId)) return null;
+                    var dt = Drawing.DrawingTypeRegistry.Get(doc, dtId);
+                    if (dt == null) return null;
+                    if (string.IsNullOrWhiteSpace(dt.Discipline) || dt.Discipline == "*") return null;
+                    return dt.Discipline;
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"ResolveActiveViewDrawingTypeDiscipline: {ex.Message}");
+                    return null;
+                }
+            }
+
+            /// <summary>
+            /// C-7: returns true when the element's derived discipline matches
+            /// the requested filter. Falls back to TagConfig.DiscMap by category
+            /// when DISC isn't yet populated; returns true (i.e. don't drop) when
+            /// the element's discipline can't be inferred.
+            /// </summary>
+            private static bool DoesElementMatchDiscipline(Element el, string catName, string requiredDisc)
+            {
+                if (string.IsNullOrEmpty(requiredDisc)) return true;
+                string elDisc = ParameterHelpers.GetString(el, ParamRegistry.DISC);
+                if (string.IsNullOrEmpty(elDisc))
+                {
+                    if (!TagConfig.DiscMap.TryGetValue(catName, out elDisc) || string.IsNullOrEmpty(elDisc))
+                        return true;
+                }
+                return string.Equals(elDisc, requiredDisc, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -1105,17 +1248,30 @@ namespace StingTools.Core
 
         private const int MaxElementsPerTrigger = 20;
 
-        // PERF-CRIT: Cached room index to avoid FilteredElementCollector on every trigger
-        private static Dictionary<ElementId, Autodesk.Revit.DB.Architecture.Room> _cachedRoomIndex;
+        // A-2: Per-document project-LOC cache, complementary to
+        // SpatialAutoDetect.BuildRoomIndex (which already caches the room index
+        // per-document with a 30 s TTL). The full room index is no longer
+        // duplicated here — calling SpatialAutoDetect.BuildRoomIndex is cheap
+        // when the cache is warm. Only the project LOC is stored locally
+        // because DetectProjectLoc is currently uncached.
         private static string _cachedProjectLoc;
-        private static DateTime _roomIndexCacheTime = DateTime.MinValue;
+        private static string _cachedProjectLocDocKey;
+        private static DateTime _projectLocCacheTime = DateTime.MinValue;
+        private static readonly object _projectLocCacheLock = new object();
 
-        /// <summary>Clear cached room index (call on document close/switch).</summary>
+        /// <summary>Clear cached project LOC (call on document close/switch).</summary>
         internal static void ClearRoomIndexCache()
         {
-            _cachedRoomIndex = null;
-            _cachedProjectLoc = null;
-            _roomIndexCacheTime = DateTime.MinValue;
+            lock (_projectLocCacheLock)
+            {
+                _cachedProjectLoc = null;
+                _cachedProjectLocDocKey = null;
+                _projectLocCacheTime = DateTime.MinValue;
+            }
+            // A-2: also nudge the shared SpatialAutoDetect cache so a stale
+            // index from a closed document never resurfaces.
+            try { SpatialAutoDetect.InvalidateRoomIndex(); }
+            catch (Exception ex) { StingLog.Warn($"ClearRoomIndexCache: {ex.Message}"); }
         }
 
         public void Execute(UpdaterData data)
@@ -1139,25 +1295,34 @@ namespace StingTools.Core
                     return;
                 }
 
-                // PERF-CRIT: Cache room index across stale marker triggers to avoid rebuilding
-                // on every geometry change. Room index is expensive (FilteredElementCollector scan).
-                // TTL of 30 seconds — rooms don't change during normal geometry editing.
+                // A-2: defer to the shared SpatialAutoDetect.BuildRoomIndex
+                // (already TTL-cached per-document); only project LOC is
+                // memoised locally to avoid repeating DetectProjectLoc on
+                // every IUpdater trigger.
                 Dictionary<ElementId, Autodesk.Revit.DB.Architecture.Room> roomIndex = null;
                 string projectLoc = null;
                 try
                 {
-                    if (_cachedRoomIndex != null && (DateTime.UtcNow - _roomIndexCacheTime).TotalSeconds < 30)
+                    roomIndex = SpatialAutoDetect.BuildRoomIndex(doc);
+
+                    string docKey = doc?.PathName ?? doc?.Title ?? "";
+                    lock (_projectLocCacheLock)
                     {
-                        roomIndex = _cachedRoomIndex;
-                        projectLoc = _cachedProjectLoc;
+                        if (string.Equals(_cachedProjectLocDocKey, docKey, StringComparison.Ordinal)
+                            && (DateTime.UtcNow - _projectLocCacheTime).TotalSeconds < 30)
+                        {
+                            projectLoc = _cachedProjectLoc;
+                        }
                     }
-                    else
+                    if (projectLoc == null)
                     {
-                        roomIndex = SpatialAutoDetect.BuildRoomIndex(doc);
                         projectLoc = SpatialAutoDetect.DetectProjectLoc(doc);
-                        _cachedRoomIndex = roomIndex;
-                        _cachedProjectLoc = projectLoc;
-                        _roomIndexCacheTime = DateTime.UtcNow;
+                        lock (_projectLocCacheLock)
+                        {
+                            _cachedProjectLoc = projectLoc;
+                            _cachedProjectLocDocKey = docKey;
+                            _projectLocCacheTime = DateTime.UtcNow;
+                        }
                     }
                 }
                 catch (Exception riEx)

--- a/StingTools/Core/StingLog.cs
+++ b/StingTools/Core/StingLog.cs
@@ -91,6 +91,77 @@ namespace StingTools.Core
             Write("ERROR", full);
         }
 
+        // ── E-1 cache hit/miss telemetry ───────────────────────────────────
+        // Lightweight Interlocked counters for the four highest-value caches.
+        // Read via DumpCacheStats(); reset on Reset(). Write paths are
+        // RecordHit/RecordMiss exposed below for cache owners to call.
+
+        public enum CacheKind
+        {
+            ParamCache,
+            RoomIndex,
+            Tag7Hash,
+            DrawingTypeRegistry,
+        }
+
+        private static long _paramCacheHits, _paramCacheMisses;
+        private static long _roomIndexHits, _roomIndexMisses;
+        private static long _tag7HashHits, _tag7HashMisses;
+        private static long _dtRegistryHits, _dtRegistryMisses;
+
+        public static void RecordHit(CacheKind kind)
+        {
+            switch (kind)
+            {
+                case CacheKind.ParamCache:           System.Threading.Interlocked.Increment(ref _paramCacheHits); break;
+                case CacheKind.RoomIndex:            System.Threading.Interlocked.Increment(ref _roomIndexHits); break;
+                case CacheKind.Tag7Hash:             System.Threading.Interlocked.Increment(ref _tag7HashHits); break;
+                case CacheKind.DrawingTypeRegistry:  System.Threading.Interlocked.Increment(ref _dtRegistryHits); break;
+            }
+        }
+
+        public static void RecordMiss(CacheKind kind)
+        {
+            switch (kind)
+            {
+                case CacheKind.ParamCache:           System.Threading.Interlocked.Increment(ref _paramCacheMisses); break;
+                case CacheKind.RoomIndex:            System.Threading.Interlocked.Increment(ref _roomIndexMisses); break;
+                case CacheKind.Tag7Hash:             System.Threading.Interlocked.Increment(ref _tag7HashMisses); break;
+                case CacheKind.DrawingTypeRegistry:  System.Threading.Interlocked.Increment(ref _dtRegistryMisses); break;
+            }
+        }
+
+        /// <summary>
+        /// E-1: write current cache hit/miss counters to the log at Info level.
+        /// Surfaced by the CheckData diagnostic command so users can see whether
+        /// caching is doing what we expect across a session.
+        /// </summary>
+        public static void DumpCacheStats()
+        {
+            string fmt(long h, long m)
+            {
+                long total = h + m;
+                return total == 0 ? "0/0 (no activity)" : $"{h}/{total} ({h * 100.0 / total:F1}% hit rate)";
+            }
+            Info($"Cache stats — _paramCache:           hits {fmt(_paramCacheHits,  _paramCacheMisses)}");
+            Info($"Cache stats — SpatialAutoDetect room index: {fmt(_roomIndexHits, _roomIndexMisses)}");
+            Info($"Cache stats — _tag7HashCache:        {fmt(_tag7HashHits, _tag7HashMisses)}");
+            Info($"Cache stats — DrawingTypeRegistry:   {fmt(_dtRegistryHits, _dtRegistryMisses)}");
+        }
+
+        /// <summary>E-1: reset all cache hit/miss counters (use sparingly — diagnostics only).</summary>
+        public static void ResetCacheStats()
+        {
+            System.Threading.Interlocked.Exchange(ref _paramCacheHits, 0);
+            System.Threading.Interlocked.Exchange(ref _paramCacheMisses, 0);
+            System.Threading.Interlocked.Exchange(ref _roomIndexHits, 0);
+            System.Threading.Interlocked.Exchange(ref _roomIndexMisses, 0);
+            System.Threading.Interlocked.Exchange(ref _tag7HashHits, 0);
+            System.Threading.Interlocked.Exchange(ref _tag7HashMisses, 0);
+            System.Threading.Interlocked.Exchange(ref _dtRegistryHits, 0);
+            System.Threading.Interlocked.Exchange(ref _dtRegistryMisses, 0);
+        }
+
         private static void Write(string level, string message)
         {
             try

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -220,7 +220,12 @@ namespace StingTools.Core
                 Model.ModelWorksetAssigner.ClearCache();
                 // TAG-SORT-LEVEL-01: Clear cached level elevations to prevent stale data
                 Tags.BatchTagCommand.ClearLevelElevationCache();
-                StingLog.Info("DocumentClosing: cleared parameter, compliance, formula, selection, deferred, workset, and level caches");
+                // C-6 / D-3: cascade through Drawing-Type subsystem caches so
+                // a stale ElementId from this document never resolves to an
+                // element in the next.
+                try { Drawing.DrawingTypeRegistry.Reload(e.Document); }
+                catch (Exception ex) { StingLog.Warn($"DocumentClosing DrawingTypeRegistry.Reload: {ex.Message}"); }
+                StingLog.Info("DocumentClosing: cleared parameter, compliance, formula, selection, deferred, workset, level, and drawing-type caches");
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -2583,6 +2583,21 @@ namespace StingTools.Core
             string existingTag = ParameterHelpers.GetString(el, ParamRegistry.TAG1);
             bool hasCompleteTag = TagIsComplete(existingTag);
 
+            // A-9: idempotency guard — if the element's last-written tag equals
+            // the current tag and the tag is complete, the element was already
+            // processed in this session. Cheap O(1) escape that avoids the
+            // collision loop entirely (only honoured when not overwriting).
+            if (collisionMode != TagCollisionMode.Overwrite && hasCompleteTag)
+            {
+                string prev = ParameterHelpers.GetString(el, "ASS_TAG_PREV_TXT");
+                if (!string.IsNullOrEmpty(prev)
+                    && string.Equals(prev, existingTag, StringComparison.Ordinal))
+                {
+                    stats?.RecordSkipped(catName);
+                    return true;
+                }
+            }
+
             if (hasCompleteTag)
             {
                 switch (collisionMode)

--- a/StingTools/Tags/LoadSharedParamsCommand.cs
+++ b/StingTools/Tags/LoadSharedParamsCommand.cs
@@ -571,6 +571,18 @@ namespace StingTools.Tags
             // Clear parameter lookup cache so newly bound parameters are found immediately
             ParameterHelpers.ClearParamCache();
 
+            // A-5: refresh ParamRegistry from PARAMETER_REGISTRY.json so any
+            // binding additions / new system codes are visible to in-session
+            // commands without a Revit restart. SharedParamGuids cached
+            // properties are flushed inside Reload().
+            try
+            {
+                ParamRegistry.Reload();
+                SharedParamGuids.InvalidateCache();
+                StingLog.Info("ParamRegistry reloaded after parameter binding.");
+            }
+            catch (Exception ex) { StingLog.Warn($"LoadSharedParams ParamRegistry.Reload: {ex.Message}"); }
+
             var td = new TaskDialog("STING Tools - Load Shared Params");
             td.MainInstruction = requiredMissing > 0
                 ? $"Binding complete — {bound} bound, {requiredMissing} REQUIRED missing!"

--- a/StingTools/Tags/SmartTagPlacementCommand.cs
+++ b/StingTools/Tags/SmartTagPlacementCommand.cs
@@ -30,6 +30,77 @@ namespace StingTools.Tags
         /// <summary>ENH-03: Default clearance margin (in feet) for leader elbow avoidance.</summary>
         private const double LeaderClearanceMargin = 0.5;
 
+        // ── B-1 SpatialGrid view cache ───────────────────────────────────
+        // Memoise the (existing-tag) SpatialGrid per (docKey, viewId) so two
+        // back-to-back placement runs against the same view don't both walk
+        // every IndependentTag and rebuild a 300-entry grid. TTL of 30 s is
+        // sufficient for sequential command runs and falls back to a fresh
+        // build when the user makes intervening edits.
+        private static readonly object _spatialGridCacheLock = new object();
+        private static readonly Dictionary<(string docKey, long viewId), (SpatialGrid grid, DateTime stamp, double cellSize, int tagCount)>
+            _spatialGridCache = new Dictionary<(string, long), (SpatialGrid, DateTime, double, int)>();
+        private static readonly TimeSpan _spatialGridTtl = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// B-1: invalidate the cached SpatialGrid for a given view (or for the
+        /// whole document when viewId is invalid). Public so external callers
+        /// can flush after non-trivial tag edits.
+        /// </summary>
+        public static void InvalidateViewCache(Document doc, ElementId viewId)
+        {
+            string docKey = doc?.PathName ?? doc?.Title ?? "";
+            lock (_spatialGridCacheLock)
+            {
+                if (viewId == null || viewId == ElementId.InvalidElementId)
+                {
+                    var keysToRemove = _spatialGridCache.Keys
+                        .Where(k => string.Equals(k.docKey, docKey, StringComparison.Ordinal))
+                        .ToList();
+                    foreach (var k in keysToRemove) _spatialGridCache.Remove(k);
+                }
+                else
+                {
+                    var key = (docKey, viewId.Value);
+                    if (_spatialGridCache.ContainsKey(key)) _spatialGridCache.Remove(key);
+                }
+            }
+        }
+
+        internal static bool TryGetCachedSpatialGrid(Document doc, View view, double cellSize, int existingTagCount, out SpatialGrid grid)
+        {
+            grid = null;
+            if (doc == null || view == null) return false;
+            string docKey = doc.PathName ?? doc.Title ?? "";
+            var key = (docKey, view.Id.Value);
+            lock (_spatialGridCacheLock)
+            {
+                if (_spatialGridCache.TryGetValue(key, out var entry))
+                {
+                    bool fresh = (DateTime.UtcNow - entry.stamp) < _spatialGridTtl;
+                    bool cellMatch = Math.Abs(entry.cellSize - cellSize) < 1e-9;
+                    bool countMatch = entry.tagCount == existingTagCount;
+                    if (fresh && cellMatch && countMatch)
+                    {
+                        grid = entry.grid;
+                        return true;
+                    }
+                    _spatialGridCache.Remove(key);
+                }
+            }
+            return false;
+        }
+
+        internal static void StoreSpatialGrid(Document doc, View view, double cellSize, int existingTagCount, SpatialGrid grid)
+        {
+            if (doc == null || view == null || grid == null) return;
+            string docKey = doc.PathName ?? doc.Title ?? "";
+            var key = (docKey, view.Id.Value);
+            lock (_spatialGridCacheLock)
+            {
+                _spatialGridCache[key] = (grid, DateTime.UtcNow, cellSize, existingTagCount);
+            }
+        }
+
         // ── Grid-based spatial index ─────────────────────────────────────
 
         /// <summary>
@@ -362,6 +433,31 @@ namespace StingTools.Tags
         /// overrides then the bundled SCALE_TIERS.json then a hardcoded
         /// fallback. Result is mm → ft × viewScale, clamped to the cap.
         /// </summary>
+        /// <summary>
+        /// B-3: estimate a tag's bounding box when get_BoundingBox returns
+        /// null. Uses the view's tag-text height × character count as a width
+        /// approximation centred on the tag's head position. Returns
+        /// <see cref="Box2D.IsEmpty"/> when no head position is available.
+        /// </summary>
+        internal static Box2D EstimateTagBoxFallback(IndependentTag tag, View view, double tagWidth, double tagHeight)
+        {
+            try
+            {
+                XYZ head = tag?.TagHeadPosition;
+                if (head == null) return new Box2D(0, 0, 0, 0);
+                string text = "";
+                try { text = tag.TagText ?? ""; } catch { }
+                int chars = Math.Max(8, text.Length);
+                // Tag text width ~ tagWidth * chars/8 (calibrated to 8-char base width).
+                double estW = Math.Max(tagWidth, tagWidth * chars / 8.0);
+                double estH = tagHeight;
+                return new Box2D(
+                    head.X - estW / 2.0, head.Y - estH / 2.0,
+                    head.X + estW / 2.0, head.Y + estH / 2.0);
+            }
+            catch { return new Box2D(0, 0, 0, 0); }
+        }
+
         public static double GetModelOffset(View view, double baseOffset = 0.01)
         {
             int viewScale = (view != null && view.Scale > 0) ? view.Scale : 100;
@@ -396,6 +492,9 @@ namespace StingTools.Tags
             {
                 MinX = minX; MinY = minY; MaxX = maxX; MaxY = maxY;
             }
+
+            /// <summary>B-3: zero-extent placeholder (used when bbox estimation fails).</summary>
+            public bool IsEmpty => MinX == 0 && MaxX == 0 && MinY == 0 && MaxY == 0;
 
             public bool Overlaps(Box2D other)
             {
@@ -797,6 +896,48 @@ namespace StingTools.Tags
         public static SkipBreakdown LastSkipBreakdown { get; private set; } = new SkipBreakdown();
 
         /// <summary>
+        /// B-4: filter the candidate element list down to those whose derived
+        /// discipline matches the active view's <see cref="DrawingType.Discipline"/>.
+        /// Returns the number of elements dropped. No-op when the view is not
+        /// stamped, the drawing type can't be resolved, or its discipline is "*"
+        /// / empty (all-discipline / coordination view).
+        /// </summary>
+        internal static int ApplyDrawingTypeDisciplineFilter(
+            Document doc, View view, List<Element> elements)
+        {
+            if (doc == null || view == null || elements == null || elements.Count == 0) return 0;
+            string dtId = null;
+            try { dtId = ParameterHelpers.GetString(view, "STING_DRAWING_TYPE_ID_TXT"); }
+            catch { return 0; }
+            if (string.IsNullOrWhiteSpace(dtId)) return 0;
+
+            StingTools.Core.Drawing.DrawingType dt;
+            try { dt = StingTools.Core.Drawing.DrawingTypeRegistry.Get(doc, dtId); }
+            catch { return 0; }
+            if (dt == null) return 0;
+            string disc = dt.Discipline;
+            if (string.IsNullOrWhiteSpace(disc) || disc == "*") return 0;
+
+            int before = elements.Count;
+            elements.RemoveAll(e =>
+            {
+                try
+                {
+                    string elDisc = ParameterHelpers.GetString(e, ParamRegistry.DISC);
+                    if (string.IsNullOrEmpty(elDisc))
+                    {
+                        string cat = ParameterHelpers.GetCategoryName(e);
+                        if (!TagConfig.DiscMap.TryGetValue(cat, out elDisc) || string.IsNullOrEmpty(elDisc))
+                            return false; // unknown discipline — leave for placement, no false drops
+                    }
+                    return !string.Equals(elDisc, disc, StringComparison.OrdinalIgnoreCase);
+                }
+                catch { return false; }
+            });
+            return before - elements.Count;
+        }
+
+        /// <summary>
         /// Enhanced tag placement with grid spatial index, 16 candidates, alignment
         /// bonus, view crop boundary awareness, and performance optimization.
         /// </summary>
@@ -832,6 +973,14 @@ namespace StingTools.Tags
 
             if (tagOnlyUntagged)
                 elements = elements.Where(e => !taggedIds.Contains(e.Id)).ToList();
+
+            // B-4: when the active view is stamped with a DrawingType, restrict
+            // visual placement to elements whose derived discipline matches the
+            // drawing type's discipline (skip when the type's discipline is "*"
+            // or empty). Avoids planting electrical tags on architectural plans.
+            int filteredOut = ApplyDrawingTypeDisciplineFilter(doc, view, elements);
+            if (filteredOut > 0)
+                StingLog.Info($"SmartTagPlacement: DrawingType discipline filter dropped {filteredOut} of {elements.Count + filteredOut} candidate elements");
 
             if (elements.Count == 0) return (0, 0, 0);
 
@@ -873,29 +1022,68 @@ namespace StingTools.Tags
             double tagHeight = offset * 1.0;
             double cellSize = Math.Max(tagWidth, tagHeight) * 2.0;
 
-            // Build spatial grid from existing tags
-            var grid = new SpatialGrid(cellSize);
+            // B-2: pre-sort placement candidates by TAG_PRIORITY_INT desc so
+            // critical (priority 10) elements claim optimal positions first
+            // and only optional (priority 0) elements end up with leaders.
+            // Stable sort is preserved by OrderByDescending (LINQ).
+            elements = elements
+                .OrderByDescending(e => ParameterHelpers.GetInt(e, "TAG_PRIORITY_INT", 5))
+                .ToList();
+
+            // B-1: try the cache before walking every existing tag.
             var tagYs = new List<double>();
             var tagXs = new List<double>();
-
-            foreach (var tag in existingTags)
+            SpatialGrid grid;
+            bool gridFromCache = TryGetCachedSpatialGrid(doc, view, cellSize, existingTags.Count, out grid);
+            if (gridFromCache)
             {
-                BoundingBoxXYZ bb = tag.get_BoundingBox(view);
-                if (bb != null)
+                // Cached grid still needs the per-tag center coordinates for
+                // alignment scoring — those are cheap to recompute from the
+                // existing-tag bounding boxes. B-3: do that without the
+                // TransactionGroup workaround since the grid itself is reused.
+                foreach (var tag in existingTags)
                 {
+                    BoundingBoxXYZ bb = tag.get_BoundingBox(view);
+                    if (bb == null) continue;
                     var box = Box2D.FromBoundingBox(bb);
-                    grid.Insert(box);
                     tagYs.Add(box.CenterY);
                     tagXs.Add(box.CenterX);
                 }
             }
-
-            // Also register element bounding boxes for element-overlap avoidance
-            foreach (var elem in elements)
+            else
             {
-                BoundingBoxXYZ bb = elem.get_BoundingBox(view);
-                if (bb != null)
-                    grid.Insert(Box2D.FromBoundingBox(bb));
+                grid = new SpatialGrid(cellSize);
+                // B-3: collect bounding boxes in a batched pass so we don't
+                // open one TransactionGroup per tag. Tags whose bbox is null
+                // get a width-by-text approximation in
+                // EstimateTagBoxFallback so the grid still reserves space.
+                foreach (var tag in existingTags)
+                {
+                    BoundingBoxXYZ bb = tag.get_BoundingBox(view);
+                    Box2D box;
+                    if (bb != null)
+                    {
+                        box = Box2D.FromBoundingBox(bb);
+                    }
+                    else
+                    {
+                        box = EstimateTagBoxFallback(tag, view, tagWidth, tagHeight);
+                        if (box.IsEmpty) continue;
+                    }
+                    grid.Insert(box);
+                    tagYs.Add(box.CenterY);
+                    tagXs.Add(box.CenterX);
+                }
+
+                // Also register element bounding boxes for element-overlap avoidance
+                foreach (var elem in elements)
+                {
+                    BoundingBoxXYZ bb = elem.get_BoundingBox(view);
+                    if (bb != null)
+                        grid.Insert(Box2D.FromBoundingBox(bb));
+                }
+
+                StoreSpatialGrid(doc, view, cellSize, existingTags.Count, grid);
             }
 
             Box2D? viewCrop = GetViewCropBox(view);

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -931,7 +931,14 @@ namespace StingTools.UI
                     case "ProjectSetup": RunCommand<Temp.ProjectSetupCommand>(app); break;
                     case "MasterSetup": RunCommand<Temp.MasterSetupCommand>(app); break;
                     case "CreateParameters": RunCommand<Temp.CreateParametersCommand>(app); break;
-                    case "CheckData": RunCommand<Temp.CheckDataCommand>(app); break;
+                    case "CheckData":
+                        RunCommand<Temp.CheckDataCommand>(app);
+                        // E-1: dump cache hit/miss counters as part of the
+                        // CheckData diagnostic so users can see whether the
+                        // caching infrastructure is doing its job.
+                        try { Core.StingLog.DumpCacheStats(); }
+                        catch (Exception ex) { Core.StingLog.Warn($"DumpCacheStats: {ex.Message}"); }
+                        break;
 
                     // ── Materials ──
                     case "CreateBLEMaterials": RunCommand<Temp.CreateBLEMaterialsCommand>(app); break;


### PR DESCRIPTION
## Summary
This PR introduces comprehensive caching optimizations, drawing-type discipline filtering for tag placement and auto-tagging, bounded queue processing with transaction grouping, and cache telemetry. The changes improve performance in long sessions, prevent unbounded memory growth, and ensure tags respect view discipline constraints.

## Key Changes

### Caching Infrastructure
- **A-6**: Added `StoreTag7Hash()` and `TryGetTag7Hash()` with 20%-eviction LRU for `_tag7HashCache` (cap: 10,000 entries) to prevent unbounded memory growth in long sessions
- **A-7**: Hard cap (50,000 entries) on parameter cache with eviction logging to prevent growth across multiple documents
- **B-1**: SpatialGrid view cache per (docKey, viewId) with 30-second TTL to avoid rebuilding spatial indices on sequential placement runs
- **C-1**: View-template ElementId cache per document in `DrawingTypePresentation` to skip FilteredElementCollector scans during batch operations
- **C-2**: ViewStylePack resolution cache per document to resolve each pack only once during batch runs
- **C-3**: Seed-view cache in `ManagedTemplateSyncer` to avoid duplicate FilteredElementCollector scans per (pack, viewType) pair
- **C-5**: Per-document memoization of `ResolveExtends()` results in `DrawingTypeRegistry` so inheritance chains aren't recomputed on every `Get()` call
- **C-6**: Document-scoped managed-template cache in `ManagedTemplateSyncer` to prevent stale ElementIds from copied/save-as'd documents
- **E-1**: Cache hit/miss telemetry for ParamCache, RoomIndex, Tag7Hash, and DrawingTypeRegistry via `RecordHit/RecordMiss()` and `DumpCacheStats()`

### Discipline Filtering
- **C-7**: Auto-tagger now resolves active view's DrawingType discipline once per drain pass and defers off-discipline elements rather than tagging them, preventing clutter on discipline-specific views
- **B-4**: SmartTagPlacement applies DrawingType discipline filter to candidate elements before placement, dropping elements whose derived discipline doesn't match the view's stamped type
- **C-8 / E-2**: DrawingDriftDetector now tracks suppressed fields (controlled by view templates) separately from actionable drifts; SyncStyles skips suppressed entries to prevent silent failures

### Queue & Transaction Management
- **A-3**: Auto-tagger queue now drains entirely within a single `TransactionGroup` so users see one undo entry for bulk-paste sessions; each MaxPerBatch chunk commits its own child Transaction for safety
- **A-8**: SEQ sidecar saved once after TransactionGroup assimilates (not per-chunk) to guarantee it reflects a committed state
- **A-9**: Idempotency guard in `BuildAndWriteTag()` — if element's last-written tag equals current tag and is complete, skip collision loop entirely

### Batch Optimization
- **D-1**: `DrawingTypePresentation.Prewarm()` pre-resolves all drawing types and their templates/packs in one pass to warm caches before batch runs
- **D-2**: Planscape sync now warns users when syncing from non-central or unsynced local copies (informational, user can proceed)
- **D-3**: Cache invalidation wired to `DrawingTypeRegistry.Reload()` and document-closed handler to prevent stale ElementIds across sessions

### Fallback & Robustness
- **B-3**: `EstimateTagBoxFallback()` estimates tag bounding box when `get_BoundingBox()` returns null, using tag text height × character count as width approximation

## Notable Implementation Details
- All caches use document-key (PathName or Title) as scope to prevent cross-document contamination
- Eviction patterns mirror existing `_elementVersionHash` 20%-eviction strategy for consistency
- Thread-safe caches use `lock` statements; high-frequency caches use `Interlocked` counters
- Cache invalidation is explicit and tied to reload/

https://claude.ai/code/session_01ERuNnvtWPsQnzrnztVuxGR