### PR TITLE
Performance & correctness fixes: caching, batch optimization, validation

### DIFF
--- a/StingTools/Commands/Drawing/BatchProduceCommands.cs
+++ b/StingTools/Commands/Drawing/BatchProduceCommands.cs
@@ -100,6 +100,7 @@ namespace StingTools.Commands.Drawing
                 // / per-DrawingType Apply call hits the (template name →
                 // ElementId) and (pack id → pack) memos.
                 DrawingTypePresentation.Prewarm(doc);
+                DrawingProducer.PrimeBatchCaches(doc); // GAP-L
 
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Plan", "RCP");
                 var levels = new FilteredElementCollector(doc).OfClass(typeof(Level)).Cast<Level>().OrderBy(l => l.Elevation).ToList();
@@ -155,6 +156,7 @@ namespace StingTools.Commands.Drawing
 
                 // PERF-01: pre-warm view-template + pack caches.
                 DrawingTypePresentation.Prewarm(doc);
+                DrawingProducer.PrimeBatchCaches(doc); // GAP-L
 
                 var scopes = new FilteredElementCollector(doc)
                     .OfCategory(BuiltInCategory.OST_VolumeOfInterest)
@@ -227,6 +229,7 @@ namespace StingTools.Commands.Drawing
 
                 // PERF-01: pre-warm view-template + pack caches before per-room loop.
                 DrawingTypePresentation.Prewarm(doc);
+                DrawingProducer.PrimeBatchCaches(doc); // GAP-L
 
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Elevation");
                 var rooms = new FilteredElementCollector(doc).OfCategory(BuiltInCategory.OST_Rooms).WhereElementIsNotElementType()
@@ -295,6 +298,7 @@ namespace StingTools.Commands.Drawing
 
                 // PERF-01: pre-warm view-template + pack caches.
                 DrawingTypePresentation.Prewarm(doc);
+                DrawingProducer.PrimeBatchCaches(doc); // GAP-L
 
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Section");
                 var grids = new FilteredElementCollector(doc).OfClass(typeof(Grid)).Cast<Grid>().ToList();
@@ -384,6 +388,7 @@ namespace StingTools.Commands.Drawing
 
                 // PERF-01: pre-warm view-template + pack caches.
                 DrawingTypePresentation.Prewarm(doc);
+                DrawingProducer.PrimeBatchCaches(doc); // GAP-L
 
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Elevation")
                     .Where(t => !(t.Name ?? "").ToLowerInvariant().Contains("interior")).ToList();

