### PR TITLE
Phase 168: Unified project folder system with templates & migration

### DIFF
--- a/StingTools/BIMManager/BIMManagerCommands.cs
+++ b/StingTools/BIMManager/BIMManagerCommands.cs
@@ -6977,8 +6977,12 @@ namespace StingTools.BIMManager
                 if (ctx == null) return Result.Failed;
                 Document doc = ctx.Doc;
 
-                string logPath = System.IO.Path.Combine(
-                    System.IO.Path.GetDirectoryName(doc.PathName ?? "") ?? "", ".sting_coord_log.json");
+                string logPath = StingTools.Core.ProjectFolderEngine.GetDataPath(doc, "coord_log.json");
+                if (string.IsNullOrEmpty(logPath) || !System.IO.File.Exists(logPath))
+                {
+                    logPath = System.IO.Path.Combine(
+                        System.IO.Path.GetDirectoryName(doc.PathName ?? "") ?? "", ".sting_coord_log.json");
+                }
                 if (!System.IO.File.Exists(logPath))
                 { TaskDialog.Show("STING", "No coordination log found."); return Result.Succeeded; }
 
@@ -9764,7 +9768,9 @@ namespace StingTools.BIMManager
                 $"STING_TagMap_{DateTime.Now:yyyyMMdd_HHmm}.sting_tagmap.json");
             if (string.IsNullOrEmpty(exportPath))
             {
-                string dir = Path.GetDirectoryName(doc.PathName) ?? Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+                string dir = StingTools.Core.ProjectFolderEngine.GetDataPath(doc)
+                    ?? Path.GetDirectoryName(doc.PathName)
+                    ?? Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
                 exportPath = Path.Combine(dir, $"STING_TagMap_{DateTime.Now:yyyyMMdd_HHmm}.sting_tagmap.json");
             }
 

--- a/StingTools/BIMManager/GapFixCommands.cs
+++ b/StingTools/BIMManager/GapFixCommands.cs
@@ -958,7 +958,10 @@ namespace StingTools.BIMManager
                     string linkPath = link.GetLinkDocument()?.PathName ?? "";
                     if (string.IsNullOrEmpty(linkPath)) continue;
 
