### PR TITLE
Fix async/await deadlocks in Revit API thread context

### DIFF
--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -77,7 +77,12 @@ public sealed class PlanscapeServerClient : IDisposable
             _serverUrl = serverUrl.TrimEnd('/');
             EnsureHttpClient(_serverUrl);
 
-            var resp = await PostJsonAsync("/api/auth/login", new { email, password });
+            // ConfigureAwait(false) prevents the continuation from being
+            // posted back to a captured SynchronizationContext (e.g. the
+            // WPF dispatcher when this is called via .GetResult() from
+            // an IExternalEventHandler). Without it, the dispatcher
+            // deadlocks waiting for itself.
+            var resp = await PostJsonAsync("/api/auth/login", new { email, password }).ConfigureAwait(false);
             if (!resp.ok) { LastError = $"Login failed: {resp.body}"; return false; }
 
             ParseAuthResponse(JObject.Parse(resp.body), email);
@@ -111,7 +116,7 @@ public sealed class PlanscapeServerClient : IDisposable
         if (string.IsNullOrEmpty(_refreshToken)) return false;
         try
         {
-            var resp = await PostJsonAsync("/api/auth/refresh", new { refreshToken = _refreshToken });
+            var resp = await PostJsonAsync("/api/auth/refresh", new { refreshToken = _refreshToken }).ConfigureAwait(false);
             if (!resp.ok) { StingLog.Warn($"Planscape: Token refresh failed: {resp.body}"); return false; }
 
             var json = JObject.Parse(resp.body);
@@ -134,7 +139,7 @@ public sealed class PlanscapeServerClient : IDisposable
         if (string.IsNullOrEmpty(_accessToken)) { LastError = "Not connected to Planscape server."; return false; }
         // Refresh if token expires within 10 minutes
         if (_tokenExpiry <= DateTime.UtcNow.AddMinutes(10))
-            return await RefreshTokenAsync();
+            return await RefreshTokenAsync().ConfigureAwait(false);
         return true;
     }
 
@@ -976,7 +981,7 @@ public sealed class PlanscapeServerClient : IDisposable
 
             // Otherwise refresh. RefreshTokenAsync rewrites _accessToken /
             // _tokenExpiry on success and persists the new state.
-            if (await RefreshTokenAsync())
+            if (await RefreshTokenAsync().ConfigureAwait(false))
             {
                 StingLog.Info($"Planscape: Session restored + refreshed for {ConnectedUser}.");
                 return true;

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Globalization;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
@@ -2048,7 +2049,11 @@ namespace StingTools.BIMManager
             Planscape.Shared.Models.SyncResult sResult;
             try
             {
-                sResult = Planscape.PluginSync.SyncScheduler.SyncNow(payload).GetAwaiter().GetResult();
+                // Task.Run escapes the WPF DispatcherSynchronizationContext
+                // so SyncNow's continuations don't deadlock against the
+                // dispatcher we're blocking on with GetResult().
+                sResult = Task.Run(() => Planscape.PluginSync.SyncScheduler.SyncNow(payload))
+                    .GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
@@ -2593,9 +2598,15 @@ namespace StingTools.BIMManager
                     return Result.Cancelled;
                 }
 
-                // Blocking async call — safe in ExternalEvent context
-                bool ok = PlanscapeServerClient.Instance
-                    .LoginAsync(serverUrl.Trim(), email.Trim(), password)
+                // Run on the threadpool, not directly on the API thread.
+                // ExternalEvent.Execute runs on the Revit API thread which
+                // carries the WPF DispatcherSynchronizationContext; bare
+                // `LoginAsync(...).GetAwaiter().GetResult()` deadlocks the
+                // dispatcher because LoginAsync's continuation needs to
+                // resume on that same dispatcher. Task.Run escapes the
+                // SyncContext so the continuation runs on the threadpool.
+                bool ok = Task.Run(() => PlanscapeServerClient.Instance
+                    .LoginAsync(serverUrl.Trim(), email.Trim(), password))
                     .GetAwaiter().GetResult();
 
                 if (!ok)

--- a/StingTools/UI/FolderHealthPanel.cs
+++ b/StingTools/UI/FolderHealthPanel.cs
@@ -10,6 +10,8 @@ using System.Windows.Shapes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using StingTools.Core;
+using Color = System.Windows.Media.Color;
+using Ellipse = System.Windows.Shapes.Ellipse;
 
 namespace StingTools.UI
 {

--- a/StingTools/UI/ProjectFolderSetupDialog.cs
+++ b/StingTools/UI/ProjectFolderSetupDialog.cs
@@ -13,6 +13,8 @@ using Autodesk.Revit.UI;
 using StingTools.Core;
 using TextBox = System.Windows.Controls.TextBox;
 using ComboBox = System.Windows.Controls.ComboBox;
+using Color = System.Windows.Media.Color;
+using Visibility = System.Windows.Visibility;
 
 namespace StingTools.UI
 {


### PR DESCRIPTION
## Summary
This PR fixes deadlock issues that occur when calling async methods from the Revit API thread (specifically within `IExternalEventHandler` contexts). The deadlocks were caused by async continuations attempting to resume on a captured `WPF DispatcherSynchronizationContext` while the dispatcher was blocked waiting for the async operation to complete.

## Key Changes

- **PlatformLinkCommands.cs**: Wrapped two blocking async calls with `Task.Run()` to escape the WPF `DispatcherSynchronizationContext`:
  - `SyncNow()` call in `SyncToPlanscapeServer()` 
  - `LoginAsync()` call in the login command handler
  - Added detailed comments explaining the deadlock scenario and the fix

- **PlanscapeServerClient.cs**: Added `.ConfigureAwait(false)` to four async/await calls to prevent continuations from being posted back to a captured `SynchronizationContext`:
  - `LoginAsync()` method
  - `RefreshTokenAsync()` method  
  - `EnsureAuthenticatedAsync()` method
  - `RestoreSessionAsync()` method

- **FolderHealthPanel.cs & ProjectFolderSetupDialog.cs**: Added explicit using aliases for WPF types (`Color`, `Ellipse`, `Visibility`) to resolve naming ambiguities with Revit API types.

## Implementation Details

The fix uses two complementary approaches:
1. **`Task.Run()` wrapper**: Executes the async operation on the threadpool instead of the API thread, completely escaping the dispatcher context
2. **`.ConfigureAwait(false)`**: Allows continuations to run on the threadpool rather than marshaling back to the dispatcher

These changes ensure that async operations can complete without deadlocking the Revit UI dispatcher when called from `IExternalEventHandler.Execute()` contexts.

https://claude.ai/code/session_01Lorx1j1z7S8G9WnrZFXq74