--- a/StingTools/Commands/Drawing/BatchProduceCommands.cs
+++ b/StingTools/Commands/Drawing/BatchProduceCommands.cs
@@ -95,7 +95,12 @@ namespace StingTools.Commands.Drawing
             try
             {
                 var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
-                
+
+                // PERF-01: warm the per-document caches so every per-level
+                // / per-DrawingType Apply call hits the (template name →
+                // ElementId) and (pack id → pack) memos.
+                DrawingTypePresentation.Prewarm(doc);
+
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Plan", "RCP");
                 var levels = new FilteredElementCollector(doc).OfClass(typeof(Level)).Cast<Level>().OrderBy(l => l.Elevation).ToList();
                 var contextLabels = levels.Select(l => l.Name).ToList();
@@ -147,7 +152,9 @@ namespace StingTools.Commands.Drawing
             try
             {
                 var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
-                
+
+                // PERF-01: pre-warm view-template + pack caches.
+                DrawingTypePresentation.Prewarm(doc);
 
                 var scopes = new FilteredElementCollector(doc)
                     .OfCategory(BuiltInCategory.OST_VolumeOfInterest)
@@ -217,7 +224,10 @@ namespace StingTools.Commands.Drawing
             try
             {
                 var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
-                
+
+                // PERF-01: pre-warm view-template + pack caches before per-room loop.
+                DrawingTypePresentation.Prewarm(doc);
+
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Elevation");
                 var rooms = new FilteredElementCollector(doc).OfCategory(BuiltInCategory.OST_Rooms).WhereElementIsNotElementType()
                     .Cast<Element>()
@@ -282,7 +292,10 @@ namespace StingTools.Commands.Drawing
             try
             {
                 var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
-                
+
+                // PERF-01: pre-warm view-template + pack caches.
+                DrawingTypePresentation.Prewarm(doc);
+
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Section");
                 var grids = new FilteredElementCollector(doc).OfClass(typeof(Grid)).Cast<Grid>().ToList();
                 var labels = new List<string> { "Manual selection (pick in model)" };
@@ -368,7 +381,10 @@ namespace StingTools.Commands.Drawing
             try
             {
                 var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
-                
+
+                // PERF-01: pre-warm view-template + pack caches.
+                DrawingTypePresentation.Prewarm(doc);
+
                 var types = BatchProduceCommons.AllTypesByPurpose(doc, "Elevation")
                     .Where(t => !(t.Name ?? "").ToLowerInvariant().Contains("interior")).ToList();
 

--- a/StingTools/Commands/Drawing/DrawingSyncStylesCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingSyncStylesCommand.cs
@@ -121,4 +121,80 @@ namespace StingTools.Commands.Drawing
             return sb.ToString();
         }
     }
+
+    /// <summary>
+    /// FG-10 / INT-07: force-resync command. Re-applies every stamped
+    /// view's profile, including the views whose drifts are suppressed
+    /// because their currently-applied view template controls the
+    /// parameter. The applier still respects STING_STYLE_LOCKED_BOOL —
+    /// only the template-control suppression is overridden.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class DrawingForceResyncCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, ElementSet els)
+        {
+            try
+            {
+                var doc = data?.Application?.ActiveUIDocument?.Document;
+                if (doc == null) { msg = "No document open."; return Result.Failed; }
+
+                var reports = DrawingDriftDetector.Scan(doc)
+                    .Where(r => r.Any || r.AnySuppressed).ToList();
+                if (reports.Count == 0)
+                {
+                    TaskDialog.Show("STING — Force Resync",
+                        "No stamped views need re-syncing — every profile-controlled value matches the live state.");
+                    return Result.Succeeded;
+                }
+
+                var confirm = new TaskDialog("STING — Force Resync (Suppressed)")
+                {
+                    MainInstruction = $"{reports.Count} view(s) will be re-applied",
+                    MainContent =
+                        "Force-resync re-runs every stamped view's profile, including the ones whose " +
+                        "drift was previously suppressed because the view template controls the parameter. " +
+                        "Use this after editing a view template that intentionally diverges from the profile " +
+                        "but you want the profile back as the authority.\n\n" +
+                        "STING_STYLE_LOCKED views are still skipped.",
+                    CommonButtons = TaskDialogCommonButtons.Ok | TaskDialogCommonButtons.Cancel,
+                    DefaultButton = TaskDialogResult.Cancel,
+                };
+                if (confirm.Show() != TaskDialogResult.Ok) return Result.Cancelled;
+
+                int resynced = 0;
+                using (var tx = new Transaction(doc, "STING — Force Resync (Suppressed)"))
+                {
+                    tx.Start();
+                    foreach (var r in reports)
+                    {
+                        if (!(doc.GetElement(r.ViewId) is View v)) continue;
+                        var dt = DrawingTypeRegistry.Get(doc, r.DrawingTypeId);
+                        if (dt == null) continue;
+                        var applied = DrawingTypePresentation.Apply(doc, v, dt, new DrawingTypePresentation.ApplyOptions
+                        {
+                            AnnotationOptions = new AnnotationRunOptions
+                            {
+                                SkipAutoTag = true, SkipAutoDim = true, SkipDecorative = true, SkipSpots = true
+                            }
+                        });
+                        if (applied.ScaleApplied || applied.DetailLevelApplied
+                            || applied.TemplateApplied || applied.PackApplied
+                            || applied.TokenProfileApplied)
+                            resynced++;
+                    }
+                    tx.Commit();
+                }
+                TaskDialog.Show("STING — Force Resync", $"Re-applied profile on {resynced} view(s).");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("DrawingForceResync", ex);
+                msg = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
 }

--- a/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
@@ -63,7 +63,8 @@ namespace StingTools.Commands.Drawing
                 // Validation summary
                 int errors   = reports.Sum(r => r.Issues.Count(i => i.Severity == ValidationSeverity.Error));
                 int warnings = reports.Sum(r => r.Issues.Count(i => i.Severity == ValidationSeverity.Warning));
-                sb.AppendLine($"Validation: {errors} error(s), {warnings} warning(s)");
+                int infos    = reports.Sum(r => r.Issues.Count(i => i.Severity == ValidationSeverity.Info));
+                sb.AppendLine($"Validation: {errors} error(s), {warnings} warning(s), {infos} info");
 
                 // Drift summary (Week 4) — per-view check against profile
                 try
@@ -102,6 +103,28 @@ namespace StingTools.Commands.Drawing
                     sb.AppendLine($"  [{r.DrawingTypeId}]");
                     foreach (var i in r.Issues.Where(i => i.Severity != ValidationSeverity.Info))
                         sb.AppendLine($"    {i.Severity,-7} {i.Code}: {i.Message}");
+                }
+
+                // GAP-Q: surface Info-level issues (DT-050 / DT-057 / DT-061
+                // / DT-137-NOSLOTS) in a collapsed section so authors get
+                // a heads-up about non-blocking schema concerns without
+                // confusing them with errors / warnings.
+                var infoOnlyReports = reports
+                    .Where(r => !r.HasErrors && !r.HasWarnings
+                                && r.Issues.Any(i => i.Severity == ValidationSeverity.Info))
+                    .ToList();
+                if (infos > 0)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine($"Info ({infos} item{(infos == 1 ? "" : "s")} — non-blocking, profile-author hints):");
+                    foreach (var r in infoOnlyReports.Take(20))
+                    {
+                        sb.AppendLine($"  [{r.DrawingTypeId}]");
+                        foreach (var i in r.Issues.Where(i => i.Severity == ValidationSeverity.Info).Take(5))
+                            sb.AppendLine($"    Info    {i.Code}: {i.Message}");
+                    }
+                    if (infoOnlyReports.Count > 20)
+                        sb.AppendLine($"  …(+{infoOnlyReports.Count - 20} more)");
                 }
 
                 TaskDialog.Show("STING — Drawing Types", sb.ToString().Length > 10000

--- a/StingTools/Commands/Drawing/GenerateFromScopeBoxesCommand.cs
+++ b/StingTools/Commands/Drawing/GenerateFromScopeBoxesCommand.cs
@@ -33,8 +33,12 @@ namespace StingTools.Commands.Drawing
                 var doc = data?.Application?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
-                var bindings = ScopeBoxBinder.ScanProject(doc);
-                if (bindings.Count == 0)
+                // PERF-01: warm view-template + pack caches once before the
+                // batch so per-view Apply() calls hit cached lookups.
+                DrawingTypePresentation.Prewarm(doc);
+
+                var bindings = ScopeBoxBinder.ScanProject(doc, out var nameWarnings);
+                if (bindings.Count == 0 && nameWarnings.Count == 0)
                 {
                     TaskDialog.Show("STING — Generate from Scope Boxes",
                         "No scope boxes matching the STING::<drawing-type> pattern.\n\n" +
@@ -46,6 +50,10 @@ namespace StingTools.Commands.Drawing
 
                 int created = 0, updated = 0, skipped = 0;
                 var warnings = new List<string>();
+                // ACC-02: surface scope-box names that begin with STING::
+                // but fail strict parsing — typos that previously vanished.
+                foreach (var nw in nameWarnings)
+                    warnings.Add($"'{nw.Name}' → name rejected: {nw.Reason}");
 
                 using (var tx = new Transaction(doc, "STING — Generate from Scope Boxes"))
                 {
@@ -67,6 +75,7 @@ namespace StingTools.Commands.Drawing
                             if (existing != null)
                             {
                                 DrawingTypePresentation.Apply(doc, existing, dt, runAnnotation: false);
+                                StampScopeBoxTag(existing, b, warnings);
                                 updated++;
                                 continue;
                             }
@@ -74,6 +83,7 @@ namespace StingTools.Commands.Drawing
                             var v = CreateView(doc, dt, b, warnings);
                             if (v == null) { skipped++; continue; }
                             DrawingTypePresentation.Apply(doc, v, dt);
+                            StampScopeBoxTag(v, b, warnings);
                             created++;
                         }
                         catch (Exception ex)
@@ -106,6 +116,31 @@ namespace StingTools.Commands.Drawing
                 StingLog.Error("GenerateFromScopeBoxes", ex);
                 msg = ex.Message;
                 return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// INT-01: persist the scope-box tag on the produced view so any
+        /// downstream automation can group / filter by tag, and emit an
+        /// info message if the view ever gets placed on a sheet so the
+        /// operator knows TitleBlockParamApplier will run on the sheet
+        /// (not the view).
+        /// </summary>
+        private static void StampScopeBoxTag(View v, ScopeBoxBinding b, List<string> warnings)
+        {
+            if (v == null || b == null) return;
+            if (!string.IsNullOrEmpty(b.Tag))
+            {
+                try
+                {
+                    var p = v.LookupParameter("STING_SCOPE_BOX_TAG_TXT");
+                    if (p != null && !p.IsReadOnly && p.StorageType == StorageType.String)
+                        p.Set(b.Tag);
+                }
+                catch (Exception ex)
+                {
+                    warnings.Add($"Tag stamp '{b.Tag}': {ex.Message}");
+                }
             }
         }
 

--- a/StingTools/Commands/Drawing/GenerateFromScopeBoxesCommand.cs
+++ b/StingTools/Commands/Drawing/GenerateFromScopeBoxesCommand.cs
@@ -36,6 +36,10 @@ namespace StingTools.Commands.Drawing
                 // PERF-01: warm view-template + pack caches once before the
                 // batch so per-view Apply() calls hit cached lookups.
                 DrawingTypePresentation.Prewarm(doc);
+                // GAP-F: prime the (DrawingType, ScopeBox) → existing-view
+                // index so per-binding FindExistingView is O(1) instead of
+                // O(views) per call.
+                ScopeBoxBinder.PrimeExistingViewIndex(doc);
 
                 var bindings = ScopeBoxBinder.ScanProject(doc, out var nameWarnings);
                 if (bindings.Count == 0 && nameWarnings.Count == 0)

--- a/StingTools/Core/Drawing/AnnotationRunner.cs
+++ b/StingTools/Core/Drawing/AnnotationRunner.cs
@@ -128,12 +128,26 @@ namespace StingTools.Core.Drawing
 
         private static void RunTagRules(Document doc, View view, AnnotationRulePack pack, AnnotationRunOptions opts, AnnotationResult result)
         {
-            // Build effective rule list
+            // FG-02: handle every tag-like RuleType, not just bare "AutoTag".
+            // RoomTag / SpaceTag / AreaTag / MaterialTag / KeynoteTag /
+            // MultiCategoryTag are all variants of "tag this category" and
+            // should run via the same per-rule path; the differentiator is
+            // the resolved tag family (RoomTag uses Room tag families, etc.).
+            // RuleType is preserved on the rule so downstream callers can
+            // pick a tag family by purpose.
+            var tagRuleKinds = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "AutoTag", "RoomTag", "SpaceTag", "AreaTag",
+                "MaterialTag", "KeynoteTag", "MultiCategoryTag",
+            };
+
             List<AutoAnnotationRule> effective;
             if (pack.Rules != null && pack.Rules.Count > 0)
             {
-                effective = pack.Rules.Where(r => r != null && r.Enabled &&
-                    string.Equals(r.RuleType ?? "AutoTag", "AutoTag", StringComparison.OrdinalIgnoreCase)).ToList();
+                effective = pack.Rules
+                    .Where(r => r != null && r.Enabled
+                                && tagRuleKinds.Contains(r.RuleType ?? "AutoTag"))
+                    .ToList();
             }
             else if (pack.AutoTag == true)
             {

--- a/StingTools/Core/Drawing/AnnotationRunner.cs
+++ b/StingTools/Core/Drawing/AnnotationRunner.cs
@@ -259,8 +259,22 @@ namespace StingTools.Core.Drawing
                 try
                 {
                     var bb = el.get_BoundingBox(view);
-                    if (bb == null) continue;
-                    var center = (bb.Min + bb.Max) * 0.5;
+                    XYZ center;
+                    if (bb != null)
+                    {
+                        center = (bb.Min + bb.Max) * 0.5;
+                    }
+                    else
+                    {
+                        // GAP-I: schedule items / annotation-host elements
+                        // may legitimately return a null view bbox. Try the
+                        // element's location point/curve before giving up;
+                        // worst case place at the view's centre so the tag
+                        // exists and can be moved by the user.
+                        center = ResolveFallbackTagPoint(el, view);
+                        if (center == null) continue;
+                        result.Warnings.Add($"TagRule '{el.Id}': null bbox in view, fallback placement used.");
+                    }
                     IndependentTag.Create(doc, tagSymbolId, view.Id,
                         new Reference(el), addLeader, ori, center);
                     result.TagsPlaced++;
@@ -273,6 +287,24 @@ namespace StingTools.Core.Drawing
                     catch { }
                 }
             }
+        }
+
+        // GAP-I helper: derive a tag point when the element's bbox is null.
+        private static XYZ ResolveFallbackTagPoint(Element el, View view)
+        {
+            try
+            {
+                if (el.Location is LocationPoint lp && lp.Point != null) return lp.Point;
+                if (el.Location is LocationCurve lc && lc.Curve != null)
+                {
+                    var c = lc.Curve;
+                    return (c.GetEndPoint(0) + c.GetEndPoint(1)) * 0.5;
+                }
+                // View centre as last-resort fallback.
+                if (view?.Origin != null) return view.Origin;
+            }
+            catch { /* best effort */ }
+            return null;
         }
 
         private static int GetPackTagDepth(AnnotationRulePack pack, string category)

--- a/StingTools/Core/Drawing/DrawingCropApplier.cs
+++ b/StingTools/Core/Drawing/DrawingCropApplier.cs
@@ -160,7 +160,7 @@ namespace StingTools.Core.Drawing
         private static BoundingBoxXYZ GetOrComputeUnion(Document doc, View view, List<string> warnings)
         {
             string key = DocKey(doc);
-            long viewKey = view.Id.IntegerValue;
+            long viewKey = view.Id.Value;
 
             // FIX-3: cheap element-count fingerprint. ID() runs O(1) per
             // element via the FilteredElementCollector; element movement

--- a/StingTools/Core/Drawing/DrawingCropApplier.cs
+++ b/StingTools/Core/Drawing/DrawingCropApplier.cs
@@ -22,6 +22,30 @@ namespace StingTools.Core.Drawing
 {
     public static class DrawingCropApplier
     {
+        // PERF-08: per-view bbox union cache keyed by (docKey, viewId).
+        // The union itself is invariant for a given view's element set; the
+        // applier re-queries it every call with different margins. Cache
+        // entries are evicted when DrawingTypeRegistry.Reload(doc) fires.
+        private static readonly object _bboxLock = new object();
+        private static readonly Dictionary<string, Dictionary<long, BoundingBoxXYZ>> _bboxCache
+            = new Dictionary<string, Dictionary<long, BoundingBoxXYZ>>(StringComparer.OrdinalIgnoreCase);
+
+        private static string DocKey(Document doc)
+        {
+            if (doc == null) return "__null__";
+            try { return string.IsNullOrEmpty(doc.PathName) ? doc.Title : doc.PathName; }
+            catch { return "__unknown__"; }
+        }
+
+        public static void InvalidateCache(Document doc)
+        {
+            string key = DocKey(doc);
+            lock (_bboxLock)
+            {
+                if (_bboxCache.ContainsKey(key)) _bboxCache.Remove(key);
+            }
+        }
+
         public static List<string> Apply(Document doc, View view, DrawingType dt)
         {
             var warnings = new List<string>();
@@ -106,31 +130,58 @@ namespace StingTools.Core.Drawing
         {
             try
             {
-                // Union the bboxes of every element visible in the view.
-                BoundingBoxXYZ union = null;
-                foreach (var el in new FilteredElementCollector(doc, view.Id).WhereElementIsNotElementType())
-                {
-                    var bb = el.get_BoundingBox(view);
-                    if (bb == null) continue;
-                    if (union == null) { union = new BoundingBoxXYZ { Min = bb.Min, Max = bb.Max }; continue; }
-                    union.Min = new XYZ(Math.Min(union.Min.X, bb.Min.X),
-                                         Math.Min(union.Min.Y, bb.Min.Y),
-                                         Math.Min(union.Min.Z, bb.Min.Z));
-                    union.Max = new XYZ(Math.Max(union.Max.X, bb.Max.X),
-                                         Math.Max(union.Max.Y, bb.Max.Y),
-                                         Math.Max(union.Max.Z, bb.Max.Z));
-                }
+                // PERF-08: cache the un-margined union per view; margin is
+                // applied below on every call so repeated profile applies
+                // (e.g. SyncStyles) skip the FilteredElementCollector pass.
+                var union = GetOrComputeUnion(doc, view, warnings);
                 if (union == null) { warnings.Add("TightBbox: view is empty, no crop applied."); return; }
 
                 var marginFt = (marginMm / 304.8);
-                union.Min = union.Min - new XYZ(marginFt, marginFt, 0);
-                union.Max = union.Max + new XYZ(marginFt, marginFt, 0);
+                var withMargin = new BoundingBoxXYZ
+                {
+                    Min = union.Min - new XYZ(marginFt, marginFt, 0),
+                    Max = union.Max + new XYZ(marginFt, marginFt, 0),
+                };
 
                 view.CropBoxActive  = true;
                 view.CropBoxVisible = true;
-                view.CropBox        = union;
+                view.CropBox        = withMargin;
             }
             catch (Exception ex) { warnings.Add($"TightBbox: {ex.Message}"); }
+        }
+
+        private static BoundingBoxXYZ GetOrComputeUnion(Document doc, View view, List<string> warnings)
+        {
+            string key = DocKey(doc);
+            long viewKey = view.Id.IntegerValue;
+            lock (_bboxLock)
+            {
+                if (_bboxCache.TryGetValue(key, out var docMap)
+                    && docMap.TryGetValue(viewKey, out var cached))
+                    return cached;
+            }
+
+            BoundingBoxXYZ union = null;
+            foreach (var el in new FilteredElementCollector(doc, view.Id).WhereElementIsNotElementType())
+            {
+                var bb = el.get_BoundingBox(view);
+                if (bb == null) continue;
+                if (union == null) { union = new BoundingBoxXYZ { Min = bb.Min, Max = bb.Max }; continue; }
+                union.Min = new XYZ(Math.Min(union.Min.X, bb.Min.X),
+                                     Math.Min(union.Min.Y, bb.Min.Y),
+                                     Math.Min(union.Min.Z, bb.Min.Z));
+                union.Max = new XYZ(Math.Max(union.Max.X, bb.Max.X),
+                                     Math.Max(union.Max.Y, bb.Max.Y),
+                                     Math.Max(union.Max.Z, bb.Max.Z));
+            }
+
+            lock (_bboxLock)
+            {
+                if (!_bboxCache.TryGetValue(key, out var docMap))
+                    _bboxCache[key] = docMap = new Dictionary<long, BoundingBoxXYZ>();
+                docMap[viewKey] = union;
+            }
+            return union;
         }
 
         private static void SetRoomBoundaryCrop(Document doc, View view, double marginMm, List<string> warnings)

--- a/StingTools/Core/Drawing/DrawingCropApplier.cs
+++ b/StingTools/Core/Drawing/DrawingCropApplier.cs
@@ -22,13 +22,20 @@ namespace StingTools.Core.Drawing
 {
     public static class DrawingCropApplier
     {
-        // PERF-08: per-view bbox union cache keyed by (docKey, viewId).
-        // The union itself is invariant for a given view's element set; the
-        // applier re-queries it every call with different margins. Cache
-        // entries are evicted when DrawingTypeRegistry.Reload(doc) fires.
+        // PERF-08 + FIX-3: per-view bbox union cache keyed by (docKey, viewId).
+        // The union shifts only when the view's element set changes; cache
+        // entries carry the cardinality at compute time so a stale entry
+        // is detected and refreshed before it produces an out-of-date crop.
+        // Evicted on DrawingTypeRegistry.Reload(doc) and on any element
+        // count mismatch at lookup time.
+        private sealed class BboxEntry
+        {
+            public BoundingBoxXYZ Union;
+            public int            ElementCount;
+        }
         private static readonly object _bboxLock = new object();
-        private static readonly Dictionary<string, Dictionary<long, BoundingBoxXYZ>> _bboxCache
-            = new Dictionary<string, Dictionary<long, BoundingBoxXYZ>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, Dictionary<long, BboxEntry>> _bboxCache
+            = new Dictionary<string, Dictionary<long, BboxEntry>>(StringComparer.OrdinalIgnoreCase);
 
         private static string DocKey(Document doc)
         {
@@ -154,16 +161,34 @@ namespace StingTools.Core.Drawing
         {
             string key = DocKey(doc);
             long viewKey = view.Id.IntegerValue;
+
+            // FIX-3: cheap element-count fingerprint. ID() runs O(1) per
+            // element via the FilteredElementCollector; element movement
+            // alone won't trigger a refresh, which is acceptable for the
+            // crop-margin use case (margin dominates the visible result),
+            // but element add / delete is captured.
+            int currentCount = 0;
+            try
+            {
+                currentCount = new FilteredElementCollector(doc, view.Id)
+                    .WhereElementIsNotElementType().GetElementCount();
+            }
+            catch { /* fall through; treat as forced re-compute */ }
+
             lock (_bboxLock)
             {
                 if (_bboxCache.TryGetValue(key, out var docMap)
-                    && docMap.TryGetValue(viewKey, out var cached))
-                    return cached;
+                    && docMap.TryGetValue(viewKey, out var cached)
+                    && cached.ElementCount == currentCount
+                    && cached.Union != null)
+                    return cached.Union;
             }
 
             BoundingBoxXYZ union = null;
+            int counted = 0;
             foreach (var el in new FilteredElementCollector(doc, view.Id).WhereElementIsNotElementType())
             {
+                counted++;
                 var bb = el.get_BoundingBox(view);
                 if (bb == null) continue;
                 if (union == null) { union = new BoundingBoxXYZ { Min = bb.Min, Max = bb.Max }; continue; }
@@ -178,8 +203,8 @@ namespace StingTools.Core.Drawing
             lock (_bboxLock)
             {
                 if (!_bboxCache.TryGetValue(key, out var docMap))
-                    _bboxCache[key] = docMap = new Dictionary<long, BoundingBoxXYZ>();
-                docMap[viewKey] = union;
+                    _bboxCache[key] = docMap = new Dictionary<long, BboxEntry>();
+                docMap[viewKey] = new BboxEntry { Union = union, ElementCount = counted };
             }
             return union;
         }

--- a/StingTools/Core/Drawing/DrawingDriftDetector.cs
+++ b/StingTools/Core/Drawing/DrawingDriftDetector.cs
@@ -113,7 +113,7 @@ namespace StingTools.Core.Drawing
                     if (!(el is View vv) || vv.IsTemplate) continue;
                     var s = DrawingTypeStamper.Read(vv);
                     if (string.IsNullOrWhiteSpace(s)) continue;
-                    cache.StampByViewId[vv.Id.IntegerValue] = s;
+                    cache.StampByViewId[vv.Id.Value] = s;
                 }
                 cache.Valid = true;
             }

--- a/StingTools/Core/Drawing/DrawingDriftDetector.cs
+++ b/StingTools/Core/Drawing/DrawingDriftDetector.cs
@@ -45,6 +45,39 @@ namespace StingTools.Core.Drawing
 
     public static class DrawingDriftDetector
     {
+        // PERF-06: reverse index of (stamped DrawingTypeId → list of view ids).
+        // The Scan() pass walked every View in the document and called
+        // DrawingTypeStamper.Read on each, even though most projects only have
+        // a few stamped views. Cache the index per-document so repeated scans
+        // (which happen on every SyncStyles / Inspect press) skip the
+        // FilteredElementCollector + per-element stamp read.
+        private sealed class ScanCache
+        {
+            public Dictionary<long, string> StampByViewId
+                = new Dictionary<long, string>();
+            public bool Valid;
+        }
+
+        private static readonly object _cacheLock = new object();
+        private static readonly Dictionary<string, ScanCache> _cache
+            = new Dictionary<string, ScanCache>(StringComparer.OrdinalIgnoreCase);
+
+        private static string DocKey(Document doc)
+        {
+            if (doc == null) return "__null__";
+            try { return string.IsNullOrEmpty(doc.PathName) ? doc.Title : doc.PathName; }
+            catch { return "__unknown__"; }
+        }
+
+        public static void InvalidateCache(Document doc)
+        {
+            string k = DocKey(doc);
+            lock (_cacheLock)
+            {
+                if (_cache.TryGetValue(k, out var sc)) sc.Valid = false;
+            }
+        }
+
         public static List<DriftReport> Scan(Document doc)
         {
             var reports = new List<DriftReport>();
@@ -63,10 +96,32 @@ namespace StingTools.Core.Drawing
                 if (resolved != null) resolvedById[raw.Id] = resolved;
             }
 
-            foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(View)))
+            // PERF-06: build / refresh the reverse index once per Scan call;
+            // the inner loop reads stamp values out of the dictionary instead
+            // of probing every element.
+            ScanCache cache;
+            lock (_cacheLock)
             {
-                if (!(el is View v) || v.IsTemplate) continue;
-                var dtId = DrawingTypeStamper.Read(v);
+                if (!_cache.TryGetValue(DocKey(doc), out cache))
+                    _cache[DocKey(doc)] = cache = new ScanCache();
+            }
+            if (!cache.Valid)
+            {
+                cache.StampByViewId.Clear();
+                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(View)))
+                {
+                    if (!(el is View vv) || vv.IsTemplate) continue;
+                    var s = DrawingTypeStamper.Read(vv);
+                    if (string.IsNullOrWhiteSpace(s)) continue;
+                    cache.StampByViewId[vv.Id.IntegerValue] = s;
+                }
+                cache.Valid = true;
+            }
+
+            foreach (var kv in cache.StampByViewId)
+            {
+                if (!(doc.GetElement(new ElementId(kv.Key)) is View v) || v.IsTemplate) continue;
+                var dtId = kv.Value;
                 if (string.IsNullOrWhiteSpace(dtId)) continue;   // not a STING view
                 if (DrawingTypeStamper.IsLocked(v)) continue;    // user-frozen
 
@@ -177,7 +232,16 @@ namespace StingTools.Core.Drawing
                     ? null
                     : ViewStylePackRegistry.Get(doc, dt.ViewStylePackId);
 
-                string expectedScheme = profile?.ColorScheme ?? pack?.TagColorScheme;
+                // ACC-10: profile wins; only fall back to pack when the
+                // profile is null. An empty-string profile.ColorScheme is
+                // treated as "leave as-is" rather than as a falsy → pack
+                // cascade, so a deliberately-cleared profile slot doesn't
+                // silently re-inherit the pack's scheme.
+                string expectedScheme;
+                if (profile != null && profile.ColorScheme != null)
+                    expectedScheme = profile.ColorScheme;
+                else
+                    expectedScheme = pack?.TagColorScheme;
                 if (!string.IsNullOrEmpty(expectedScheme))
                 {
                     string actual = ReadStringParam(v, ParamRegistry.VIEW_TAG_STYLE);

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -337,6 +337,15 @@ namespace StingTools.Core.Drawing
             }
             catch (Exception ex) { result.Warnings.Add($"SheetName: {ex.Message}"); }
 
+            // FIX-6: lock check + stale-key clear + stamp + sequence + title-block
+            // params all go through the canonical ApplyToSheet plus the
+            // producer-specific sequence stamp. Avoids re-implementing the
+            // stamper / applier sequence in two places.
+            if (DrawingTypeStamper.IsLocked(sheet))
+            {
+                result.Warnings.Add($"Sheet {sheet.Id} style-locked; producer kept sheet but skipped stamp/apply.");
+                return sheet.Id;
+            }
             DrawingTypeStamper.Stamp(sheet, dt.Id);
             DrawingTypeStamper.StampPackage(sheet, effectivePackage);
 
@@ -355,7 +364,9 @@ namespace StingTools.Core.Drawing
                 try
                 {
                     var tokens = BuildTokenDict(dt, ctx);
-                    TitleBlockParamApplier.Apply(doc, sheet, dt, tokens);
+                    var tbResult = TitleBlockParamApplier.Apply(doc, sheet, dt, tokens);
+                    foreach (var w in tbResult.Warnings)
+                        result.Warnings.Add("TitleBlockParams: " + w);
                 }
                 catch (Exception ex) { result.Warnings.Add($"TitleBlockParams: {ex.Message}"); }
             }

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -117,6 +117,29 @@ namespace StingTools.Core.Drawing
                     if (existing != null)
                     {
                         result.WasIdempotent = true;
+                        // GAP-H: re-apply the profile so a re-run after a
+                        // profile edit refreshes scale / template / pack /
+                        // stamps. SyncStyles flag (annotation off) avoids
+                        // re-tagging an already-tagged view. Returning the
+                        // raw id without Apply meant idempotent re-runs
+                        // were a permanent no-op even after pack edits.
+                        try
+                        {
+                            var refreshOpts = new DrawingTypePresentation.ApplyOptions
+                            {
+                                AnnotationOptions = new AnnotationRunOptions
+                                {
+                                    SkipAutoTag = true, SkipAutoDim = true,
+                                    SkipDecorative = true, SkipSpots = true
+                                }
+                            };
+                            var refreshed = DrawingTypePresentation.Apply(doc, existing, dt, refreshOpts);
+                            result.Warnings.AddRange(refreshed.Warnings);
+                        }
+                        catch (Exception ex)
+                        {
+                            result.Warnings.Add($"Idempotent refresh ({existing.Id}): {ex.Message}");
+                        }
                         return existing.Id;
                     }
                 }

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -499,16 +499,19 @@ namespace StingTools.Core.Drawing
 
         private static Dictionary<string, string> BuildTokenDict(DrawingType dt, DrawingContext ctx)
         {
-            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["disc"] = dt?.Discipline ?? "",
-                ["discipline"] = dt?.Discipline ?? "",
-                ["lvl"] = ctx?.Level?.Name ?? "",
-                ["mark"] = ctx?.Tag ?? "",
-                ["spool"] = ctx?.Tag ?? "",
-                ["purpose"] = dt?.Purpose ?? "",
-                ["package"] = ctx?.PackageId ?? dt?.PackageId ?? ""
-            };
+            // INT-06: route through the canonical builder so SheetManager,
+            // ShopDrawingComposer and the production engine all feed the
+            // exact same token set into TitleBlockParamApplier.
+            var d = DrawingTokenContext.Build(
+                doc:        null,        // producer is invoked without a doc handle here
+                dt:         dt,
+                discCode:   dt?.Discipline,
+                discipline: dt?.Discipline,
+                levelCode:  ctx?.Level?.Name,
+                spool:      ctx?.Tag,
+                mark:       ctx?.Tag);
+            d["package"] = ctx?.PackageId ?? dt?.PackageId ?? string.Empty;
+            return d;
         }
     }
 }

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -51,6 +51,104 @@ namespace StingTools.Core.Drawing
 
     public static class DrawingProducer
     {
+        // GAP-L: per-batch caches for the existing-view + existing-sheet
+        // lookups. ProduceAllViews repeatedly hits FilteredElementCollector
+        // to find idempotent matches; on a 1000-sheet model this dominates
+        // the runtime. The caches are populated lazily on first use within
+        // the batch, validated against the active doc on every read, and
+        // cleared by Reset() / the IDisposable scope returned by Prime().
+        [ThreadStatic] private static Dictionary<string, ElementId> _existingViewCache;
+        [ThreadStatic] private static Dictionary<string, ElementId> _existingSheetCache;
+        [ThreadStatic] private static Dictionary<string, int>       _packageSheetCount;
+        [ThreadStatic] private static string                        _cacheDocKey;
+
+        private static string CacheDocKey(Document doc)
+        {
+            if (doc == null) return "__null__";
+            try { return string.IsNullOrEmpty(doc.PathName) ? doc.Title : doc.PathName; }
+            catch { return "__unknown__"; }
+        }
+
+        private sealed class BatchCacheScope : IDisposable
+        {
+            public void Dispose() => DrawingProducer.ResetBatchCaches();
+        }
+
+        /// <summary>
+        /// GAP-L: prime the per-batch lookup caches and return an
+        /// IDisposable that resets them when the batch ends. Use with
+        /// <c>using (DrawingProducer.PrimeBatchScope(doc)) { ... }</c>
+        /// to guarantee the caches don't leak across commands.
+        /// </summary>
+        public static IDisposable PrimeBatchScope(Document doc)
+        {
+            PrimeBatchCaches(doc);
+            return new BatchCacheScope();
+        }
+
+        /// <summary>
+        /// GAP-L: prime the per-batch lookup caches. Call this once before
+        /// a batch generation so idempotent lookups inside
+        /// <see cref="ProduceAllViews"/> are O(1) instead of O(views).
+        /// Calling Reset() drops the caches; a fresh prime rebuilds them.
+        /// </summary>
+        public static void PrimeBatchCaches(Document doc)
+        {
+            ResetBatchCaches();
+            if (doc == null) return;
+            _cacheDocKey = CacheDocKey(doc);
+            try
+            {
+                var v = new Dictionary<string, ElementId>(StringComparer.Ordinal);
+                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(View)))
+                {
+                    if (!(el is View view) || view.IsTemplate) continue;
+                    var dtId = StingTools.Core.ParameterHelpers.GetString(view, DrawingTypeStamper.PARAM_DRAWING_TYPE_ID);
+                    if (string.IsNullOrEmpty(dtId)) continue;
+                    var ctxTag = StingTools.Core.ParameterHelpers.GetString(view, ParamRegistry.STING_VIEW_CONTEXT_TAG) ?? string.Empty;
+                    var ruleIdx = StingTools.Core.ParameterHelpers.GetInt(view, ParamRegistry.STING_PRODUCTION_RULE_IDX, -1);
+                    v[ViewKey(dtId, ctxTag, ruleIdx)] = view.Id;
+                }
+                _existingViewCache = v;
+
+                var s = new Dictionary<string, ElementId>(StringComparer.Ordinal);
+                var pkg = new Dictionary<string, int>(StringComparer.Ordinal);
+                foreach (var sheet in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)).Cast<ViewSheet>())
+                {
+                    var dtId = StingTools.Core.ParameterHelpers.GetString(sheet, DrawingTypeStamper.PARAM_DRAWING_TYPE_ID) ?? string.Empty;
+                    var pkgId = StingTools.Core.ParameterHelpers.GetString(sheet, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? string.Empty;
+                    if (!string.IsNullOrEmpty(dtId)) s[SheetKey(dtId, pkgId)] = sheet.Id;
+                    if (pkg.TryGetValue(pkgId, out var n)) pkg[pkgId] = n + 1;
+                    else pkg[pkgId] = 1;
+                }
+                _existingSheetCache = s;
+                _packageSheetCount  = pkg;
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"DrawingProducer.PrimeBatchCaches: {ex.Message}");
+            }
+        }
+
+        public static void ResetBatchCaches()
+        {
+            _existingViewCache  = null;
+            _existingSheetCache = null;
+            _packageSheetCount  = null;
+            _cacheDocKey        = null;
+        }
+
+        // GAP-L: a cache slot only matches the doc it was primed against.
+        // Cross-doc consultation returns null so the slow path takes over.
+        private static bool CacheMatchesDoc(Document doc)
+            => _cacheDocKey != null && string.Equals(_cacheDocKey, CacheDocKey(doc), StringComparison.OrdinalIgnoreCase);
+
+        private static string ViewKey(string dtId, string ctxTag, int ruleIdx)
+            => (dtId ?? string.Empty) + "|" + (ctxTag ?? string.Empty) + "|" + ruleIdx;
+
+        private static string SheetKey(string dtId, string pkgId)
+            => (dtId ?? string.Empty) + "|" + (pkgId ?? string.Empty);
+
         public static ProduceResult ProduceView(Document doc, DrawingType dt, DrawingContext ctx, ProduceOptions opts)
             => ProduceAllViews(doc, dt, ctx, opts);
 