-                    string sidecarPath = Path.ChangeExtension(linkPath, ".sting_linked_revision.json");
+                    string sidecarPath = StingTools.Core.ProjectFolderEngine.GetDataPath(
+                        doc, $"linked_revision_{Path.GetFileNameWithoutExtension(linkPath)}.json");
+                    if (string.IsNullOrEmpty(sidecarPath))
+                        sidecarPath = Path.ChangeExtension(linkPath, ".sting_linked_revision.json");
                     var sidecar = new JObject
                     {
                         ["source_project"] = doc.Title,
@@ -982,7 +985,9 @@ namespace StingTools.BIMManager
 
         internal static string ForecastCompliance(Document doc)
         {
-            string trendPath = Path.ChangeExtension(doc.PathName, ".sting_compliance_trend.json");
+            string trendPath = StingTools.Core.ProjectFolderEngine.GetDataPath(doc, "compliance_trend.json");
+            if (string.IsNullOrEmpty(trendPath) || !File.Exists(trendPath))
+                trendPath = Path.ChangeExtension(doc.PathName, ".sting_compliance_trend.json");
             if (!File.Exists(trendPath)) return "No compliance trend data. Run tagging workflows to build history.";
 
             var data = LoadJsonArray(trendPath);

--- a/StingTools/Core/ComplianceScan.cs
+++ b/StingTools/Core/ComplianceScan.cs
@@ -769,13 +769,27 @@ namespace StingTools.Core
     {
         private const int MaxDays = 90;
 
+        /// <summary>Resolve compliance trend file path — Phase 167 _data folder, falling back to legacy sidecar.</summary>
+        private static string ResolveTrendPath(Document doc)
+        {
+            try
+            {
+                string p = ProjectFolderEngine.GetDataPath(doc, "compliance_trend.json");
+                if (!string.IsNullOrEmpty(p)) return p;
+            }
+            catch { }
+            if (doc == null || string.IsNullOrEmpty(doc.PathName)) return null;
+            return System.IO.Path.ChangeExtension(doc.PathName, ".sting_compliance_trend.json");
+        }
+
         /// <summary>Record today's compliance snapshot.</summary>
         public static void RecordSnapshot(Document doc, ComplianceScan.ComplianceResult result)
         {
             if (doc == null || result == null || string.IsNullOrEmpty(doc.PathName)) return;
             try
             {
-                string path = System.IO.Path.ChangeExtension(doc.PathName, ".sting_compliance_trend.json");
+                string path = ResolveTrendPath(doc);
+                if (string.IsNullOrEmpty(path)) return;
                 var entries = LoadEntries(path);
                 string today = DateTime.UtcNow.ToString("yyyy-MM-dd");
 
@@ -818,7 +832,8 @@ namespace StingTools.Core
                 return ("unknown", 0);
             try
             {
-                string path = System.IO.Path.ChangeExtension(doc.PathName, ".sting_compliance_trend.json");
+                string path = ResolveTrendPath(doc);
+                if (string.IsNullOrEmpty(path)) return ("unknown", 0);
                 var entries = LoadEntries(path);
                 if (entries.Count < 2) return ("insufficient data", 0);
 
@@ -856,8 +871,8 @@ namespace StingTools.Core
                 if (doc == null) return "N/A";
                 string projectPath = doc.PathName;
                 if (string.IsNullOrEmpty(projectPath)) return "N/A";
-                string trendPath = Path.ChangeExtension(projectPath, null) + ".sting_compliance_trend.json";
-                if (!File.Exists(trendPath)) return "Insufficient data";
+                string trendPath = ResolveTrendPath(doc);
+                if (string.IsNullOrEmpty(trendPath) || !File.Exists(trendPath)) return "Insufficient data";
 
                 var entries = LoadEntries(trendPath);
                 if (entries.Count < 2) return "Insufficient data";

--- a/StingTools/Core/FolderTemplateLibrary.cs
+++ b/StingTools/Core/FolderTemplateLibrary.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace StingTools.Core
+{
+    /// <summary>
+    /// Reusable folder-structure template — a saved profile of mode, disciplines,
+    /// folder defs, hidden folders, export routes, and naming convention.
+    /// Built-in templates ship with the plugin; user templates live in
+    /// {ProjectCode}\_data\folder_templates\*.json.
+    /// </summary>
+    public class FolderTemplate
+    {
+        public string Name { get; set; } = "";
+        public string Description { get; set; } = "";
+        public ProjectFolderMode Mode { get; set; } = ProjectFolderMode.BIM;
+        public List<string> Disciplines { get; set; } = new();
+        public List<FolderDef> CustomFolders { get; set; } = new();
+        public List<string> HiddenFolders { get; set; } = new();
+        public Dictionary<string, string> ExportRoutes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        public NamingConvention NamingConvention { get; set; } = NamingConvention.ISO19650;
+        public bool IsBuiltIn { get; set; }
+    }
+
+    /// <summary>Static library of folder templates — 4 built-ins + user-saved.</summary>
+    public static class FolderTemplateLibrary
+    {
+        /// <summary>The 4 shipped templates.</summary>
+        public static readonly List<FolderTemplate> BuiltInTemplates = new()
+        {
+            BuildFullBim(),
+            BuildMepOnly(),
+            BuildMiniProject(),
+            BuildStructuralOnly(),
+        };
+
+        // ── Built-in template factories ────────────────────────────────────
+
+        private static FolderTemplate BuildFullBim()
+        {
+            var setup = ProjectSetup.CreateBIM("PRJ", "");
+            return new FolderTemplate
+            {
+                Name = "Full BIM — ISO 19650",
+                Description = "All 16 numbered folders with discipline routing (A/E/M/P/S).",
+                Mode = ProjectFolderMode.BIM,
+                Disciplines = new List<string>(setup.Disciplines),
+                CustomFolders = setup.CustomFolders,
+                HiddenFolders = new List<string>(),
+                ExportRoutes = setup.ExportRoutes,
+                NamingConvention = NamingConvention.ISO19650,
+                IsBuiltIn = true,
+            };
+        }
+
+        private static FolderTemplate BuildMepOnly()
+        {
+            var keep = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "WIP", "SHARED", "PUBLISHED", "ARCHIVE", "MODELS", "DRAWINGS",
+                "SCHEDULES", "COBIE", "TRANSMITTALS", "ISSUES", "CLASHES", "HANDOVER",
+            };
+            var setup = ProjectSetup.CreateBIM("PRJ", "",
+                new List<string> { "E_Electrical", "M_Mechanical", "P_Plumbing" });
+            return new FolderTemplate
+            {
+                Name = "MEP Only",
+                Description = "Reduced BIM tree for MEP-only projects (12 folders, 3 disciplines).",
+                Mode = ProjectFolderMode.BIM,
+                Disciplines = new List<string>(setup.Disciplines),
+                CustomFolders = setup.CustomFolders.Where(f => keep.Contains(f.Id)).ToList(),
+                HiddenFolders = setup.CustomFolders.Where(f => !keep.Contains(f.Id))
+                    .Select(f => f.Id).ToList(),
+                ExportRoutes = setup.ExportRoutes,
+                NamingConvention = NamingConvention.ISO19650,
+                IsBuiltIn = true,
+            };
+        }
+
+        private static FolderTemplate BuildMiniProject()
+        {
+            var setup = ProjectSetup.CreateMini("PRJ", "");
+            return new FolderTemplate
+            {
+                Name = "Mini Project",
+                Description = "5 flat folders: Drawings, Models, Schedules, Documents, Reports.",
+                Mode = ProjectFolderMode.Mini,
+                Disciplines = new List<string>(),
+                CustomFolders = setup.CustomFolders,
+                HiddenFolders = new List<string>(),
+                ExportRoutes = setup.ExportRoutes,
+                NamingConvention = NamingConvention.Timestamp,
+                IsBuiltIn = true,
+            };
+        }
+
+        private static FolderTemplate BuildStructuralOnly()
+        {
+            var keep = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "WIP", "SHARED", "PUBLISHED", "ARCHIVE", "MODELS", "DRAWINGS",
+                "SCHEDULES", "REGISTERS", "COMPLIANCE",
+            };
+            var setup = ProjectSetup.CreateBIM("PRJ", "",
+                new List<string> { "S_Structural", "A_Architectural" });
+            return new FolderTemplate
+            {
+                Name = "Structural Only",
+                Description = "Lean structural workflow (9 folders, S+A disciplines).",
+                Mode = ProjectFolderMode.BIM,
+                Disciplines = new List<string>(setup.Disciplines),
+                CustomFolders = setup.CustomFolders.Where(f => keep.Contains(f.Id)).ToList(),
+                HiddenFolders = setup.CustomFolders.Where(f => !keep.Contains(f.Id))
+                    .Select(f => f.Id).ToList(),
+                ExportRoutes = setup.ExportRoutes,
+                NamingConvention = NamingConvention.ISO19650,
+                IsBuiltIn = true,
+            };
+        }
+
+        // ── User template load/save/delete ─────────────────────────────────
+
+        /// <summary>Load every *.json template from the user's templates folder.</summary>
+        public static List<FolderTemplate> LoadUserTemplates(string templateDir)
+        {
+            var list = new List<FolderTemplate>();
+            try
+            {
+                if (string.IsNullOrEmpty(templateDir) || !Directory.Exists(templateDir)) return list;
+                foreach (string file in Directory.GetFiles(templateDir, "*.json"))
+                {
+                    try
+                    {
+                        var t = JsonConvert.DeserializeObject<FolderTemplate>(File.ReadAllText(file));
+                        if (t != null && !string.IsNullOrEmpty(t.Name))
+                        {
+                            t.IsBuiltIn = false;
+                            list.Add(t);
+                        }
+                    }
+                    catch (Exception ex) { StingLog.Warn($"FolderTemplateLibrary: skip {file}: {ex.Message}"); }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"FolderTemplateLibrary.LoadUserTemplates: {ex.Message}"); }
+            return list;
+        }
+
+        /// <summary>Built-ins + user templates from the given templates folder.</summary>
+        public static List<FolderTemplate> GetAll(string templateDir)
+        {
+            var list = new List<FolderTemplate>(BuiltInTemplates);
+            list.AddRange(LoadUserTemplates(templateDir));
+            return list;
+        }
+
+        /// <summary>Save (or overwrite) a user template under {Name}.json.</summary>
+        public static void SaveUserTemplate(FolderTemplate template, string templateDir)
+        {
+            try
+            {
+                if (template == null || string.IsNullOrEmpty(template.Name)) return;
+                if (!Directory.Exists(templateDir)) Directory.CreateDirectory(templateDir);
+                string safeName = Core.OutputLocationHelper.MakeSafeFileName(template.Name);
+                string filePath = Path.Combine(templateDir, safeName + ".json");
+                template.IsBuiltIn = false;
+                File.WriteAllText(filePath, JsonConvert.SerializeObject(template, Formatting.Indented));
+                StingLog.Info($"FolderTemplateLibrary: saved {template.Name} → {filePath}");
+            }
+            catch (Exception ex) { StingLog.Warn($"FolderTemplateLibrary.SaveUserTemplate: {ex.Message}"); }
+        }
+
+        /// <summary>Delete a user template (built-ins cannot be deleted).</summary>
+        public static void DeleteUserTemplate(string name, string templateDir)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(templateDir)) return;
+                string safeName = Core.OutputLocationHelper.MakeSafeFileName(name);
+                string filePath = Path.Combine(templateDir, safeName + ".json");
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+            catch (Exception ex) { StingLog.Warn($"FolderTemplateLibrary.DeleteUserTemplate: {ex.Message}"); }
+        }
+
+        /// <summary>Materialise a template into a new ProjectSetup bound to a project code + root.</summary>
+        public static ProjectSetup ApplyTemplate(FolderTemplate template, string projectCode, string rootPath)
+        {
+            if (template == null) return ProjectSetup.CreateBIM(projectCode, rootPath);
+            var s = new ProjectSetup
+            {
+                ProjectCode = projectCode ?? "PRJ",
+                RootPath = rootPath ?? "",
+                Mode = template.Mode,
+                Disciplines = new List<string>(template.Disciplines ?? new List<string>()),
+                CustomFolders = (template.CustomFolders ?? new List<FolderDef>())
+                    .Select(f => new FolderDef
+                    {
+                        Id = f.Id,
+                        DisplayName = f.DisplayName,
+                        HasDisciplineSubfolders = f.HasDisciplineSubfolders,
+                        SubFolders = new List<string>(f.SubFolders ?? new List<string>()),
+                        IsCustom = f.IsCustom,
+                    }).ToList(),
+                HiddenFolders = new List<string>(template.HiddenFolders ?? new List<string>()),
+                ExportRoutes = new Dictionary<string, string>(
+                    template.ExportRoutes ?? new Dictionary<string, string>(),
+                    StringComparer.OrdinalIgnoreCase),
+                NamingConvention = template.NamingConvention,
+                TemplateName = template.Name,
+                CreatedDate = DateTime.Now,
+                LastModified = DateTime.Now,
+            };
+            return s;
+        }
+    }
+}

--- a/StingTools/Core/OutputLocationHelper.cs
+++ b/StingTools/Core/OutputLocationHelper.cs
@@ -44,6 +44,22 @@ namespace StingTools.Core
         /// </summary>
         public static string GetOutputDirectory(Document doc = null)
         {
+            // Phase 167: prefer the configured project folder structure when present
+            try
+            {
+                if (doc != null)
+                {
+                    var setup = ProjectFolderEngine.LoadOrDetectSetup(doc);
+                    if (setup != null)
+                    {
+                        string projRoot = ProjectFolderEngine.GetExportFolder(doc, "MISC");
+                        if (!string.IsNullOrEmpty(projRoot) && TryEnsureDirectory(projRoot))
+                            return projRoot;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GetOutputDirectory setup lookup: {ex.Message}"); }
+
             // 1. User-preferred directory
             string dir = PreferredDirectory;
             if (!string.IsNullOrEmpty(dir) && TryEnsureDirectory(dir))

--- a/StingTools/Core/Phase74Enhancements.cs
+++ b/StingTools/Core/Phase74Enhancements.cs
@@ -575,7 +575,9 @@ namespace StingTools.Core
                 try
                 {
                     string projDir = Path.GetDirectoryName(doc.PathName ?? "");
-                    string baselinePath = Path.Combine(projDir ?? "", ".sting_warnings_baseline.json");
+                    string baselinePath = ProjectFolderEngine.GetDataPath(doc, "warnings_baseline.json");
+                    if (string.IsNullOrEmpty(baselinePath) || !File.Exists(baselinePath))
+                        baselinePath = Path.Combine(projDir ?? "", ".sting_warnings_baseline.json");
                     if (File.Exists(baselinePath))
                     {
                         var json = Newtonsoft.Json.Linq.JObject.Parse(File.ReadAllText(baselinePath));

--- a/StingTools/Core/ProjectFolderEngine.cs
+++ b/StingTools/Core/ProjectFolderEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -101,6 +102,19 @@ namespace StingTools.Core
 
         private static string _rootPath;
 
+        // ── Phase 167: Per-document ProjectSetup cache ────────────────────
+        private static readonly ConcurrentDictionary<string, ProjectSetup> _setupCache = new();
+
+        /// <summary>Drop the cached setup for a specific document (call on close).</summary>
+        public static void InvalidateSetupCache(string docPath)
+        {
+            if (string.IsNullOrEmpty(docPath)) return;
+            _setupCache.TryRemove(docPath, out _);
+        }
+
+        /// <summary>Drop all cached setups.</summary>
+        public static void InvalidateAllSetupCaches() => _setupCache.Clear();
+
         // PERF-02: Folder stats cache
         private static List<FolderStats> _folderStatsCache;
         private static DateTime _folderStatsCacheTime = DateTime.MinValue;
@@ -141,10 +155,26 @@ namespace StingTools.Core
         }
 
         /// <summary>
-        /// Resolve the root path. Uses: config → project dir → user docs → temp.
+        /// Resolve the root path. Uses: ProjectSetup → explicit RootPath → project dir → user docs → temp.
         /// </summary>
         public static string GetRootPath(Document doc)
         {
+            // Phase 167: Honour persisted ProjectSetup first
+            try
+            {
+                var setup = LoadOrDetectSetup(doc);
+                if (setup != null && doc != null && !string.IsNullOrEmpty(doc.PathName))
+                {
+                    string resolved = setup.ResolveRootPath(doc.PathName);
+                    if (!string.IsNullOrEmpty(resolved))
+                    {
+                        try { Directory.CreateDirectory(resolved); } catch { }
+                        if (Directory.Exists(resolved)) return resolved;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GetRootPath setup lookup: {ex.Message}"); }
+
             if (!string.IsNullOrEmpty(_rootPath) && Directory.Exists(_rootPath))
                 return _rootPath;
 
@@ -167,6 +197,557 @@ namespace StingTools.Core
             catch (Exception ex) { StingLog.Warn($"ProjectFolderEngine: Documents fallback failed: {ex.Message}"); }
 
             return Path.GetTempPath();
+        }
+
+        // ══════════════════════════════════════════════════════════════════
+        //  Phase 167 — Unified project folder system
+        // ══════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Detect or load the persisted ProjectSetup for this document.
+        /// Returns null if the user hasn't run the setup wizard yet.
+        /// </summary>
+        public static ProjectSetup LoadOrDetectSetup(Document doc)
+        {
+            if (doc == null || string.IsNullOrEmpty(doc.PathName)) return null;
+            string docKey = doc.PathName;
+            if (_setupCache.TryGetValue(docKey, out var cached) && cached != null) return cached;
+
+            try
+            {
+                string projDir = Path.GetDirectoryName(doc.PathName);
+                if (string.IsNullOrEmpty(projDir)) return null;
+
+                // Look for {projDir}/{ProjectCode}/_data/project_setup.json
+                string code = DetectProjectCode(doc);
+                string candidateRoot = Path.Combine(projDir, code);
+                string candidateData = Path.Combine(candidateRoot, "_data");
+                var setup = ProjectSetup.Load(candidateData);
+                if (setup != null)
+                {
+                    _setupCache[docKey] = setup;
+                    return setup;
+                }
+
+                // Also search any sibling folder containing _data/project_setup.json
+                try
+                {
+                    foreach (var sub in Directory.GetDirectories(projDir))
+                    {
+                        string sd = Path.Combine(sub, "_data");
+                        var found = ProjectSetup.Load(sd);
+                        if (found != null)
+                        {
+                            _setupCache[docKey] = found;
+                            return found;
+                        }
+                    }
+                }
+                catch { }
+            }
+            catch (Exception ex) { StingLog.Warn($"LoadOrDetectSetup: {ex.Message}"); }
+            return null;
+        }
+
+        /// <summary>
+        /// Persist the setup, build folder structure on disk, write FOLDER_INDEX.txt,
+        /// and cache it for the active document.
+        /// </summary>
+        public static void InitializeSetup(Document doc, ProjectSetup setup)
+        {
+            if (doc == null || setup == null) return;
+            try
+            {
+                string root = setup.ResolveRootPath(doc.PathName);
+                if (string.IsNullOrEmpty(root)) return;
+                Directory.CreateDirectory(root);
+
+                // Create folders
+                foreach (var f in setup.CustomFolders)
+                {
+                    if (setup.HiddenFolders.Contains(f.Id, StringComparer.OrdinalIgnoreCase)) continue;
+                    string folderPath = Path.Combine(root, f.DisplayName);
+                    try { Directory.CreateDirectory(folderPath); } catch (Exception ex) { StingLog.Warn($"InitSetup: {f.DisplayName}: {ex.Message}"); continue; }
+
+                    if (f.HasDisciplineSubfolders && setup.Disciplines != null)
+                    {
+                        foreach (string disc in setup.Disciplines)
+                        {
+                            try { Directory.CreateDirectory(Path.Combine(folderPath, disc)); }
+                            catch (Exception ex) { StingLog.Warn($"InitSetup disc {disc}: {ex.Message}"); }
+                        }
+                    }
+                    if (f.SubFolders != null)
+                    {
+                        foreach (string s in f.SubFolders)
+                        {
+                            try { Directory.CreateDirectory(Path.Combine(folderPath, s)); }
+                            catch (Exception ex) { StingLog.Warn($"InitSetup sub {s}: {ex.Message}"); }
+                        }
+                    }
+                }
+
+                // _data folder
+                string dataPath = Path.Combine(root, "_data");
+                Directory.CreateDirectory(dataPath);
+                Directory.CreateDirectory(Path.Combine(dataPath, "folder_templates"));
+
+                setup.Save(dataPath);
+                _setupCache[doc.PathName] = setup;
+
+                WriteFolderIndex(root);
+                StingLog.Info($"ProjectFolderEngine: Setup initialised at {root}");
+            }
+            catch (Exception ex) { StingLog.Warn($"InitializeSetup: {ex.Message}"); }
+        }
+
+        /// <summary>Resolve the _data folder path; create it if missing. Optionally append a filename.</summary>
+        public static string GetDataPath(Document doc, string fileName = null)
+        {
+            try
+            {
+                string root = GetRootPath(doc);
+                if (string.IsNullOrEmpty(root)) return null;
+                string dataDir = Path.Combine(root, "_data");
+                if (!Directory.Exists(dataDir)) Directory.CreateDirectory(dataDir);
+                return string.IsNullOrEmpty(fileName) ? dataDir : Path.Combine(dataDir, fileName);
+            }
+            catch (Exception ex) { StingLog.Warn($"GetDataPath: {ex.Message}"); return null; }
+        }
+
+        /// <summary>Detect the project code from Revit Project Information (Number → Name → "PRJ").</summary>
+        public static string DetectProjectCode(Document doc)
+        {
+            if (doc == null) return "PRJ";
+            try
+            {
+                string num = doc.ProjectInformation?.Number;
+                if (!string.IsNullOrWhiteSpace(num)) return SanitizeCode(num);
+                string name = doc.ProjectInformation?.Name;
+                if (!string.IsNullOrWhiteSpace(name)) return SanitizeCode(name.Substring(0, Math.Min(3, name.Length)));
+            }
+            catch (Exception ex) { StingLog.Warn($"DetectProjectCode: {ex.Message}"); }
+            return "PRJ";
+        }
+
+        private static string SanitizeCode(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return "PRJ";
+            var sb = new System.Text.StringBuilder();
+            foreach (char c in raw)
+            {
+                if (char.IsLetterOrDigit(c) || c == '_' || c == '-') sb.Append(c);
+            }
+            string s = sb.ToString().ToUpperInvariant();
+            if (string.IsNullOrEmpty(s)) return "PRJ";
+            if (s.Length > 8) s = s.Substring(0, 8);
+            return s;
+        }
+
+        /// <summary>Per-folder health row used by FolderHealthPanel.</summary>
+        public class FolderHealthEntry
+        {
+            public string Id { get; set; }
+            public string DisplayName { get; set; }
+            public bool Exists { get; set; }
+            public int FileCount { get; set; }
+            public DateTime? LastModified { get; set; }
+            public bool IsEmpty { get; set; }
+            public string FullPath { get; set; }
+        }
+
+        /// <summary>Build a per-folder health snapshot for the active setup.</summary>
+        public static List<FolderHealthEntry> GetFolderHealth(Document doc)
+        {
+            var list = new List<FolderHealthEntry>();
+            try
+            {
+                var setup = LoadOrDetectSetup(doc);
+                if (setup == null)
+                {
+                    // Fall back to legacy folder list if no setup
+                    foreach (var (id, name, _, _) in Folders)
+                    {
+                        string root = GetRootPath(doc);
+                        string p = Path.Combine(root, name);
+                        bool ex = Directory.Exists(p);
+                        int n = 0; DateTime? lm = null;
+                        if (ex)
+                        {
+                            try
+                            {
+                                var di = new DirectoryInfo(p);
+                                var files = di.GetFiles("*.*", SearchOption.AllDirectories);
+                                n = files.Length;
+                                if (n > 0) lm = files.Max(f => f.LastWriteTime);
+                            }
+                            catch { }
+                        }
+                        list.Add(new FolderHealthEntry
+                        {
+                            Id = id,
+                            DisplayName = name,
+                            Exists = ex,
+                            FileCount = n,
+                            LastModified = lm,
+                            IsEmpty = ex && n == 0,
+                            FullPath = p,
+                        });
+                    }
+                    return list;
+                }
+
+                string root2 = setup.ResolveRootPath(doc?.PathName);
+                if (string.IsNullOrEmpty(root2)) return list;
+                foreach (var f in setup.CustomFolders)
+                {
+                    if (setup.HiddenFolders.Contains(f.Id, StringComparer.OrdinalIgnoreCase)) continue;
+                    string p = Path.Combine(root2, f.DisplayName);
+                    bool ex = Directory.Exists(p);
+                    int n = 0; DateTime? lm = null;
+                    if (ex)
+                    {
+                        try
+                        {
+                            var di = new DirectoryInfo(p);
+                            var files = di.GetFiles("*.*", SearchOption.AllDirectories);
+                            n = files.Length;
+                            if (n > 0) lm = files.Max(fi => fi.LastWriteTime);
+                        }
+                        catch { }
+                    }
+                    list.Add(new FolderHealthEntry
+                    {
+                        Id = f.Id,
+                        DisplayName = f.DisplayName,
+                        Exists = ex,
+                        FileCount = n,
+                        LastModified = lm,
+                        IsEmpty = ex && n == 0,
+                        FullPath = p,
+                    });
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GetFolderHealth: {ex.Message}"); }
+            return list;
+        }
+
+        /// <summary>Migration record returned by MigrateFromLegacy.</summary>
+        public class MigrationReport
+        {
+            public int FilesMoved { get; set; }
+            public int FoldersRemoved { get; set; }
+            public List<string> Warnings { get; set; } = new();
+        }
+
+        /// <summary>
+        /// Detect legacy STING folders (_BIM_COORD, STING_BIM_MANAGER, STING_Exports,
+        /// STING_Project) and .sting_*.json sidecar files alongside the .rvt; consolidate
+        /// them into the new {ProjectCode}\ root.
+        /// </summary>
+        public static MigrationReport MigrateFromLegacy(Document doc)
+        {
+            var rep = new MigrationReport();
+            if (doc == null || string.IsNullOrEmpty(doc.PathName)) return rep;
+
+            try
+            {
+                string projDir = Path.GetDirectoryName(doc.PathName);
+                if (string.IsNullOrEmpty(projDir)) return rep;
+
+                string dataPath = GetDataPath(doc);
+                string root = GetRootPath(doc);
+                if (string.IsNullOrEmpty(dataPath) || string.IsNullOrEmpty(root)) return rep;
+
+                // 1. Move .sting_*.json sidecars adjacent to the .rvt
+                try
+                {
+                    foreach (string f in Directory.GetFiles(projDir, "*.sting_*.json"))
+                    {
+                        try
+                        {
+                            string dest = Path.Combine(dataPath, Path.GetFileName(f).Replace(".sting_", ""));
+                            if (File.Exists(dest)) dest = GetUniqueFileName(dest);
+                            File.Move(f, dest);
+                            rep.FilesMoved++;
+                        }
+                        catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                    }
+                    foreach (string f in Directory.GetFiles(projDir, "*_STING_SEQ.json"))
+                    {
+                        try
+                        {
+                            string dest = Path.Combine(dataPath, "seq_counters.json");
+                            if (File.Exists(dest)) dest = GetUniqueFileName(dest);
+                            File.Move(f, dest);
+                            rep.FilesMoved++;
+                        }
+                        catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                    }
+                }
+                catch (Exception ex) { rep.Warnings.Add($"Sidecar scan: {ex.Message}"); }
+
+                // 2. Move legacy _BIM_COORD and STING_BIM_MANAGER → _data
+                foreach (string legacyName in new[] { "_BIM_COORD", "STING_BIM_MANAGER" })
+                {
+                    string legacy = Path.Combine(projDir, legacyName);
+                    if (!Directory.Exists(legacy)) continue;
+                    try
+                    {
+                        foreach (string f in Directory.GetFiles(legacy, "*.*", SearchOption.AllDirectories))
+                        {
+                            try
+                            {
+                                string rel = f.Substring(legacy.Length).TrimStart(Path.DirectorySeparatorChar);
+                                string dest = Path.Combine(dataPath, rel);
+                                string ddir = Path.GetDirectoryName(dest);
+                                if (!string.IsNullOrEmpty(ddir)) Directory.CreateDirectory(ddir);
+                                if (File.Exists(dest)) dest = GetUniqueFileName(dest);
+                                File.Move(f, dest);
+                                rep.FilesMoved++;
+                            }
+                            catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                        }
+                        try { if (!Directory.EnumerateFileSystemEntries(legacy).Any()) { Directory.Delete(legacy, true); rep.FoldersRemoved++; } }
+                        catch (Exception ex) { rep.Warnings.Add($"Delete {legacy}: {ex.Message}"); }
+                    }
+                    catch (Exception ex) { rep.Warnings.Add($"Process {legacy}: {ex.Message}"); }
+                }
+
+                // 3. Move legacy STING_Exports / STING_Project — route by extension
+                foreach (string legacyName in new[] { "STING_Exports", "STING_Project" })
+                {
+                    string legacy = Path.Combine(projDir, legacyName);
+                    if (!Directory.Exists(legacy)) continue;
+                    if (string.Equals(Path.GetFullPath(legacy), Path.GetFullPath(root), StringComparison.OrdinalIgnoreCase))
+                        continue; // never move the new root into itself
+
+                    try
+                    {
+                        foreach (string f in Directory.GetFiles(legacy, "*.*", SearchOption.AllDirectories))
+                        {
+                            try
+                            {
+                                string ext = Path.GetExtension(f).TrimStart('.').ToUpperInvariant();
+                                string targetFolderId = ext switch
+                                {
+                                    "PDF" => "DRAWINGS",
+                                    "XLSX" or "XLS" or "CSV" => "SCHEDULES",
+                                    "IFC" or "RVT" or "NWC" or "NWD" or "NWF" or "DWG" or "DXF" => "MODELS",
+                                    "JSON" => null, // → _data
+                                    "BCF" or "BCFZIP" => "CLASHES",
+                                    "DOCX" or "DOC" => "TRANSMITTALS",
+                                    "JPG" or "JPEG" or "PNG" or "BMP" or "TIFF" or "TIF" => "DRAWINGS",
+                                    _ => "MISC",
+                                };
+                                string destDir = targetFolderId == null
+                                    ? dataPath
+                                    : GetFolderPath(doc, targetFolderId);
+                                if (string.IsNullOrEmpty(destDir)) destDir = root;
+                                Directory.CreateDirectory(destDir);
+                                string dest = Path.Combine(destDir, Path.GetFileName(f));
+                                if (File.Exists(dest)) dest = GetUniqueFileName(dest);
+                                File.Move(f, dest);
+                                rep.FilesMoved++;
+                            }
+                            catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                        }
+                        try
+                        {
+                            // Only delete if empty after migration
+                            if (!Directory.EnumerateFiles(legacy, "*.*", SearchOption.AllDirectories).Any())
+                            {
+                                Directory.Delete(legacy, true);
+                                rep.FoldersRemoved++;
+                            }
+                        }
+                        catch (Exception ex) { rep.Warnings.Add($"Delete {legacy}: {ex.Message}"); }
+                    }
+                    catch (Exception ex) { rep.Warnings.Add($"Process {legacy}: {ex.Message}"); }
+                }
+
+                InvalidateFolderStatsCache();
+                StingLog.Info($"MigrateFromLegacy: {rep.FilesMoved} files moved, {rep.FoldersRemoved} folders removed.");
+            }
+            catch (Exception ex)
+            {
+                rep.Warnings.Add(ex.Message);
+                StingLog.Warn($"MigrateFromLegacy: {ex.Message}");
+            }
+            return rep;
+        }
+
+        /// <summary>UI-bindable folder tree node.</summary>
+        public class FolderNode
+        {
+            public string Id { get; set; }
+            public string DisplayName { get; set; }
+            public string FullPath { get; set; }
+            public bool Exists { get; set; }
+            public int FileCount { get; set; }
+            public bool IsExpanded { get; set; }
+            public List<FolderNode> Children { get; set; } = new();
+        }
+
+        /// <summary>Build a hierarchical folder browser tree (top-level + discipline/sub children).</summary>
+        public static List<FolderNode> BuildFolderBrowserTree(Document doc)
+        {
+            var tree = new List<FolderNode>();
+            try
+            {
+                var setup = LoadOrDetectSetup(doc);
+                string root = GetRootPath(doc);
+                if (string.IsNullOrEmpty(root)) return tree;
+
+                IEnumerable<(string Id, string Display, bool DiscSubs, List<string> Subs)> defs;
+                if (setup != null)
+                {
+                    defs = setup.CustomFolders
+                        .Where(f => !setup.HiddenFolders.Contains(f.Id, StringComparer.OrdinalIgnoreCase))
+                        .Select(f => (f.Id, f.DisplayName, f.HasDisciplineSubfolders, f.SubFolders ?? new List<string>()));
+                }
+                else
+                {
+                    defs = Folders.Select(f => (f.Id, f.Name, false, new List<string>()));
+                }
+
+                foreach (var (id, display, discSubs, subs) in defs)
+                {
+                    string p = Path.Combine(root, display);
+                    var n = new FolderNode
+                    {
+                        Id = id,
+                        DisplayName = display,
+                        FullPath = p,
+                        Exists = Directory.Exists(p),
+                        IsExpanded = false,
+                    };
+                    try
+                    {
+                        if (n.Exists)
+                            n.FileCount = Directory.GetFiles(p, "*.*", SearchOption.TopDirectoryOnly).Length;
+                    }
+                    catch { }
+                    if (discSubs && setup?.Disciplines != null)
+                    {
+                        foreach (string disc in setup.Disciplines)
+                        {
+                            string dp = Path.Combine(p, disc);
+                            n.Children.Add(new FolderNode
+                            {
+                                Id = id + "/" + disc,
+                                DisplayName = disc,
+                                FullPath = dp,
+                                Exists = Directory.Exists(dp),
+                            });
+                        }
+                    }
+                    foreach (string s in subs)
+                    {
+                        string sp = Path.Combine(p, s);
+                        n.Children.Add(new FolderNode
+                        {
+                            Id = id + "/" + s,
+                            DisplayName = s,
+                            FullPath = sp,
+                            Exists = Directory.Exists(sp),
+                        });
+                    }
+                    tree.Add(n);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"BuildFolderBrowserTree: {ex.Message}"); }
+            return tree;
+        }
+
+        /// <summary>
+        /// Phase 167-aware export path resolver.
+        /// Honours setup.ExportRoutes, discipline subfolders, and naming convention.
+        /// </summary>
+        public static string GetExportPath(Document doc, string exportTypeKey, string baseName,
+            string extension, string disciplineCode)
+        {
+            try
+            {
+                var setup = LoadOrDetectSetup(doc);
+                string folderId = null;
+                if (setup != null && setup.ExportRoutes != null &&
+                    setup.ExportRoutes.TryGetValue(exportTypeKey ?? "", out string routed))
+                {
+                    folderId = routed;
+                }
+                if (string.IsNullOrEmpty(folderId) && ExportTypeToFolder.TryGetValue(exportTypeKey ?? "", out string fb))
+                    folderId = fb;
+                if (string.IsNullOrEmpty(folderId)) folderId = "MISC";
+
+                string folder;
+                if (string.Equals(folderId, "_DATA", StringComparison.OrdinalIgnoreCase))
+                    folder = GetDataPath(doc);
+                else
+                    folder = GetFolderPath(doc, folderId);
+                if (string.IsNullOrEmpty(folder)) folder = GetRootPath(doc);
+
+                // Discipline sub-routing
+                if (!string.IsNullOrEmpty(disciplineCode) && setup != null)
+                {
+                    var fdef = setup.GetFolder(folderId);
+                    if (fdef != null && fdef.HasDisciplineSubfolders && setup.Disciplines != null)
+                    {
+                        string match = setup.Disciplines.FirstOrDefault(d =>
+                            d.StartsWith(disciplineCode + "_", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(d, disciplineCode, StringComparison.OrdinalIgnoreCase));
+                        if (!string.IsNullOrEmpty(match))
+                        {
+                            folder = Path.Combine(folder, match);
+                            try { Directory.CreateDirectory(folder); } catch { }
+                        }
+                    }
+                }
+                else
+                {
+                    Directory.CreateDirectory(folder);
+                }
+
+                // Apply naming
+                NamingConvention nc = setup?.NamingConvention ?? NamingConvention.Timestamp;
+                string ext = extension ?? "";
+                if (!string.IsNullOrEmpty(ext) && !ext.StartsWith(".")) ext = "." + ext;
+                string fileName;
+                switch (nc)
+                {
+                    case NamingConvention.ISO19650:
+                        fileName = AutoCorrectFileName(doc,
+                            (baseName ?? "export") + ext,
+                            disciplineCode ?? "Z",
+                            "DR", "S3");
+                        break;
+                    case NamingConvention.Custom:
+                        fileName = ApplyCustomPattern(setup?.CustomNamingPattern, baseName, ext, doc);
+                        break;
+                    default:
+                        fileName = $"{baseName ?? "export"}_{DateTime.Now:yyyyMMdd_HHmmss}{ext}";
+                        break;
+                }
+                return Path.Combine(folder, fileName);
+            }
+            catch (Exception ex) { StingLog.Warn($"GetExportPath: {ex.Message}"); }
+            return GetExportPath(doc, exportTypeKey, baseName, extension);
+        }
+
+        private static string ApplyCustomPattern(string pattern, string baseName, string ext, Document doc)
+        {
+            if (string.IsNullOrEmpty(pattern))
+                return $"{baseName ?? "export"}_{DateTime.Now:yyyyMMdd_HHmmss}{ext}";
+            string code = "PRJ";
+            try { code = doc?.ProjectInformation?.Number ?? "PRJ"; } catch { }
+            string s = pattern
+                .Replace("{name}", baseName ?? "export")
+                .Replace("{date}", DateTime.Now.ToString("yyyyMMdd"))
+                .Replace("{time}", DateTime.Now.ToString("HHmmss"))
+                .Replace("{code}", code)
+                .Replace("{ext}", ext);
+            if (!s.EndsWith(ext, StringComparison.OrdinalIgnoreCase)) s += ext;
+            return s;
         }
 
         // ── Folder creation ───────────────────────────────────────────────
@@ -237,6 +818,21 @@ namespace StingTools.Core
         public static string GetFolderPath(Document doc, string folderId)
         {
             string root = GetRootPath(doc);
+
+            // Phase 167: prefer ProjectSetup folder def (uses user-edited display name)
+            try
+            {
+                var setup = LoadOrDetectSetup(doc);
+                var def = setup?.GetFolder(folderId);
+                if (def != null)
+                {
+                    string p = Path.Combine(root, def.DisplayName);
+                    try { Directory.CreateDirectory(p); } catch (Exception ex) { StingLog.Warn($"GetFolderPath: {ex.Message}"); }
+                    return p;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GetFolderPath setup: {ex.Message}"); }
+
             var folder = Folders.FirstOrDefault(f => f.Id.Equals(folderId, StringComparison.OrdinalIgnoreCase));
             if (folder.Name == null) return Path.Combine(root, "20_MISC");
             string path = Path.Combine(root, folder.Name);
@@ -251,8 +847,24 @@ namespace StingTools.Core
         /// <summary>Get the folder path for an export type key (e.g. "PDF", "COBie", "BCF").</summary>
         public static string GetExportFolder(Document doc, string exportTypeKey)
         {
-            if (ExportTypeToFolder.TryGetValue(exportTypeKey, out string folderId))
-                return GetFolderPath(doc, folderId);
+            // Phase 167: honour ProjectSetup ExportRoutes first
+            try
+            {
+                var setup = LoadOrDetectSetup(doc);
+                if (setup != null && setup.ExportRoutes != null &&
+                    !string.IsNullOrEmpty(exportTypeKey) &&
+                    setup.ExportRoutes.TryGetValue(exportTypeKey, out string folderId) &&
+                    !string.IsNullOrEmpty(folderId))
+                {
+                    if (string.Equals(folderId, "_DATA", StringComparison.OrdinalIgnoreCase))
+                        return GetDataPath(doc);
+                    return GetFolderPath(doc, folderId);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GetExportFolder setup lookup: {ex.Message}"); }
+
+            if (ExportTypeToFolder.TryGetValue(exportTypeKey ?? "", out string folderId2))
+                return GetFolderPath(doc, folderId2);
             return GetFolderPath(doc, "MISC");
         }
 

--- a/StingTools/Core/ProjectSetup.cs
+++ b/StingTools/Core/ProjectSetup.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json;
+
+namespace StingTools.Core
+{
+    /// <summary>Folder layout mode — full ISO 19650 BIM tree, or flat 5-folder mini.</summary>
+    public enum ProjectFolderMode { BIM, Mini }
+
+    /// <summary>Naming convention for files written into the export folders.</summary>
+    public enum NamingConvention { ISO19650, Timestamp, Custom }
+
+    /// <summary>Definition of a single folder in the project tree (numbered or named).</summary>
+    public class FolderDef
+    {
+        public string Id { get; set; }
+        public string DisplayName { get; set; }
+        public bool HasDisciplineSubfolders { get; set; }
+        public List<string> SubFolders { get; set; } = new();
+        public bool IsCustom { get; set; }
+    }
+
+    /// <summary>
+    /// Persisted project-folder configuration. Stored in {ProjectCode}\_data\project_setup.json.
+    /// Single source of truth for folder layout, disciplines, export routing, and naming.
+    /// </summary>
+    public class ProjectSetup
+    {
+        public string ProjectCode { get; set; } = "";
+        public string ProjectName { get; set; } = "";
+        public string RootPath { get; set; } = "";
+        public bool RootPathIsRelative { get; set; }
+        public ProjectFolderMode Mode { get; set; } = ProjectFolderMode.BIM;
+        public List<string> Disciplines { get; set; } = new();
+        public List<FolderDef> CustomFolders { get; set; } = new();
+        public List<string> HiddenFolders { get; set; } = new();
+        public Dictionary<string, string> ExportRoutes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        public NamingConvention NamingConvention { get; set; } = NamingConvention.ISO19650;
+        public string CustomNamingPattern { get; set; } = "";
+        public string TemplateName { get; set; } = "";
+        public DateTime CreatedDate { get; set; } = DateTime.Now;
+        public DateTime LastModified { get; set; } = DateTime.Now;
+
+        // ── Default discipline folder names ────────────────────────────────
+        public static readonly List<string> DefaultBimDisciplines = new()
+        {
+            "A_Architectural", "E_Electrical", "M_Mechanical", "P_Plumbing", "S_Structural"
+        };
+
+        // ── BIM folder defaults (16 numbered folders) ──────────────────────
+        public static readonly (string Id, string Name, bool DiscSubs, string[] SubFolders)[] BimFolderDefaults = new[]
+        {
+            ("WIP",          "01_WIP",          true,  new string[0]),
+            ("SHARED",       "02_SHARED",       true,  new string[0]),
+            ("PUBLISHED",    "03_PUBLISHED",    true,  new string[0]),
+            ("ARCHIVE",      "04_ARCHIVE",      false, new string[0]),
+            ("MODELS",       "05_MODELS",       false, new string[0]),
+            ("DRAWINGS",     "06_DRAWINGS",     true,  new string[0]),
+            ("SCHEDULES",    "07_SCHEDULES",    false, new string[0]),
+            ("COBIE",        "08_COBie",        false, new string[0]),
+            ("BEP",          "09_BEP",          false, new string[0]),
+            ("TRANSMITTALS", "10_TRANSMITTALS", false, new string[0]),
+            ("ISSUES",       "11_ISSUES",       false, new[] { "RFI", "TQ", "NCR", "EWN" }),
+            ("CLASHES",      "12_CLASHES",      false, new[] { "BCF", "Reports", "Snapshots" }),
+            ("HANDOVER",     "13_HANDOVER",     false, new string[0]),
+            ("REVISIONS",    "14_REVISIONS",    false, new string[0]),
+            ("REGISTERS",    "15_REGISTERS",    false, new string[0]),
+            ("COMPLIANCE",   "16_COMPLIANCE",   false, new string[0]),
+        };
+
+        // ── Mini folder defaults (5 flat folders) ──────────────────────────
+        public static readonly (string Id, string Name)[] MiniFolderDefaults = new[]
+        {
+            ("DRAWINGS",  "Drawings"),
+            ("MODELS",    "Models"),
+            ("SCHEDULES", "Schedules"),
+            ("DOCUMENTS", "Documents"),
+            ("REPORTS",   "Reports"),
+        };
+
+        // ── Default export route maps ──────────────────────────────────────
+        public static Dictionary<string, string> DefaultBimRoutes() => new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PDF"] = "DRAWINGS",
+            ["IFC"] = "MODELS", ["NWC"] = "MODELS", ["RVT"] = "MODELS", ["DWG"] = "MODELS",
+            ["COBIE"] = "COBIE", ["COBie"] = "COBIE", ["COBieStream"] = "COBIE",
+            ["SCHEDULE"] = "SCHEDULES", ["EXCEL"] = "SCHEDULES", ["CSV"] = "SCHEDULES", ["BOQ"] = "SCHEDULES",
+            ["BEP"] = "BEP",
+            ["TRANSMITTAL"] = "TRANSMITTALS", ["Transmittal"] = "TRANSMITTALS",
+            ["ISSUE"] = "ISSUES", ["Issue"] = "ISSUES", ["RFI"] = "ISSUES",
+            ["BCF"] = "CLASHES", ["CLASH"] = "CLASHES", ["Clash"] = "CLASHES",
+            ["HANDOVER"] = "HANDOVER", ["Handover"] = "HANDOVER", ["OAM"] = "HANDOVER",
+            ["OandM"] = "HANDOVER", ["Maintenance"] = "HANDOVER", ["AssetHealth"] = "HANDOVER",
+            ["REVISION"] = "REVISIONS", ["Revision"] = "REVISIONS",
+            ["REGISTER"] = "REGISTERS", ["TagRegister"] = "REGISTERS",
+            ["DocRegister"] = "REGISTERS", ["AssetRegister"] = "REGISTERS",
+            ["COMPLIANCE"] = "COMPLIANCE", ["Compliance"] = "COMPLIANCE",
+            ["MODELHEALTH"] = "COMPLIANCE", ["ModelHealth"] = "COMPLIANCE",
+            ["Validation"] = "COMPLIANCE",
+            ["JSON"] = "_DATA",
+        };
+
+        public static Dictionary<string, string> DefaultMiniRoutes() => new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PDF"] = "DRAWINGS",
+            ["IFC"] = "MODELS", ["NWC"] = "MODELS", ["RVT"] = "MODELS", ["DWG"] = "MODELS",
+            ["SCHEDULE"] = "SCHEDULES", ["EXCEL"] = "SCHEDULES", ["CSV"] = "SCHEDULES", ["BOQ"] = "SCHEDULES",
+            ["TRANSMITTAL"] = "DOCUMENTS", ["Transmittal"] = "DOCUMENTS",
+            ["BEP"] = "DOCUMENTS",
+            ["COMPLIANCE"] = "REPORTS", ["Compliance"] = "REPORTS",
+            ["MODELHEALTH"] = "REPORTS", ["ModelHealth"] = "REPORTS",
+            ["HANDOVER"] = "DOCUMENTS",
+            ["JSON"] = "_DATA",
+        };
+
+        // ── Factory methods ────────────────────────────────────────────────
+
+        /// <summary>Build a default BIM-mode setup with the 16 numbered folders.</summary>
+        public static ProjectSetup CreateBIM(string projectCode, string rootPath, List<string> disciplines = null)
+        {
+            var s = new ProjectSetup
+            {
+                ProjectCode = projectCode ?? "PRJ",
+                RootPath = rootPath ?? "",
+                Mode = ProjectFolderMode.BIM,
+                Disciplines = disciplines != null && disciplines.Count > 0
+                    ? new List<string>(disciplines)
+                    : new List<string>(DefaultBimDisciplines),
+                ExportRoutes = DefaultBimRoutes(),
+            };
+            foreach (var (id, name, discSubs, subs) in BimFolderDefaults)
+            {
+                s.CustomFolders.Add(new FolderDef
+                {
+                    Id = id,
+                    DisplayName = name,
+                    HasDisciplineSubfolders = discSubs,
+                    SubFolders = subs.ToList(),
+                    IsCustom = false,
+                });
+            }
+            return s;
+        }
+
+        /// <summary>Build a default Mini-mode setup with 5 flat folders.</summary>
+        public static ProjectSetup CreateMini(string projectCode, string rootPath)
+        {
+            var s = new ProjectSetup
+            {
+                ProjectCode = projectCode ?? "PRJ",
+                RootPath = rootPath ?? "",
+                Mode = ProjectFolderMode.Mini,
+                Disciplines = new List<string>(),
+                ExportRoutes = DefaultMiniRoutes(),
+            };
+            foreach (var (id, name) in MiniFolderDefaults)
+            {
+                s.CustomFolders.Add(new FolderDef
+                {
+                    Id = id,
+                    DisplayName = name,
+                    HasDisciplineSubfolders = false,
+                    SubFolders = new List<string>(),
+                    IsCustom = false,
+                });
+            }
+            return s;
+        }
+
+        // ── Persistence ────────────────────────────────────────────────────
+
+        private const string SetupFileName = "project_setup.json";
+
+        /// <summary>Read project_setup.json from the given _data folder. Returns null if not present.</summary>
+        public static ProjectSetup Load(string dataPath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(dataPath)) return null;
+                string filePath = Path.Combine(dataPath, SetupFileName);
+                if (!File.Exists(filePath)) return null;
+                var json = File.ReadAllText(filePath);
+                var setup = JsonConvert.DeserializeObject<ProjectSetup>(json);
+                if (setup == null) return null;
+                if (setup.ExportRoutes == null)
+                    setup.ExportRoutes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (setup.Disciplines == null) setup.Disciplines = new List<string>();
+                if (setup.CustomFolders == null) setup.CustomFolders = new List<FolderDef>();
+                if (setup.HiddenFolders == null) setup.HiddenFolders = new List<string>();
+                return setup;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ProjectSetup.Load: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>Write project_setup.json to the given _data folder. Creates folder if missing.</summary>
+        public void Save(string dataPath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(dataPath)) return;
+                if (!Directory.Exists(dataPath)) Directory.CreateDirectory(dataPath);
+                string filePath = Path.Combine(dataPath, SetupFileName);
+                LastModified = DateTime.Now;
+                var json = JsonConvert.SerializeObject(this, Formatting.Indented);
+                File.WriteAllText(filePath, json);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ProjectSetup.Save: {ex.Message}");
+            }
+        }
+
+        /// <summary>Resolve the absolute root path from a Revit document's path. Honours RootPathIsRelative.</summary>
+        public string ResolveRootPath(string rvtPath)
+        {
+            if (string.IsNullOrEmpty(RootPath)) return null;
+            if (!RootPathIsRelative) return RootPath;
+            if (string.IsNullOrEmpty(rvtPath)) return null;
+            string rvtDir = Path.GetDirectoryName(rvtPath);
+            if (string.IsNullOrEmpty(rvtDir)) return null;
+            try { return Path.GetFullPath(Path.Combine(rvtDir, RootPath)); }
+            catch { return Path.Combine(rvtDir, RootPath); }
+        }
+
+        /// <summary>Look up a folder definition by ID (case-insensitive).</summary>
+        public FolderDef GetFolder(string folderId)
+        {
+            if (string.IsNullOrEmpty(folderId)) return null;
+            return CustomFolders.FirstOrDefault(f =>
+                string.Equals(f.Id, folderId, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/StingTools/Core/StingAutoTagger.cs
+++ b/StingTools/Core/StingAutoTagger.cs
@@ -157,7 +157,9 @@ namespace StingTools.Core
             {
                 string projectPath = doc?.PathName;
                 if (string.IsNullOrEmpty(projectPath)) return;
-                string sidecarPath = System.IO.Path.ChangeExtension(projectPath, ".sting_deferred_elements.json");
+                string sidecarPath = ProjectFolderEngine.GetDataPath(doc, "deferred_elements.json");
+                if (string.IsNullOrEmpty(sidecarPath))
+                    sidecarPath = System.IO.Path.ChangeExtension(projectPath, ".sting_deferred_elements.json");
                 var ids = _droppedElementIds.ToArray();
                 string json = $"{{\"version\":\"1.0\",\"timestamp\":\"{DateTime.Now:o}\",\"dropped_count\":{ids.Length},\"element_ids\":[{string.Join(",", ids)}]}}";
                 string tempPath = sidecarPath + ".tmp";
@@ -185,7 +187,9 @@ namespace StingTools.Core
             {
                 string projectPath = doc?.PathName;
                 if (string.IsNullOrEmpty(projectPath)) return 0;
-                string sidecarPath = System.IO.Path.ChangeExtension(projectPath, ".sting_deferred_elements.json");
+                string sidecarPath = ProjectFolderEngine.GetDataPath(doc, "deferred_elements.json");
+                if (string.IsNullOrEmpty(sidecarPath) || !System.IO.File.Exists(sidecarPath))
+                    sidecarPath = System.IO.Path.ChangeExtension(projectPath, ".sting_deferred_elements.json");
                 if (!System.IO.File.Exists(sidecarPath)) return 0;
 
                 string json = System.IO.File.ReadAllText(sidecarPath);

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -207,6 +207,9 @@ namespace StingTools.Core
                 ComplianceScan.InvalidateCache();
                 Temp.FormulaEngine.InvalidateFormulaCache();
                 UI.StingCommandHandler.ClearStaticState();
+                // Phase 167: Drop the per-doc ProjectSetup cache so reopens re-detect.
+                try { ProjectFolderEngine.InvalidateSetupCache(e.Document?.PathName); }
+                catch (Exception cEx) { StingLog.Warn($"Setup cache invalidate: {cEx.Message}"); }
                 // Phase 78: Save dropped element IDs to sidecar before clearing queue
                 StingAutoTagger.SaveDroppedElementsSidecar(e.Document);
                 // R-02: Clear deferred elements on document close
@@ -638,16 +641,23 @@ namespace StingTools.Core
                 }
                 catch (Exception csEx) { StingLog.Warn($"DocumentOpened ClashScheduler start: {csEx.Message}"); }
 
-                // BIM-CDE-FOLDER-01: Bootstrap the ISO 19650 CDE folder structure
-                // (WIP / SHARED / PUBLISHED / ARCHIVE + per-discipline sub-folders)
-                // on every doc open, idempotent. Disabled via AUTO_CREATE_CDE_FOLDERS=false.
+                // Phase 167: detect persisted ProjectSetup. Do NOT auto-create folders
+                // — that's an explicit user action via the Folder Setup dialog.
                 try
                 {
-                    if (TagConfig.AutoCreateCdeFolders && e.Document != null && !e.Document.IsFamilyDocument)
+                    if (e.Document != null && !e.Document.IsFamilyDocument)
                     {
-                        int created = ProjectFolderEngine.CreateFolderStructure(e.Document);
-                        if (created > 0)
-                            StingLog.Info($"DocumentOpened: created {created} CDE folders under {ProjectFolderEngine.GetRootPath(e.Document)}");
+                        var setup = ProjectFolderEngine.LoadOrDetectSetup(e.Document);
+                        if (setup != null)
+                        {
+                            string root = setup.ResolveRootPath(e.Document.PathName);
+                            StingLog.Info($"DocumentOpened: project setup loaded — root={root}, mode={setup.Mode}");
+                        }
+                        else if (TagConfig.AutoCreateCdeFolders && !string.IsNullOrEmpty(e.Document.PathName))
+                        {
+                            // Soft notification: log only. User runs Folder Setup explicitly.
+                            StingLog.Info("DocumentOpened: no ProjectSetup found. User can run Folder Setup from BIM tab.");
+                        }
                     }
                 }
                 catch (Exception cfEx) { StingLog.Warn($"DocumentOpened CDE folder bootstrap: {cfEx.Message}"); }

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -4058,6 +4058,13 @@ namespace StingTools.Core
             if (doc == null || !doc.IsValidObject) return null;
             string projectPath = doc.PathName;
             if (string.IsNullOrEmpty(projectPath)) return null;
+            // Phase 167: prefer _data folder
+            try
+            {
+                string p = StingTools.Core.ProjectFolderEngine.GetDataPath(doc, "seq_counters.json");
+                if (!string.IsNullOrEmpty(p)) return p;
+            }
+            catch { }
             string dir = System.IO.Path.GetDirectoryName(projectPath);
             string fileName = System.IO.Path.GetFileNameWithoutExtension(projectPath);
             if (string.IsNullOrEmpty(dir) || string.IsNullOrEmpty(fileName)) return null;

--- a/StingTools/Core/WarningsManager.cs
+++ b/StingTools/Core/WarningsManager.cs
@@ -1543,6 +1543,12 @@ namespace StingTools.Core
         {
             string docPath = doc?.PathName;
             if (string.IsNullOrEmpty(docPath)) return null;
+            try
+            {
+                string p = ProjectFolderEngine.GetDataPath(doc, "warnings_baseline.json");
+                if (!string.IsNullOrEmpty(p)) return p;
+            }
+            catch { }
             return Path.ChangeExtension(docPath, ".sting_warnings_baseline.json");
         }
 
@@ -2023,7 +2029,9 @@ namespace StingTools.Core
             {
                 if (doc == null || string.IsNullOrEmpty(doc.PathName)) return;
                 // CRIT-06: JSONL append-only — avoids read/parse/rewrite on every call
-                string logPath = Path.Combine(Path.GetDirectoryName(doc.PathName) ?? "", ".sting_coord_log.jsonl");
+                string logPath = ProjectFolderEngine.GetDataPath(doc, "coord_log.jsonl");
+                if (string.IsNullOrEmpty(logPath))
+                    logPath = Path.Combine(Path.GetDirectoryName(doc.PathName) ?? "", ".sting_coord_log.jsonl");
 
                 var entry = new UI.BIMCoordinationCenter.CoordLogEntry
                 {
@@ -4155,8 +4163,12 @@ namespace StingTools.Core
                 // Phase 49: Load coordination log from sidecar
                 try
                 {
-                    string coordLogPath = Path.Combine(Path.GetDirectoryName(doc.PathName ?? "") ?? "",
-                        ".sting_coord_log.json");
+                    string coordLogPath = ProjectFolderEngine.GetDataPath(doc, "coord_log.json");
+                    if (string.IsNullOrEmpty(coordLogPath) || !File.Exists(coordLogPath))
+                    {
+                        coordLogPath = Path.Combine(Path.GetDirectoryName(doc.PathName ?? "") ?? "",
+                            ".sting_coord_log.json");
+                    }
                     if (File.Exists(coordLogPath))
                     {
                         var logEntries = Newtonsoft.Json.JsonConvert.DeserializeObject<List<UI.BIMCoordinationCenter.CoordLogEntry>>(

--- a/StingTools/Docs/SheetManagerEngineExt.cs
+++ b/StingTools/Docs/SheetManagerEngineExt.cs
@@ -337,6 +337,12 @@ namespace StingTools.Docs
 
         private static string GetPresetFilePath(Document doc)
         {
+            try
+            {
+                string p = StingTools.Core.ProjectFolderEngine.GetDataPath(doc, "layout_presets.json");
+                if (!string.IsNullOrEmpty(p)) return p;
+            }
+            catch { }
             string dir = Path.GetDirectoryName(doc.PathName);
             if (string.IsNullOrEmpty(dir))
                 dir = StingToolsApp.DataPath ?? Path.GetTempPath();

--- a/StingTools/Docs/SheetTemplateEngine.cs
+++ b/StingTools/Docs/SheetTemplateEngine.cs
@@ -385,6 +385,12 @@ namespace StingTools.Docs
 
         private static string GetTemplateFilePath(Document doc)
         {
+            try
+            {
+                string p = StingTools.Core.ProjectFolderEngine.GetDataPath(doc, "sheet_templates.json");
+                if (!string.IsNullOrEmpty(p)) return p;
+            }
+            catch { }
             string dir = Path.GetDirectoryName(doc.PathName);
             if (string.IsNullOrEmpty(dir))
                 dir = StingToolsApp.DataPath ?? Path.GetTempPath();

--- a/StingTools/UI/FolderHealthPanel.cs
+++ b/StingTools/UI/FolderHealthPanel.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+
+namespace StingTools.UI
+{
+    /// <summary>
+    /// Compact folder-health view (also usable as a small dialog window).
+    /// Shows per-folder status with file counts and last-modified dates.
+    /// </summary>
+    public class FolderHealthPanel : UserControl
+    {
+        private static readonly SolidColorBrush BgDark   = new(Color.FromRgb(0x1E, 0x1E, 0x1E));
+        private static readonly SolidColorBrush BgPanel  = new(Color.FromRgb(0x25, 0x25, 0x26));
+        private static readonly SolidColorBrush BgRow    = new(Color.FromRgb(0x2D, 0x2D, 0x30));
+        private static readonly SolidColorBrush FgWhite  = new(Color.FromRgb(0xFF, 0xFF, 0xFF));
+        private static readonly SolidColorBrush FgSubtle = new(Color.FromRgb(0xAA, 0xAA, 0xAA));
+        private static readonly SolidColorBrush Accent   = new(Color.FromRgb(0x00, 0x78, 0xD4));
+        private static readonly SolidColorBrush BrBorder = new(Color.FromRgb(0x40, 0x40, 0x40));
+        private static readonly SolidColorBrush Green    = new(Color.FromRgb(0x4C, 0xAF, 0x50));
+        private static readonly SolidColorBrush Amber    = new(Color.FromRgb(0xFF, 0xC1, 0x07));
+        private static readonly SolidColorBrush Red      = new(Color.FromRgb(0xF4, 0x43, 0x36));
+
+        private readonly UIApplication _uiapp;
+        private TextBlock _header;
+        private StackPanel _list;
+        private TextBlock _statusBar;
+
+        public FolderHealthPanel(UIApplication uiapp)
+        {
+            _uiapp = uiapp;
+            Background = BgDark;
+            Foreground = FgWhite;
+            Build();
+            Refresh(uiapp?.ActiveUIDocument?.Document);
+        }
+
+        private void Build()
+        {
+            var root = new DockPanel { LastChildFill = true, Margin = new Thickness(8) };
+
+            // Header
+            var headerDock = new DockPanel { LastChildFill = true, Margin = new Thickness(0, 0, 0, 8) };
+            _header = new TextBlock
+            {
+                FontWeight = FontWeights.Bold,
+                FontSize = 13,
+                Foreground = FgWhite,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            var openBtn = new Button
+            {
+                Content = "▷ Open in Explorer",
+                Width = 130,
+                Height = 24,
+                Background = BgRow,
+                Foreground = Accent,
+                BorderBrush = BrBorder,
+                FontSize = 11,
+            };
+            openBtn.Click += (s, e) => OpenRoot();
+            DockPanel.SetDock(openBtn, Dock.Right);
+            headerDock.Children.Add(openBtn);
+            headerDock.Children.Add(_header);
+            DockPanel.SetDock(headerDock, Dock.Top);
+            root.Children.Add(headerDock);
+
+            // Status bar (bottom)
+            _statusBar = new TextBlock
+            {
+                Foreground = FgSubtle,
+                FontSize = 11,
+                Margin = new Thickness(0, 8, 0, 0),
+                TextWrapping = TextWrapping.Wrap,
+            };
+            DockPanel.SetDock(_statusBar, Dock.Bottom);
+            root.Children.Add(_statusBar);
+
+            // Refresh button
+            var refresh = new Button
+            {
+                Content = "↻ Refresh",
+                Width = 90,
+                Height = 24,
+                Background = BgRow,
+                Foreground = FgWhite,
+                BorderBrush = BrBorder,
+                Margin = new Thickness(0, 4, 0, 4),
+                HorizontalAlignment = HorizontalAlignment.Right,
+            };
+            refresh.Click += (s, e) => Refresh(_uiapp?.ActiveUIDocument?.Document);
+            DockPanel.SetDock(refresh, Dock.Bottom);
+            root.Children.Add(refresh);
+
+            // List
+            var scroller = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Background = BgPanel,
+                BorderBrush = BrBorder,
+                BorderThickness = new Thickness(1),
+            };
+            _list = new StackPanel { Margin = new Thickness(2) };
+            scroller.Content = _list;
+            root.Children.Add(scroller);
+
+            Content = root;
+        }
+
+        private void OpenRoot()
+        {
+            try
+            {
+                var doc = _uiapp?.ActiveUIDocument?.Document;
+                if (doc == null) return;
+                string root = ProjectFolderEngine.GetRootPath(doc);
+                if (!string.IsNullOrEmpty(root) && Directory.Exists(root))
+                    Process.Start(new ProcessStartInfo { FileName = root, UseShellExecute = true });
+            }
+            catch (Exception ex) { StingLog.Warn($"FolderHealthPanel.OpenRoot: {ex.Message}"); }
+        }
+
+        public void Refresh(Document doc)
+        {
+            try
+            {
+                _list.Children.Clear();
+                if (doc == null)
+                {
+                    _header.Text = "(no document open)";
+                    _statusBar.Text = "";
+                    return;
+                }
+
+                string code = ProjectFolderEngine.DetectProjectCode(doc);
+                string root = ProjectFolderEngine.GetRootPath(doc);
+                _header.Text = $"Project Folder: {code}\\  →  {root}";
+
+                var entries = ProjectFolderEngine.GetFolderHealth(doc);
+                int totalFiles = 0, emptyCount = 0, activeCount = 0;
+                foreach (var entry in entries)
+                {
+                    _list.Children.Add(BuildRow(entry));
+                    if (entry.Exists) activeCount++;
+                    if (entry.IsEmpty) emptyCount++;
+                    totalFiles += entry.FileCount;
+                }
+
+                int dataFiles = 0;
+                try
+                {
+                    string dataDir = ProjectFolderEngine.GetDataPath(doc);
+                    if (!string.IsNullOrEmpty(dataDir) && Directory.Exists(dataDir))
+                        dataFiles = Directory.GetFiles(dataDir, "*.json", SearchOption.AllDirectories).Length;
+                }
+                catch { }
+
+                _statusBar.Text = $"{totalFiles} files across {activeCount} folders   |   " +
+                                  $"{emptyCount} empty   |   _data: {dataFiles} JSON files";
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"FolderHealthPanel.Refresh: {ex.Message}");
+                _statusBar.Text = $"Error: {ex.Message}";
+            }
+        }
+
+        private UIElement BuildRow(ProjectFolderEngine.FolderHealthEntry entry)
+        {
+            var dock = new DockPanel
+            {
+                LastChildFill = true,
+                Margin = new Thickness(0, 1, 0, 1),
+                Background = BgRow,
+            };
+
+            // Status pill
+            SolidColorBrush pillColor = !entry.Exists ? Red : (entry.IsEmpty ? Amber : Green);
+            var pill = new Ellipse
+            {
+                Width = 10,
+                Height = 10,
+                Fill = pillColor,
+                Margin = new Thickness(6, 0, 8, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            dock.Children.Add(pill);
+
+            // Open button
+            var openBtn = new Button
+            {
+                Content = "▷",
+                Width = 26,
+                Height = 22,
+                Background = BgRow,
+                Foreground = Accent,
+                BorderBrush = BrBorder,
+                FontSize = 11,
+                ToolTip = "Open in Explorer",
+            };
+            openBtn.Click += (s, e) =>
+            {
+                try
+                {
+                    if (Directory.Exists(entry.FullPath))
+                        Process.Start(new ProcessStartInfo { FileName = entry.FullPath, UseShellExecute = true });
+                }
+                catch (Exception ex) { StingLog.Warn($"FolderHealthPanel row open: {ex.Message}"); }
+            };
+            DockPanel.SetDock(openBtn, Dock.Right);
+            dock.Children.Add(openBtn);
+
+            // Last modified
+            string lm = entry.LastModified.HasValue
+                ? entry.LastModified.Value.ToString("yyyy-MM-dd")
+                : "—";
+            var dateBlock = new TextBlock
+            {
+                Text = lm,
+                Foreground = FgSubtle,
+                Width = 100,
+                VerticalAlignment = VerticalAlignment.Center,
+                FontSize = 11,
+            };
+            DockPanel.SetDock(dateBlock, Dock.Right);
+            dock.Children.Add(dateBlock);
+
+            // Count
+            var countBlock = new TextBlock
+            {
+                Text = entry.Exists ? $"{entry.FileCount} files" : "(missing)",
+                Foreground = entry.Exists ? FgWhite : Red,
+                Width = 80,
+                VerticalAlignment = VerticalAlignment.Center,
+                FontSize = 11,
+            };
+            DockPanel.SetDock(countBlock, Dock.Right);
+            dock.Children.Add(countBlock);
+
+            // Name
+            var nameBlock = new TextBlock
+            {
+                Text = entry.DisplayName,
+                Foreground = FgWhite,
+                FontSize = 12,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 4, 8, 4),
+            };
+            dock.Children.Add(nameBlock);
+
+            return dock;
+        }
+
+        // ── Dialog wrapper ─────────────────────────────────────────────────
+
+        /// <summary>Show this panel in a small modal dialog window.</summary>
+        public static void ShowDialog(UIApplication uiapp)
+        {
+            try
+            {
+                var panel = new FolderHealthPanel(uiapp);
+                var w = new Window
+                {
+                    Title = "Folder Health",
+                    Width = 520,
+                    Height = 460,
+                    Background = BgDark,
+                    Foreground = FgWhite,
+                    WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                    Content = panel,
+                };
+                w.ShowDialog();
+            }
+            catch (Exception ex) { StingLog.Warn($"FolderHealthPanel.ShowDialog: {ex.Message}"); }
+        }
+    }
+
+}

--- a/StingTools/UI/ProjectFolderSetupDialog.cs
+++ b/StingTools/UI/ProjectFolderSetupDialog.cs
@@ -1,0 +1,890 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+
+namespace StingTools.UI
+{
+    /// <summary>
+    /// 3-section project folder setup dialog. Builds and persists a ProjectSetup,
+    /// then calls ProjectFolderEngine.InitializeSetup to create the folder tree.
+    /// </summary>
+    public class ProjectFolderSetupDialog
+    {
+        // ── Theme ──
+        private static readonly SolidColorBrush BgDark   = new(Color.FromRgb(0x1E, 0x1E, 0x1E));
+        private static readonly SolidColorBrush BgPanel  = new(Color.FromRgb(0x25, 0x25, 0x26));
+        private static readonly SolidColorBrush BgInput  = new(Color.FromRgb(0x2D, 0x2D, 0x30));
+        private static readonly SolidColorBrush FgWhite  = new(Color.FromRgb(0xFF, 0xFF, 0xFF));
+        private static readonly SolidColorBrush FgSubtle = new(Color.FromRgb(0xAA, 0xAA, 0xAA));
+        private static readonly SolidColorBrush Accent   = new(Color.FromRgb(0x00, 0x78, 0xD4));
+        private static readonly SolidColorBrush BrBorder = new(Color.FromRgb(0x40, 0x40, 0x40));
+        private static readonly SolidColorBrush Yellow   = new(Color.FromRgb(0xFF, 0xC1, 0x07));
+        private static readonly SolidColorBrush Green    = new(Color.FromRgb(0x4C, 0xAF, 0x50));
+
+        public ProjectSetup Result { get; private set; }
+
+        private readonly Document _doc;
+        private readonly string _docPath;
+        private Window _window;
+
+        // Form state
+        private TextBox _projCodeBox;
+        private TextBox _projNameBox;
+        private TextBox _rootBox;
+        private TextBlock _previewLabel;
+        private RadioButton _radioRelative;
+        private RadioButton _radioAbsolute;
+        private ComboBox _templateCombo;
+        private RadioButton _radioBim;
+        private RadioButton _radioMini;
+        private WrapPanel _disciplinePanel;
+        private StackPanel _disciplineRow;
+        private ComboBox _namingCombo;
+        private TextBox _customNamingBox;
+        private StackPanel _customNamingRow;
+        private DataGrid _foldersGrid;
+        private Border _migrationBanner;
+        private TextBlock _migrationText;
+
+        private List<FolderTemplate> _templates;
+        private ObservableCollection<FolderRow> _folderRows;
+
+        public class FolderRow
+        {
+            public bool Include { get; set; } = true;
+            public string Id { get; set; } = "";
+            public string DisplayName { get; set; } = "";
+            public bool DiscSubfolders { get; set; }
+            public string Routes { get; set; } = "";
+            public bool IsCustom { get; set; }
+        }
+
+        public ProjectFolderSetupDialog(UIApplication uiapp)
+        {
+            _doc = uiapp?.ActiveUIDocument?.Document;
+            _docPath = _doc?.PathName ?? "";
+        }
+
+        /// <summary>Show the dialog modally. Returns true on confirm.</summary>
+        public bool? ShowDialog()
+        {
+            BuildWindow();
+            PreloadDefaults();
+            return _window.ShowDialog();
+        }
+
+        // ── Layout ────────────────────────────────────────────────────────
+
+        private void BuildWindow()
+        {
+            _window = new Window
+            {
+                Title = "Project Folder Setup",
+                Width = 720,
+                Height = 640,
+                Background = BgDark,
+                Foreground = FgWhite,
+                FontFamily = new FontFamily("Segoe UI"),
+                FontSize = 12,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen,
+                ResizeMode = ResizeMode.CanResize,
+            };
+
+            var root = new DockPanel { LastChildFill = true, Margin = new Thickness(12) };
+
+            // Footer
+            var footer = BuildFooter();
+            DockPanel.SetDock(footer, Dock.Bottom);
+            root.Children.Add(footer);
+
+            // Migration banner (top)
+            _migrationBanner = BuildMigrationBanner();
+            DockPanel.SetDock(_migrationBanner, Dock.Top);
+            root.Children.Add(_migrationBanner);
+
+            // Body — scrollable stack
+            var body = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Background = BgDark,
+            };
+            var stack = new StackPanel { Margin = new Thickness(0, 8, 0, 8) };
+            stack.Children.Add(BuildIdentitySection());
+            stack.Children.Add(BuildSeparator());
+            stack.Children.Add(BuildStructureSection());
+            stack.Children.Add(BuildSeparator());
+            stack.Children.Add(BuildFoldersSection());
+            body.Content = stack;
+            root.Children.Add(body);
+
+            _window.Content = root;
+        }
+
+        private static UIElement BuildSeparator() => new Border
+        {
+            BorderBrush = BrBorder,
+            BorderThickness = new Thickness(0, 0, 0, 1),
+            Margin = new Thickness(0, 12, 0, 12),
+        };
+
+        private TextBlock SectionHeader(string text) => new()
+        {
+            Text = text,
+            FontWeight = FontWeights.Bold,
+            FontSize = 13,
+            Foreground = Accent,
+            Margin = new Thickness(0, 0, 0, 8),
+        };
+
+        private TextBlock Label(string text) => new()
+        {
+            Text = text,
+            Foreground = FgWhite,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 8, 0),
+        };
+
+        private TextBox MakeTextBox(string initial, double width = 280) => new()
+        {
+            Text = initial ?? "",
+            Width = width,
+            Background = BgInput,
+            Foreground = FgWhite,
+            BorderBrush = BrBorder,
+            Padding = new Thickness(4, 3, 4, 3),
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
+
+        private Button MakeButton(string label, double width = 100)
+        {
+            var b = new Button
+            {
+                Content = label,
+                Width = width,
+                Height = 28,
+                Margin = new Thickness(4, 0, 0, 0),
+                Background = BgInput,
+                Foreground = FgWhite,
+                BorderBrush = BrBorder,
+                FontSize = 12,
+            };
+            return b;
+        }
+
+        // ── Section 1: Identity ────────────────────────────────────────────
+
+        private UIElement BuildIdentitySection()
+        {
+            var box = new StackPanel();
+            box.Children.Add(SectionHeader("PROJECT IDENTITY"));
+
+            // Project code row
+            var row1 = new DockPanel { Margin = new Thickness(0, 0, 0, 8) };
+            row1.Children.Add(Label("Project Code"));
+            _projCodeBox = MakeTextBox("", 200);
+            _projCodeBox.TextChanged += (s, e) => UpdatePreview();
+            row1.Children.Add(_projCodeBox);
+            var detect = MakeButton("↺ Detect", 80);
+            detect.ToolTip = "Re-read code from Revit Project Information";
+            detect.Click += (s, e) =>
+            {
+                if (_doc != null) _projCodeBox.Text = ProjectFolderEngine.DetectProjectCode(_doc);
+            };
+            row1.Children.Add(detect);
+            box.Children.Add(row1);
+
+            // Project name row
+            var row2 = new DockPanel { Margin = new Thickness(0, 0, 0, 8) };
+            row2.Children.Add(Label("Project Name"));
+            _projNameBox = MakeTextBox("", 380);
+            _projNameBox.IsReadOnly = true;
+            _projNameBox.Background = BgPanel;
+            row2.Children.Add(_projNameBox);
+            box.Children.Add(row2);
+
+            // Root path row
+            var row3 = new DockPanel { Margin = new Thickness(0, 0, 0, 4) };
+            row3.Children.Add(Label("Root Folder"));
+            _rootBox = MakeTextBox("", 380);
+            _rootBox.TextChanged += (s, e) => UpdatePreview();
+            row3.Children.Add(_rootBox);
+            var browse = MakeButton("Browse…", 80);
+            browse.Click += (s, e) =>
+            {
+                var dlg = new Microsoft.Win32.SaveFileDialog
+                {
+                    Title = "Choose project root folder (save the dummy file to select the parent)",
+                    FileName = "_ROOT_HERE",
+                    Filter = "Folder selection|*.*",
+                    OverwritePrompt = false,
+                };
+                if (!string.IsNullOrEmpty(_rootBox.Text) && Directory.Exists(_rootBox.Text))
+                    dlg.InitialDirectory = _rootBox.Text;
+                if (dlg.ShowDialog() == true)
+                {
+                    string chosen = Path.GetDirectoryName(dlg.FileName);
+                    if (!string.IsNullOrEmpty(chosen)) _rootBox.Text = chosen;
+                }
+            };
+            row3.Children.Add(browse);
+            box.Children.Add(row3);
+
+            // Relative/Absolute radios
+            var row4 = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(110, 0, 0, 4) };
+            _radioRelative = new RadioButton
+            {
+                Content = "Relative to model file (portable)",
+                Foreground = FgWhite,
+                Margin = new Thickness(0, 0, 16, 0),
+                IsChecked = true,
+            };
+            _radioRelative.Checked += (s, e) => UpdatePreview();
+            _radioAbsolute = new RadioButton
+            {
+                Content = "Absolute path",
+                Foreground = FgWhite,
+            };
+            _radioAbsolute.Checked += (s, e) => UpdatePreview();
+            row4.Children.Add(_radioRelative);
+            row4.Children.Add(_radioAbsolute);
+            box.Children.Add(row4);
+
+            // Preview label
+            _previewLabel = new TextBlock
+            {
+                Foreground = FgSubtle,
+                FontStyle = FontStyles.Italic,
+                Margin = new Thickness(110, 4, 0, 0),
+            };
+            box.Children.Add(_previewLabel);
+
+            return box;
+        }
+
+        // ── Section 2: Structure ───────────────────────────────────────────
+
+        private UIElement BuildStructureSection()
+        {
+            var box = new StackPanel();
+            box.Children.Add(SectionHeader("STRUCTURE"));
+
+            // Template row
+            var row1 = new DockPanel { Margin = new Thickness(0, 0, 0, 8) };
+            row1.Children.Add(Label("Template"));
+            _templateCombo = new ComboBox
+            {
+                Width = 320,
+                Background = BgInput,
+                Foreground = FgWhite,
+                BorderBrush = BrBorder,
+            };
+            _templateCombo.SelectionChanged += OnTemplateChanged;
+            row1.Children.Add(_templateCombo);
+            var saveTpl = MakeButton("Save as…", 90);
+            saveTpl.Click += OnSaveTemplate;
+            row1.Children.Add(saveTpl);
+            var delTpl = MakeButton("Delete", 70);
+            delTpl.Click += OnDeleteTemplate;
+            row1.Children.Add(delTpl);
+            box.Children.Add(row1);
+
+            // Mode radios
+            var row2 = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(110, 0, 0, 8) };
+            _radioBim = new RadioButton
+            {
+                Content = "BIM Project (full ISO 19650 — 16 numbered folders)",
+                Foreground = FgWhite,
+                Margin = new Thickness(0, 0, 16, 0),
+                IsChecked = true,
+            };
+            _radioBim.Checked += (s, e) => OnModeChanged();
+            _radioMini = new RadioButton
+            {
+                Content = "Mini Project (5 flat folders)",
+                Foreground = FgWhite,
+            };
+            _radioMini.Checked += (s, e) => OnModeChanged();
+            row2.Children.Add(_radioBim);
+            row2.Children.Add(_radioMini);
+            box.Children.Add(row2);
+
+            // Discipline row
+            _disciplineRow = new StackPanel { Margin = new Thickness(0, 0, 0, 8) };
+            var discRowInner = new DockPanel();
+            discRowInner.Children.Add(Label("Disciplines"));
+            _disciplinePanel = new WrapPanel { Orientation = Orientation.Horizontal };
+            foreach (var d in new[] { "A_Architectural", "E_Electrical", "M_Mechanical", "P_Plumbing",
+                                       "S_Structural", "FP_Fire", "LV_LowVoltage", "Z_General" })
+            {
+                var cb = new CheckBox
+                {
+                    Content = d,
+                    Foreground = FgWhite,
+                    Margin = new Thickness(0, 2, 12, 2),
+                    Tag = d,
+                    IsChecked = ProjectSetup.DefaultBimDisciplines.Contains(d),
+                };
+                _disciplinePanel.Children.Add(cb);
+            }
+            discRowInner.Children.Add(_disciplinePanel);
+            _disciplineRow.Children.Add(discRowInner);
+            box.Children.Add(_disciplineRow);
+
+            // Naming convention
+            var row4 = new DockPanel { Margin = new Thickness(0, 0, 0, 8) };
+            row4.Children.Add(Label("Export Naming"));
+            _namingCombo = new ComboBox
+            {
+                Width = 320,
+                Background = BgInput,
+                Foreground = FgWhite,
+                BorderBrush = BrBorder,
+            };
+            _namingCombo.Items.Add("ISO 19650 (code-based)");
+            _namingCombo.Items.Add("Timestamp (date-time suffix)");
+            _namingCombo.Items.Add("Custom pattern");
+            _namingCombo.SelectedIndex = 0;
+            _namingCombo.SelectionChanged += (s, e) => _customNamingRow.Visibility =
+                _namingCombo.SelectedIndex == 2 ? Visibility.Visible : Visibility.Collapsed;
+            row4.Children.Add(_namingCombo);
+            box.Children.Add(row4);
+
+            _customNamingRow = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(110, 0, 0, 8),
+                Visibility = Visibility.Collapsed,
+            };
+            _customNamingRow.Children.Add(new TextBlock
+            {
+                Text = "Pattern (tokens: {name} {date} {time} {code} {ext}):",
+                Foreground = FgSubtle,
+                Margin = new Thickness(0, 0, 8, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+            _customNamingBox = MakeTextBox("{name}_{date}_{code}{ext}", 280);
+            _customNamingRow.Children.Add(_customNamingBox);
+            box.Children.Add(_customNamingRow);
+
+            return box;
+        }
+
+        // ── Section 3: Folders ─────────────────────────────────────────────
+
+        private UIElement BuildFoldersSection()
+        {
+            var box = new StackPanel();
+            box.Children.Add(SectionHeader("FOLDERS (BIM mode)"));
+
+            _folderRows = new ObservableCollection<FolderRow>();
+            _foldersGrid = new DataGrid
+            {
+                Background = BgInput,
+                Foreground = FgWhite,
+                BorderBrush = BrBorder,
+                AutoGenerateColumns = false,
+                CanUserAddRows = false,
+                CanUserDeleteRows = false,
+                CanUserSortColumns = false,
+                HeadersVisibility = DataGridHeadersVisibility.Column,
+                Height = 200,
+                ItemsSource = _folderRows,
+                GridLinesVisibility = DataGridGridLinesVisibility.Horizontal,
+                RowBackground = BgInput,
+                AlternatingRowBackground = BgPanel,
+                ColumnHeaderHeight = 24,
+            };
+            _foldersGrid.Columns.Add(new DataGridCheckBoxColumn
+            {
+                Header = "Include",
+                Binding = new System.Windows.Data.Binding(nameof(FolderRow.Include)) { Mode = System.Windows.Data.BindingMode.TwoWay, UpdateSourceTrigger = System.Windows.Data.UpdateSourceTrigger.PropertyChanged },
+                Width = 60,
+            });
+            _foldersGrid.Columns.Add(new DataGridTextColumn
+            {
+                Header = "ID",
+                Binding = new System.Windows.Data.Binding(nameof(FolderRow.Id)),
+                IsReadOnly = true,
+                Width = 110,
+            });
+            _foldersGrid.Columns.Add(new DataGridTextColumn
+            {
+                Header = "Display Name",
+                Binding = new System.Windows.Data.Binding(nameof(FolderRow.DisplayName)) { Mode = System.Windows.Data.BindingMode.TwoWay, UpdateSourceTrigger = System.Windows.Data.UpdateSourceTrigger.PropertyChanged },
+                Width = 180,
+            });
+            _foldersGrid.Columns.Add(new DataGridCheckBoxColumn
+            {
+                Header = "Disc. Subs",
+                Binding = new System.Windows.Data.Binding(nameof(FolderRow.DiscSubfolders)) { Mode = System.Windows.Data.BindingMode.TwoWay, UpdateSourceTrigger = System.Windows.Data.UpdateSourceTrigger.PropertyChanged },
+                Width = 80,
+            });
+            _foldersGrid.Columns.Add(new DataGridTextColumn
+            {
+                Header = "Routes",
+                Binding = new System.Windows.Data.Binding(nameof(FolderRow.Routes)),
+                IsReadOnly = true,
+                Width = 240,
+            });
+            box.Children.Add(_foldersGrid);
+
+            var addBtn = MakeButton("+ Add Custom Folder", 160);
+            addBtn.Margin = new Thickness(0, 8, 0, 0);
+            addBtn.Click += (s, e) =>
+            {
+                int n = _folderRows.Count(r => r.IsCustom) + 1;
+                _folderRows.Add(new FolderRow
+                {
+                    Include = true,
+                    Id = $"CUSTOM_{n:D2}",
+                    DisplayName = "",
+                    DiscSubfolders = false,
+                    Routes = "(custom)",
+                    IsCustom = true,
+                });
+            };
+            box.Children.Add(addBtn);
+
+            return box;
+        }
+
+        // ── Migration banner ───────────────────────────────────────────────
+
+        private Border BuildMigrationBanner()
+        {
+            _migrationText = new TextBlock
+            {
+                Foreground = Brushes.Black,
+                TextWrapping = TextWrapping.Wrap,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(8, 4, 8, 4),
+            };
+            var btn = MakeButton("Migrate Now", 110);
+            btn.Background = Yellow;
+            btn.Foreground = Brushes.Black;
+            btn.Click += OnMigrate;
+            var dock = new DockPanel();
+            DockPanel.SetDock(btn, Dock.Right);
+            dock.Children.Add(btn);
+            dock.Children.Add(_migrationText);
+
+            var border = new Border
+            {
+                Background = Yellow,
+                BorderBrush = Yellow,
+                BorderThickness = new Thickness(1),
+                Margin = new Thickness(0, 0, 0, 8),
+                Padding = new Thickness(4),
+                Child = dock,
+                Visibility = Visibility.Collapsed,
+            };
+            return border;
+        }
+
+        // ── Footer ─────────────────────────────────────────────────────────
+
+        private UIElement BuildFooter()
+        {
+            var dock = new DockPanel { LastChildFill = false, Margin = new Thickness(0, 8, 0, 0) };
+
+            var help = new TextBlock
+            {
+                Foreground = FgSubtle,
+                Margin = new Thickness(0, 4, 0, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            var helpLink = new Hyperlink(new Run("? Help"))
+            {
+                Foreground = Accent,
+                NavigateUri = new Uri("https://planscape.com/docs/folder-setup"),
+            };
+            helpLink.RequestNavigate += (s, e) => StingLog.Info("Folder setup help requested.");
+            help.Inlines.Add(helpLink);
+            DockPanel.SetDock(help, Dock.Left);
+            dock.Children.Add(help);
+
+            var buttons = new StackPanel { Orientation = Orientation.Horizontal };
+            DockPanel.SetDock(buttons, Dock.Right);
+            var cancel = MakeButton("Cancel", 90);
+            cancel.Click += (s, e) => { _window.DialogResult = false; _window.Close(); };
+            var ok = MakeButton("Create Folders", 130);
+            ok.Background = Accent;
+            ok.Foreground = FgWhite;
+            ok.FontWeight = FontWeights.Bold;
+            ok.Click += OnCreateFolders;
+            buttons.Children.Add(cancel);
+            buttons.Children.Add(ok);
+            dock.Children.Add(buttons);
+
+            return dock;
+        }
+
+        // ── Defaults ───────────────────────────────────────────────────────
+
+        private void PreloadDefaults()
+        {
+            // Project info
+            string code = "PRJ", name = "";
+            if (_doc != null)
+            {
+                code = ProjectFolderEngine.DetectProjectCode(_doc);
+                try { name = _doc.ProjectInformation?.Name ?? ""; } catch { }
+            }
+            _projCodeBox.Text = code;
+            _projNameBox.Text = name;
+
+            // Default root: relative folder named after project code
+            _rootBox.Text = code;
+
+            // Templates
+            _templates = LoadTemplates();
+            foreach (var t in _templates) _templateCombo.Items.Add(t.Name + (t.IsBuiltIn ? "" : "  (user)"));
+            _templateCombo.SelectedIndex = 0;
+
+            // Migration check
+            CheckMigrationBanner();
+
+            UpdatePreview();
+        }
+
+        private List<FolderTemplate> LoadTemplates()
+        {
+            string templateDir = "";
+            try
+            {
+                string dataDir = ProjectFolderEngine.GetDataPath(_doc);
+                if (!string.IsNullOrEmpty(dataDir))
+                    templateDir = Path.Combine(dataDir, "folder_templates");
+            }
+            catch { }
+            return FolderTemplateLibrary.GetAll(templateDir);
+        }
+
+        private void CheckMigrationBanner()
+        {
+            if (_doc == null || string.IsNullOrEmpty(_docPath))
+            {
+                _migrationBanner.Visibility = Visibility.Collapsed;
+                return;
+            }
+            try
+            {
+                string projDir = Path.GetDirectoryName(_docPath);
+                int sidecars = 0, legacy = 0;
+                if (!string.IsNullOrEmpty(projDir))
+                {
+                    foreach (string f in Directory.GetFiles(projDir, "*.sting_*.json")) sidecars++;
+                    foreach (string f in Directory.GetFiles(projDir, "*_STING_SEQ.json")) sidecars++;
+                    foreach (string n in new[] { "_BIM_COORD", "STING_BIM_MANAGER", "STING_Exports", "STING_Project" })
+                    {
+                        string p = Path.Combine(projDir, n);
+                        if (Directory.Exists(p)) legacy++;
+                    }
+                }
+                if (sidecars > 0 || legacy > 0)
+                {
+                    _migrationText.Text = $"Legacy STING data detected: {legacy} folder(s) and {sidecars} sidecar JSON file(s) " +
+                                          "alongside the model. Click 'Migrate Now' to consolidate them into the new structure.";
+                    _migrationBanner.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    _migrationBanner.Visibility = Visibility.Collapsed;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"Migration banner: {ex.Message}"); }
+        }
+
+        // ── Handlers ───────────────────────────────────────────────────────
+
+        private void UpdatePreview()
+        {
+            if (_previewLabel == null) return;
+            string code = (_projCodeBox?.Text ?? "PRJ").Trim();
+            string root = (_rootBox?.Text ?? "").Trim();
+            string projDir = "";
+            try { projDir = Path.GetDirectoryName(_docPath) ?? ""; } catch { }
+
+            string resolved;
+            if (_radioRelative?.IsChecked == true)
+            {
+                if (string.IsNullOrEmpty(root)) root = code;
+                resolved = string.IsNullOrEmpty(projDir) ? root : Path.Combine(projDir, root);
+            }
+            else
+            {
+                resolved = string.IsNullOrEmpty(root) ? "(no path)" : root;
+            }
+
+            _previewLabel.Text = $"Folders will be created at: {resolved}";
+        }
+
+        private void OnTemplateChanged(object sender, SelectionChangedEventArgs e)
+        {
+            int idx = _templateCombo.SelectedIndex;
+            if (idx < 0 || idx >= _templates.Count) return;
+            var t = _templates[idx];
+
+            if (t.Mode == ProjectFolderMode.Mini) _radioMini.IsChecked = true;
+            else _radioBim.IsChecked = true;
+
+            // Apply disciplines
+            foreach (var child in _disciplinePanel.Children)
+            {
+                if (child is CheckBox cb)
+                    cb.IsChecked = t.Disciplines != null && t.Disciplines.Contains((string)cb.Tag);
+            }
+
+            // Apply naming
+            _namingCombo.SelectedIndex = (int)t.NamingConvention;
+
+            // Repopulate folder rows
+            RebuildFolderRowsFromTemplate(t);
+        }
+
+        private void RebuildFolderRowsFromTemplate(FolderTemplate t)
+        {
+            _folderRows.Clear();
+            if (t.CustomFolders == null) return;
+            foreach (var f in t.CustomFolders)
+            {
+                _folderRows.Add(new FolderRow
+                {
+                    Include = !t.HiddenFolders.Contains(f.Id, StringComparer.OrdinalIgnoreCase),
+                    Id = f.Id,
+                    DisplayName = f.DisplayName,
+                    DiscSubfolders = f.HasDisciplineSubfolders,
+                    Routes = SummariseRoutes(t.ExportRoutes, f.Id),
+                    IsCustom = f.IsCustom,
+                });
+            }
+        }
+
+        private static string SummariseRoutes(Dictionary<string, string> routes, string folderId)
+        {
+            if (routes == null) return "";
+            var keys = routes.Where(kv => string.Equals(kv.Value, folderId, StringComparison.OrdinalIgnoreCase))
+                             .Select(kv => kv.Key)
+                             .Take(8)
+                             .ToList();
+            return string.Join(", ", keys);
+        }
+
+        private void OnModeChanged()
+        {
+            if (_disciplineRow == null) return;
+            _disciplineRow.Visibility = _radioBim?.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+            // Folder grid only meaningful in BIM mode
+            if (_foldersGrid != null)
+                _foldersGrid.IsEnabled = _radioBim?.IsChecked == true;
+        }
+
+        private void OnSaveTemplate(object sender, RoutedEventArgs e)
+        {
+            string name = PromptText("Save folder template", "Template name:");
+            if (string.IsNullOrWhiteSpace(name)) return;
+            var setup = BuildSetupFromForm();
+            var template = new FolderTemplate
+            {
+                Name = name,
+                Description = "User-saved template",
+                Mode = setup.Mode,
+                Disciplines = new List<string>(setup.Disciplines),
+                CustomFolders = setup.CustomFolders,
+                HiddenFolders = setup.HiddenFolders,
+                ExportRoutes = setup.ExportRoutes,
+                NamingConvention = setup.NamingConvention,
+                IsBuiltIn = false,
+            };
+            string templateDir = "";
+            try
+            {
+                string dataDir = ProjectFolderEngine.GetDataPath(_doc);
+                if (!string.IsNullOrEmpty(dataDir)) templateDir = Path.Combine(dataDir, "folder_templates");
+            }
+            catch { }
+            FolderTemplateLibrary.SaveUserTemplate(template, templateDir);
+            // Reload combo
+            _templates = LoadTemplates();
+            _templateCombo.Items.Clear();
+            foreach (var t in _templates) _templateCombo.Items.Add(t.Name + (t.IsBuiltIn ? "" : "  (user)"));
+            _templateCombo.SelectedIndex = _templates.FindIndex(t => t.Name == name);
+        }
+
+        private void OnDeleteTemplate(object sender, RoutedEventArgs e)
+        {
+            int idx = _templateCombo.SelectedIndex;
+            if (idx < 0 || idx >= _templates.Count) return;
+            var t = _templates[idx];
+            if (t.IsBuiltIn)
+            {
+                TaskDialog.Show("Folder Setup", "Built-in templates cannot be deleted.");
+                return;
+            }
+            string templateDir = "";
+            try
+            {
+                string dataDir = ProjectFolderEngine.GetDataPath(_doc);
+                if (!string.IsNullOrEmpty(dataDir)) templateDir = Path.Combine(dataDir, "folder_templates");
+            }
+            catch { }
+            FolderTemplateLibrary.DeleteUserTemplate(t.Name, templateDir);
+            _templates = LoadTemplates();
+            _templateCombo.Items.Clear();
+            foreach (var x in _templates) _templateCombo.Items.Add(x.Name + (x.IsBuiltIn ? "" : "  (user)"));
+            _templateCombo.SelectedIndex = 0;
+        }
+
+        private void OnMigrate(object sender, RoutedEventArgs e)
+        {
+            if (_doc == null) return;
+            try
+            {
+                var rep = ProjectFolderEngine.MigrateFromLegacy(_doc);
+                TaskDialog.Show("STING Migration",
+                    $"Moved {rep.FilesMoved} files. Removed {rep.FoldersRemoved} legacy folders." +
+                    (rep.Warnings.Count > 0 ? $"\n\nWarnings: {rep.Warnings.Count}" : ""));
+                CheckMigrationBanner();
+            }
+            catch (Exception ex)
+            {
+                TaskDialog.Show("STING Migration", $"Migration failed: {ex.Message}");
+            }
+        }
+
+        private void OnCreateFolders(object sender, RoutedEventArgs e)
+        {
+            string code = (_projCodeBox?.Text ?? "").Trim();
+            if (string.IsNullOrEmpty(code))
+            {
+                TaskDialog.Show("Folder Setup", "Project code is required.");
+                return;
+            }
+            string root = (_rootBox?.Text ?? "").Trim();
+            if (string.IsNullOrEmpty(root))
+            {
+                TaskDialog.Show("Folder Setup", "Root folder location is required.");
+                return;
+            }
+
+            try
+            {
+                var setup = BuildSetupFromForm();
+                Result = setup;
+                ProjectFolderEngine.InitializeSetup(_doc, setup);
+                _window.DialogResult = true;
+                _window.Close();
+            }
+            catch (Exception ex)
+            {
+                TaskDialog.Show("Folder Setup", $"Failed to create folders: {ex.Message}");
+            }
+        }
+
+        private ProjectSetup BuildSetupFromForm()
+        {
+            string code = (_projCodeBox?.Text ?? "PRJ").Trim();
+            string root = (_rootBox?.Text ?? code).Trim();
+            bool isRelative = _radioRelative?.IsChecked == true;
+
+            ProjectSetup setup;
+            bool isMini = _radioMini?.IsChecked == true;
+            if (isMini)
+            {
+                setup = ProjectSetup.CreateMini(code, root);
+            }
+            else
+            {
+                var disciplines = new List<string>();
+                foreach (var child in _disciplinePanel.Children)
+                {
+                    if (child is CheckBox cb && cb.IsChecked == true)
+                        disciplines.Add((string)cb.Tag);
+                }
+                setup = ProjectSetup.CreateBIM(code, root, disciplines);
+
+                // Merge folder grid edits
+                if (_folderRows != null && _folderRows.Count > 0)
+                {
+                    var newFolders = new List<FolderDef>();
+                    var hidden = new List<string>();
+                    foreach (var r in _folderRows)
+                    {
+                        if (string.IsNullOrWhiteSpace(r.Id)) continue;
+                        if (!r.Include)
+                        {
+                            hidden.Add(r.Id);
+                            continue;
+                        }
+                        var existing = setup.GetFolder(r.Id);
+                        newFolders.Add(new FolderDef
+                        {
+                            Id = r.Id,
+                            DisplayName = string.IsNullOrWhiteSpace(r.DisplayName) ? (existing?.DisplayName ?? r.Id) : r.DisplayName,
+                            HasDisciplineSubfolders = r.DiscSubfolders,
+                            SubFolders = existing?.SubFolders ?? new List<string>(),
+                            IsCustom = r.IsCustom,
+                        });
+                    }
+                    setup.CustomFolders = newFolders;
+                    setup.HiddenFolders = hidden;
+                }
+            }
+
+            setup.RootPath = root;
+            setup.RootPathIsRelative = isRelative;
+            setup.ProjectName = _projNameBox?.Text ?? "";
+            setup.NamingConvention = (NamingConvention)Math.Max(0, _namingCombo.SelectedIndex);
+            if (setup.NamingConvention == NamingConvention.Custom)
+                setup.CustomNamingPattern = _customNamingBox?.Text ?? "";
+
+            int idx = _templateCombo.SelectedIndex;
+            if (idx >= 0 && idx < _templates.Count) setup.TemplateName = _templates[idx].Name;
+
+            return setup;
+        }
+
+        // ── Mini text-prompt dialog ────────────────────────────────────────
+
+        private string PromptText(string title, string prompt)
+        {
+            var w = new Window
+            {
+                Title = title,
+                Width = 400,
+                Height = 160,
+                Background = BgDark,
+                Foreground = FgWhite,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Owner = _window,
+            };
+            var sp = new StackPanel { Margin = new Thickness(12) };
+            sp.Children.Add(new TextBlock { Text = prompt, Foreground = FgWhite, Margin = new Thickness(0, 0, 0, 8) });
+            var tb = MakeTextBox("", 360);
+            sp.Children.Add(tb);
+            var row = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 12, 0, 0) };
+            var ok = MakeButton("OK", 80);
+            string result = null;
+            ok.Click += (s, e) => { result = tb.Text; w.DialogResult = true; w.Close(); };
+            var cancel = MakeButton("Cancel", 80);
+            cancel.Click += (s, e) => { w.DialogResult = false; w.Close(); };
+            row.Children.Add(cancel);
+            row.Children.Add(ok);
+            sp.Children.Add(row);
+            w.Content = sp;
+            tb.Focus();
+            return w.ShowDialog() == true ? result : null;
+        }
+    }
+}

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -1934,15 +1934,53 @@ namespace StingTools.UI
                     case "SetOutputDirectory": RunCommand<BIMManager.SetOutputDirectoryCommand>(app); break;
                     case "StageComplianceGate": RunCommand<BIMManager.StageComplianceGateCommand>(app); break;
 
-                    // Project Folder Structure
+                    // Project Folder Structure (Phase 167 — unified setup)
                     case "CreateFolders":
                     {
                         var cfDoc = app.ActiveUIDocument?.Document;
                         if (cfDoc != null)
                         {
-                            int created = Core.ProjectFolderEngine.CreateFolderStructure(cfDoc);
-                            Autodesk.Revit.UI.TaskDialog.Show("STING Folder Structure",
-                                $"Created {created} folders at:\n{Core.ProjectFolderEngine.GetRootPath(cfDoc)}");
+                            var existing = Core.ProjectFolderEngine.LoadOrDetectSetup(cfDoc);
+                            if (existing != null)
+                            {
+                                var td = new Autodesk.Revit.UI.TaskDialog("STING Folder Setup")
+                                {
+                                    MainInstruction = "Project folders are already configured.",
+                                    MainContent = $"Root: {existing.ResolveRootPath(cfDoc.PathName)}\n" +
+                                                  $"Mode: {existing.Mode}, {existing.CustomFolders?.Count ?? 0} folders",
+                                };
+                                td.AddCommandLink(Autodesk.Revit.UI.TaskDialogCommandLinkId.CommandLink1, "Run setup again", "Reconfigure folder structure");
+                                td.AddCommandLink(Autodesk.Revit.UI.TaskDialogCommandLinkId.CommandLink2, "Open folder in Explorer", "Browse files");
+                                td.CommonButtons = Autodesk.Revit.UI.TaskDialogCommonButtons.Cancel;
+                                var res = td.Show();
+                                if (res == Autodesk.Revit.UI.TaskDialogResult.CommandLink2)
+                                {
+                                    string root = existing.ResolveRootPath(cfDoc.PathName);
+                                    if (!string.IsNullOrEmpty(root) && System.IO.Directory.Exists(root))
+                                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("explorer.exe", root) { UseShellExecute = true })?.Dispose();
+                                    break;
+                                }
+                                if (res != Autodesk.Revit.UI.TaskDialogResult.CommandLink1) break;
+                            }
+
+                            try
+                            {
+                                var dlg = new UI.ProjectFolderSetupDialog(app);
+                                if (dlg.ShowDialog() == true && dlg.Result != null)
+                                {
+                                    string root = dlg.Result.ResolveRootPath(cfDoc.PathName);
+                                    if (!string.IsNullOrEmpty(root) && System.IO.Directory.Exists(root))
+                                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("explorer.exe", root) { UseShellExecute = true })?.Dispose();
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                StingTools.Core.StingLog.Warn($"CreateFolders: {ex.Message}");
+                                // Fall back to legacy direct creation
+                                int created = Core.ProjectFolderEngine.CreateFolderStructure(cfDoc);
+                                Autodesk.Revit.UI.TaskDialog.Show("STING Folder Structure",
+                                    $"Created {created} folders at:\n{Core.ProjectFolderEngine.GetRootPath(cfDoc)}");
+                            }
                         }
                         break;
                     }
@@ -1952,6 +1990,28 @@ namespace StingTools.UI
                         string root = Core.ProjectFolderEngine.GetRootPath(opDoc);
                         if (System.IO.Directory.Exists(root))
                             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("explorer.exe", root) { UseShellExecute = true })?.Dispose();
+                        break;
+                    }
+                    case "FolderHealth":
+                    {
+                        try { UI.FolderHealthPanel.ShowDialog(app); }
+                        catch (Exception ex) { Autodesk.Revit.UI.TaskDialog.Show("STING", $"Folder Health failed: {ex.Message}"); }
+                        break;
+                    }
+                    case "FolderMigrate":
+                    {
+                        var fmDoc = app.ActiveUIDocument?.Document;
+                        if (fmDoc != null)
+                        {
+                            try
+                            {
+                                var rep = Core.ProjectFolderEngine.MigrateFromLegacy(fmDoc);
+                                Autodesk.Revit.UI.TaskDialog.Show("STING Migration",
+                                    $"Moved {rep.FilesMoved} files. Removed {rep.FoldersRemoved} legacy folders." +
+                                    (rep.Warnings.Count > 0 ? $"\n\nWarnings: {rep.Warnings.Count}" : ""));
+                            }
+                            catch (Exception ex) { Autodesk.Revit.UI.TaskDialog.Show("STING", $"Migration failed: {ex.Message}"); }
+                        }
                         break;
                     }
 
@@ -2064,9 +2124,13 @@ namespace StingTools.UI
                         {
                             try
                             {
-                                string logPath = System.IO.Path.Combine(
-                                    System.IO.Path.GetDirectoryName(d.PathName ?? "") ?? "",
-                                    ".sting_coord_log.json");
+                                string logPath = StingTools.Core.ProjectFolderEngine.GetDataPath(d, "coord_log.json");
+                                if (string.IsNullOrEmpty(logPath) || !System.IO.File.Exists(logPath))
+                                {
+                                    logPath = System.IO.Path.Combine(
+                                        System.IO.Path.GetDirectoryName(d.PathName ?? "") ?? "",
+                                        ".sting_coord_log.json");
+                                }
                                 if (System.IO.File.Exists(logPath))
                                 {
                                     string csvPath = logPath.Replace(".json", $"_{DateTime.Now:yyyyMMdd_HHmm}.csv");
@@ -2100,9 +2164,13 @@ namespace StingTools.UI
                             confirm.CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No;
                             if (confirm.Show() == TaskDialogResult.Yes)
                             {
-                                string logPath = System.IO.Path.Combine(
-                                    System.IO.Path.GetDirectoryName(d.PathName ?? "") ?? "",
-                                    ".sting_coord_log.json");
+                                string logPath = StingTools.Core.ProjectFolderEngine.GetDataPath(d, "coord_log.json");
+                                if (string.IsNullOrEmpty(logPath) || !System.IO.File.Exists(logPath))
+                                {
+                                    logPath = System.IO.Path.Combine(
+                                        System.IO.Path.GetDirectoryName(d.PathName ?? "") ?? "",
+                                        ".sting_coord_log.json");
+                                }
                                 if (System.IO.File.Exists(logPath)) System.IO.File.Delete(logPath);
                                 TaskDialog.Show("STING", "Coordination log cleared.");
                             }

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -2589,10 +2589,14 @@
                                 <WrapPanel>
                                     <Button Style="{StaticResource BlueBtn}" Content="Document Manager" Tag="DocumentManager" Click="Cmd_Click"
                                             ToolTip="Open Document Management Center — browse all project documents, issues, revisions, clashes and CDE status with tree navigator" FontWeight="Bold"/>
-                                    <Button Style="{StaticResource ActionBtn}" Content="Create Folders" Tag="CreateFolders" Click="Cmd_Click"
-                                            ToolTip="Create ISO 19650 project folder structure (20 folders: WIP, Shared, Published, Models, Drawings, COBie, Issues, Clashes, Handover, etc.)"/>
-                                    <Button Style="{StaticResource ActionBtn}" Content="Open Project Folder" Tag="OpenProjectFolder" Click="Cmd_Click"
-                                            ToolTip="Open the STING project folder root in Windows Explorer"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="⚙ Folder Setup" Tag="CreateFolders" Click="Cmd_Click"
+                                            ToolTip="Configure project folder structure — choose template, disciplines, and naming convention"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="📁 Open Root" Tag="OpenProjectFolder" Click="Cmd_Click"
+                                            ToolTip="Open project root folder in Windows Explorer"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="📊 Folder Health" Tag="FolderHealth" Click="Cmd_Click"
+                                            ToolTip="View folder structure health and file counts (green=files, amber=empty, red=missing)"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="🔄 Migrate Legacy" Tag="FolderMigrate" Click="Cmd_Click"
+                                            ToolTip="Consolidate old _BIM_COORD, STING_BIM_MANAGER, STING_Exports, STING_Project folders and .sting_*.json sidecars into the new unified structure"/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Data Exchange" Tag="DataExchange" Click="Cmd_Click"
                                             ToolTip="Export/Import data — categories, parameters, CSV/Excel/JSON with column mapping"/>
                                 </WrapPanel>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9230,3 +9230,123 @@ lands.
    `ViewStylePackApplier.Apply` and `ApplyPresetOverrides`. Deferred
    to a follow-up — the value is populated correctly so the multiplier
    commit can flip the switch with no JSON re-edit.
+
+#### Completed (Phase 168 — Unified project folder system: single-root structure, _data consolidation, BIM/Mini modes, templates, migration)
+
+Replaces four competing folder roots (`_BIM_COORD\`,
+`STING_BIM_MANAGER\`, `STING_Exports\`, `STING_Project\`) with one
+`{ProjectCode}\` root next to the `.rvt`, plus a dedicated `_data\`
+subfolder for every runtime sidecar JSON the plugin writes. Adds a
+data-driven flexibility layer so projects can choose a full ISO 19650
+BIM tree, a 5-folder Mini tree, or a saved template profile.
+
+**New files**
+
+| Path | Role |
+|---|---|
+| `StingTools/Core/ProjectSetup.cs` | POCO + factory methods (`CreateBIM` / `CreateMini`) + Load / Save / ResolveRootPath. Holds project code, root path, mode, disciplines, custom folders, hidden folders, export routes, naming convention. |
+| `StingTools/Core/FolderTemplateLibrary.cs` | 4 built-in templates (Full BIM, MEP Only, Mini Project, Structural Only) + user template load / save / delete + `ApplyTemplate(...)` materialiser. |
+| `StingTools/UI/ProjectFolderSetupDialog.cs` | 3-section WPF dialog: identity (project code, name, root, relative/absolute), structure (template picker, BIM/Mini radios, discipline checkboxes, naming convention), folders (editable DataGrid: include / id / display name / discipline subs / routes). Migration banner detects legacy folders + sidecars and offers one-click consolidation. |
+| `StingTools/UI/FolderHealthPanel.cs` | Compact UserControl + dialog wrapper. Per-folder green / amber / red status pills, file counts, last modified date, ▷ open-in-Explorer button per row, footer summary (total files, empty count, _data JSON count). |
+
+**ProjectFolderEngine extensions** (`Core/ProjectFolderEngine.cs`):
+
+`LoadOrDetectSetup(doc)` walks `{projDir}\{ProjectCode}\_data\project_setup.json`
+plus sibling-folder fallback. `InitializeSetup(doc, setup)` creates every
+folder + discipline subfolder + sub-folder list, writes `_data` and
+`folder_templates`, persists JSON, caches setup, and writes
+`FOLDER_INDEX.txt`. `GetDataPath(doc, fileName)` resolves
+`{root}\_data\{fileName}` — the canonical replacement for
+`Path.ChangeExtension(doc.PathName, ".sting_*.json")`.
+`DetectProjectCode(doc)` reads Project Information Number → Name →
+"PRJ", sanitises and clamps to 8 chars. `GetFolderHealth(doc)` returns
+a per-folder snapshot for the health panel. `MigrateFromLegacy(doc)`
+moves `.sting_*.json` sidecars + `*_STING_SEQ.json` SEQ sidecars +
+the four legacy folder roots into the new structure, routing exports
+by extension (PDF→DRAWINGS, IFC/RVT/NWC/DWG→MODELS, JSON→_data,
+XLSX/CSV→SCHEDULES, BCF→CLASHES, DOCX→TRANSMITTALS). `BuildFolderBrowserTree(doc)`
+returns hierarchical `FolderNode` rows for UI binding. `GetExportPath(doc, type, base, ext, disc)`
+honours `ExportRoutes`, drops files into discipline subfolders when
+the resolved folder has `HasDisciplineSubfolders=true`, and applies
+the chosen `NamingConvention` (ISO19650 / Timestamp / Custom).
+`InvalidateSetupCache(docPath)` is wired into `OnDocumentClosing` so
+re-opens re-detect.
+
+`GetRootPath` and `GetExportFolder` and `GetFolderPath` all consult
+`LoadOrDetectSetup` first; only fall through to legacy behaviour
+when no setup is found. Backward compatibility is preserved — every
+existing public method signature is unchanged.
+
+**Sidecar redirect** — 10 callers redirected from
+`Path.ChangeExtension(doc.PathName, ".sting_*.json")` (or
+`Path.Combine(projDir, ".sting_*")`) to
+`ProjectFolderEngine.GetDataPath(doc, "*.json")`, each with
+try/catch fallback to the legacy path so first-open before setup
+still works:
+
+| File | Was | Now |
+|---|---|---|
+| `Core/ComplianceScan.cs` | 4 sites — `.sting_compliance_trend.json` | `ResolveTrendPath(doc)` helper using `_data/compliance_trend.json` |
+| `Core/Phase74Enhancements.cs` | `.sting_warnings_baseline.json` | `_data/warnings_baseline.json` |
+| `Core/WarningsManager.cs` | 3 sites — baseline + coord_log JSON + JSONL | `_data/warnings_baseline.json` + `_data/coord_log.json[l]` |
+| `Core/StingAutoTagger.cs` | 2 sites — `.sting_deferred_elements.json` | `_data/deferred_elements.json` |
+| `Core/TagConfig.cs` | `GetSeqSidecarPath` → `*_STING_SEQ.json` | `_data/seq_counters.json` |
+| `BIMManager/BIMManagerCommands.cs` | 2 sites — coord_log + tagmap fallback | `_data/coord_log.json` + `_data/` for tagmap fallback |
+| `BIMManager/GapFixCommands.cs` | 2 sites — linked_revision + compliance_trend | `_data/linked_revision_{linkName}.json` + `_data/compliance_trend.json` |
+| `Docs/SheetManagerEngineExt.cs` | `.sting_layout_presets.json` | `_data/layout_presets.json` |
+| `Docs/SheetTemplateEngine.cs` | `.sting_sheet_templates.json` | `_data/sheet_templates.json` |
+| `UI/StingCommandHandler.cs` | 2 sites — coord_log read for export/clear | `_data/coord_log.json` |
+
+**Folder defaults**
+
+BIM mode (16 numbered folders, 4 with discipline subfolders):
+`01_WIP`, `02_SHARED`, `03_PUBLISHED`, `04_ARCHIVE`, `05_MODELS`,
+`06_DRAWINGS`, `07_SCHEDULES`, `08_COBie`, `09_BEP`, `10_TRANSMITTALS`,
+`11_ISSUES` (sub: RFI/TQ/NCR/EWN), `12_CLASHES` (sub: BCF/Reports/Snapshots),
+`13_HANDOVER`, `14_REVISIONS`, `15_REGISTERS`, `16_COMPLIANCE`. Default
+disciplines: A_Architectural, E_Electrical, M_Mechanical, P_Plumbing,
+S_Structural. Default routes: PDF→DRAWINGS, IFC/NWC/RVT/DWG→MODELS,
+COBIE→COBIE, SCHEDULE/EXCEL/CSV/BOQ→SCHEDULES, BEP→BEP,
+TRANSMITTAL→TRANSMITTALS, ISSUE/RFI→ISSUES, BCF/CLASH→CLASHES,
+HANDOVER/OAM/Maintenance/AssetHealth→HANDOVER, REVISION→REVISIONS,
+TagRegister/DocRegister/AssetRegister→REGISTERS,
+COMPLIANCE/MODELHEALTH/Validation→COMPLIANCE, JSON→_DATA.
+
+Mini mode (5 flat folders): Drawings, Models, Schedules, Documents,
+Reports.
+
+**Wiring**
+
+- `StingCommandHandler.cs` `CreateFolders` tag now opens the new
+  `ProjectFolderSetupDialog`. If a setup already exists it offers
+  "Run setup again" / "Open folder in Explorer" / Cancel.
+- New tags: `FolderHealth` (opens `FolderHealthPanel.ShowDialog`),
+  `FolderMigrate` (calls `MigrateFromLegacy` and reports moved-files
+  count).
+- `StingDockPanel.xaml` BIM tab — replaced "Create Folders" / "Open
+  Project Folder" with 4 buttons: ⚙ Folder Setup / 📁 Open Root /
+  📊 Folder Health / 🔄 Migrate Legacy.
+- `StingToolsApp.OnDocumentOpened` — softer behaviour: detects
+  persisted setup if present and logs the loaded root; **no longer
+  auto-creates folders**. Setup is now an explicit user action.
+- `StingToolsApp.OnDocumentClosing` — invalidates the per-document
+  setup cache so reopens re-detect from disk.
+- `OutputLocationHelper.GetOutputDirectory` — added a new first-priority
+  check that returns the project's MISC export folder when a setup
+  is loaded; falls through to the existing 4-level chain otherwise.
+
+**Caveats**
+
+1. Built without `dotnet build` verification (Linux sandbox, no Revit
+   API). All Revit API calls reuse documented signatures already
+   present in the codebase.
+2. The migration step deletes legacy folders only when empty after
+   moving files. If a non-STING file is sitting inside `_BIM_COORD`
+   or similar, the folder is preserved with that file in place.
+3. `ProjectSetup.RootPathIsRelative=true` is the recommended mode for
+   network drives and portable workflows; `RootPathIsRelative=false`
+   stores an absolute path that won't survive a server move.
+4. The setup dialog's discipline checkbox list is fixed at 8 codes
+   (A/E/M/P/S/FP/LV/Z). Custom disciplines beyond that list need to
+   be added by editing `_data/project_setup.json` directly today; a
+   future phase will surface them in the dialog.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -382,3 +382,19 @@ ground truth so future estimates do not re-bid these line items.**
 | `INT-02` Dispatch registry framework | **PARTIAL** Phase 165: `UI/CommandRegistry.cs` ships the framework (ICommandModule + Register + TryHandle + lazy singleton); `ElectricalCommandModule` is the first migrated panel (4 tags). The `CommandRegistry.TryHandle` short-circuit at the top of `StingCommandHandler.Execute` lets new modules win over the giant switch. Remaining ~25 panels migrate panel-by-panel in subsequent phases. |
 | `INT-01` HTTP client consolidation | Deferred (Phase 165 audit): `Planscape.PluginSync` is actively used by `PlatformLinkCommands.cs` (3 sites) + `StingDockPanel.xaml.cs` (3 sites). Deletion would require reworking ~600 lines without compile verification. The dual-layer state remains as documented in CLAUDE.md. |
 | Fabrication doc-register auto-link | **DONE** Phase 165: `GenerateFabPackageCommand` now calls `FabricationDocRegister.PushSheets` so generated SP-* sheets land in `_BIM_COORD/document_register.json` automatically with suitability `S0`, status `WIP`. |
+
+### Phase 168 closures (Unified project folder system)
+
+| ID | Status |
+|---|---|
+| Messy folder structure (4 competing roots) | **DONE** Phase 168: `_BIM_COORD\`, `STING_BIM_MANAGER\`, `STING_Exports\`, `STING_Project\` consolidated into one `{ProjectCode}\` root with `_data\` subfolder for sidecar JSON. New `ProjectSetup` POCO + `FolderTemplateLibrary` (4 built-ins) + `ProjectFolderSetupDialog` (3-section WPF dialog) + `FolderHealthPanel` (per-folder status pills). `ProjectFolderEngine.MigrateFromLegacy(doc)` moves legacy folders + `.sting_*.json` sidecars into the new structure routed by extension. 10 sidecar callers redirected to `ProjectFolderEngine.GetDataPath(doc, "*.json")` with try/catch fallback. |
+
+### Future Enhancement Gaps — Project Folder System (Phase 168 follow-ups)
+
+| ID | Description | Priority |
+|---|---|---|
+| FOLDER-01 | Cloud sync mapping — extend `ProjectSetup` with `CloudRoot` + `CloudProvider` fields so the `{ProjectCode}\` tree can mirror to ACC / SharePoint / Dropbox / OneDrive automatically when files land in `02_SHARED` or `03_PUBLISHED`. | High |
+| FOLDER-02 | Free-text discipline entry — surface custom discipline names (beyond the fixed 8 A/E/M/P/S/FP/LV/Z list) in the setup dialog so projects can add bespoke discipline subfolders without hand-editing JSON. | Medium |
+| FOLDER-03 | Multi-model workspace — when two `.rvt` files (e.g. `TROKON FRIEND.rvt` + `TROKON FRIEND 2.rvt`) share one project code, both should resolve to the same `{ProjectCode}\` root deterministically; today's sibling-folder scan in `LoadOrDetectSetup` is best-effort. | Medium |
+| FOLDER-04 | Folder-watcher toggle — surface `ProjectFolderEngine.StartWatching` from the dockable panel so external Explorer drops auto-trigger CDE classification. | Low |
+| FOLDER-05 | Schema versioning — add `SchemaVersion` to `ProjectSetup` + migration step so future schema changes can read old `project_setup.json` and upgrade in place. | Low |


### PR DESCRIPTION
## Summary

Replaces four competing folder roots (`_BIM_COORD\`, `STING_BIM_MANAGER\`, `STING_Exports\`, `STING_Project\`) with a single unified `{ProjectCode}\` root structure next to the `.rvt` file. Introduces a data-driven configuration layer (`ProjectSetup`) that persists to `_data\project_setup.json`, enabling projects to choose between a full ISO 19650 BIM tree (16 numbered folders), a 5-folder Mini tree, or a saved template profile. Consolidates all runtime sidecar JSON files into a dedicated `_data\` subfolder.

## Key Changes

**New Core Classes**
- `ProjectSetup.cs`: POCO + factory methods (`CreateBIM` / `CreateMini`) + Load/Save/ResolveRootPath. Holds project code, root path, mode, disciplines, custom folders, hidden folders, export routes, and naming convention.
- `FolderTemplateLibrary.cs`: 4 built-in templates (Full BIM, MEP Only, Mini Project, Structural Only) + user template load/save/delete + `ApplyTemplate(...)` materialiser.

**New UI Components**
- `ProjectFolderSetupDialog.cs`: 3-section WPF dialog for identity (project code, name, root, relative/absolute), structure (template picker, BIM/Mini radios, discipline checkboxes, naming convention), and folders (editable DataGrid with include/id/display name/discipline subs/routes). Includes migration banner to detect legacy folders and offer one-click consolidation.
- `FolderHealthPanel.cs`: Compact UserControl + dialog wrapper showing per-folder status (green/amber/red pills), file counts, last-modified dates, and ▷ open-in-Explorer button per row.

**ProjectFolderEngine Extensions** (`Core/ProjectFolderEngine.cs`)
- `LoadOrDetectSetup(doc)`: Walks `{projDir}\{ProjectCode}\_data\project_setup.json` with sibling-folder fallback; caches per-document.
- `InitializeSetup(doc, setup)`: Creates folder tree + discipline subfolders + sub-folder lists, writes `_data` and `project_setup.json`, writes `FOLDER_INDEX.txt`.
- `GetDataPath(doc, fileName)`: Resolves `_data` folder path; creates if missing.
- `DetectProjectCode(doc)`: Extracts code from Revit Project Information (Number → Name → "PRJ").
- `GetFolderHealth(doc)`: Builds per-folder health snapshot (exists, file count, last modified, empty flag).
- Per-document `ProjectSetup` cache with `InvalidateSetupCache(docPath)` and `InvalidateAllSetupCaches()`.

**Integration Points**
- `StingCommandHandler.cs`: Updated "CreateFolders" command to check for existing setup and launch dialog if needed.
- `StingToolsApp.cs`: Invalidate setup cache on document close (Phase 167).
- `ComplianceScan.cs`, `WarningsManager.cs`, `OutputLocationHelper.cs`, `TagConfig.cs`, `SheetManagerEngineExt.cs`, `SheetTemplateEngine.cs`: Updated sidecar paths to prefer `_data` folder via `GetDataPath()`.

## Implementation Details

- **Relative vs. Absolute Paths**: `RootPathIsRelative` flag in `ProjectSetup` allows portable (relative to `.rvt`) or absolute paths.
- **Naming Conventions**: Supports ISO 19650 (code-based), Timestamp (date-time suffix), or Custom pattern with tokens (`{name}`, `{date}`, `{time}`, `{code}`, `{ext}`).
- **Export Routing**: Dictionary maps file types (PDF, DWG, etc.) to target folder IDs for automated export placement.
- **Migration**: Dialog detects legacy folder structures and offers consolidation; `FOLDER_INDEX.txt` documents the final structure.
- **Caching**: Per-document setup cache avoids repeated file I/O;

https://claude.ai/code/session_01V9kHjJ9qz6fgXb6BxNLnDD