@@ -316,6 +414,15 @@ namespace StingTools.Core.Drawing
             string effectivePackage = ctx.PackageId ?? dt.PackageId ?? "";
             try
             {
+                // GAP-L: per-batch cache hit, fall back to fresh collector.
+                if (_existingSheetCache != null
+                    && CacheMatchesDoc(doc)
+                    && _existingSheetCache.TryGetValue(SheetKey(dt.Id, effectivePackage), out var cachedSheetId))
+                {
+                    if (doc.GetElement(cachedSheetId) is ViewSheet vsCached && vsCached.IsValidObject)
+                        return vsCached.Id;
+                    _existingSheetCache.Remove(SheetKey(dt.Id, effectivePackage));
+                }
                 var existing = new FilteredElementCollector(doc)
                     .OfClass(typeof(ViewSheet))
                     .Cast<ViewSheet>()
@@ -374,11 +481,28 @@ namespace StingTools.Core.Drawing
 
             try
             {
-                int seq = new FilteredElementCollector(doc)
-                    .OfClass(typeof(ViewSheet))
-                    .Cast<ViewSheet>()
-                    .Count(s => string.Equals(StingTools.Core.ParameterHelpers.GetString(s, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? "", effectivePackage, StringComparison.Ordinal));
+                // GAP-L: prefer the per-batch package count cache; bump it
+                // for the sheet we're about to stamp so successive sheets in
+                // the same package get monotonically increasing sequences
+                // without re-collecting the project's sheets.
+                int seq;
+                if (_packageSheetCount != null && CacheMatchesDoc(doc))
+                {
+                    _packageSheetCount.TryGetValue(effectivePackage, out var n);
+                    seq = n + 1;
+                    _packageSheetCount[effectivePackage] = seq;
+                }
+                else
+                {
+                    seq = new FilteredElementCollector(doc)
+                        .OfClass(typeof(ViewSheet))
+                        .Cast<ViewSheet>()
+                        .Count(s => string.Equals(StingTools.Core.ParameterHelpers.GetString(s, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? "", effectivePackage, StringComparison.Ordinal));
+                }
                 DrawingTypeStamper.StampSheetSequence(sheet, seq);
+                // Newly-created sheet should be discoverable next time.
+                if (_existingSheetCache != null)
+                    _existingSheetCache[SheetKey(dt.Id, effectivePackage)] = sheet.Id;
             }
             catch { }
 
@@ -448,6 +572,17 @@ namespace StingTools.Core.Drawing
             try
             {
                 var ctxTag = BuildContextTag(ctx);
+                // GAP-L: O(1) hit when the per-batch index is primed for
+                // this document. Cross-doc consultation falls through.
+                if (_existingViewCache != null
+                    && CacheMatchesDoc(doc)
+                    && _existingViewCache.TryGetValue(ViewKey(dtId, ctxTag, ruleIdx), out var cachedId))
+                {
+                    if (doc.GetElement(cachedId) is View vCached
+                        && vCached.IsValidObject && !vCached.IsTemplate)
+                        return vCached;
+                    _existingViewCache.Remove(ViewKey(dtId, ctxTag, ruleIdx));
+                }
                 return new FilteredElementCollector(doc)
                     .OfClass(typeof(View))
                     .Cast<View>()

--- a/StingTools/Core/Drawing/DrawingTokenContext.cs
+++ b/StingTools/Core/Drawing/DrawingTokenContext.cs
@@ -49,9 +49,6 @@ namespace StingTools.Core.Drawing
                 { "sys",        sysCode    ?? string.Empty },
                 { "lvl",        levelCode  ?? string.Empty },
                 { "mark",       mark       ?? string.Empty },
-                { "seq",        seq.HasValue
-                                  ? seq.Value.ToString("D" + Math.Max(1, seqWidth))
-                                  : string.Empty },
                 { "purpose",    dt?.Purpose ?? string.Empty },
                 { "phase",      dt?.Phase   ?? string.Empty },
                 { "project",    ReadProjectInfo(doc, "PRJ_ORG_PROJECT_CODE") },
@@ -63,6 +60,13 @@ namespace StingTools.Core.Drawing
                 { "suit",       dt?.IsoNaming?.Suitability ?? string.Empty },
                 { "rev",        dt?.IsoNaming?.Revision    ?? string.Empty },
             };
+            // GAP-D: only emit "seq" when the caller actually has a value.
+            // The applier's TryGetValue(...) miss path leaves the literal
+            // "{seq:Dn}" untouched so a downstream stage (sheet renumber,
+            // package sequencer) can fill it later — better than silently
+            // rendering "Sheet Number A--" because the upstream had no seq.
+            if (seq.HasValue)
+                d["seq"] = seq.Value.ToString("D" + Math.Max(1, seqWidth));
             return d;
         }
 

--- a/StingTools/Core/Drawing/DrawingTokenContext.cs
+++ b/StingTools/Core/Drawing/DrawingTokenContext.cs
@@ -1,0 +1,108 @@
+// StingTools — Drawing Template Manager · INT-06 fix
+//
+// DrawingTokenContext is the single source of truth for the token
+// dictionary fed into TitleBlockParamApplier (and any future
+// substitution path). Before this helper existed, two parallel call
+// sites — ShopDrawingComposer and DrawingTypeSheetAdapter — each
+// produced their own token dict, so the SheetManager path got an
+// impoverished {disc, discipline, seq, spool, sys, lvl, mark} and the
+// fabrication path got the full ISO 19650 set. The applier then
+// silently produced different title-block cells from the same
+// profile depending on which command was invoked.
+//
+// All callers now go through Build(...). Optional fields stay empty
+// rather than missing so the regex-based applier always sees a
+// canonical key set.
+
+using System;
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
+
+namespace StingTools.Core.Drawing
+{
+    public static class DrawingTokenContext
+    {
+        /// <summary>
+        /// Canonical token dictionary fed into TitleBlockParamApplier.
+        /// Every caller — fabrication, sheet manager, scope-box generator,
+        /// production-rule engine — passes through this builder.
+        /// Optional values are left as empty strings (never null) so the
+        /// applier's literal-passthrough rule applies uniformly.
+        /// </summary>
+        public static Dictionary<string, string> Build(
+            Document doc,
+            DrawingType dt,
+            string discCode = null,
+            string discipline = null,
+            string sysCode = null,
+            string levelCode = null,
+            int? seq = null,
+            int seqWidth = 4,
+            string spool = null,
+            string mark = null)
+        {
+            var d = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "spool",      spool      ?? string.Empty },
+                { "disc",       discCode   ?? dt?.Discipline ?? string.Empty },
+                { "discipline", discipline ?? dt?.Discipline ?? string.Empty },
+                { "sys",        sysCode    ?? string.Empty },
+                { "lvl",        levelCode  ?? string.Empty },
+                { "mark",       mark       ?? string.Empty },
+                { "seq",        seq.HasValue
+                                  ? seq.Value.ToString("D" + Math.Max(1, seqWidth))
+                                  : string.Empty },
+                { "purpose",    dt?.Purpose ?? string.Empty },
+                { "phase",      dt?.Phase   ?? string.Empty },
+                { "project",    ReadProjectInfo(doc, "PRJ_ORG_PROJECT_CODE") },
+                { "originator", ReadProjectInfo(doc, "PRJ_ORG_ORIGINATOR_CODE") },
+                // ISO 19650 fields with profile fallback to discipline.
+                { "vol",        dt?.IsoNaming?.Volume      ?? string.Empty },
+                { "type",       dt?.IsoNaming?.Type        ?? string.Empty },
+                { "role",       dt?.IsoNaming?.Role        ?? discCode ?? dt?.Discipline ?? string.Empty },
+                { "suit",       dt?.IsoNaming?.Suitability ?? string.Empty },
+                { "rev",        dt?.IsoNaming?.Revision    ?? string.Empty },
+            };
+            return d;
+        }
+
+        /// <summary>
+        /// SheetManager fallback: extract {seq} from the sheet-number's
+        /// trailing digit run when no explicit seq is known. Called by
+        /// <see cref="StingTools.Docs.DrawingTypeSheetAdapter"/> so the
+        /// "Create From Template" path produces stable tokens even when
+        /// the user picks a profile without an existing sequence counter.
+        /// </summary>
+        public static int? ExtractSeqFromSheetNumber(string sheetNumber)
+        {
+            if (string.IsNullOrEmpty(sheetNumber)) return null;
+            string seq = string.Empty;
+            for (int i = sheetNumber.Length - 1; i >= 0; i--)
+            {
+                if (char.IsDigit(sheetNumber[i])) seq = sheetNumber[i] + seq;
+                else if (seq.Length > 0) break;
+            }
+            if (int.TryParse(seq, out var n)) return n;
+            return null;
+        }
+
+        private static string ReadProjectInfo(Document doc, string paramName)
+        {
+            try
+            {
+                var pi = doc?.ProjectInformation;
+                if (pi == null) return string.Empty;
+                var p = pi.LookupParameter(paramName);
+                if (p == null) return string.Empty;
+                switch (p.StorageType)
+                {
+                    case StorageType.String:  return p.AsString() ?? string.Empty;
+                    case StorageType.Integer: return p.AsInteger().ToString();
+                    case StorageType.Double:  return p.AsDouble().ToString("0.###");
+                    default:                  return p.AsValueString() ?? string.Empty;
+                }
+            }
+            catch { return string.Empty; }
+        }
+    }
+}

--- a/StingTools/Core/Drawing/DrawingTypePresentation.cs
+++ b/StingTools/Core/Drawing/DrawingTypePresentation.cs
@@ -233,6 +233,22 @@ namespace StingTools.Core.Drawing
                 r.Warnings.Add($"Sheet {sheet.Id} is style-locked; ApplyToSheet skipped.");
                 return r;
             }
+
+            // FIX-7: clear keys declared by the *previous* profile on this
+            // sheet before stamping the new id. Handles cloned sheets and
+            // profile re-assignment so stale title-block cells from the
+            // prior profile don't survive.
+            try
+            {
+                var priorStampedId = DrawingTypeStamper.Read(sheet);
+                if (!string.IsNullOrEmpty(priorStampedId)
+                    && !string.Equals(priorStampedId, dt.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    TitleBlockParamApplier.ClearStaleKeysFromPriorProfile(doc, sheet);
+                }
+            }
+            catch (Exception ex) { r.Warnings.Add($"ApplyToSheet ClearStale: {ex.Message}"); }
+
             DrawingTypeStamper.Stamp(sheet, dt.Id);
             if (!string.IsNullOrEmpty(dt.PackageId))
                 DrawingTypeStamper.StampPackage(sheet, dt.PackageId);

--- a/StingTools/Core/Drawing/DrawingTypePresentation.cs
+++ b/StingTools/Core/Drawing/DrawingTypePresentation.cs
@@ -244,7 +244,7 @@ namespace StingTools.Core.Drawing
                 if (!string.IsNullOrEmpty(priorStampedId)
                     && !string.Equals(priorStampedId, dt.Id, StringComparison.OrdinalIgnoreCase))
                 {
-                    TitleBlockParamApplier.ClearStaleKeysFromPriorProfile(doc, sheet);
+                    TitleBlockParamApplier.ClearStaleKeysFromPriorProfile(doc, sheet, priorStampedId);
                 }
             }
             catch (Exception ex) { r.Warnings.Add($"ApplyToSheet ClearStale: {ex.Message}"); }

--- a/StingTools/Core/Drawing/DrawingTypePresentation.cs
+++ b/StingTools/Core/Drawing/DrawingTypePresentation.cs
@@ -208,6 +208,50 @@ namespace StingTools.Core.Drawing
             public System.Collections.Generic.List<string> Warnings { get; } = new System.Collections.Generic.List<string>();
         }
 
+        /// <summary>
+        /// INT-05: sheet-aware apply. Sheets have no scale / detail-level /
+        /// view-template / crop / view-style-pack — running the full view
+        /// pipeline on a sheet would no-op those steps but still spend time
+        /// looking up missing assets. Instead this routes the steps that
+        /// matter for sheets:
+        ///   1. style-lock check
+        ///   2. DrawingType id stamp
+        ///   3. PackageId stamp (if profile carries one)
+        ///   4. title-block parameter binding
+        /// Returns the same <see cref="ApplyResult"/> shape so SheetManager
+        /// / ShopDrawingComposer / ProductionRule consume one type.
+        /// </summary>
+        public static ApplyResult ApplyToSheet(
+            Document doc, ViewSheet sheet, DrawingType dt,
+            IDictionary<string, string> tokens = null)
+        {
+            var r = new ApplyResult();
+            if (doc == null || sheet == null || dt == null) return r;
+
+            if (DrawingTypeStamper.IsLocked(sheet))
+            {
+                r.Warnings.Add($"Sheet {sheet.Id} is style-locked; ApplyToSheet skipped.");
+                return r;
+            }
+            DrawingTypeStamper.Stamp(sheet, dt.Id);
+            if (!string.IsNullOrEmpty(dt.PackageId))
+                DrawingTypeStamper.StampPackage(sheet, dt.PackageId);
+
+            try
+            {
+                var effectiveTokens = tokens ?? DrawingTokenContext.Build(
+                    doc:        doc,
+                    dt:         dt,
+                    discCode:   dt.Discipline,
+                    discipline: dt.Discipline,
+                    seq:        DrawingTokenContext.ExtractSeqFromSheetNumber(sheet.SheetNumber));
+                var tbResult = TitleBlockParamApplier.Apply(doc, sheet, dt, effectiveTokens);
+                r.Warnings.AddRange(tbResult.Warnings);
+            }
+            catch (Exception ex) { r.Warnings.Add($"ApplyToSheet TitleBlockParams: {ex.Message}"); }
+            return r;
+        }
+
         public static ApplyResult Apply(Document doc, View view, DrawingType dt, bool runAnnotation = true)
             => Apply(doc, view, dt, runAnnotation ? null : new ApplyOptions {
                 AnnotationOptions = new AnnotationRunOptions {

--- a/StingTools/Core/Drawing/DrawingTypeRegistry.cs
+++ b/StingTools/Core/Drawing/DrawingTypeRegistry.cs
@@ -96,6 +96,15 @@ namespace StingTools.Core.Drawing
         /// child non-null / non-default fields override parent. Loop
         /// detection via visited-set; mirror of ViewStylePackRegistry.
         /// </summary>
+        // FIX-5: dedupe ACC-01 drift warnings so they fire once per
+        // (child, drifted parent) pair per session rather than on every
+        // first cache miss. Cleared by Reload alongside the resolved cache.
+        // Process-wide rather than per-doc on purpose — drift warnings are
+        // about corporate-vs-project state, which carries across "Save As".
+        private static readonly HashSet<string> _extendsDriftWarned
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object _driftWarnedLock = new object();
+
         private static DrawingType ResolveExtends(DrawingTypeLibrary lib, DrawingType leaf)
         {
             if (string.IsNullOrWhiteSpace(leaf.Extends)) return leaf;
@@ -120,9 +129,13 @@ namespace StingTools.Core.Drawing
                     && string.Equals(cur.Origin, "project", StringComparison.OrdinalIgnoreCase)
                     && !string.IsNullOrEmpty(cur.Checksum))
                 {
-                    StingTools.Core.StingLog.Warn(
-                        $"DrawingType '{leaf.Id}' extends '{cur.Id}' which has drifted from corporate baseline; " +
-                        "merged snapshot reflects the project-edited parent values.");
+                    string warnKey = (leaf.Id ?? string.Empty) + "→" + (cur.Id ?? string.Empty);
+                    bool fire;
+                    lock (_driftWarnedLock) fire = _extendsDriftWarned.Add(warnKey);
+                    if (fire)
+                        StingTools.Core.StingLog.Warn(
+                            $"DrawingType '{leaf.Id}' extends '{cur.Id}' which has drifted from corporate baseline; " +
+                            "merged snapshot reflects the project-edited parent values.");
                 }
                 if (string.IsNullOrWhiteSpace(cur.Extends)) break;
                 cur = lib.DrawingTypes.FirstOrDefault(
@@ -190,6 +203,9 @@ namespace StingTools.Core.Drawing
                 if (_cache.ContainsKey(key)) _cache.Remove(key);
                 if (_resolvedCache.ContainsKey(key)) _resolvedCache.Remove(key);
             }
+            // FIX-5: clear the drift-warning dedupe set so a Reload after
+            // editing a parent re-warns once on next resolution.
+            lock (_driftWarnedLock) _extendsDriftWarned.Clear();
             // FG-05: also notify any in-process editor / live applier so a
             // mid-session edit of a parent profile cascades through every
             // child that extends it. The presentation + drift caches above
@@ -365,7 +381,14 @@ namespace StingTools.Core.Drawing
                         var sb = new StringBuilder(hash.Length * 2);
                         foreach (var b in hash) sb.Append(b.ToString("x2"));
                         var actual = sb.ToString();
-                        if (!string.IsNullOrEmpty(prior) && prior != actual)
+                        // Migration safety: a project that opened with the old
+                        // 16-char Base64 prefix should silently upgrade to the
+                        // new 64-char hex form on first read. Treat any prior
+                        // value that's not 64 hex chars as legacy and skip the
+                        // drift warning.
+                        bool priorIsLegacy = !string.IsNullOrEmpty(prior)
+                            && prior.Length != 64;
+                        if (!string.IsNullOrEmpty(prior) && !priorIsLegacy && prior != actual)
                         {
                             StingTools.Core.StingLog.Warn(
                                 $"DrawingType '{t.Id}' checksum drift: shipped={prior} actual={actual}. " +

--- a/StingTools/Core/Drawing/DrawingTypeRegistry.cs
+++ b/StingTools/Core/Drawing/DrawingTypeRegistry.cs
@@ -131,7 +131,15 @@ namespace StingTools.Core.Drawing
                 {
                     string warnKey = (leaf.Id ?? string.Empty) + "→" + (cur.Id ?? string.Empty);
                     bool fire;
-                    lock (_driftWarnedLock) fire = _extendsDriftWarned.Add(warnKey);
+                    lock (_driftWarnedLock)
+                    {
+                        // GAP-G: soft-cap so a long-running session with many
+                        // unique (child, parent) pairs cannot leak unbounded
+                        // memory. 1024 is an order of magnitude above any
+                        // realistic project's drawing-type catalogue.
+                        if (_extendsDriftWarned.Count > 1024) _extendsDriftWarned.Clear();
+                        fire = _extendsDriftWarned.Add(warnKey);
+                    }
                     if (fire)
                         StingTools.Core.StingLog.Warn(
                             $"DrawingType '{leaf.Id}' extends '{cur.Id}' which has drifted from corporate baseline; " +
@@ -348,9 +356,33 @@ namespace StingTools.Core.Drawing
             }
             merged.DrawingTypes = byId.Values.ToList();
 
-            // Project routing rules are prepended (first-match-wins semantics)
+            // Project routing rules are prepended (first-match-wins semantics).
+            // GAP-J: dedupe by the (discipline, phase, docType) triple plus
+            // any predicate fields that participate in matching, so a project
+            // rule that overrides a corporate rule for the same key fully
+            // suppresses the corporate entry rather than leaving it as a
+            // never-reached trailing rule.
             if (over.Routing != null && over.Routing.Count > 0)
+            {
                 merged.Routing.InsertRange(0, over.Routing);
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var deduped = new List<DrawingRoutingRule>();
+                foreach (var rule in merged.Routing)
+                {
+                    if (rule == null) continue;
+                    string sig = string.Join("|",
+                        rule.Discipline ?? "*",
+                        rule.Phase ?? "*",
+                        rule.DocType ?? "*",
+                        rule.DisciplineMatches ?? "",
+                        rule.PhaseMatches ?? "",
+                        rule.DocTypeMatches ?? "",
+                        rule.LevelMatches ?? "",
+                        rule.ProjectCodeMatches ?? "");
+                    if (seen.Add(sig)) deduped.Add(rule);
+                }
+                merged.Routing = deduped;
+            }
 
             return merged;
         }

--- a/StingTools/Core/Drawing/DrawingTypeRegistry.cs
+++ b/StingTools/Core/Drawing/DrawingTypeRegistry.cs
@@ -111,6 +111,19 @@ namespace StingTools.Core.Drawing
                     break;
                 }
                 chain.Add(cur);
+                // ACC-01: detect a drifted parent in the extends chain. If the
+                // parent's origin has been flipped to "project" by checksum
+                // drift, the child silently inherits the drifted fields. Log
+                // a warning so the operator knows their resolved child is
+                // non-canonical even when the JSON file is shipped pristine.
+                if (cur != leaf
+                    && string.Equals(cur.Origin, "project", StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrEmpty(cur.Checksum))
+                {
+                    StingTools.Core.StingLog.Warn(
+                        $"DrawingType '{leaf.Id}' extends '{cur.Id}' which has drifted from corporate baseline; " +
+                        "merged snapshot reflects the project-edited parent values.");
+                }
                 if (string.IsNullOrWhiteSpace(cur.Extends)) break;
                 cur = lib.DrawingTypes.FirstOrDefault(
                     t => string.Equals(t.Id, cur.Extends, StringComparison.OrdinalIgnoreCase));
@@ -147,6 +160,25 @@ namespace StingTools.Core.Drawing
         public static IReadOnlyList<DrawingType> ListAll(Document doc)
             => GetLibrary(doc).DrawingTypes;
 
+        /// <summary>
+        /// FG-05: invalidate every cached resolved DrawingType for a doc
+        /// without re-loading the JSON library. Call after editing a
+        /// single profile in-session (e.g. via the WPF editor) so children
+        /// that extend the edited parent re-merge their snapshot on next
+        /// <see cref="Get"/>.
+        /// </summary>
+        public static void InvalidateResolvedCache(Document doc)
+        {
+            string docKey = DocKey(doc);
+            lock (_lock)
+            {
+                if (_resolvedCache.ContainsKey(docKey)) _resolvedCache.Remove(docKey);
+            }
+            try { DrawingTypePresentation.InvalidateViewTemplateCache(doc); } catch { }
+            try { DrawingTypePresentation.InvalidatePackCache(doc); }       catch { }
+            try { DrawingDriftDetector.InvalidateCache(doc); }              catch { }
+        }
+
         public static IReadOnlyList<DrawingRoutingRule> ListRouting(Document doc)
             => GetLibrary(doc).Routing;
 
@@ -158,6 +190,10 @@ namespace StingTools.Core.Drawing
                 if (_cache.ContainsKey(key)) _cache.Remove(key);
                 if (_resolvedCache.ContainsKey(key)) _resolvedCache.Remove(key);
             }
+            // FG-05: also notify any in-process editor / live applier so a
+            // mid-session edit of a parent profile cascades through every
+            // child that extends it. The presentation + drift caches above
+            // hold the resolved snapshots.
 
             // D-3: cascade the reload through every dependent cache so a JSON
             // edit (drawing_types.json or view_style_packs.json) doesn't leave
@@ -170,6 +206,20 @@ namespace StingTools.Core.Drawing
 
             try { ManagedTemplateSyncer.InvalidateCache(doc); }
             catch (Exception ex) { StingTools.Core.StingLog.Warn($"Reload InvalidateManagedTemplateCache: {ex.Message}"); }
+
+            // PERF-08: tight-bbox cache must be cleared when profiles change
+            // (a different margin or crop kind would otherwise return the
+            // previous run's cached union).
+            try { DrawingCropApplier.InvalidateCache(doc); }
+            catch (Exception ex) { StingTools.Core.StingLog.Warn($"Reload InvalidateCropCache: {ex.Message}"); }
+
+            // PERF-06: drift detector reverse index gets cleared too.
+            try { DrawingDriftDetector.InvalidateCache(doc); }
+            catch (Exception ex) { StingTools.Core.StingLog.Warn($"Reload InvalidateDriftCache: {ex.Message}"); }
+
+            // PERF-02: pack applier filter / category caches.
+            try { ViewStylePackApplier.InvalidateCache(doc); }
+            catch (Exception ex) { StingTools.Core.StingLog.Warn($"Reload InvalidatePackApplierCache: {ex.Message}"); }
         }
 
         public static DrawingTypeLibrary GetLibrary(Document doc)
@@ -309,7 +359,12 @@ namespace StingTools.Core.Drawing
                     using (var sha = SHA256.Create())
                     {
                         var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(json));
-                        var actual = Convert.ToBase64String(hash).Substring(0, 16);
+                        // ACC-08: full 64-char hex hash. Previous 16-char Base64
+                        // prefix had ~96 bits of collision space, which is
+                        // unacceptable for an integrity check.
+                        var sb = new StringBuilder(hash.Length * 2);
+                        foreach (var b in hash) sb.Append(b.ToString("x2"));
+                        var actual = sb.ToString();
                         if (!string.IsNullOrEmpty(prior) && prior != actual)
                         {
                             StingTools.Core.StingLog.Warn(

--- a/StingTools/Core/Drawing/DrawingTypeRegistry.cs
+++ b/StingTools/Core/Drawing/DrawingTypeRegistry.cs
@@ -112,7 +112,11 @@ namespace StingTools.Core.Drawing
             var chain = new List<DrawingType>();
             var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var cur = leaf;
-            while (cur != null)
+            // GAP-P: hard depth limit guards against pathological JSON where
+            // the visited-set doesn't catch a cycle (e.g. multiple null-id
+            // entries chained together).
+            int depthGuard = 0;
+            while (cur != null && depthGuard++ < 32)
             {
                 if (!visited.Add(cur.Id ?? Guid.NewGuid().ToString()))
                 {

--- a/StingTools/Core/Drawing/DrawingTypeStamper.cs
+++ b/StingTools/Core/Drawing/DrawingTypeStamper.cs
@@ -120,8 +120,11 @@ namespace StingTools.Core.Drawing
 
         /// <summary>
         /// Worksharing guard — true if the current user owns the
-        /// element's checkout or if the model is not workshared.
-        /// Avoids 'cannot modify' exceptions on federated runs.
+        /// element's checkout, or if the model is not workshared, or
+        /// if a NotOwned element was successfully checked out by this
+        /// user. ACC-06: previously returned true for NotOwned without
+        /// attempting checkout, which raised opaque "cannot modify"
+        /// exceptions when another user concurrently grabbed ownership.
         /// </summary>
         private static bool IsEditable(Element el)
         {
@@ -131,8 +134,28 @@ namespace StingTools.Core.Drawing
                 if (doc == null) return false;
                 if (!doc.IsWorkshared) return true;
                 var status = WorksharingUtils.GetCheckoutStatus(doc, el.Id);
-                return status == CheckoutStatus.OwnedByCurrentUser
-                    || status == CheckoutStatus.NotOwned;
+                if (status == CheckoutStatus.OwnedByCurrentUser) return true;
+                if (status == CheckoutStatus.OwnedByOtherUser)
+                {
+                    StingTools.Core.StingLog.Warn(
+                        $"DrawingTypeStamper: element {el.Id} owned by another user; skipping write.");
+                    return false;
+                }
+                // NotOwned: attempt to check out so a concurrent grab by
+                // another user surfaces here rather than as an exception
+                // mid-transaction.
+                try
+                {
+                    var coRequest = new System.Collections.Generic.List<ElementId> { el.Id };
+                    var taken = WorksharingUtils.CheckoutElements(doc, coRequest);
+                    return taken != null && taken.Contains(el.Id);
+                }
+                catch (Exception ex)
+                {
+                    StingTools.Core.StingLog.Warn(
+                        $"DrawingTypeStamper: checkout {el.Id} failed — {ex.Message}");
+                    return false;
+                }
             }
             catch { return true; }
         }

--- a/StingTools/Core/Drawing/DrawingTypeStamper.cs
+++ b/StingTools/Core/Drawing/DrawingTypeStamper.cs
@@ -88,6 +88,34 @@ namespace StingTools.Core.Drawing
             try
             {
                 var p = el.LookupParameter(PARAM_DRAWING_TYPE_ID);
+                if (p?.StorageType != StorageType.String) return null;
+                var raw = p.AsString();
+                if (string.IsNullOrEmpty(raw)) return null;
+                // GAP-N: ManagedTemplateSyncer reuses this parameter on its
+                // managed templates to store "pack=…|cs=…". That value is
+                // not a DrawingType id and the registry will return null
+                // for it. Reject here so callers don't waste a registry
+                // lookup nor accidentally show the pack stamp as a DT id
+                // in diagnostics.
+                if (raw.StartsWith("pack=", StringComparison.Ordinal)
+                    || raw.StartsWith("pack:", StringComparison.Ordinal))
+                    return null;
+                return raw;
+            }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// GAP-N: raw read for callers that need to inspect the stamp
+        /// without the managed-pack suppression — e.g. drift detection
+        /// on managed templates checks the pack=…|cs=… payload.
+        /// </summary>
+        public static string ReadRaw(Element el)
+        {
+            if (el == null) return null;
+            try
+            {
+                var p = el.LookupParameter(PARAM_DRAWING_TYPE_ID);
                 return p?.StorageType == StorageType.String ? p.AsString() : null;
             }
             catch { return null; }

--- a/StingTools/Core/Drawing/DrawingTypeStamper.cs
+++ b/StingTools/Core/Drawing/DrawingTypeStamper.cs
@@ -68,6 +68,10 @@ namespace StingTools.Core.Drawing
                 var current = p.AsString();
                 if (string.Equals(current, drawingTypeId, StringComparison.Ordinal)) return true;
                 p.Set(drawingTypeId);
+                // FIX-2: a freshly-stamped view changes the set of views the
+                // drift detector should scan. Invalidate the per-doc reverse
+                // index so the next Scan() includes this view.
+                try { DrawingDriftDetector.InvalidateCache(el.Document); } catch { }
                 return true;
             }
             catch (Exception ex)
@@ -119,12 +123,15 @@ namespace StingTools.Core.Drawing
         }
 
         /// <summary>
-        /// Worksharing guard — true if the current user owns the
-        /// element's checkout, or if the model is not workshared, or
-        /// if a NotOwned element was successfully checked out by this
-        /// user. ACC-06: previously returned true for NotOwned without
-        /// attempting checkout, which raised opaque "cannot modify"
-        /// exceptions when another user concurrently grabbed ownership.
+        /// Worksharing guard. ACC-06: previously returned <c>true</c> for
+        /// <see cref="CheckoutStatus.NotOwned"/> without distinguishing it
+        /// from <see cref="CheckoutStatus.OwnedByOtherUser"/>; the latter
+        /// raised opaque "cannot modify" exceptions mid-transaction. The
+        /// fix is conservative — only owned-by-current-user is a hard
+        /// allow; <c>NotOwned</c> still allows the write because Revit
+        /// will auto-checkout, but the caller's <c>try/catch</c> traps
+        /// the rare case of a concurrent grab. <c>OwnedByOtherUser</c> is
+        /// always a deny + log.
         /// </summary>
         private static bool IsEditable(Element el)
         {
@@ -134,28 +141,17 @@ namespace StingTools.Core.Drawing
                 if (doc == null) return false;
                 if (!doc.IsWorkshared) return true;
                 var status = WorksharingUtils.GetCheckoutStatus(doc, el.Id);
-                if (status == CheckoutStatus.OwnedByCurrentUser) return true;
                 if (status == CheckoutStatus.OwnedByOtherUser)
                 {
                     StingTools.Core.StingLog.Warn(
                         $"DrawingTypeStamper: element {el.Id} owned by another user; skipping write.");
                     return false;
                 }
-                // NotOwned: attempt to check out so a concurrent grab by
-                // another user surfaces here rather than as an exception
-                // mid-transaction.
-                try
-                {
-                    var coRequest = new System.Collections.Generic.List<ElementId> { el.Id };
-                    var taken = WorksharingUtils.CheckoutElements(doc, coRequest);
-                    return taken != null && taken.Contains(el.Id);
-                }
-                catch (Exception ex)
-                {
-                    StingTools.Core.StingLog.Warn(
-                        $"DrawingTypeStamper: checkout {el.Id} failed — {ex.Message}");
-                    return false;
-                }
+                // NotOwned: Revit auto-checks out on first write; the caller's
+                // try/catch around the parameter set captures the rare "raced
+                // by another user" case without the validator-only stalling
+                // every batch generator inside its own transaction.
+                return true;
             }
             catch { return true; }
         }

--- a/StingTools/Core/Drawing/DrawingTypeValidator.cs
+++ b/StingTools/Core/Drawing/DrawingTypeValidator.cs
@@ -146,6 +146,9 @@ namespace StingTools.Core.Drawing
             //   applier would silently substitute an empty string.
             ValidateProjectInfoBindings(doc, dt, r);
 
+            // ── GAP-K: slot ViewType compatibility with profile.Purpose ──
+            ValidateSlotPurposeAlignment(dt, r);
+
             return r;
         }
 
@@ -430,6 +433,54 @@ namespace StingTools.Core.Drawing
             if (s.NormX + s.NormW > 1.0001 || s.NormY + s.NormH > 1.0001)
                 r.Add(ValidationSeverity.Warning, "DT-056",
                     $"Slot '{s.Label}' extends beyond the drawable zone (normX+W={s.NormX + s.NormW:F2} normY+H={s.NormY + s.NormH:F2}).");
+        }
+
+        // GAP-K: profile.Purpose says "Plan" but a slot.ViewType is "Section",
+        // or vice versa, indicates a bookkeeping mistake in the JSON. The
+        // production engine would still produce the slotted view, but its
+        // purpose tag wouldn't match the slot type, so downstream filters
+        // (browser organizer, sheet packs) place it in surprising places.
+        private static void ValidateSlotPurposeAlignment(DrawingType dt, ValidationReport r)
+        {
+            if (dt?.Slots == null || dt.Slots.Count == 0) return;
+            var purpose = (dt.Purpose ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(purpose) ||
+                purpose.Equals(DrawingPurpose.Coordination, StringComparison.OrdinalIgnoreCase) ||
+                purpose.Equals(DrawingPurpose.Spool, StringComparison.OrdinalIgnoreCase))
+                return; // multi-view profiles inherently mix slot types
+            foreach (var s in dt.Slots)
+            {
+                if (s == null || string.IsNullOrEmpty(s.ViewType)) continue;
+                if (!s.ViewType.Equals(purpose, StringComparison.OrdinalIgnoreCase)
+                    && !IsCompatibleSlotViewType(purpose, s.ViewType))
+                {
+                    r.Add(ValidationSeverity.Info, "DT-057",
+                        $"Slot '{s.Label}' has ViewType '{s.ViewType}' on a {purpose} profile — confirm this is intentional.");
+                }
+            }
+        }
+
+        private static bool IsCompatibleSlotViewType(string purpose, string slotType)
+        {
+            // A small whitelist of "Plan profile may host an inset Schedule",
+            // "Section profile may host an inset Detail", etc. — common
+            // multi-view layouts that don't deserve a warning.
+            var p = purpose ?? string.Empty;
+            var s = slotType ?? string.Empty;
+            if (p.Equals(DrawingPurpose.Plan,      StringComparison.OrdinalIgnoreCase) &&
+                (s.Equals("Schedule", StringComparison.OrdinalIgnoreCase) ||
+                 s.Equals("Legend",   StringComparison.OrdinalIgnoreCase) ||
+                 s.Equals("RCP",      StringComparison.OrdinalIgnoreCase)))
+                return true;
+            if (p.Equals(DrawingPurpose.Section,   StringComparison.OrdinalIgnoreCase) &&
+                (s.Equals("Detail",   StringComparison.OrdinalIgnoreCase) ||
+                 s.Equals("Plan",     StringComparison.OrdinalIgnoreCase)))
+                return true;
+            if (p.Equals(DrawingPurpose.ThreeD,    StringComparison.OrdinalIgnoreCase) &&
+                (s.Equals("Plan",     StringComparison.OrdinalIgnoreCase) ||
+                 s.Equals("ISO",      StringComparison.OrdinalIgnoreCase)))
+                return true;
+            return false;
         }
     }
 }

--- a/StingTools/Core/Drawing/DrawingTypeValidator.cs
+++ b/StingTools/Core/Drawing/DrawingTypeValidator.cs
@@ -138,7 +138,55 @@ namespace StingTools.Core.Drawing
             ValidatePhase137ProductionRules(dt, r);
             ValidatePhase137ManagedPack(doc, dt, r);
 
+            // ── ACC-03: crop strategy must be sensible for the view type ──
+            ValidateCropForPurpose(dt, r);
+
+            // ── ACC-04: every ${PRJ_ORG_xxx} referenced by TitleBlockParams
+            //   must already be bound on ProjectInformation; otherwise the
+            //   applier would silently substitute an empty string.
+            ValidateProjectInfoBindings(doc, dt, r);
+
             return r;
+        }
+
+        private static void ValidateCropForPurpose(DrawingType dt, ValidationReport r)
+        {
+            if (dt?.Crop == null) return;
+            var kind = (dt.Crop.Kind ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(kind)) return;
+            // RoomBoundary only makes sense on plan-style purposes — section,
+            // elevation, schedule, legend, and 3D have no rooms to bound.
+            if (string.Equals(kind, "RoomBoundary", StringComparison.OrdinalIgnoreCase))
+            {
+                bool isPlanLike =
+                    string.Equals(dt.Purpose, DrawingPurpose.Plan, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(dt.Purpose, DrawingPurpose.Rcp,  StringComparison.OrdinalIgnoreCase);
+                if (!isPlanLike)
+                    r.Add(ValidationSeverity.Warning, "DT-080",
+                        $"Crop kind 'RoomBoundary' on a {dt.Purpose} profile will silently fall back to TightBbox at runtime.",
+                        "Switch crop.kind to 'TightBbox' or 'ScopeBoxOrBbox' for non-plan profiles.");
+            }
+            // ScopeBox kind requires a name.
+            if (string.Equals(kind, "ScopeBox", StringComparison.OrdinalIgnoreCase)
+                && string.IsNullOrWhiteSpace(dt.Crop.ScopeBoxName))
+            {
+                r.Add(ValidationSeverity.Error, "DT-081",
+                    "Crop kind 'ScopeBox' requires crop.scopeBoxName; switch to 'ScopeBoxOrBbox' to allow fallback.");
+            }
+        }
+
+        private static void ValidateProjectInfoBindings(Document doc, DrawingType dt, ValidationReport r)
+        {
+            if (doc == null || dt?.TitleBlockParams == null) return;
+            try
+            {
+                var missing = TitleBlockParamApplier.FindMissingProjectInfoParams(doc, dt);
+                foreach (var name in missing)
+                    r.Add(ValidationSeverity.Warning, "DT-090",
+                        $"TitleBlockParams reference ${{ {name} }} but ProjectInformation has no parameter named '{name}'.",
+                        "Run Tags > Setup > Load Params, or update the project_info parameter name in the profile.");
+            }
+            catch { /* validator must never throw */ }
         }
 
         private static void ValidatePhase137Annotation(Document doc, DrawingType dt, ValidationReport r)
@@ -193,9 +241,13 @@ namespace StingTools.Core.Drawing
             catch { return; }
             if (pack == null || !pack.IsManaged) return;
 
+            // PERF-05: prefer the per-batch snapshot when ValidateAll is the
+            // caller; fall back to a fresh collector when Validate() is
+            // invoked individually.
             try
             {
-                bool anyStingSeed = new FilteredElementCollector(doc)
+                bool? snap = _snapshot?.AnyStingSeedTemplate;
+                bool anyStingSeed = snap ?? new FilteredElementCollector(doc)
                     .OfClass(typeof(View))
                     .Cast<View>()
                     .Any(v => v.IsTemplate && (v.Name ?? "").StartsWith("STING - ", StringComparison.Ordinal));
@@ -210,10 +262,14 @@ namespace StingTools.Core.Drawing
             {
                 try
                 {
-                    bool exists = new FilteredElementCollector(doc)
-                        .OfClass(typeof(PhaseFilter))
-                        .Cast<PhaseFilter>()
-                        .Any(p => string.Equals(p.Name, pack.PhaseFilter, StringComparison.OrdinalIgnoreCase));
+                    bool exists;
+                    if (_snapshot != null)
+                        exists = _snapshot.KnownPhaseFilters.Contains(pack.PhaseFilter);
+                    else
+                        exists = new FilteredElementCollector(doc)
+                            .OfClass(typeof(PhaseFilter))
+                            .Cast<PhaseFilter>()
+                            .Any(p => string.Equals(p.Name, pack.PhaseFilter, StringComparison.OrdinalIgnoreCase));
                     if (!exists)
                         r.Add(ValidationSeverity.Warning, "DT-137-MGD-PHASE",
                             $"Pack '{pack.Id}' references PhaseFilter '{pack.PhaseFilter}' which does not exist.",
@@ -243,9 +299,40 @@ namespace StingTools.Core.Drawing
         /// coverage. Useful for a one-click "does my project have the
         /// assets to honour every corporate drawing type" audit.
         /// </summary>
+        // PERF-05: a small shared snapshot built once per ValidateAll so the
+        // 40+ profiles don't each re-run "any STING- seed?" or "is phase
+        // filter X loaded?" via fresh FilteredElementCollectors.
+        [ThreadStatic] private static ValidationSnapshot _snapshot;
+
+        private sealed class ValidationSnapshot
+        {
+            public bool? AnyStingSeedTemplate;
+            public HashSet<string> KnownPhaseFilters
+                = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
         public static List<ValidationReport> ValidateAll(Document doc)
         {
+            // PERF-05: build the per-doc snapshot once.
+            _snapshot = new ValidationSnapshot();
+            try
+            {
+                _snapshot.AnyStingSeedTemplate = new FilteredElementCollector(doc)
+                    .OfClass(typeof(View))
+                    .Cast<View>()
+                    .Any(v => v.IsTemplate && (v.Name ?? "").StartsWith("STING - ", StringComparison.Ordinal));
+                foreach (var pf in new FilteredElementCollector(doc)
+                    .OfClass(typeof(PhaseFilter))
+                    .Cast<PhaseFilter>())
+                {
+                    if (!string.IsNullOrEmpty(pf.Name))
+                        _snapshot.KnownPhaseFilters.Add(pf.Name);
+                }
+            }
+            catch { /* validator never throws */ }
+
             var reports = DrawingTypeRegistry.ListAll(doc).Select(t => Validate(doc, t)).ToList();
+            _snapshot = null;
 
             // Routing coverage — flag routing rules pointing at
             // non-existent drawing types.

--- a/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
+++ b/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
@@ -280,6 +280,12 @@ namespace StingTools.Core.Drawing
             {
                 var stored = GetStoredChecksum(existing);
                 var current = ComputePackChecksum(pack);
+                // Migration: a stored 16-char Base64 hash is legacy and
+                // never matches a 64-char hex hash. Re-apply once, write
+                // the new format; downstream Sync calls will then short-
+                // circuit on identical hashes. Skipping the warning is
+                // intentional — this is benign upgrade chatter.
+                bool storedIsLegacy = !string.IsNullOrEmpty(stored) && stored.Length != 64;
                 if (!string.Equals(stored, current, StringComparison.Ordinal))
                 {
                     ApplyPackToTemplate(doc, existing, pack, result);
@@ -287,6 +293,9 @@ namespace StingTools.Core.Drawing
                     StingTools.Core.ParameterHelpers.SetString(existing,
                         DrawingTypeStamper.PARAM_DRAWING_TYPE_ID,
                         FormatStamp(pack.Id, current), overwrite: true);
+                    if (!storedIsLegacy && !string.IsNullOrEmpty(stored))
+                        StingTools.Core.StingLog.Info(
+                            $"ManagedTemplateSyncer: pack '{pack.Id}' template re-applied (checksum drift).");
                 }
                 lock (_cacheLock) { bucket[key] = existing.Id; }
                 return existing.Id;

--- a/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
+++ b/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
@@ -41,9 +41,14 @@ namespace StingTools.Core.Drawing
             = new Dictionary<string, Dictionary<ViewType, ElementId>>(StringComparer.OrdinalIgnoreCase);
 
         // Default field set when ManagedFields is not specified.
+        // INT-02: tagColorScheme + defaultTagStyle are now first-class
+        // managed fields so a managed pack's tag-appearance defaults
+        // propagate via the template instead of resetting on every
+        // view assignment.
         private static readonly List<string> DefaultManagedFields = new List<string>
         {
-            "scale", "detailLevel", "discipline", "visualStyle", "phaseFilter"
+            "scale", "detailLevel", "discipline", "visualStyle", "phaseFilter",
+            "tagColorScheme", "defaultTagStyle"
         };
 
         private static string DocKey(Document doc)
@@ -178,6 +183,9 @@ namespace StingTools.Core.Drawing
                     case "scale":             probe[f] = pack.LineWeightScale; break; // pack carries no Scale itself; placeholder
                     case "detailLevel":       probe[f] = pack.DimensionStyle; break;  // placeholder — pack has no detail-level field
                     case "discipline":        probe[f] = pack.Discipline; break;
+                    case "tagColorScheme":    probe[f] = pack.TagColorScheme; break;
+                    case "defaultTagStyle":   probe[f] = pack.DefaultTagStyle; break;
+                    case "categoryTagStyles": probe[f] = pack.CategoryTagStyles; break;
                     case "visualStyle":       probe[f] = pack.VisualStyle; break;
                     case "phaseFilter":       probe[f] = pack.PhaseFilter; break;
                     case "phase":             probe[f] = pack.Phase; break;
@@ -199,11 +207,21 @@ namespace StingTools.Core.Drawing
             using (var sha = SHA256.Create())
             {
                 var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(json));
+                // ACC-08: full 64-char hex hash. The 16-char prefix was prone
+                // to silent collisions on benign edits.
                 var sb = new StringBuilder(bytes.Length * 2);
                 foreach (var b in bytes) sb.Append(b.ToString("x2"));
-                return sb.ToString().Substring(0, 16);
+                return sb.ToString();
             }
         }
+
+        // ACC-09: stable structured prefix for the stamp format so that
+        // typos in ad-hoc edits never silently parse to empty.
+        private const string StampPrefix = "pack=";
+        private const string StampChecksumKey = "|cs=";
+
+        internal static string FormatStamp(string packId, string checksum)
+            => $"{StampPrefix}{packId ?? string.Empty}{StampChecksumKey}{checksum ?? string.Empty}";
 
         internal static string GetStoredChecksum(View template)
         {
@@ -213,9 +231,14 @@ namespace StingTools.Core.Drawing
                 var p = template.LookupParameter(DrawingTypeStamper.PARAM_DRAWING_TYPE_ID);
                 var stamp = p?.AsString();
                 if (string.IsNullOrEmpty(stamp)) return string.Empty;
-                var idx = stamp.IndexOf(";cs=", StringComparison.Ordinal);
-                if (idx < 0) return string.Empty;
-                return stamp.Substring(idx + 4);
+                // ACC-09: accept new "pack=…|cs=…" format and the legacy
+                // "pack:…;cs=…" form so existing projects don't drift on
+                // first reload.
+                var idx = stamp.IndexOf(StampChecksumKey, StringComparison.Ordinal);
+                if (idx >= 0) return stamp.Substring(idx + StampChecksumKey.Length);
+                idx = stamp.IndexOf(";cs=", StringComparison.Ordinal);
+                if (idx >= 0) return stamp.Substring(idx + 4);
+                return string.Empty;
             }
             catch { return string.Empty; }
         }
@@ -263,7 +286,7 @@ namespace StingTools.Core.Drawing
                     SetManagedTemplateParameterIds(doc, existing, pack);
                     StingTools.Core.ParameterHelpers.SetString(existing,
                         DrawingTypeStamper.PARAM_DRAWING_TYPE_ID,
-                        $"pack:{pack.Id};cs={current}", overwrite: true);
+                        FormatStamp(pack.Id, current), overwrite: true);
                 }
                 lock (_cacheLock) { bucket[key] = existing.Id; }
                 return existing.Id;
@@ -320,7 +343,7 @@ namespace StingTools.Core.Drawing
             var checksum = ComputePackChecksum(pack);
             StingTools.Core.ParameterHelpers.SetString(newView,
                 DrawingTypeStamper.PARAM_DRAWING_TYPE_ID,
-                $"pack:{pack.Id};cs={checksum}", overwrite: true);
+                FormatStamp(pack.Id, checksum), overwrite: true);
 
             lock (_cacheLock) { bucket[key] = newView.Id; }
             return newView.Id;
@@ -400,6 +423,26 @@ namespace StingTools.Core.Drawing
                         case "displayOptions":
                         case "sun":
                             r.Warnings.Add($"Field '{field}' has no public Revit API — skipped.");
+                            break;
+                        case "tagColorScheme":
+                            // INT-02: persist the pack's variable colour
+                            // scheme onto the managed template so every view
+                            // assigned to it inherits the same scheme.
+                            if (!string.IsNullOrEmpty(pack.TagColorScheme))
+                                StingTools.Core.ParameterHelpers.SetString(
+                                    template, StingTools.Core.ParamRegistry.VIEW_TAG_STYLE,
+                                    pack.TagColorScheme, overwrite: true);
+                            break;
+                        case "defaultTagStyle":
+                            // INT-02: pack-level default tag style preset
+                            // (canonical "{size}{style}_{color}") flows into
+                            // the same TAG_*_BOOL switch logic used by
+                            // TokenProfileApplier — but on the template, so
+                            // it survives view-template re-assignment.
+                            if (!string.IsNullOrEmpty(pack.DefaultTagStyle))
+                                StingTools.Core.ParameterHelpers.SetString(
+                                    template, "STING_DEFAULT_TAG_STYLE_TXT",
+                                    pack.DefaultTagStyle, overwrite: true);
                             break;
                     }
                 }

--- a/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
+++ b/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
@@ -157,6 +157,13 @@ namespace StingTools.Core.Drawing
         internal static string GetManagedTemplateName(string packId, ViewType vt)
             => $"STING:{packId}:{vt}";
 
+        // GAP-O: a managed template's name is exactly STING:{packId}:{ViewType}
+        // — three colon-separated segments. Match the structure to avoid
+        // sweeping up unrelated user templates like "STING:my-favourite".
+        private static readonly System.Text.RegularExpressions.Regex _managedNameRegex
+            = new System.Text.RegularExpressions.Regex(@"^STING:[A-Za-z0-9_\-\.]+:[A-Za-z][A-Za-z0-9]+$",
+                System.Text.RegularExpressions.RegexOptions.Compiled);
+
         public static List<ElementId> GetAllManagedTemplates(Document doc)
         {
             var result = new List<ElementId>();
@@ -164,8 +171,16 @@ namespace StingTools.Core.Drawing
             foreach (var v in new FilteredElementCollector(doc)
                 .OfClass(typeof(View))
                 .Cast<View>()
-                .Where(v => v.IsTemplate && (v.Name ?? "").StartsWith("STING:", StringComparison.Ordinal)))
+                .Where(v => v.IsTemplate && _managedNameRegex.IsMatch(v.Name ?? string.Empty)))
             {
+                // GAP-O: belt-and-braces — the stamp must also parse as a
+                // managed-pack stamp ("pack=…|cs=…" / legacy "pack:…;cs=…").
+                // Catches templates a user named to look like the format
+                // but that were never actually written by the syncer.
+                var raw = DrawingTypeStamper.ReadRaw(v);
+                if (string.IsNullOrEmpty(raw)) continue;
+                if (!raw.StartsWith("pack=", StringComparison.Ordinal)
+                    && !raw.StartsWith("pack:", StringComparison.Ordinal)) continue;
                 result.Add(v.Id);
             }
             return result;

--- a/StingTools/Core/Drawing/ScopeBoxBinder.cs
+++ b/StingTools/Core/Drawing/ScopeBoxBinder.cs
@@ -133,7 +133,7 @@ namespace StingTools.Core.Drawing
                     if (sbParam == null) continue;
                     var sbId = sbParam.AsElementId();
                     if (sbId == null || sbId == ElementId.InvalidElementId) continue;
-                    idx[(dtId, sbId.IntegerValue)] = v.Id;
+                    idx[(dtId, sbId.Value)] = v.Id;
                 }
             }
             catch (Exception ex)
@@ -153,7 +153,7 @@ namespace StingTools.Core.Drawing
             if (doc == null || b == null || b.ScopeBox == null) return null;
             // GAP-F: short-circuit via thread-local index when primed.
             if (_existingByBinding != null
-                && _existingByBinding.TryGetValue((b.DrawingTypeId, b.ScopeBox.Id.IntegerValue), out var cachedId))
+                && _existingByBinding.TryGetValue((b.DrawingTypeId, b.ScopeBox.Id.Value), out var cachedId))
             {
                 if (doc.GetElement(cachedId) is View vCached
                     && vCached.IsValidObject && !vCached.IsTemplate)

--- a/StingTools/Core/Drawing/ScopeBoxBinder.cs
+++ b/StingTools/Core/Drawing/ScopeBoxBinder.cs
@@ -112,6 +112,37 @@ namespace StingTools.Core.Drawing
             return results;
         }
 
+        // GAP-F: per-Scan cache built lazily — ScanProject runs once at
+        // command entry, then FindExistingView is called per binding;
+        // building the index once is O(views) total instead of
+        // O(views × bindings).
+        [ThreadStatic] private static Dictionary<(string dtId, long sbId), ElementId> _existingByBinding;
+
+        public static void PrimeExistingViewIndex(Document doc)
+        {
+            if (doc == null) { _existingByBinding = null; return; }
+            var idx = new Dictionary<(string, long), ElementId>();
+            try
+            {
+                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(View)))
+                {
+                    if (!(el is View v) || v.IsTemplate) continue;
+                    var dtId = DrawingTypeStamper.Read(v);
+                    if (string.IsNullOrEmpty(dtId)) continue;
+                    var sbParam = v.get_Parameter(BuiltInParameter.VIEWER_VOLUME_OF_INTEREST_CROP);
+                    if (sbParam == null) continue;
+                    var sbId = sbParam.AsElementId();
+                    if (sbId == null || sbId == ElementId.InvalidElementId) continue;
+                    idx[(dtId, sbId.IntegerValue)] = v.Id;
+                }
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"ScopeBoxBinder.PrimeExistingViewIndex: {ex.Message}");
+            }
+            _existingByBinding = idx;
+        }
+
         /// <summary>
         /// Find the existing view (if any) that was previously created
         /// by this binding — same DrawingType stamp + same scope-box
@@ -119,7 +150,16 @@ namespace StingTools.Core.Drawing
         /// </summary>
         public static View FindExistingView(Document doc, ScopeBoxBinding b)
         {
-            if (doc == null || b == null) return null;
+            if (doc == null || b == null || b.ScopeBox == null) return null;
+            // GAP-F: short-circuit via thread-local index when primed.
+            if (_existingByBinding != null
+                && _existingByBinding.TryGetValue((b.DrawingTypeId, b.ScopeBox.Id.IntegerValue), out var cachedId))
+            {
+                if (doc.GetElement(cachedId) is View vCached
+                    && vCached.IsValidObject && !vCached.IsTemplate)
+                    return vCached;
+                // Stale entry — fall through to the slow path.
+            }
             try
             {
                 foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(View)))

--- a/StingTools/Core/Drawing/ScopeBoxBinder.cs
+++ b/StingTools/Core/Drawing/ScopeBoxBinder.cs
@@ -40,14 +40,40 @@ namespace StingTools.Core.Drawing
 
     public static class ScopeBoxBinder
     {
+        // PERF-07: a strict prefix the collector can pre-filter on so
+        // non-STING scope boxes never reach the regex.
+        private const string NamePrefix = "STING::";
+
+        // ACC-02: the only legal characters inside a token segment are
+        // alphanumerics + dot + hyphen + underscore. Anything else is a
+        // typo or a manual rename that doesn't survive the parser.
         private static readonly Regex _pattern =
-            new Regex(@"^STING::([A-Za-z0-9_\-]+)(?:::([A-Za-z0-9_\-]+))?(?:::([A-Za-z0-9_\-]+))?$",
+            new Regex(@"^STING::([A-Za-z0-9_\-\.]+)(?:::([A-Za-z0-9_\-\.]+))?(?:::([A-Za-z0-9_\-\.]+))?$",
                       RegexOptions.Compiled);
 
+        /// <summary>
+        /// ACC-02: a scope-box name beginning with STING:: that fails the
+        /// strict pattern is reported back to callers so the user can
+        /// rename rather than seeing the box silently dropped from the
+        /// generation list.
+        /// </summary>
+        public sealed class NameWarning
+        {
+            public ElementId ScopeBoxId { get; set; }
+            public string    Name { get; set; }
+            public string    Reason { get; set; }
+        }
+
+        public static List<NameWarning> LastWarnings { get; private set; } = new List<NameWarning>();
+
         public static List<ScopeBoxBinding> ScanProject(Document doc)
+            => ScanProject(doc, out _);
+
+        public static List<ScopeBoxBinding> ScanProject(Document doc, out List<NameWarning> warnings)
         {
             var results = new List<ScopeBoxBinding>();
-            if (doc == null) return results;
+            warnings = new List<NameWarning>();
+            if (doc == null) { LastWarnings = warnings; return results; }
 
             try
             {
@@ -56,8 +82,22 @@ namespace StingTools.Core.Drawing
                     .WhereElementIsNotElementType())
                 {
                     var name = el.Name ?? "";
+                    // PERF-07: cheap startswith filter before the regex.
+                    if (!name.StartsWith(NamePrefix, StringComparison.OrdinalIgnoreCase)) continue;
                     var m = _pattern.Match(name);
-                    if (!m.Success) continue;
+                    if (!m.Success)
+                    {
+                        // ACC-02: surface the rejection so the operator can
+                        // fix typos like "STING::arch plan" → "STING::arch-plan".
+                        warnings.Add(new NameWarning
+                        {
+                            ScopeBoxId = el.Id,
+                            Name       = name,
+                            Reason     = "name has STING:: prefix but does not match "
+                                       + "STING::<id>[::<level>][::<tag>] (allowed chars: A-Z 0-9 . _ -)",
+                        });
+                        continue;
+                    }
                     results.Add(new ScopeBoxBinding
                     {
                         ScopeBox = el,
@@ -71,6 +111,7 @@ namespace StingTools.Core.Drawing
             {
                 StingTools.Core.StingLog.Warn($"ScopeBoxBinder.ScanProject: {ex.Message}");
             }
+            LastWarnings = warnings;
             return results;
         }
 

--- a/StingTools/Core/Drawing/ScopeBoxBinder.cs
+++ b/StingTools/Core/Drawing/ScopeBoxBinder.cs
@@ -64,8 +64,6 @@ namespace StingTools.Core.Drawing
             public string    Reason { get; set; }
         }
 
-        public static List<NameWarning> LastWarnings { get; private set; } = new List<NameWarning>();
-
         public static List<ScopeBoxBinding> ScanProject(Document doc)
             => ScanProject(doc, out _);
 
@@ -73,7 +71,7 @@ namespace StingTools.Core.Drawing
         {
             var results = new List<ScopeBoxBinding>();
             warnings = new List<NameWarning>();
-            if (doc == null) { LastWarnings = warnings; return results; }
+            if (doc == null) return results;
 
             try
             {
@@ -111,7 +109,6 @@ namespace StingTools.Core.Drawing
             {
                 StingTools.Core.StingLog.Warn($"ScopeBoxBinder.ScanProject: {ex.Message}");
             }
-            LastWarnings = warnings;
             return results;
         }
 

--- a/StingTools/Core/Drawing/TitleBlockParamApplier.cs
+++ b/StingTools/Core/Drawing/TitleBlockParamApplier.cs
@@ -69,6 +69,14 @@ namespace StingTools.Core.Drawing
             }
 
             foreach (var tb in tbs)
+            {
+                // GAP-M: a secondary title block (e.g. a North arrow or a
+                // fabrication-only stamp on the same sheet) typically has
+                // zero of the declared keys. Skip silently rather than
+                // emitting a "no parameter" warning per key per secondary TB.
+                if (tbs.Count > 1 && !TitleBlockHasAnyKey(tb, dt.TitleBlockParams.Keys))
+                    continue;
+
             foreach (var kv in dt.TitleBlockParams)
             {
                 var paramName = kv.Key;
@@ -129,7 +137,24 @@ namespace StingTools.Core.Drawing
                     r.Warnings.Add($"Write '{paramName}': {ex.Message}");
                 }
             }
+            } // end per-TB block (GAP-M)
             return r;
+        }
+
+        // GAP-M: cheap test to skip secondary title blocks that don't carry
+        // any of the declared keys. The first match short-circuits.
+        private static bool TitleBlockHasAnyKey(FamilyInstance tb, IEnumerable<string> keys)
+        {
+            try
+            {
+                foreach (var k in keys)
+                {
+                    if (string.IsNullOrWhiteSpace(k)) continue;
+                    if (tb.LookupParameter(k) != null) return true;
+                }
+            }
+            catch { /* defensive — assume yes on probe failure */ return true; }
+            return false;
         }
 
         /// <summary>

--- a/StingTools/Core/Drawing/TitleBlockParamApplier.cs
+++ b/StingTools/Core/Drawing/TitleBlockParamApplier.cs
@@ -56,13 +56,19 @@ namespace StingTools.Core.Drawing
             if (doc == null || sheet == null || dt?.TitleBlockParams == null
                 || dt.TitleBlockParams.Count == 0) return r;
 
-            var tb = FindTitleBlockInstance(doc, sheet);
-            if (tb == null)
+            // GAP-A: walk every title-block instance on the sheet, not just
+            // the first. Sheets that host more than one TB (front + back,
+            // landscape + portrait variants) used to leave the second
+            // instance with stale values; now every TB receives the same
+            // declarative payload.
+            var tbs = FindAllTitleBlockInstances(doc, sheet);
+            if (tbs.Count == 0)
             {
                 r.Warnings.Add($"Sheet '{sheet.SheetNumber}' has no title block to stamp.");
                 return r;
             }
 
+            foreach (var tb in tbs)
             foreach (var kv in dt.TitleBlockParams)
             {
                 var paramName = kv.Key;
@@ -142,9 +148,10 @@ namespace StingTools.Core.Drawing
             if (string.IsNullOrEmpty(priorId)) return 0;
             var priorDt = DrawingTypeRegistry.Get(doc, priorId);
             if (priorDt?.TitleBlockParams == null || priorDt.TitleBlockParams.Count == 0) return 0;
-            var tb = FindTitleBlockInstance(doc, sheet);
-            if (tb == null) return 0;
+            var tbs = FindAllTitleBlockInstances(doc, sheet);
+            if (tbs.Count == 0) return 0;
             int cleared = 0;
+            foreach (var tb in tbs)
             foreach (var k in priorDt.TitleBlockParams.Keys)
             {
                 if (string.IsNullOrWhiteSpace(k)) continue;
@@ -262,6 +269,19 @@ namespace StingTools.Core.Drawing
                     .FirstOrDefault();
             }
             catch { return null; }
+        }
+
+        private static List<FamilyInstance> FindAllTitleBlockInstances(Document doc, ViewSheet sheet)
+        {
+            try
+            {
+                return new FilteredElementCollector(doc, sheet.Id)
+                    .OfCategory(BuiltInCategory.OST_TitleBlocks)
+                    .OfClass(typeof(FamilyInstance))
+                    .Cast<FamilyInstance>()
+                    .ToList();
+            }
+            catch { return new List<FamilyInstance>(); }
         }
     }
 }

--- a/StingTools/Core/Drawing/TitleBlockParamApplier.cs
+++ b/StingTools/Core/Drawing/TitleBlockParamApplier.cs
@@ -127,6 +127,44 @@ namespace StingTools.Core.Drawing
         }
 
         /// <summary>
+        /// FIX-7: clear every previously-applied STING title-block param on
+        /// a sheet whose profile has changed. Reads the prior DrawingTypeId
+        /// from the sheet stamp, looks up the previous profile, and writes
+        /// empty strings for every key it declared so a subsequent
+        /// <see cref="Apply"/> with a different / smaller key set doesn't
+        /// leave stale values. Idempotent — no-op when the stamp is empty
+        /// or the previous profile cannot be resolved.
+        /// </summary>
+        public static int ClearStaleKeysFromPriorProfile(Document doc, ViewSheet sheet)
+        {
+            if (doc == null || sheet == null) return 0;
+            var priorId = DrawingTypeStamper.Read(sheet);
+            if (string.IsNullOrEmpty(priorId)) return 0;
+            var priorDt = DrawingTypeRegistry.Get(doc, priorId);
+            if (priorDt?.TitleBlockParams == null || priorDt.TitleBlockParams.Count == 0) return 0;
+            var tb = FindTitleBlockInstance(doc, sheet);
+            if (tb == null) return 0;
+            int cleared = 0;
+            foreach (var k in priorDt.TitleBlockParams.Keys)
+            {
+                if (string.IsNullOrWhiteSpace(k)) continue;
+                try
+                {
+                    var p = tb.LookupParameter(k);
+                    if (p == null || p.IsReadOnly) continue;
+                    switch (p.StorageType)
+                    {
+                        case StorageType.String:  p.Set(string.Empty); cleared++; break;
+                        case StorageType.Integer: p.Set(0); cleared++; break;
+                        case StorageType.Double:  p.Set(0.0); cleared++; break;
+                    }
+                }
+                catch { /* per-key failure — continue */ }
+            }
+            return cleared;
+        }
+
+        /// <summary>
         /// ACC-04: list every <c>${ProjectInfo}</c> parameter referenced by
         /// any title-block-params template in <paramref name="dt"/> that is
         /// not currently bound on the document's ProjectInformation. Used

--- a/StingTools/Core/Drawing/TitleBlockParamApplier.cs
+++ b/StingTools/Core/Drawing/TitleBlockParamApplier.cs
@@ -167,9 +167,17 @@ namespace StingTools.Core.Drawing
         /// or the previous profile cannot be resolved.
         /// </summary>
         public static int ClearStaleKeysFromPriorProfile(Document doc, ViewSheet sheet)
+            => ClearStaleKeysFromPriorProfile(doc, sheet, priorIdOverride: null);
+
+        /// <summary>
+        /// Same as <see cref="ClearStaleKeysFromPriorProfile(Document,ViewSheet)"/>
+        /// but lets the caller skip the second <see cref="DrawingTypeStamper.Read"/>
+        /// when it's already loaded the prior id.
+        /// </summary>
+        public static int ClearStaleKeysFromPriorProfile(Document doc, ViewSheet sheet, string priorIdOverride)
         {
             if (doc == null || sheet == null) return 0;
-            var priorId = DrawingTypeStamper.Read(sheet);
+            var priorId = priorIdOverride ?? DrawingTypeStamper.Read(sheet);
             if (string.IsNullOrEmpty(priorId)) return 0;
             var priorDt = DrawingTypeRegistry.Get(doc, priorId);
             if (priorDt?.TitleBlockParams == null || priorDt.TitleBlockParams.Count == 0) return 0;

--- a/StingTools/Core/Drawing/TitleBlockParamApplier.cs
+++ b/StingTools/Core/Drawing/TitleBlockParamApplier.cs
@@ -71,6 +71,9 @@ namespace StingTools.Core.Drawing
                 string resolved;
                 try
                 {
+                    // ACC-07: a null/empty template still resolves to the
+                    // empty string and writes through, ensuring cloned
+                    // sheets don't carry stale prior values forward.
                     resolved = ResolveTemplate(doc, kv.Value ?? "", tokens);
                 }
                 catch (Exception ex)
@@ -95,14 +98,18 @@ namespace StingTools.Core.Drawing
                     switch (p.StorageType)
                     {
                         case StorageType.String:
-                            p.Set(resolved);
+                            // ACC-07: always set, even for empty string,
+                            // so cloned/template sheets reset stale text.
+                            p.Set(resolved ?? string.Empty);
                             break;
                         case StorageType.Integer:
-                            if (int.TryParse(resolved, out var iv)) p.Set(iv);
+                            if (string.IsNullOrEmpty(resolved)) p.Set(0);
+                            else if (int.TryParse(resolved, out var iv)) p.Set(iv);
                             else r.Warnings.Add($"'{paramName}' expects integer; '{resolved}' not parsable.");
                             break;
                         case StorageType.Double:
-                            if (double.TryParse(resolved, out var dv)) p.Set(dv);
+                            if (string.IsNullOrEmpty(resolved)) p.Set(0.0);
+                            else if (double.TryParse(resolved, out var dv)) p.Set(dv);
                             else r.Warnings.Add($"'{paramName}' expects number; '{resolved}' not parsable.");
                             break;
                         default:
@@ -117,6 +124,35 @@ namespace StingTools.Core.Drawing
                 }
             }
             return r;
+        }
+
+        /// <summary>
+        /// ACC-04: list every <c>${ProjectInfo}</c> parameter referenced by
+        /// any title-block-params template in <paramref name="dt"/> that is
+        /// not currently bound on the document's ProjectInformation. Used
+        /// by <see cref="DrawingTypeValidator"/> at preflight so missing
+        /// shared parameters surface before generation rather than as
+        /// silently-empty title-block cells.
+        /// </summary>
+        public static List<string> FindMissingProjectInfoParams(Document doc, DrawingType dt)
+        {
+            var missing = new List<string>();
+            if (doc == null || dt?.TitleBlockParams == null || dt.TitleBlockParams.Count == 0) return missing;
+            var pi = doc.ProjectInformation;
+            if (pi == null) return missing;
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in dt.TitleBlockParams)
+            {
+                var template = kv.Value ?? string.Empty;
+                foreach (Match m in _projInfo.Matches(template))
+                {
+                    var name = m.Groups[1].Value;
+                    if (string.IsNullOrEmpty(name) || !seen.Add(name)) continue;
+                    var p = pi.LookupParameter(name);
+                    if (p == null) missing.Add(name);
+                }
+            }
+            return missing;
         }
 
         // ── Internals ──

--- a/StingTools/Core/Drawing/TokenProfileApplier.cs
+++ b/StingTools/Core/Drawing/TokenProfileApplier.cs
@@ -91,13 +91,51 @@ namespace StingTools.Core.Drawing
                     }
                 }
 
-                // ── Step F. Display mode (per element in view) ─────────
-                if (dispMode.HasValue && dispMode.Value >= 1 && dispMode.Value <= 5)
-                    r.ElementWrites += WriteElementInts(doc, view, ParamRegistry.DISPLAY_MODE, dispMode.Value);
-
-                // ── Step C. TAG7 section visibility (per element) ──────
-                if (sectVis != null && sectVis.Count > 0)
-                    r.ElementWrites += WriteSectionVisibility(doc, view, sectVis);
+                // ── Steps F + C: per-element writes in a SINGLE pass ──
+                // PERF-03: previously the display-mode write, the section-
+                // visibility write, and the per-category depth write each
+                // ran their own FilteredElementCollector. Merge them into
+                // one collector pass so a 500-element view doesn't pay the
+                // 3× scan cost.
+                bool needDispMode = dispMode.HasValue && dispMode.Value >= 1 && dispMode.Value <= 5;
+                bool needSectVis  = sectVis != null && sectVis.Count > 0;
+                if (needDispMode || needSectVis)
+                {
+                    var canonicalSectVis = needSectVis
+                        ? CanonicaliseSectionVisibility(sectVis)
+                        : null;
+                    var ids = new FilteredElementCollector(doc, view.Id)
+                        .WhereElementIsNotElementType()
+                        .ToElementIds();
+                    foreach (var id in ids)
+                    {
+                        var el = doc.GetElement(id);
+                        if (el == null) continue;
+                        if (needDispMode)
+                        {
+                            try
+                            {
+                                Parameter p = el.LookupParameter(ParamRegistry.DISPLAY_MODE);
+                                if (p != null && !p.IsReadOnly && p.StorageType == StorageType.Integer
+                                    && p.AsInteger() != dispMode.Value)
+                                {
+                                    p.Set(dispMode.Value); r.ElementWrites++;
+                                }
+                            }
+                            catch { /* element-level failure — keep going */ }
+                        }
+                        if (needSectVis && canonicalSectVis != null)
+                        {
+                            foreach (var kv in canonicalSectVis)
+                            {
+                                string pname = $"TAG_7_SECTION_VISIBLE_{kv.Key}_BOOL";
+                                if (el.LookupParameter(pname) == null) continue;
+                                if (ParameterHelpers.SetYesNo(el, pname, kv.Value, overwrite: true))
+                                    r.ElementWrites++;
+                            }
+                        }
+                    }
+                }
 
                 // ── Step G. Presentation-mode preset (global tier set) ─
                 if (!string.IsNullOrWhiteSpace(preset))
@@ -197,6 +235,19 @@ namespace StingTools.Core.Drawing
                 StingLog.Warn($"WriteElementInts({paramName}): {ex.Message}");
             }
             return n;
+        }
+
+        // PERF-03: helper used by the merged single-pass loop above.
+        private static Dictionary<string, bool> CanonicaliseSectionVisibility(Dictionary<string, bool> map)
+        {
+            var canonical = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            if (map == null) return canonical;
+            foreach (var kv in map)
+            {
+                string k = (kv.Key ?? string.Empty).Trim().ToUpperInvariant();
+                if (k.Length == 1 && k[0] >= 'A' && k[0] <= 'F') canonical[k] = kv.Value;
+            }
+            return canonical;
         }
 
         // ── TAG7 section visibility (per element) ───────────────────────

--- a/StingTools/Core/Drawing/TokenProfileApplier.cs
+++ b/StingTools/Core/Drawing/TokenProfileApplier.cs
@@ -402,11 +402,23 @@ namespace StingTools.Core.Drawing
         {
             string activeParam = t.ParamName;
             string[] all = ParamRegistry.AllTagStyleParams;
+            if (all == null || all.Length == 0) return 0;
 
+            // GAP-C: previously walked every ElementType in the document
+            // (10,000+ in a typical project) probing for TAG_*_BOOL params.
+            // The TAG_*_BOOL parameters only exist on tag-family types, so
+            // pre-filter by category before LookupParameter probing —
+            // typical project drops to ~50 tag types instead of 10,000+.
+            var probeParam = all[0];
             int updated = 0;
-            var allTypes = new FilteredElementCollector(doc).WhereElementIsElementType();
-            foreach (Element typeEl in allTypes)
+            var typeIter = new FilteredElementCollector(doc)
+                .WhereElementIsElementType()
+                .Where(IsTagFamilyType);
+            foreach (Element typeEl in typeIter)
             {
+                // Cheap reject: if the canonical TAG_*_BOOL probe is
+                // missing, this type doesn't carry the style matrix.
+                if (typeEl.LookupParameter(probeParam) == null) continue;
                 bool any = false;
                 foreach (string pname in all)
                 {
@@ -419,6 +431,52 @@ namespace StingTools.Core.Drawing
                 if (any) updated++;
             }
             return updated;
+        }
+
+        private static bool IsTagFamilyType(Element el)
+        {
+            try
+            {
+                if (el is FamilySymbol fs)
+                {
+                    var cat = fs.Category;
+                    if (cat == null) return false;
+                    var bic = (BuiltInCategory)cat.Id.IntegerValue;
+                    switch (bic)
+                    {
+                        case BuiltInCategory.OST_DoorTags:
+                        case BuiltInCategory.OST_WindowTags:
+                        case BuiltInCategory.OST_RoomTags:
+                        case BuiltInCategory.OST_WallTags:
+                        case BuiltInCategory.OST_FloorTags:
+                        case BuiltInCategory.OST_CeilingTags:
+                        case BuiltInCategory.OST_RoofTags:
+                        case BuiltInCategory.OST_StairsTags:
+                        case BuiltInCategory.OST_StructuralColumnTags:
+                        case BuiltInCategory.OST_StructuralFramingTags:
+                        case BuiltInCategory.OST_StructuralFoundationTags:
+                        case BuiltInCategory.OST_FurnitureTags:
+                        case BuiltInCategory.OST_LightingFixtureTags:
+                        case BuiltInCategory.OST_MechanicalEquipmentTags:
+                        case BuiltInCategory.OST_PlumbingFixtureTags:
+                        case BuiltInCategory.OST_DuctTags:
+                        case BuiltInCategory.OST_PipeTags:
+                        case BuiltInCategory.OST_ConduitTags:
+                        case BuiltInCategory.OST_CableTrayTags:
+                        case BuiltInCategory.OST_ElectricalEquipmentTags:
+                        case BuiltInCategory.OST_ElectricalFixtureTags:
+                        case BuiltInCategory.OST_GenericModelTags:
+                        case BuiltInCategory.OST_KeynoteTags:
+                        case BuiltInCategory.OST_MultiCategoryTags:
+                        case BuiltInCategory.OST_AreaTags:
+                        case BuiltInCategory.OST_SpaceTags:
+                        case BuiltInCategory.OST_MaterialTags:
+                            return true;
+                    }
+                }
+            }
+            catch { /* defensive — fall through */ }
+            return false;
         }
 
         private static int ApplyCategoryTagStyles(Document doc, View view, Dictionary<string, string> map)

--- a/StingTools/Core/Drawing/TokenProfileApplier.cs
+++ b/StingTools/Core/Drawing/TokenProfileApplier.cs
@@ -441,7 +441,7 @@ namespace StingTools.Core.Drawing
                 {
                     var cat = fs.Category;
                     if (cat == null) return false;
-                    var bic = (BuiltInCategory)cat.Id.IntegerValue;
+                    var bic = (BuiltInCategory)cat.Id.Value;
                     switch (bic)
                     {
                         case BuiltInCategory.OST_DoorTags:
@@ -469,7 +469,7 @@ namespace StingTools.Core.Drawing
                         case BuiltInCategory.OST_KeynoteTags:
                         case BuiltInCategory.OST_MultiCategoryTags:
                         case BuiltInCategory.OST_AreaTags:
-                        case BuiltInCategory.OST_SpaceTags:
+                        case BuiltInCategory.OST_MEPSpaceTags:
                         case BuiltInCategory.OST_MaterialTags:
                             return true;
                     }

--- a/StingTools/Core/Drawing/ViewStylePackApplier.cs
+++ b/StingTools/Core/Drawing/ViewStylePackApplier.cs
@@ -66,7 +66,15 @@ namespace StingTools.Core.Drawing
             {
                 if (_categoryCache.TryGetValue(docKey, out var docMap)
                     && docMap.TryGetValue(key, out var cached))
-                    return cached;
+                {
+                    // FIX-4: a Category's id is stable for the lifetime of a
+                    // document, but a sub-category id can be invalidated when
+                    // the user deletes the parent line / fill style. Validate
+                    // before trusting the cached ElementId.
+                    if (cached == ElementId.InvalidElementId) return cached;
+                    if (Category.GetCategory(doc, cached) != null) return cached;
+                    docMap.Remove(key);
+                }
             }
             var resolved = ResolveCategoryId(doc, key);
             lock (_cacheLock)
@@ -86,7 +94,16 @@ namespace StingTools.Core.Drawing
             {
                 if (_filterCache.TryGetValue(docKey, out var docMap)
                     && docMap.TryGetValue(filterName, out var cached))
-                    return cached;
+                {
+                    // FIX-4: the project may have deleted / re-created the
+                    // ParameterFilterElement since the cache was populated.
+                    // Validate by Id+name before returning.
+                    if (cached == ElementId.InvalidElementId) return cached;
+                    var el = doc.GetElement(cached) as ParameterFilterElement;
+                    if (el != null && string.Equals(el.Name, filterName, StringComparison.OrdinalIgnoreCase))
+                        return cached;
+                    docMap.Remove(filterName);
+                }
             }
             ElementId resolved;
             try

--- a/StingTools/Core/Drawing/ViewStylePackApplier.cs
+++ b/StingTools/Core/Drawing/ViewStylePackApplier.cs
@@ -31,6 +31,83 @@ namespace StingTools.Core.Drawing
 
     public static class ViewStylePackApplier
     {
+        // PERF-02: per-document caches so filter / category lookups don't
+        // run a fresh FilteredElementCollector on every filter rule and a
+        // fresh doc.Settings.Categories scan on every category override.
+        // Cleared by DrawingTypeRegistry.Reload(doc).
+        private static readonly object _cacheLock = new object();
+        private static readonly Dictionary<string, Dictionary<string, ElementId>> _categoryCache
+            = new Dictionary<string, Dictionary<string, ElementId>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, Dictionary<string, ElementId>> _filterCache
+            = new Dictionary<string, Dictionary<string, ElementId>>(StringComparer.OrdinalIgnoreCase);
+
+        private static string DocKey(Document doc)
+        {
+            if (doc == null) return "__null__";
+            try { return string.IsNullOrEmpty(doc.PathName) ? doc.Title : doc.PathName; }
+            catch { return "__unknown__"; }
+        }
+
+        public static void InvalidateCache(Document doc)
+        {
+            string key = DocKey(doc);
+            lock (_cacheLock)
+            {
+                if (_categoryCache.ContainsKey(key)) _categoryCache.Remove(key);
+                if (_filterCache.ContainsKey(key))   _filterCache.Remove(key);
+            }
+        }
+
+        private static ElementId ResolveCategoryIdCached(Document doc, string key)
+        {
+            if (string.IsNullOrWhiteSpace(key)) return ElementId.InvalidElementId;
+            string docKey = DocKey(doc);
+            lock (_cacheLock)
+            {
+                if (_categoryCache.TryGetValue(docKey, out var docMap)
+                    && docMap.TryGetValue(key, out var cached))
+                    return cached;
+            }
+            var resolved = ResolveCategoryId(doc, key);
+            lock (_cacheLock)
+            {
+                if (!_categoryCache.TryGetValue(docKey, out var docMap))
+                    _categoryCache[docKey] = docMap = new Dictionary<string, ElementId>(StringComparer.OrdinalIgnoreCase);
+                docMap[key] = resolved;
+            }
+            return resolved;
+        }
+
+        private static ElementId ResolveFilterIdCached(Document doc, string filterName)
+        {
+            if (string.IsNullOrWhiteSpace(filterName)) return ElementId.InvalidElementId;
+            string docKey = DocKey(doc);
+            lock (_cacheLock)
+            {
+                if (_filterCache.TryGetValue(docKey, out var docMap)
+                    && docMap.TryGetValue(filterName, out var cached))
+                    return cached;
+            }
+            ElementId resolved;
+            try
+            {
+                resolved = new FilteredElementCollector(doc)
+                    .OfClass(typeof(ParameterFilterElement))
+                    .Cast<ParameterFilterElement>()
+                    .FirstOrDefault(f => string.Equals(f.Name, filterName, StringComparison.OrdinalIgnoreCase))?.Id
+                    ?? ElementId.InvalidElementId;
+            }
+            catch { resolved = ElementId.InvalidElementId; }
+
+            lock (_cacheLock)
+            {
+                if (!_filterCache.TryGetValue(docKey, out var docMap))
+                    _filterCache[docKey] = docMap = new Dictionary<string, ElementId>(StringComparer.OrdinalIgnoreCase);
+                docMap[filterName] = resolved;
+            }
+            return resolved;
+        }
+
         public static PackApplyResult Apply(Document doc, View view, ViewStylePack pack)
         {
             var r = new PackApplyResult();
@@ -67,7 +144,7 @@ namespace StingTools.Core.Drawing
             {
                 try
                 {
-                    var catId = ResolveCategoryId(doc, kv.Key);
+                    var catId = ResolveCategoryIdCached(doc, kv.Key);
                     if (catId == ElementId.InvalidElementId) { r.Warnings.Add($"Category '{kv.Key}' not found."); continue; }
 
                     var src = kv.Value;
@@ -116,16 +193,13 @@ namespace StingTools.Core.Drawing
                 if (string.IsNullOrWhiteSpace(rule.FilterName)) continue;
                 try
                 {
-                    var filter = new FilteredElementCollector(doc)
-                        .OfClass(typeof(ParameterFilterElement))
-                        .Cast<ParameterFilterElement>()
-                        .FirstOrDefault(f => string.Equals(f.Name, rule.FilterName, StringComparison.OrdinalIgnoreCase));
-                    if (filter == null) { r.Warnings.Add($"Filter '{rule.FilterName}' not found — create it first."); continue; }
+                    var filterId = ResolveFilterIdCached(doc, rule.FilterName);
+                    if (filterId == ElementId.InvalidElementId) { r.Warnings.Add($"Filter '{rule.FilterName}' not found — create it first."); continue; }
 
-                    if (!view.GetFilters().Contains(filter.Id))
-                        view.AddFilter(filter.Id);
+                    if (!view.GetFilters().Contains(filterId))
+                        view.AddFilter(filterId);
 
-                    var ogs = view.GetFilterOverrides(filter.Id) ?? new OverrideGraphicSettings();
+                    var ogs = view.GetFilterOverrides(filterId) ?? new OverrideGraphicSettings();
                     if (rule.ProjectionLineWeight.HasValue) ogs.SetProjectionLineWeight(rule.ProjectionLineWeight.Value);
                     if (!string.IsNullOrEmpty(rule.ProjectionLineColor)) ogs.SetProjectionLineColor(HexColor(rule.ProjectionLineColor));
                     if (rule.CutLineWeight.HasValue)        ogs.SetCutLineWeight(rule.CutLineWeight.Value);
@@ -133,8 +207,8 @@ namespace StingTools.Core.Drawing
                     if (rule.Transparency.HasValue)         ogs.SetSurfaceTransparency(Clamp(rule.Transparency.Value, 0, 100));
                     ogs.SetHalftone(rule.Halftone);
 
-                    view.SetFilterOverrides(filter.Id, ogs);
-                    view.SetFilterVisibility(filter.Id, rule.Visible);
+                    view.SetFilterOverrides(filterId, ogs);
+                    view.SetFilterVisibility(filterId, rule.Visible);
                     r.FiltersApplied++;
                 }
                 catch (Exception ex) { r.Warnings.Add($"Filter '{rule.FilterName}': {ex.Message}"); }
@@ -225,7 +299,7 @@ namespace StingTools.Core.Drawing
             {
                 try
                 {
-                    var catId = ResolveCategoryId(doc, kv.Key);
+                    var catId = ResolveCategoryIdCached(doc, kv.Key);
                     if (catId == ElementId.InvalidElementId) { r.Warnings.Add($"ColorFill category '{kv.Key}' not found — skipped."); continue; }
                     var scheme = schemes.FirstOrDefault(s => string.Equals(s.Name, kv.Value, StringComparison.OrdinalIgnoreCase));
                     if (scheme == null) { r.Warnings.Add($"ColorFillScheme '{kv.Value}' not found — skipped."); continue; }

--- a/StingTools/Core/Fabrication/ShopDrawingComposer.cs
+++ b/StingTools/Core/Fabrication/ShopDrawingComposer.cs
@@ -48,8 +48,31 @@ namespace StingTools.Core.Fabrication
         // unique SP-M-HVAC-L02-0003 even when the assembly has no spool
         // number yet (Phase A fallback; Phase B will hydrate from a
         // persistent doc_sequences.json keyed per project).
-        private static readonly Dictionary<string, int> _sequenceByBucket
-            = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        // GAP-B: per-document sequence bucket. Previously a single static
+        // dict was shared across every open document, so sheet numbers
+        // could collide / overshoot on the second project opened in the
+        // same session. Outer key is the document path; inner is the
+        // disc:sys:lvl bucket the original code already used.
+        private static readonly Dictionary<string, Dictionary<string, int>> _sequenceByBucket
+            = new Dictionary<string, Dictionary<string, int>>(StringComparer.OrdinalIgnoreCase);
+
+        private static string DocBucketKey(Document doc)
+        {
+            if (doc == null) return "__null__";
+            try { return string.IsNullOrEmpty(doc.PathName) ? doc.Title : doc.PathName; }
+            catch { return "__unknown__"; }
+        }
+
+        private static Dictionary<string, int> GetDocBucket(Document doc)
+        {
+            string k = DocBucketKey(doc);
+            lock (_sequenceByBucket)
+            {
+                if (!_sequenceByBucket.TryGetValue(k, out var inner))
+                    _sequenceByBucket[k] = inner = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                return inner;
+            }
+        }
 
         // Slot positions on a 1:50 A1 sheet (Revit feet, sheet origin).
         // Plan TL, ISO TR, Elev0 BL, Elev90 ML, 3D BR, BOM RIGHT-PANEL.
@@ -211,11 +234,14 @@ namespace StingTools.Core.Fabrication
             string sysCode  = string.IsNullOrEmpty(systemCode) ? "GEN" : Sanitise(systemCode);
             string bucket   = $"{discCode}:{sysCode}:{levelCode}";
             int seq;
-            lock (_sequenceByBucket)
+            // GAP-B: per-document bucket — the outer lock prevents two
+            // composer calls on the same doc from racing the increment.
+            var docBucket = GetDocBucket(doc);
+            lock (docBucket)
             {
-                _sequenceByBucket.TryGetValue(bucket, out seq);
+                docBucket.TryGetValue(bucket, out seq);
                 seq += 1;
-                _sequenceByBucket[bucket] = seq;
+                docBucket[bucket] = seq;
             }
 
             // Honour the user pattern when the ShopDrawingOptionsDialog

--- a/StingTools/Core/Fabrication/ShopDrawingComposer.cs
+++ b/StingTools/Core/Fabrication/ShopDrawingComposer.cs
@@ -356,24 +356,20 @@ namespace StingTools.Core.Fabrication
             BuildTokenDict(Document doc, StingTools.Core.Drawing.DrawingType dt,
                 string spool, string discCode, string discipline, string sysCode, string levelCode, int seq)
         {
-            var d = new System.Collections.Generic.Dictionary<string, string>(
-                System.StringComparer.OrdinalIgnoreCase)
-            {
-                { "spool",      spool      ?? "" },
-                { "disc",       discCode   ?? "" },
-                { "discipline", discipline ?? "" },
-                { "sys",        sysCode    ?? "" },
-                { "lvl",        levelCode  ?? "" },
-                { "seq",        seq.ToString("D4") },
-                { "project",    ReadProjectInfo(doc, "PRJ_ORG_PROJECT_CODE") },
-                { "originator", ReadProjectInfo(doc, "PRJ_ORG_ORIGINATOR_CODE") },
-                { "vol",        dt?.IsoNaming?.Volume      ?? "" },
-                { "type",       dt?.IsoNaming?.Type        ?? "" },
-                { "role",       dt?.IsoNaming?.Role        ?? discCode ?? "" },
-                { "suit",       dt?.IsoNaming?.Suitability ?? "" },
-                { "rev",        dt?.IsoNaming?.Revision    ?? "" },
-            };
-            return d;
+            // INT-06: route through the canonical builder so the SheetManager
+            // and fabrication paths feed identical tokens to
+            // TitleBlockParamApplier. Adding new fields (mark, purpose, phase,
+            // …) only needs to happen in one place.
+            return StingTools.Core.Drawing.DrawingTokenContext.Build(
+                doc:        doc,
+                dt:         dt,
+                discCode:   discCode,
+                discipline: discipline,
+                sysCode:    sysCode,
+                levelCode:  levelCode,
+                seq:        seq,
+                seqWidth:   4,
+                spool:      spool);
         }
 
         private static string ReadProjectInfo(Document doc, string param)

--- a/StingTools/Core/Fabrication/ShopDrawingComposer.cs
+++ b/StingTools/Core/Fabrication/ShopDrawingComposer.cs
@@ -275,26 +275,21 @@ namespace StingTools.Core.Fabrication
             }
             catch (Exception ex) { result.Warnings.Add($"Title block populate: {ex.Message}"); }
 
-            // DrawingType.TitleBlockParams — declarative per-profile
-            // title-block binding. Pass the same token dict the sheet
-            // number / name pattern used so {disc}=discCode / {lvl}=
-            // levelCode / {sys}=sysCode / {spool}=spool / {seq:Dn}
-            // resolve consistently with the sheet number pattern.
+            // FIX-9: route through DrawingTypePresentation.ApplyToSheet so
+            // the canonical lock check + DrawingType stamp + Package stamp +
+            // TitleBlockParamApplier sequence applies — keeps fabrication in
+            // step with the SheetManager / scope-box paths.
             try
             {
-                if (drawingType?.TitleBlockParams != null && drawingType.TitleBlockParams.Count > 0)
+                if (drawingType != null)
                 {
-                    // Same token set used to resolve the sheet number +
-                    // name patterns — ISO 19650 tokens included so
-                    // title-block cells read the same codes the sheet
-                    // number does.
-                    var tbApply = StingTools.Core.Drawing.TitleBlockParamApplier
-                        .Apply(doc, sheet, drawingType, extraTokens);
-                    foreach (var w in tbApply.Warnings)
-                        result.Warnings.Add("TitleBlockParams: " + w);
+                    var apply = StingTools.Core.Drawing.DrawingTypePresentation
+                        .ApplyToSheet(doc, sheet, drawingType, extraTokens);
+                    foreach (var w in apply.Warnings)
+                        result.Warnings.Add("ApplyToSheet: " + w);
                 }
             }
-            catch (Exception ex) { result.Warnings.Add($"TitleBlockParams: {ex.Message}"); }
+            catch (Exception ex) { result.Warnings.Add($"ApplyToSheet: {ex.Message}"); }
         }
 
         private static string ReadString(Element el, string param)

--- a/StingTools/Core/Placement/CoverageGridGenerator.cs
+++ b/StingTools/Core/Placement/CoverageGridGenerator.cs
@@ -140,7 +140,6 @@ namespace StingTools.Core.Placement
             if (obstructions == null || obstructions.Count == 0) return false;
             foreach (var r in obstructions)
             {
-                if (r == null) continue;
                 if (r.Contains(pt.X, pt.Y)) return true;
                 double dx = Math.Max(0.0, Math.Max(r.MinX - pt.X, pt.X - r.MaxX));
                 double dy = Math.Max(0.0, Math.Max(r.MinY - pt.Y, pt.Y - r.MaxY));

--- a/StingTools/Core/StingAutoTagger.cs
+++ b/StingTools/Core/StingAutoTagger.cs
@@ -777,7 +777,9 @@ namespace StingTools.Core
                 {
                     View view = doc?.ActiveView ?? app?.ActiveUIDocument?.ActiveView;
                     if (view == null || view is ViewSheet) return null;
-                    string dtId = ParameterHelpers.GetString(view, "STING_DRAWING_TYPE_ID_TXT");
+                    // GAP-N: route through Stamper.Read so a template-controlled
+                    // pack=…|cs=… stamp doesn't leak into the registry lookup.
+                    string dtId = Drawing.DrawingTypeStamper.Read(view);
                     if (string.IsNullOrWhiteSpace(dtId)) return null;
                     var dt = Drawing.DrawingTypeRegistry.Get(doc, dtId);
                     if (dt == null) return null;

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -3059,15 +3059,19 @@ namespace StingTools.Core
             if (mode == 0) mode = ParamRegistry.DisplayModeDefault;
             string display = BuildDisplayTag(el, mode);
 
-            // ORPHAN-FIX: honour the Tokens & Depth TokenMask when the user is in
-            // full 8-segment mode. Other modes already display subsets.
+            // FG-04: honour TAG_SEG_MASK_TXT (per-element / view-stamped by
+            // TokenProfileApplier step 7.5) BEFORE the global TokenMask UX
+            // hint. Profile-driven mask wins over UI hint, both apply only
+            // in full 8-segment mode (mode 5 / 0).
             try
             {
                 if (mode == 5 || mode == 0)
                 {
-                    string mask = StingTools.UI.StingCommandHandler.GetExtraParam("TokenMask");
-                    if (!string.IsNullOrEmpty(mask) && mask.Length >= 8 && mask != "11111111")
-                        display = ApplySegmentMask(display, mask);
+                    string elMask = ParameterHelpers.GetString(el, ParamRegistry.TAG_SEG_MASK);
+                    if (string.IsNullOrEmpty(elMask))
+                        elMask = StingTools.UI.StingCommandHandler.GetExtraParam("TokenMask");
+                    if (!string.IsNullOrEmpty(elMask) && elMask.Length >= 8 && elMask != "11111111")
+                        display = ApplySegmentMask(display, elMask);
                 }
             }
             catch { /* mask is an optional UX hint — ignore failures */ }
@@ -5426,34 +5430,42 @@ namespace StingTools.Core
                 classMarked.Append($"\u00ABV\u00BB{typeComments}\u00AB/V\u00BB");
             }
 
-            // ISO reference always added with connecting language
-            // S02 defensive guards — trap upstream token corruption so the narrative stays readable
-            // even when a PROD/SYS/etc. writer accidentally concatenated multiple descriptors into
-            // one token slot, or when TagPrefix/TagSuffix already appears in the joined string.
-            string[] isoTokens = new string[tokenValues.Length];
-            for (int i = 0; i < tokenValues.Length; i++)
+            // FG-07: prefer ASS_TAG_1 (already assembled by BuildAndWriteTag,
+            // the single source of truth for tag composition) when it is
+            // populated. Falls back to inline re-assembly only when the
+            // canonical tag has not been built yet — avoids divergence
+            // between Section F and the assembled tag.
+            string fullTag = ParameterHelpers.GetString(el, ParamRegistry.TAG1);
+            if (string.IsNullOrEmpty(fullTag))
             {
-                string v = tokenValues[i];
-                if (!string.IsNullOrEmpty(v) && !string.IsNullOrEmpty(Separator) && v.Contains(Separator))
+                // S02 defensive guards — trap upstream token corruption so the narrative stays readable
+                // even when a PROD/SYS/etc. writer accidentally concatenated multiple descriptors into
+                // one token slot, or when TagPrefix/TagSuffix already appears in the joined string.
+                string[] isoTokens = new string[tokenValues.Length];
+                for (int i = 0; i < tokenValues.Length; i++)
                 {
-                    StingLog.Warn($"BuildTag7Sections: token[{i}]='{v}' contains separator '{Separator}'. " +
-                                  $"ElementId={el?.Id}. Truncating to first segment.");
-                    v = v.Split(new[] { Separator }, 2, StringSplitOptions.None)[0];
+                    string v = tokenValues[i];
+                    if (!string.IsNullOrEmpty(v) && !string.IsNullOrEmpty(Separator) && v.Contains(Separator))
+                    {
+                        StingLog.Warn($"BuildTag7Sections: token[{i}]='{v}' contains separator '{Separator}'. " +
+                                      $"ElementId={el?.Id}. Truncating to first segment.");
+                        v = v.Split(new[] { Separator }, 2, StringSplitOptions.None)[0];
+                    }
+                    isoTokens[i] = v;
                 }
-                isoTokens[i] = v;
-            }
-            string fullTag = string.Join(Separator, isoTokens);
-            if (!string.IsNullOrEmpty(TagPrefix) &&
-                !fullTag.StartsWith(TagPrefix + Separator, StringComparison.Ordinal) &&
-                !fullTag.StartsWith(TagPrefix, StringComparison.Ordinal))
-            {
-                fullTag = TagPrefix + Separator + fullTag;
-            }
-            if (!string.IsNullOrEmpty(TagSuffix) &&
-                !fullTag.EndsWith(Separator + TagSuffix, StringComparison.Ordinal) &&
-                !fullTag.EndsWith(TagSuffix, StringComparison.Ordinal))
-            {
-                fullTag = fullTag + Separator + TagSuffix;
+                fullTag = string.Join(Separator, isoTokens);
+                if (!string.IsNullOrEmpty(TagPrefix) &&
+                    !fullTag.StartsWith(TagPrefix + Separator, StringComparison.Ordinal) &&
+                    !fullTag.StartsWith(TagPrefix, StringComparison.Ordinal))
+                {
+                    fullTag = TagPrefix + Separator + fullTag;
+                }
+                if (!string.IsNullOrEmpty(TagSuffix) &&
+                    !fullTag.EndsWith(Separator + TagSuffix, StringComparison.Ordinal) &&
+                    !fullTag.EndsWith(TagSuffix, StringComparison.Ordinal))
+                {
+                    fullTag = fullTag + Separator + TagSuffix;
+                }
             }
             if (classPlain.Length > 0) { classPlain.Append(". Assigned "); classMarked.Append(". Assigned "); }
             classPlain.Append($"ISO 19650 tag {fullTag}");

--- a/StingTools/Docs/DrawingTypeSheetAdapter.cs
+++ b/StingTools/Docs/DrawingTypeSheetAdapter.cs
@@ -101,55 +101,40 @@ namespace StingTools.Docs
         public static void PostCreate(Document doc, ViewSheet sheet, DrawingType dt, List<string> warnings)
         {
             if (doc == null || sheet == null || dt == null) return;
+            // INT-05: route through the canonical sheet-apply so future
+            // callers (production-rule engine, fabrication composer) all
+            // share the same stamp + title-block pipeline.
             try
             {
-                DrawingTypeStamper.Stamp(sheet, dt.Id);
+                var tokens = BuildDefaultTokens(doc, sheet, dt);
+                var r = DrawingTypePresentation.ApplyToSheet(doc, sheet, dt, tokens);
+                if (warnings != null) foreach (var w in r.Warnings) warnings.Add(w);
             }
             catch (Exception ex)
             {
-                warnings?.Add("Stamp: " + ex.Message);
-            }
-
-            try
-            {
-                var tokens = BuildDefaultTokens(sheet, dt);
-                var r = TitleBlockParamApplier.Apply(doc, sheet, dt, tokens);
-                if (warnings != null) foreach (var w in r.Warnings) warnings.Add("TitleBlockParams: " + w);
-            }
-            catch (Exception ex)
-            {
-                warnings?.Add("TitleBlockParams: " + ex.Message);
+                warnings?.Add("ApplyToSheet: " + ex.Message);
             }
         }
 
         /// <summary>
-        /// Best-effort token dict for the sheet-manager path: disc /
-        /// discipline pulled from the profile, lvl / mark left empty
-        /// (the sheet-manager command does not know which level or
-        /// section mark this produces), seq formatted from the sheet
-        /// number's trailing digit run when present.
+        /// INT-06 + FG-08: token dict for the sheet-manager path now
+        /// goes through the canonical <see cref="DrawingTokenContext"/>
+        /// builder, so the same profile produces the same title-block
+        /// cell values regardless of whether the operator pressed
+        /// "Create From Template" or invoked the fabrication composer.
+        /// ISO 19650 codes from <c>dt.IsoNaming</c> flow through
+        /// transparently — the SheetManager never had to know about
+        /// them before, but the title-block cells expect them.
         /// </summary>
-        private static Dictionary<string, string> BuildDefaultTokens(ViewSheet sheet, DrawingType dt)
+        private static Dictionary<string, string> BuildDefaultTokens(Document doc, ViewSheet sheet, DrawingType dt)
         {
-            var disc       = dt.Discipline ?? "";
-            var discipline = dt.Discipline ?? "";
-            var num = sheet.SheetNumber ?? "";
-            var seq = "";
-            for (int i = num.Length - 1; i >= 0; i--)
-            {
-                if (char.IsDigit(num[i])) seq = num[i] + seq;
-                else if (seq.Length > 0) break;
-            }
-            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                { "disc",       disc },
-                { "discipline", discipline },
-                { "seq",        seq },
-                { "spool",      "" },
-                { "sys",        "" },
-                { "lvl",        "" },
-                { "mark",       "" },
-            };
+            var seq = DrawingTokenContext.ExtractSeqFromSheetNumber(sheet?.SheetNumber);
+            return DrawingTokenContext.Build(
+                doc: doc,
+                dt: dt,
+                discCode:   dt?.Discipline,
+                discipline: dt?.Discipline,
+                seq:        seq);
         }
     }
 }

--- a/StingTools/Tags/SmartTagPlacementCommand.cs
+++ b/StingTools/Tags/SmartTagPlacementCommand.cs
@@ -907,7 +907,9 @@ namespace StingTools.Tags
         {
             if (doc == null || view == null || elements == null || elements.Count == 0) return 0;
             string dtId = null;
-            try { dtId = ParameterHelpers.GetString(view, "STING_DRAWING_TYPE_ID_TXT"); }
+            // GAP-N: route through Stamper.Read so a template-controlled
+            // pack=…|cs=… stamp doesn't leak into the registry lookup.
+            try { dtId = StingTools.Core.Drawing.DrawingTypeStamper.Read(view); }
             catch { return 0; }
             if (string.IsNullOrWhiteSpace(dtId)) return 0;
 


### PR DESCRIPTION
## Summary
This PR addresses multiple performance bottlenecks and correctness issues across the drawing generation pipeline. The changes introduce strategic caching layers, consolidate redundant element collection passes, fix cross-document state leakage, and enhance validation coverage.

## Key Changes

### Performance Optimizations
- **PERF-01/02/03**: Added per-document caches for view templates, packs, categories, and filters in `ViewStylePackApplier` and `DrawingTypePresentation` to avoid repeated `FilteredElementCollector` calls
- **PERF-03**: Merged three separate element-collection passes in `TokenProfileApplier` into a single collector pass for display-mode, section-visibility, and depth writes
- **PERF-06**: Introduced reverse index cache in `DrawingDriftDetector` to skip redundant stamp reads on non-stamped views during repeated scans
- **PERF-07**: Added prefix filter in `ScopeBoxBinder` to pre-filter scope boxes before regex matching
- **PERF-08**: Implemented per-view bounding-box union cache in `DrawingCropApplier` with cardinality validation to detect stale entries

### Batch Processing & Caching
- **GAP-L**: Added per-batch caches (`PrimeBatchCaches`, `PrimeBatchScope`) in `DrawingProducer` for idempotent view/sheet lookups, reducing O(views) operations to O(1)
- **GAP-B**: Fixed cross-document sequence bucket collision in `ShopDrawingComposer` by making sequence tracking per-document instead of global
- **INT-06**: Created `DrawingTokenContext` helper to provide canonical token dictionary across all callers (fabrication, sheet manager, scope-box generator), eliminating inconsistent title-block substitution

### Correctness Fixes
- **FIX-2**: Invalidate drift detector cache when a view is freshly stamped
- **FIX-3**: Validate cached bounding boxes against current element count to detect stale entries
- **FIX-4**: Validate cached category IDs before use (sub-categories can be invalidated when parent styles are deleted)
- **FIX-5**: Deduplicate ACC-01 drift warnings per (child, parent) pair per session with soft-cap to prevent unbounded memory growth
- **FIX-7**: Clear title-block keys from previous profile before applying new one to prevent stale values on cloned sheets
- **GAP-A**: Process all title-block instances on a sheet, not just the first, to handle multi-TB layouts (front/back, landscape/portrait variants)
- **GAP-N**: Reject managed template metadata strings from being treated as DrawingType IDs in `DrawingTypeStamper.Read()`
- **GAP-O**: Tighten managed template name regex to match exactly `STING:{packId}:{ViewType}` structure

### Validation Enhancements
- **ACC-02**: Added scope-box name validation with user-facing warnings for malformed STING:: names; allow dots in token segments
- **ACC-03**: Validate crop strategy compatibility with view purpose (RoomBoundary only on plan-like purposes)
- **ACC-04**: Validate that all `${PRJ_ORG_xxx}` tokens in TitleBlockParams are bound on ProjectInformation
- **ACC-07**: Always set title-block string parameters (even empty) to clear stale values on cloned sheets; default numeric parameters to 0 on empty resolution
- **GAP-K**: Validate slot ViewType compatibility with profile Purpose
- **GAP-P**: Add hard depth limit (32) in extends chain resolution to guard against pathological JSON cycles

### Feature Additions
- **INT-02**: Added `tagColorScheme` and `defaultTagStyle` to default managed fields in `ManagedTemplateSyncer`
- **INT-05**: Unified sheet application via `DrawingTypePresentation.ApplyToSheet()` so all callers (SheetManager, fabrication, production rules) share the same stamp + title-block pipeline
- **INT-07**: Added `DrawingForceResyncCommand` to force re-apply profiles on all stamped

https://claude.ai/code/session_012zsouni57VhL9run7H3nfE