### PR TITLE
Consolidate project folders into unified root with auto-bootstrap

### DIFF
--- a/StingTools/BIMManager/BIMManagerCommands.cs
+++ b/StingTools/BIMManager/BIMManagerCommands.cs
@@ -6688,9 +6688,14 @@ namespace StingTools.BIMManager
                 string outputDir;
                 if (!string.IsNullOrEmpty(modelPath))
                 {
-                    string dir = Path.GetDirectoryName(modelPath);
                     string name = Path.GetFileNameWithoutExtension(modelPath);
-                    outputDir = Path.Combine(dir, $"{name}_Briefcase_{DateTime.Now:yyyyMMdd_HHmmss}");
+                    // Folder consolidation: nest the briefcase inside the unified
+                    // project root's 17_BRIEFCASE_<code>/ folder rather than a
+                    // sibling timestamp directory next to the .rvt.
+                    string briefcaseRoot = ProjectFolderEngine.GetFolderPath(doc, "BRIEFCASE");
+                    if (string.IsNullOrEmpty(briefcaseRoot))
+                        briefcaseRoot = Path.GetDirectoryName(modelPath);
+                    outputDir = Path.Combine(briefcaseRoot, $"{name}_Briefcase_{DateTime.Now:yyyyMMdd_HHmmss}");
                 }
                 else
                 {

--- a/StingTools/BOQ/BOQRateSourceHeatMapCommand.cs
+++ b/StingTools/BOQ/BOQRateSourceHeatMapCommand.cs
@@ -92,7 +92,12 @@ namespace StingTools.BOQ
                 }
                 html.AppendLine("</table></body></html>");
 
-                string outDir = Path.Combine(Path.GetDirectoryName(doc.PathName ?? "") ?? "", "STING_BOQ_RateHeatMap");
+                // Folder consolidation: nest BOQ heatmap exports inside the
+                // unified project root's 16_COMPLIANCE_<code>/RateHeatMap/ folder.
+                string compRoot = StingTools.Core.ProjectFolderEngine.GetFolderPath(doc, "COMPLIANCE");
+                string outDir = string.IsNullOrEmpty(compRoot)
+                    ? Path.Combine(Path.GetDirectoryName(doc.PathName ?? "") ?? "", "STING_BOQ_RateHeatMap")
+                    : Path.Combine(compRoot, "RateHeatMap");
                 Directory.CreateDirectory(outDir);
                 string ts = DateTime.Now.ToString("yyyyMMdd_HHmm");
                 string htmlPath = Path.Combine(outDir, $"rate_heatmap_{ts}.html");

--- a/StingTools/Clash/ClashDetectionCommands.cs
+++ b/StingTools/Clash/ClashDetectionCommands.cs
@@ -1249,7 +1249,10 @@ namespace StingTools.Clash
             try
             {
                 if (string.IsNullOrEmpty(doc?.PathName)) return "";
-                string dir = Path.Combine(Path.GetDirectoryName(doc.PathName) ?? "", ".bimmanager");
+                // Folder consolidation: nest .bimmanager inside <root>/_data/
+                string dir = StingTools.Core.ProjectFolderEngine.GetMetaPath(doc, ".bimmanager");
+                if (string.IsNullOrEmpty(dir))
+                    dir = Path.Combine(Path.GetDirectoryName(doc.PathName) ?? "", ".bimmanager");
                 if (!Directory.Exists(dir))
                 {
                     try { Directory.CreateDirectory(dir); }

--- a/StingTools/Core/OutputLocationHelper.cs
+++ b/StingTools/Core/OutputLocationHelper.cs
@@ -41,15 +41,25 @@ namespace StingTools.Core
         /// <summary>
         /// Resolve the best output directory using the fallback chain.
         /// Creates the directory if it doesn't exist.
+        ///
+        /// Resolution order:
+        ///   1. Phase 167 unified project root (auto-bootstrapped if missing) → 20_MISC_<code>
+        ///   2. User-configured PreferredDirectory (overrides only if explicitly set)
+        ///   3. System temp (with one-shot warning so the user notices)
+        ///
+        /// The legacy {projectDir}/STING_Exports/ and {Documents}/STING_Exports/
+        /// fallbacks have been removed: every export now lands inside the single
+        /// project container so the user no longer sees a sprawl of sibling
+        /// folders next to the .rvt.
         /// </summary>
         public static string GetOutputDirectory(Document doc = null)
         {
-            // Phase 167: prefer the configured project folder structure when present
+            // 1. Phase 167 — unified project folder structure (auto-bootstrap if needed)
             try
             {
                 if (doc != null)
                 {
-                    var setup = ProjectFolderEngine.LoadOrDetectSetup(doc);
+                    var setup = ProjectFolderEngine.LoadOrBootstrapSetup(doc);
                     if (setup != null)
                     {
                         string projRoot = ProjectFolderEngine.GetExportFolder(doc, "MISC");
@@ -60,35 +70,12 @@ namespace StingTools.Core
             }
             catch (Exception ex) { StingLog.Warn($"GetOutputDirectory setup lookup: {ex.Message}"); }
 
-            // 1. User-preferred directory
+            // 2. User-preferred directory (explicit override only)
             string dir = PreferredDirectory;
             if (!string.IsNullOrEmpty(dir) && TryEnsureDirectory(dir))
                 return dir;
 
-            // 2. Project directory / STING_Exports subfolder
-            if (doc != null && !string.IsNullOrEmpty(doc.PathName))
-            {
-                string projDir = Path.GetDirectoryName(doc.PathName);
-                if (!string.IsNullOrEmpty(projDir))
-                {
-                    string exportsDir = Path.Combine(projDir, "STING_Exports");
-                    if (TryEnsureDirectory(exportsDir))
-                        return exportsDir;
-                    if (TryEnsureDirectory(projDir))
-                        return projDir;
-                }
-            }
-
-            // 3. Documents/STING_Exports
-            string docsDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            if (!string.IsNullOrEmpty(docsDir))
-            {
-                string stingDocsDir = Path.Combine(docsDir, "STING_Exports");
-                if (TryEnsureDirectory(stingDocsDir))
-                    return stingDocsDir;
-            }
-
-            // 4. Temp directory (last resort — warn so user knows exports are not in a project folder)
+            // 3. Temp directory (last resort — warn so user knows exports are not in a project folder)
             string tempDir = Path.GetTempPath();
             StingLog.Warn($"OutputLocationHelper: All preferred directories failed. Falling back to system temp: {tempDir}");
 

--- a/StingTools/Core/ProjectFolderEngine.cs
+++ b/StingTools/Core/ProjectFolderEngine.cs
@@ -178,21 +178,25 @@ namespace StingTools.Core
             if (!string.IsNullOrEmpty(_rootPath) && Directory.Exists(_rootPath))
                 return _rootPath;
 
-            // Try project directory
+            // Try project directory: name root after the project code so the
+            // user sees one container per project (e.g. FIRESTONE_LIBERIA/),
+            // not a generic "STING_Project" sibling.
             if (doc != null && !string.IsNullOrEmpty(doc.PathName))
             {
                 string projDir = Path.GetDirectoryName(doc.PathName);
                 if (!string.IsNullOrEmpty(projDir))
                 {
-                    string stingRoot = Path.Combine(projDir, "STING_Project");
+                    string code = DetectProjectCode(doc);
+                    string stingRoot = Path.Combine(projDir, code);
                     try { Directory.CreateDirectory(stingRoot); _rootPath = stingRoot; return stingRoot; }
                     catch (Exception ex) { StingLog.Warn($"ProjectFolderEngine: Cannot create at project dir: {ex.Message}"); }
                 }
             }
 
-            // Fallback to Documents
+            // Fallback to Documents/<code> when project dir is unwritable
             string docsDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            string fallback = Path.Combine(docsDir, "STING_Project");
+            string codeDocs = doc != null ? DetectProjectCode(doc) : "STING_Project";
+            string fallback = Path.Combine(docsDir, codeDocs);
             try { Directory.CreateDirectory(fallback); _rootPath = fallback; return fallback; }
             catch (Exception ex) { StingLog.Warn($"ProjectFolderEngine: Documents fallback failed: {ex.Message}"); }
 
@@ -247,6 +251,49 @@ namespace StingTools.Core
             }
             catch (Exception ex) { StingLog.Warn($"LoadOrDetectSetup: {ex.Message}"); }
             return null;
+        }
+
+        /// <summary>
+        /// Like LoadOrDetectSetup, but if nothing is persisted, mints a default
+        /// BIM ProjectSetup rooted at <projDir>/<projectCode>/ and persists it.
+        /// Lets every subsystem call into the unified folder structure without
+        /// asking the user to run the Folder Setup wizard first. Idempotent.
+        /// </summary>
+        public static ProjectSetup LoadOrBootstrapSetup(Document doc)
+        {
+            var existing = LoadOrDetectSetup(doc);
+            if (existing != null) return existing;
+            if (doc == null || string.IsNullOrEmpty(doc.PathName) || doc.IsFamilyDocument) return null;
+            try
+            {
+                string code = DetectProjectCode(doc);
+                var setup = ProjectSetup.CreateBIM(code, code); // root = relative folder named after the code
+                setup.RootPathIsRelative = true;
+                setup.ProjectName = "";
+                try { setup.ProjectName = doc.ProjectInformation?.Name ?? ""; } catch { }
+                InitializeSetup(doc, setup);
+                StingLog.Info($"LoadOrBootstrapSetup: minted default BIM setup for {code}");
+                return setup;
+            }
+            catch (Exception ex) { StingLog.Warn($"LoadOrBootstrapSetup: {ex.Message}"); }
+            return null;
+        }
+
+        /// <summary>
+        /// Resolve a metadata bucket path inside the consolidated <root>/_data/
+        /// folder. Replaces 47-site hardcoded sibling-of-RVT folders like
+        /// "_BIM_COORD" / "_bim_manager" / "STING_BIM_MANAGER" by nesting them
+        /// inside the project root, so the user only sees ONE folder per project.
+        /// </summary>
+        public static string GetMetaPath(Document doc, string bucket = null, params string[] subParts)
+        {
+            string data = GetDataPath(doc);
+            if (string.IsNullOrEmpty(data)) return null;
+            string p = string.IsNullOrEmpty(bucket) ? data : Path.Combine(data, bucket);
+            foreach (var part in subParts ?? Array.Empty<string>())
+                if (!string.IsNullOrEmpty(part)) p = Path.Combine(p, part);
+            try { Directory.CreateDirectory(p); } catch (Exception ex) { StingLog.Warn($"GetMetaPath: {ex.Message}"); }
+            return p;
         }
 
         /// <summary>
@@ -366,10 +413,12 @@ namespace StingTools.Core
                 if (setup == null)
                 {
                     // Fall back to legacy folder list if no setup
+                    string codeH = doc != null ? DetectProjectCode(doc) : "";
                     foreach (var (id, name, _, _) in Folders)
                     {
                         string root = GetRootPath(doc);
-                        string p = Path.Combine(root, name);
+                        string suffixedH = ProjectSetup.WithCodeSuffix(name, codeH);
+                        string p = Path.Combine(root, suffixedH);
                         bool ex = Directory.Exists(p);
                         int n = 0; DateTime? lm = null;
                         if (ex)
@@ -487,19 +536,23 @@ namespace StingTools.Core
                 }
                 catch (Exception ex) { rep.Warnings.Add($"Sidecar scan: {ex.Message}"); }
 
-                // 2. Move legacy _BIM_COORD and STING_BIM_MANAGER → _data
-                foreach (string legacyName in new[] { "_BIM_COORD", "STING_BIM_MANAGER" })
+                // 2. Move legacy metadata buckets into _data/<bucket>/ — preserves
+                //    subsystem code that hard-codes these names while tucking the
+                //    files inside the unified project root.
+                foreach (string legacyName in new[] { "_BIM_COORD", "_bim_manager", "STING_BIM_MANAGER" })
                 {
                     string legacy = Path.Combine(projDir, legacyName);
                     if (!Directory.Exists(legacy)) continue;
+                    string bucket = Path.Combine(dataPath, legacyName);
                     try
                     {
+                        Directory.CreateDirectory(bucket);
                         foreach (string f in Directory.GetFiles(legacy, "*.*", SearchOption.AllDirectories))
                         {
                             try
                             {
                                 string rel = f.Substring(legacy.Length).TrimStart(Path.DirectorySeparatorChar);
-                                string dest = Path.Combine(dataPath, rel);
+                                string dest = Path.Combine(bucket, rel);
                                 string ddir = Path.GetDirectoryName(dest);
                                 if (!string.IsNullOrEmpty(ddir)) Directory.CreateDirectory(ddir);
                                 if (File.Exists(dest)) dest = GetUniqueFileName(dest);
@@ -508,11 +561,108 @@ namespace StingTools.Core
                             }
                             catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
                         }
-                        try { if (!Directory.EnumerateFileSystemEntries(legacy).Any()) { Directory.Delete(legacy, true); rep.FoldersRemoved++; } }
+                        try { if (!Directory.EnumerateFiles(legacy, "*.*", SearchOption.AllDirectories).Any()) { Directory.Delete(legacy, true); rep.FoldersRemoved++; } }
                         catch (Exception ex) { rep.Warnings.Add($"Delete {legacy}: {ex.Message}"); }
                     }
                     catch (Exception ex) { rep.Warnings.Add($"Process {legacy}: {ex.Message}"); }
                 }
+
+                // 2b. Hidden helper folder used by clash detection
+                {
+                    string hiddenLegacy = Path.Combine(projDir, ".bimmanager");
+                    if (Directory.Exists(hiddenLegacy))
+                    {
+                        string dest = Path.Combine(dataPath, ".bimmanager");
+                        try
+                        {
+                            Directory.CreateDirectory(dest);
+                            foreach (string f in Directory.GetFiles(hiddenLegacy, "*.*", SearchOption.AllDirectories))
+                            {
+                                try
+                                {
+                                    string rel = f.Substring(hiddenLegacy.Length).TrimStart(Path.DirectorySeparatorChar);
+                                    string dst = Path.Combine(dest, rel);
+                                    string ddir = Path.GetDirectoryName(dst);
+                                    if (!string.IsNullOrEmpty(ddir)) Directory.CreateDirectory(ddir);
+                                    if (File.Exists(dst)) dst = GetUniqueFileName(dst);
+                                    File.Move(f, dst);
+                                    rep.FilesMoved++;
+                                }
+                                catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                            }
+                            try { if (!Directory.EnumerateFiles(hiddenLegacy, "*.*", SearchOption.AllDirectories).Any()) { Directory.Delete(hiddenLegacy, true); rep.FoldersRemoved++; } }
+                            catch (Exception ex) { rep.Warnings.Add($"Delete {hiddenLegacy}: {ex.Message}"); }
+                        }
+                        catch (Exception ex) { rep.Warnings.Add($"Process {hiddenLegacy}: {ex.Message}"); }
+                    }
+                }
+
+                // 2c. Workflow run log written as a flat file alongside the .rvt
+                foreach (string logName in new[] { "STING_WORKFLOW_LOG.json", "STING_WORKFLOW_LOG.jsonl" })
+                {
+                    string src = Path.Combine(projDir, logName);
+                    if (!File.Exists(src)) continue;
+                    try
+                    {
+                        string dst = Path.Combine(dataPath, "workflow_log" + Path.GetExtension(logName));
+                        if (File.Exists(dst)) dst = GetUniqueFileName(dst);
+                        File.Move(src, dst);
+                        rep.FilesMoved++;
+                    }
+                    catch (Exception ex) { rep.Warnings.Add($"Move {src}: {ex.Message}"); }
+                }
+
+                // 2d. BOQ rate-source heat-map exports
+                {
+                    string boqLegacy = Path.Combine(projDir, "STING_BOQ_RateHeatMap");
+                    if (Directory.Exists(boqLegacy))
+                    {
+                        string dest = Path.Combine(GetFolderPath(doc, "COMPLIANCE"), "RateHeatMap");
+                        try
+                        {
+                            Directory.CreateDirectory(dest);
+                            foreach (string f in Directory.GetFiles(boqLegacy, "*.*", SearchOption.AllDirectories))
+                            {
+                                try
+                                {
+                                    string rel = f.Substring(boqLegacy.Length).TrimStart(Path.DirectorySeparatorChar);
+                                    string dst = Path.Combine(dest, rel);
+                                    string ddir = Path.GetDirectoryName(dst);
+                                    if (!string.IsNullOrEmpty(ddir)) Directory.CreateDirectory(ddir);
+                                    if (File.Exists(dst)) dst = GetUniqueFileName(dst);
+                                    File.Move(f, dst);
+                                    rep.FilesMoved++;
+                                }
+                                catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                            }
+                            try { if (!Directory.EnumerateFiles(boqLegacy, "*.*", SearchOption.AllDirectories).Any()) { Directory.Delete(boqLegacy, true); rep.FoldersRemoved++; } }
+                            catch (Exception ex) { rep.Warnings.Add($"Delete {boqLegacy}: {ex.Message}"); }
+                        }
+                        catch (Exception ex) { rep.Warnings.Add($"Process {boqLegacy}: {ex.Message}"); }
+                    }
+                }
+
+                // 2e. Briefcase export folders ({ModelName}_Briefcase_{ts}/)
+                try
+                {
+                    string briefcaseTarget = GetFolderPath(doc, "BRIEFCASE");
+                    if (!string.IsNullOrEmpty(briefcaseTarget) && Directory.Exists(projDir))
+                    {
+                        foreach (string sub in Directory.GetDirectories(projDir, "*_Briefcase_*"))
+                        {
+                            try
+                            {
+                                string subName = Path.GetFileName(sub);
+                                string dest = Path.Combine(briefcaseTarget, subName);
+                                if (Directory.Exists(dest)) dest = GetUniqueFileName(dest);
+                                Directory.Move(sub, dest);
+                                rep.FoldersRemoved++;
+                            }
+                            catch (Exception ex) { rep.Warnings.Add($"Move {sub}: {ex.Message}"); }
+                        }
+                    }
+                }
+                catch (Exception ex) { rep.Warnings.Add($"Briefcase scan: {ex.Message}"); }
 
                 // 3. Move legacy STING_Exports / STING_Project — route by extension
                 foreach (string legacyName in new[] { "STING_Exports", "STING_Project" })
@@ -608,7 +758,8 @@ namespace StingTools.Core
                 }
                 else
                 {
-                    defs = Folders.Select(f => (f.Id, f.Name, false, new List<string>()));
+                    string code0 = doc != null ? DetectProjectCode(doc) : "";
+                    defs = Folders.Select(f => (f.Id, ProjectSetup.WithCodeSuffix(f.Name, code0), false, new List<string>()));
                 }
 
                 foreach (var (id, display, discSubs, subs) in defs)
@@ -756,20 +907,22 @@ namespace StingTools.Core
         public static int CreateFolderStructure(Document doc)
         {
             string root = GetRootPath(doc);
+            string code = doc != null ? DetectProjectCode(doc) : "";
             int created = 0;
             foreach (var (id, name, desc, _) in Folders)
             {
-                string path = Path.Combine(root, name);
+                string suffixed = ProjectSetup.WithCodeSuffix(name, code);
+                string path = Path.Combine(root, suffixed);
                 if (!Directory.Exists(path))
                 {
                     try { Directory.CreateDirectory(path); created++; }
-                    catch (Exception ex) { StingLog.Warn($"ProjectFolderEngine: Cannot create {name}: {ex.Message}"); }
+                    catch (Exception ex) { StingLog.Warn($"ProjectFolderEngine: Cannot create {suffixed}: {ex.Message}"); }
                 }
             }
             // Create sub-folders for CDE folders (CONFIG-02: configurable)
             foreach (string cdeFolder in new[] { "01_WIP", "02_SHARED", "03_PUBLISHED" })
             {
-                string cdePath = Path.Combine(root, cdeFolder);
+                string cdePath = Path.Combine(root, ProjectSetup.WithCodeSuffix(cdeFolder, code));
                 foreach (string disc in _disciplineFolders)
                 {
                     string discPath = Path.Combine(cdePath, disc);
@@ -782,7 +935,7 @@ namespace StingTools.Core
             }
 
             // Create clash sub-folders
-            string clashRoot = Path.Combine(root, "12_CLASHES");
+            string clashRoot = Path.Combine(root, ProjectSetup.WithCodeSuffix("12_CLASHES", code));
             foreach (string sub in new[] { "BCF", "Reports", "Snapshots" })
             {
                 string subPath = Path.Combine(clashRoot, sub);
@@ -794,7 +947,7 @@ namespace StingTools.Core
             }
 
             // Create issue sub-folders by type
-            string issueRoot = Path.Combine(root, "11_ISSUES");
+            string issueRoot = Path.Combine(root, ProjectSetup.WithCodeSuffix("11_ISSUES", code));
             foreach (string sub in new[] { "RFI", "TQ", "NCR", "EWN", "SI", "VO", "AI", "CVI", "CE", "DESIGN", "CLASH", "SNAGGING", "RFA", "PMI" })
             {
                 string subPath = Path.Combine(issueRoot, sub);
@@ -822,7 +975,7 @@ namespace StingTools.Core
             // Phase 167: prefer ProjectSetup folder def (uses user-edited display name)
             try
             {
-                var setup = LoadOrDetectSetup(doc);
+                var setup = LoadOrBootstrapSetup(doc);
                 var def = setup?.GetFolder(folderId);
                 if (def != null)
                 {
@@ -833,9 +986,13 @@ namespace StingTools.Core
             }
             catch (Exception ex) { StingLog.Warn($"GetFolderPath setup: {ex.Message}"); }
 
+            // No setup — apply the project-code suffix to the built-in name so
+            // we still produce a uniquely-named folder (e.g. 20_MISC_FIRESTONE).
+            string code = doc != null ? DetectProjectCode(doc) : "";
             var folder = Folders.FirstOrDefault(f => f.Id.Equals(folderId, StringComparison.OrdinalIgnoreCase));
-            if (folder.Name == null) return Path.Combine(root, "20_MISC");
-            string path = Path.Combine(root, folder.Name);
+            string name = folder.Name ?? "20_MISC";
+            string suffixed = ProjectSetup.WithCodeSuffix(name, code);
+            string path = Path.Combine(root, suffixed);
             if (!Directory.Exists(path))
             {
                 try { Directory.CreateDirectory(path); }
@@ -886,11 +1043,18 @@ namespace StingTools.Core
             var files = new List<ProjectFile>();
             string root = GetRootPath(doc);
             if (!Directory.Exists(root)) return files;
+            string codeAF = doc != null ? DetectProjectCode(doc) : "";
 
             foreach (var (id, name, desc, cde) in Folders)
             {
-                string folderPath = Path.Combine(root, name);
-                if (!Directory.Exists(folderPath)) continue;
+                string folderPath = Path.Combine(root, ProjectSetup.WithCodeSuffix(name, codeAF));
+                if (!Directory.Exists(folderPath))
+                {
+                    // Backwards-compat: fall back to the un-suffixed legacy path
+                    string legacyPath = Path.Combine(root, name);
+                    if (!Directory.Exists(legacyPath)) continue;
+                    folderPath = legacyPath;
+                }
 
                 try
                 {
@@ -939,10 +1103,17 @@ namespace StingTools.Core
             var stats = new List<FolderStats>();
             string root = GetRootPath(doc);
             if (!Directory.Exists(root)) return stats;
+            string codeFS = doc != null ? DetectProjectCode(doc) : "";
 
             foreach (var (id, name, desc, cde) in Folders)
             {
-                string folderPath = Path.Combine(root, name);
+                string suffixedName = ProjectSetup.WithCodeSuffix(name, codeFS);
+                string folderPath = Path.Combine(root, suffixedName);
+                if (!Directory.Exists(folderPath))
+                {
+                    string legacyFs = Path.Combine(root, name);
+                    if (Directory.Exists(legacyFs)) folderPath = legacyFs;
+                }
                 int fileCount = 0;
                 long totalSize = 0;
                 DateTime? lastModified = null;
@@ -1534,12 +1705,11 @@ namespace StingTools.Core
 
             try
             {
-                string bimDir = "";
-                if (doc != null && !string.IsNullOrEmpty(doc.PathName))
-                    bimDir = Path.Combine(Path.GetDirectoryName(doc.PathName) ?? "", "STING_BIM_MANAGER");
-                if (string.IsNullOrEmpty(bimDir) || !Directory.Exists(bimDir))
+                string bimDir = GetMetaPath(doc, "STING_BIM_MANAGER");
+                if (string.IsNullOrEmpty(bimDir))
                 {
-                    try { Directory.CreateDirectory(bimDir); } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); return; }
+                    StingLog.Warn("AutoLogTransmittal: cannot resolve metadata path");
+                    return;
                 }
 
                 string transPath = Path.Combine(bimDir, "transmittals.json");
@@ -1587,9 +1757,8 @@ namespace StingTools.Core
             var groups = new List<ClashGroup>();
             try
             {
-                string bimDir = "";
-                if (doc != null && !string.IsNullOrEmpty(doc.PathName))
-                    bimDir = Path.Combine(Path.GetDirectoryName(doc.PathName) ?? "", "STING_BIM_MANAGER");
+                string bimDir = GetMetaPath(doc, "STING_BIM_MANAGER");
+                if (string.IsNullOrEmpty(bimDir)) return groups;
                 string issuePath = Path.Combine(bimDir, "issues.json");
                 if (!File.Exists(issuePath)) return groups;
 

--- a/StingTools/Core/ProjectSetup.cs
+++ b/StingTools/Core/ProjectSetup.cs
@@ -51,6 +51,9 @@ namespace StingTools.Core
         };
 
         // ── BIM folder defaults (16 numbered folders) ──────────────────────
+        // Display names get suffixed with the project code at setup time
+        // (e.g. "01_WIP" → "01_WIP_FIRESTONE_LIBERIA"). This makes every
+        // folder uniquely identifiable when copied or zipped out of the root.
         public static readonly (string Id, string Name, bool DiscSubs, string[] SubFolders)[] BimFolderDefaults = new[]
         {
             ("WIP",          "01_WIP",          true,  new string[0]),
@@ -69,6 +72,10 @@ namespace StingTools.Core
             ("REVISIONS",    "14_REVISIONS",    false, new string[0]),
             ("REGISTERS",    "15_REGISTERS",    false, new string[0]),
             ("COMPLIANCE",   "16_COMPLIANCE",   false, new string[0]),
+            ("BRIEFCASE",    "17_BRIEFCASE",    false, new string[0]),
+            ("PHOTOS",       "18_PHOTOS",       false, new string[0]),
+            ("CORRESPONDENCE","19_CORRESPONDENCE",false, new string[0]),
+            ("MISC",         "20_MISC",         false, new string[0]),
         };
 
         // ── Mini folder defaults (5 flat folders) ──────────────────────────
@@ -80,6 +87,20 @@ namespace StingTools.Core
             ("DOCUMENTS", "Documents"),
             ("REPORTS",   "Reports"),
         };
+
+        /// <summary>
+        /// Append `_<projectCode>` to a folder display name if not already suffixed.
+        /// Idempotent: WithCodeSuffix("01_WIP", "FIRESTONE") → "01_WIP_FIRESTONE"
+        /// but a second call returns the same string.
+        /// </summary>
+        public static string WithCodeSuffix(string folderName, string projectCode)
+        {
+            if (string.IsNullOrWhiteSpace(folderName)) return folderName;
+            if (string.IsNullOrWhiteSpace(projectCode)) return folderName;
+            string suffix = "_" + projectCode;
+            if (folderName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) return folderName;
+            return folderName + suffix;
+        }
 
         // ── Default export route maps ──────────────────────────────────────
         public static Dictionary<string, string> DefaultBimRoutes() => new(StringComparer.OrdinalIgnoreCase)
@@ -136,7 +157,7 @@ namespace StingTools.Core
                 s.CustomFolders.Add(new FolderDef
                 {
                     Id = id,
-                    DisplayName = name,
+                    DisplayName = WithCodeSuffix(name, s.ProjectCode),
                     HasDisciplineSubfolders = discSubs,
                     SubFolders = subs.ToList(),
                     IsCustom = false,
@@ -161,7 +182,7 @@ namespace StingTools.Core
                 s.CustomFolders.Add(new FolderDef
                 {
                     Id = id,
-                    DisplayName = name,
+                    DisplayName = WithCodeSuffix(name, s.ProjectCode),
                     HasDisciplineSubfolders = false,
                     SubFolders = new List<string>(),
                     IsCustom = false,

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -641,22 +641,34 @@ namespace StingTools.Core
                 }
                 catch (Exception csEx) { StingLog.Warn($"DocumentOpened ClashScheduler start: {csEx.Message}"); }
 
-                // Phase 167: detect persisted ProjectSetup. Do NOT auto-create folders
-                // — that's an explicit user action via the Folder Setup dialog.
+                // Phase 167 + folder consolidation: auto-bootstrap a default
+                // ProjectSetup so every subsystem writes into ONE project root,
+                // then silently sweep any legacy sibling folders (_BIM_COORD,
+                // _bim_manager, STING_BIM_MANAGER, STING_Exports, STING_Project,
+                // .bimmanager, *_Briefcase_*, STING_BOQ_RateHeatMap,
+                // STING_WORKFLOW_LOG.json) into the unified container.
                 try
                 {
-                    if (e.Document != null && !e.Document.IsFamilyDocument)
+                    if (e.Document != null && !e.Document.IsFamilyDocument && !string.IsNullOrEmpty(e.Document.PathName))
                     {
-                        var setup = ProjectFolderEngine.LoadOrDetectSetup(e.Document);
+                        var setup = ProjectFolderEngine.LoadOrBootstrapSetup(e.Document);
                         if (setup != null)
                         {
                             string root = setup.ResolveRootPath(e.Document.PathName);
-                            StingLog.Info($"DocumentOpened: project setup loaded — root={root}, mode={setup.Mode}");
-                        }
-                        else if (TagConfig.AutoCreateCdeFolders && !string.IsNullOrEmpty(e.Document.PathName))
-                        {
-                            // Soft notification: log only. User runs Folder Setup explicitly.
-                            StingLog.Info("DocumentOpened: no ProjectSetup found. User can run Folder Setup from BIM tab.");
+                            StingLog.Info($"DocumentOpened: project setup ready — root={root}, mode={setup.Mode}");
+
+                            // Idempotent silent migration. Only reports if it
+                            // actually moved something — no UI prompt, never
+                            // blocks the open path.
+                            try
+                            {
+                                var rep = ProjectFolderEngine.MigrateFromLegacy(e.Document);
+                                if (rep != null && (rep.FilesMoved > 0 || rep.FoldersRemoved > 0))
+                                {
+                                    StingLog.Info($"DocumentOpened auto-migration: {rep.FilesMoved} files moved, {rep.FoldersRemoved} legacy folders removed.");
+                                }
+                            }
+                            catch (Exception mEx) { StingLog.Warn($"DocumentOpened auto-migration: {mEx.Message}"); }
                         }
                     }
                 }

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -2596,10 +2596,20 @@ namespace StingTools.Core
         private const long MaxLogSizeBytes = 500 * 1024; // 500 KB
 
         /// <summary>
-        /// LOG-13: Get the log file path alongside the project file (or data dir fallback).
+        /// LOG-13: Get the log file path inside the unified project root's
+        /// _data folder so it never appears as a sibling of the .rvt.
         /// </summary>
         private static string GetLogPath(Document doc)
         {
+            // Folder consolidation: prefer <root>/_data/workflow_log.jsonl
+            try
+            {
+                string consolidated = ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated))
+                    return Path.Combine(consolidated, "workflow_log.jsonl");
+            }
+            catch (Exception ex) { StingLog.Warn($"GetLogPath consolidated: {ex.Message}"); }
+
             string dir = null;
             try
             {

--- a/StingTools/Docs/Search/DocumentIndex.cs
+++ b/StingTools/Docs/Search/DocumentIndex.cs
@@ -224,6 +224,14 @@ namespace Planscape.Docs.Search
 
         private static string ResolveProjectRoot(Autodesk.Revit.DB.Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Templates/DeliverableLifecycle.cs
+++ b/StingTools/Docs/Templates/DeliverableLifecycle.cs
@@ -217,6 +217,14 @@ namespace Planscape.Docs.Templates
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Templates/DocumentIdentityGenerator.cs
+++ b/StingTools/Docs/Templates/DocumentIdentityGenerator.cs
@@ -166,6 +166,14 @@ namespace Planscape.Docs.Templates
 
         private static string TryProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 if (doc != null)

--- a/StingTools/Docs/Templates/EmbeddedTemplates.cs
+++ b/StingTools/Docs/Templates/EmbeddedTemplates.cs
@@ -153,6 +153,14 @@ namespace Planscape.Docs.Templates
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Templates/TemplateEngine.cs
+++ b/StingTools/Docs/Templates/TemplateEngine.cs
@@ -99,6 +99,14 @@ namespace Planscape.Docs.Templates
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Templates/TransmittalOrchestrator.cs
+++ b/StingTools/Docs/Templates/TransmittalOrchestrator.cs
@@ -172,6 +172,14 @@ namespace Planscape.Docs.Templates
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Workflow/AuditLog.cs
+++ b/StingTools/Docs/Workflow/AuditLog.cs
@@ -198,6 +198,14 @@ namespace Planscape.Docs.Workflow
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Workflow/DistributionGroups.cs
+++ b/StingTools/Docs/Workflow/DistributionGroups.cs
@@ -106,6 +106,14 @@ namespace Planscape.Docs.Workflow
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Workflow/WorkflowEngine.cs
+++ b/StingTools/Docs/Workflow/WorkflowEngine.cs
@@ -195,6 +195,14 @@ namespace Planscape.Docs.Workflow
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/Docs/Workflow/WorkflowRegistry.cs
+++ b/StingTools/Docs/Workflow/WorkflowRegistry.cs
@@ -52,6 +52,14 @@ namespace Planscape.Docs.Workflow
 
         private static string ResolveProjectRoot(Document doc)
         {
+            // Folder consolidation: nest "_BIM_COORD" inside the unified
+            // project root's _data folder rather than as a sibling of the .rvt.
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated)) return consolidated;
+            }
+            catch { /* fall through to legacy lookup */ }
             try
             {
                 string p = doc?.PathName;

--- a/StingTools/UI/BEPDashboard.cs
+++ b/StingTools/UI/BEPDashboard.cs
@@ -21,21 +21,23 @@ namespace StingTools.UI
 
     internal static class BEPDashboard
     {
-        // ── Frozen brush pattern ──
+        // Palette routed through ThemeManager so the dashboard tracks the
+        // active theme (Corporate by default — navy header, orange accent).
         private static SolidColorBrush FZ(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
 
-        private static readonly SolidColorBrush BgBrush = FZ(Color.FromRgb(0xF5, 0xF5, 0xF5));
-        private static readonly SolidColorBrush HeaderBg = FZ(Color.FromRgb(0x1A, 0x23, 0x7E));
-        private static readonly SolidColorBrush AccentBrush = FZ(Color.FromRgb(0xE8, 0x91, 0x2D));
-        private static readonly SolidColorBrush PanelBg = FZ(Brushes.White.Color);
-        private static readonly SolidColorBrush FgDark = FZ(Color.FromRgb(0x22, 0x22, 0x22));
-        private static readonly SolidColorBrush FgWhite = FZ(Colors.White);
-        private static readonly SolidColorBrush FgMuted = FZ(Color.FromRgb(0x66, 0x66, 0x66));
-        private static readonly SolidColorBrush BorderLight = FZ(Color.FromRgb(0xDD, 0xDD, 0xDD));
-        private static readonly SolidColorBrush GreenAccent = FZ(Color.FromRgb(0x2E, 0x7D, 0x32));
-        private static readonly SolidColorBrush BlueAccent = FZ(Color.FromRgb(0x15, 0x65, 0xC0));
+        private static SolidColorBrush BgBrush      => ThemeManager.GetBrush("AltRowBg");
+        private static SolidColorBrush HeaderBg     => ThemeManager.GetBrush("HeaderBg");
+        private static SolidColorBrush AccentBrush  => ThemeManager.GetBrush("AccentBrush");
+        private static SolidColorBrush PanelBg      => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush FgDark       => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush FgWhite      => ThemeManager.GetBrush("HeaderFg");
+        private static SolidColorBrush FgMuted      => ThemeManager.GetBrush("SubtleFg");
+        private static SolidColorBrush BorderLight  => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush GreenAccent  => ThemeManager.GetBrush("SuccessColor");
+        private static SolidColorBrush BlueAccent   => ThemeManager.GetBrush("InfoBlue");
+        private static SolidColorBrush RedAccent    => ThemeManager.GetBrush("ErrorColor");
+        // Brand-fixed accent retained outside the theme matrix
         private static readonly SolidColorBrush PurpleAccent = FZ(Color.FromRgb(0x6A, 0x1B, 0x9A));
-        private static readonly SolidColorBrush RedAccent = FZ(Color.FromRgb(0xC6, 0x28, 0x28));
 
         // ── Field references for value collection ──
         private static TextBox _txtProjectName;

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -38,18 +38,26 @@ namespace StingTools.UI
 
     internal class BIMCoordinationCenter : Window
     {
-        // ── Theme colours ──
-        private static readonly Color CHeaderBg    = Color.FromRgb(0x1A, 0x23, 0x7E);
-        private static readonly Color CAccent      = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color CCardBg      = Colors.White;
-        private static readonly Color CPageBg      = Color.FromRgb(0xF4, 0xF5, 0xF7);
-        private static readonly Color CBorder      = Color.FromRgb(0xE0, 0xE0, 0xE8);
-        private static readonly Color CNavBg       = Color.FromRgb(0x1E, 0x27, 0x45);
-        private static readonly Color CNavHover    = Color.FromRgb(0x2A, 0x35, 0x5A);
-        private static readonly Color CNavSelected = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color CGreen       = Color.FromRgb(0x2E, 0x7D, 0x32);
-        private static readonly Color CAmber       = Color.FromRgb(0xF5, 0x7F, 0x17);
-        private static readonly Color CRed         = Color.FromRgb(0xC6, 0x28, 0x28);
+        // ── Theme palette routed through ThemeManager ──
+        // Theme-driven colours: read live from the active palette so the
+        // BCC tracks Corporate (default), Light, Warm, or Cool when the
+        // user cycles themes. The `darken` helper produces a navy nav
+        // panel that's visibly subordinate to the brand-navy header.
+        private static Color CHeaderBg    => BrushColor("HeaderBg");
+        private static Color CAccent      => BrushColor("AccentBrush");
+        private static Color CCardBg      => BrushColor("CardBg");
+        private static Color CPageBg      => BrushColor("PrimaryBg");
+        private static Color CBorder      => BrushColor("BorderColor");
+        private static Color CNavBg       => Darken(BrushColor("HeaderBg"), 0.85);
+        private static Color CNavHover    => Darken(BrushColor("HeaderBg"), 0.92);
+        private static Color CNavSelected => BrushColor("AccentBrush");
+        private static Color CGreen       => BrushColor("SuccessColor");
+        private static Color CAmber       => BrushColor("WarningColor");
+        private static Color CRed         => BrushColor("ErrorColor");
+
+        private static Color BrushColor(string key) => ((SolidColorBrush)ThemeManager.GetBrush(key)).Color;
+        private static Color Darken(Color c, double f)
+            => Color.FromArgb(c.A, (byte)(c.R * f), (byte)(c.G * f), (byte)(c.B * f));
 
         private static SolidColorBrush Br(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
 

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -98,14 +98,16 @@ namespace StingTools.UI
 
         // ── Theming ────────────────────────────────────────────────────────
 
-        private static readonly Brush NavyBrush = new SolidColorBrush(Color.FromRgb(0x1A, 0x23, 0x7E));
-        private static readonly Brush OrangeBrush = new SolidColorBrush(Color.FromRgb(0xE8, 0x91, 0x2D));
-        private static readonly Brush GreenBrush = new SolidColorBrush(Color.FromRgb(0x2E, 0x7D, 0x32));
-        private static readonly Brush AmberBrush = new SolidColorBrush(Color.FromRgb(0xE6, 0x8A, 0x00));
-        private static readonly Brush RedBrush = new SolidColorBrush(Color.FromRgb(0xC6, 0x28, 0x28));
-        private static readonly Brush PanelBg = new SolidColorBrush(Color.FromRgb(0xF5, 0xF6, 0xFA));
-        private static readonly Brush HeaderFg = new SolidColorBrush(Color.FromRgb(0xFF, 0xFF, 0xFF));
-        private static readonly Brush BorderColor = new SolidColorBrush(Color.FromRgb(0xD1, 0xD5, 0xDB));
+        // Theme-routed palette: tracks ThemeManager so the panel follows
+        // the active theme (Corporate by default — navy header, orange accent).
+        private static Brush NavyBrush   => ThemeManager.GetBrush("HeaderBg");
+        private static Brush OrangeBrush => ThemeManager.GetBrush("AccentBrush");
+        private static Brush GreenBrush  => ThemeManager.GetBrush("SuccessColor");
+        private static Brush AmberBrush  => ThemeManager.GetBrush("WarningColor");
+        private static Brush RedBrush    => ThemeManager.GetBrush("ErrorColor");
+        private static Brush PanelBg     => ThemeManager.GetBrush("PrimaryBg");
+        private static Brush HeaderFg    => ThemeManager.GetBrush("HeaderFg");
+        private static Brush BorderColor => ThemeManager.GetBrush("BorderColor");
 
         static BOQCostManagerPanel()
         {

--- a/StingTools/UI/COBieExportDashboard.cs
+++ b/StingTools/UI/COBieExportDashboard.cs
@@ -30,20 +30,22 @@ namespace StingTools.UI
     /// </summary>
     internal static class COBieExportDashboard
     {
-        // ── Frozen Brushes ──────────────────────────────────────────────
+        // ── Theme-routed palette ─────────────────────────────────────────
+        // All colours come from ThemeManager so the dashboard tracks the
+        // active theme (Corporate by default — navy header, orange accent).
         private static SolidColorBrush FZ(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
 
-        private static readonly SolidColorBrush BgBrush = FZ(Color.FromRgb(0xF5, 0xF5, 0xF5));
-        private static readonly SolidColorBrush HeaderBg = FZ(Color.FromRgb(0x1A, 0x23, 0x7E));
-        private static readonly SolidColorBrush AccentBrush = FZ(Color.FromRgb(0xE8, 0x91, 0x2D));
-        private static readonly SolidColorBrush PanelBg = FZ(Colors.White);
-        private static readonly SolidColorBrush FgDark = FZ(Color.FromRgb(0x22, 0x22, 0x22));
-        private static readonly SolidColorBrush FgWhite = FZ(Colors.White);
-        private static readonly SolidColorBrush FgMuted = FZ(Color.FromRgb(0x66, 0x66, 0x66));
-        private static readonly SolidColorBrush BorderLight = FZ(Color.FromRgb(0xDD, 0xDD, 0xDD));
-        private static readonly SolidColorBrush GreenAccent = FZ(Color.FromRgb(0x2E, 0x7D, 0x32));
-        private static readonly SolidColorBrush BlueAccent = FZ(Color.FromRgb(0x15, 0x65, 0xC0));
-        private static readonly SolidColorBrush RedAccent = FZ(Color.FromRgb(0xC6, 0x28, 0x28));
+        private static SolidColorBrush BgBrush     => ThemeManager.GetBrush("AltRowBg");
+        private static SolidColorBrush HeaderBg    => ThemeManager.GetBrush("HeaderBg");
+        private static SolidColorBrush AccentBrush => ThemeManager.GetBrush("AccentBrush");
+        private static SolidColorBrush PanelBg     => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush FgDark      => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush FgWhite     => ThemeManager.GetBrush("HeaderFg");
+        private static SolidColorBrush FgMuted     => ThemeManager.GetBrush("SubtleFg");
+        private static SolidColorBrush BorderLight => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush GreenAccent => ThemeManager.GetBrush("SuccessColor");
+        private static SolidColorBrush BlueAccent  => ThemeManager.GetBrush("InfoBlue");
+        private static SolidColorBrush RedAccent   => ThemeManager.GetBrush("ErrorColor");
 
         // ── Preset list ─────────────────────────────────────────────────
         private static readonly string[] PresetKeys = new[]

--- a/StingTools/UI/DocAutomationDialog.cs
+++ b/StingTools/UI/DocAutomationDialog.cs
@@ -32,7 +32,7 @@ namespace StingTools.UI
         // ── Theme colours (light theme with orange accents) ─────────────
         private static readonly Color BgLight = Color.FromRgb(0xF5, 0xF5, 0xF5);
         private static readonly Color BgWhite = Color.FromRgb(0xFF, 0xFF, 0xFF);
-        private static readonly Color BgHeader = Color.FromRgb(0x2D, 0x2D, 0x30);
+        private static readonly Color BgHeader = Color.FromRgb(0x1A, 0x23, 0x7E);
         private static readonly Color AccentOrange = Color.FromRgb(0xE8, 0x91, 0x2D);
         private static readonly Color AccentOrangeHover = Color.FromRgb(0xF0, 0xA0, 0x45);
         private static readonly Color FgDark = Color.FromRgb(0x22, 0x22, 0x22);

--- a/StingTools/UI/FolderHealthPanel.cs
+++ b/StingTools/UI/FolderHealthPanel.cs
@@ -21,16 +21,17 @@ namespace StingTools.UI
     /// </summary>
     public class FolderHealthPanel : UserControl
     {
-        private static readonly SolidColorBrush BgDark   = new(Color.FromRgb(0x1E, 0x1E, 0x1E));
-        private static readonly SolidColorBrush BgPanel  = new(Color.FromRgb(0x25, 0x25, 0x26));
-        private static readonly SolidColorBrush BgRow    = new(Color.FromRgb(0x2D, 0x2D, 0x30));
-        private static readonly SolidColorBrush FgWhite  = new(Color.FromRgb(0xFF, 0xFF, 0xFF));
-        private static readonly SolidColorBrush FgSubtle = new(Color.FromRgb(0xAA, 0xAA, 0xAA));
-        private static readonly SolidColorBrush Accent   = new(Color.FromRgb(0x00, 0x78, 0xD4));
-        private static readonly SolidColorBrush BrBorder = new(Color.FromRgb(0x40, 0x40, 0x40));
-        private static readonly SolidColorBrush Green    = new(Color.FromRgb(0x4C, 0xAF, 0x50));
-        private static readonly SolidColorBrush Amber    = new(Color.FromRgb(0xFF, 0xC1, 0x07));
-        private static readonly SolidColorBrush Red      = new(Color.FromRgb(0xF4, 0x43, 0x36));
+        // Corporate palette — matches ThemeManager "Corporate" + StingTools brand
+        private static readonly SolidColorBrush BgDark   = new(Color.FromRgb(0xFA, 0xFA, 0xFA));  // page bg
+        private static readonly SolidColorBrush BgPanel  = new(Color.FromRgb(0xEC, 0xEF, 0xF1));  // header / read-only panel
+        private static readonly SolidColorBrush BgRow    = new(Color.FromRgb(0xFF, 0xFF, 0xFF));  // row bg
+        private static readonly SolidColorBrush FgWhite  = new(Color.FromRgb(0x37, 0x47, 0x4F));  // body text (slate)
+        private static readonly SolidColorBrush FgSubtle = new(Color.FromRgb(0x60, 0x7D, 0x8B));  // muted slate
+        private static readonly SolidColorBrush Accent   = new(Color.FromRgb(0x1A, 0x23, 0x7E));  // STING navy
+        private static readonly SolidColorBrush BrBorder = new(Color.FromRgb(0xCF, 0xD8, 0xDC));  // light slate
+        private static readonly SolidColorBrush Green    = new(Color.FromRgb(0x2E, 0x7D, 0x32));
+        private static readonly SolidColorBrush Amber    = new(Color.FromRgb(0xE6, 0x51, 0x00));
+        private static readonly SolidColorBrush Red      = new(Color.FromRgb(0xB7, 0x1C, 0x1C));
 
         private readonly UIApplication _uiapp;
         private TextBlock _header;

--- a/StingTools/UI/HeadingStyleDialog.cs
+++ b/StingTools/UI/HeadingStyleDialog.cs
@@ -43,7 +43,7 @@ namespace StingTools.UI
         private static readonly Color CardBorder = Color.FromRgb(0xCF, 0xD8, 0xDC);
         private static readonly Color FgColor = Color.FromRgb(0x22, 0x22, 0x22);
         private static readonly Color SubtleColor = Color.FromRgb(0x66, 0x66, 0x66);
-        private static readonly Color PreviewBg = Color.FromRgb(0x1E, 0x1E, 0x1E);
+        private static readonly Color PreviewBg = Color.FromRgb(0x1A, 0x23, 0x7E);
 
         private HeadingStyleDialog(string currentTier2Style, string currentTier3Style)
         {

--- a/StingTools/UI/IssueTrackerDashboard.cs
+++ b/StingTools/UI/IssueTrackerDashboard.cs
@@ -31,22 +31,26 @@ namespace StingTools.UI
     /// </summary>
     internal static class IssueTrackerDashboard
     {
-        // ── Frozen Brushes ──────────────────────────────────────────────
+        // ── Theme-routed palette ─────────────────────────────────────────
+        // Theme constants come from ThemeManager so the dashboard follows
+        // the active theme (Corporate by default). Severity-specific
+        // brushes (Critical/High/Medium/Low) stay fixed to industry RAG.
         private static SolidColorBrush FZ(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
 
-        private static readonly SolidColorBrush BgBrush       = FZ(Color.FromRgb(0xF5, 0xF5, 0xF5));
-        private static readonly SolidColorBrush HeaderBrush    = FZ(Color.FromRgb(0x1A, 0x23, 0x7E));
-        private static readonly SolidColorBrush AccentBrush    = FZ(Color.FromRgb(0xE8, 0x91, 0x2D));
-        private static readonly SolidColorBrush PanelBrush     = FZ(Color.FromRgb(0xFF, 0xFF, 0xFF));
-        private static readonly SolidColorBrush FgDarkBrush    = FZ(Color.FromRgb(0x22, 0x22, 0x22));
-        private static readonly SolidColorBrush FgLightBrush   = FZ(Color.FromRgb(0xFF, 0xFF, 0xFF));
-        private static readonly SolidColorBrush BorderBrush    = FZ(Color.FromRgb(0xDD, 0xDD, 0xDD));
-        private static readonly SolidColorBrush CriticalBrush  = FZ(Color.FromRgb(0xE5, 0x39, 0x35));
-        private static readonly SolidColorBrush HighBrush      = FZ(Color.FromRgb(0xFB, 0x8C, 0x00));
-        private static readonly SolidColorBrush MediumBrush    = FZ(Color.FromRgb(0xFD, 0xD8, 0x35));
-        private static readonly SolidColorBrush LowBrush       = FZ(Color.FromRgb(0x43, 0xA0, 0x47));
-        private static readonly SolidColorBrush SubtleBgBrush  = FZ(Color.FromRgb(0xF0, 0xF0, 0xF0));
-        private static readonly SolidColorBrush HoverBrush     = FZ(Color.FromRgb(0xE3, 0xF2, 0xFD));
+        private static SolidColorBrush BgBrush      => ThemeManager.GetBrush("AltRowBg");
+        private static SolidColorBrush HeaderBrush  => ThemeManager.GetBrush("HeaderBg");
+        private static SolidColorBrush AccentBrush  => ThemeManager.GetBrush("AccentBrush");
+        private static SolidColorBrush PanelBrush   => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush FgDarkBrush  => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush FgLightBrush => ThemeManager.GetBrush("HeaderFg");
+        private static SolidColorBrush BorderBrush  => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush SubtleBgBrush => ThemeManager.GetBrush("SecondaryBg");
+        private static SolidColorBrush HoverBrush   => ThemeManager.GetBrush("RowHover");
+        // Severity colours stay fixed (Critical/High/Medium/Low RAG)
+        private static readonly SolidColorBrush CriticalBrush = FZ(Color.FromRgb(0xE5, 0x39, 0x35));
+        private static readonly SolidColorBrush HighBrush     = FZ(Color.FromRgb(0xFB, 0x8C, 0x00));
+        private static readonly SolidColorBrush MediumBrush   = FZ(Color.FromRgb(0xFD, 0xD8, 0x35));
+        private static readonly SolidColorBrush LowBrush      = FZ(Color.FromRgb(0x43, 0xA0, 0x47));
 
         // Phase 78 Section 2.3: Issue types now sourced from BIMCoordinationCenter.IsoIssueTypes
         // Kept as property for backward compatibility with any remaining direct IssueTypes[] references.

--- a/StingTools/UI/NewSheetDialog.cs
+++ b/StingTools/UI/NewSheetDialog.cs
@@ -24,7 +24,7 @@ namespace StingTools.UI
         // ── Theme colours (matching Sheet Manager) ───────────────────
         private static readonly SolidColorBrush BrBgLight = new(Color.FromRgb(0xF5, 0xF5, 0xF5));
         private static readonly SolidColorBrush BrBgWhite = new(Color.FromRgb(0xFF, 0xFF, 0xFF));
-        private static readonly SolidColorBrush BrBgHeader = new(Color.FromRgb(0x2D, 0x2D, 0x30));
+        private static readonly SolidColorBrush BrBgHeader = new(Color.FromRgb(0x1A, 0x23, 0x7E));
         private static readonly SolidColorBrush BrAccent = new(Color.FromRgb(0xE8, 0x91, 0x2D));
         private static readonly SolidColorBrush BrFgDark = new(Color.FromRgb(0x22, 0x22, 0x22));
         private static readonly SolidColorBrush BrFgWhite = new(Color.FromRgb(0xFF, 0xFF, 0xFF));

--- a/StingTools/UI/ProjectFolderSetupDialog.cs
+++ b/StingTools/UI/ProjectFolderSetupDialog.cs
@@ -24,16 +24,16 @@ namespace StingTools.UI
     /// </summary>
     public class ProjectFolderSetupDialog
     {
-        // ── Theme ──
-        private static readonly SolidColorBrush BgDark   = new(Color.FromRgb(0x1E, 0x1E, 0x1E));
-        private static readonly SolidColorBrush BgPanel  = new(Color.FromRgb(0x25, 0x25, 0x26));
-        private static readonly SolidColorBrush BgInput  = new(Color.FromRgb(0x2D, 0x2D, 0x30));
-        private static readonly SolidColorBrush FgWhite  = new(Color.FromRgb(0xFF, 0xFF, 0xFF));
-        private static readonly SolidColorBrush FgSubtle = new(Color.FromRgb(0xAA, 0xAA, 0xAA));
-        private static readonly SolidColorBrush Accent   = new(Color.FromRgb(0x00, 0x78, 0xD4));
-        private static readonly SolidColorBrush BrBorder = new(Color.FromRgb(0x40, 0x40, 0x40));
-        private static readonly SolidColorBrush Yellow   = new(Color.FromRgb(0xFF, 0xC1, 0x07));
-        private static readonly SolidColorBrush Green    = new(Color.FromRgb(0x4C, 0xAF, 0x50));
+        // ── Theme (Corporate — matches ThemeManager "Corporate" palette) ──
+        private static readonly SolidColorBrush BgDark   = new(Color.FromRgb(0xFA, 0xFA, 0xFA));  // PrimaryBg
+        private static readonly SolidColorBrush BgPanel  = new(Color.FromRgb(0xEC, 0xEF, 0xF1));  // HeaderBg / read-only panel
+        private static readonly SolidColorBrush BgInput  = new(Color.FromRgb(0xFF, 0xFF, 0xFF));  // input/grid background
+        private static readonly SolidColorBrush FgWhite  = new(Color.FromRgb(0x37, 0x47, 0x4F));  // PanelFg slate
+        private static readonly SolidColorBrush FgSubtle = new(Color.FromRgb(0x60, 0x7D, 0x8B));  // muted slate
+        private static readonly SolidColorBrush Accent   = new(Color.FromRgb(0x19, 0x76, 0xD2));  // corporate blue
+        private static readonly SolidColorBrush BrBorder = new(Color.FromRgb(0xCF, 0xD8, 0xDC));  // light slate border
+        private static readonly SolidColorBrush Yellow   = new(Color.FromRgb(0xFF, 0xC1, 0x07));  // amber banner
+        private static readonly SolidColorBrush Green    = new(Color.FromRgb(0x2E, 0x7D, 0x32));  // success
 
         public ProjectSetup Result { get; private set; }
 
@@ -524,7 +524,7 @@ namespace StingTools.UI
             cancel.Click += (s, e) => { _window.DialogResult = false; _window.Close(); };
             var ok = MakeButton("Create Folders", 130);
             ok.Background = Accent;
-            ok.Foreground = FgWhite;
+            ok.Foreground = Brushes.White;
             ok.FontWeight = FontWeights.Bold;
             ok.Click += OnCreateFolders;
             buttons.Children.Add(cancel);

--- a/StingTools/UI/RevisionManagerDashboard.cs
+++ b/StingTools/UI/RevisionManagerDashboard.cs
@@ -27,29 +27,22 @@ namespace StingTools.UI
     /// </summary>
     internal static class RevisionManagerDashboard
     {
-        // ── Theme colours (light corporate with orange accents) ─────────
-        private static readonly Color BgLight = Color.FromRgb(0xF5, 0xF5, 0xF5);
-        private static readonly Color BgWhite = Color.FromRgb(0xFF, 0xFF, 0xFF);
-        private static readonly Color BgHeader = Color.FromRgb(0x1A, 0x23, 0x7E);
-        private static readonly Color AccentOrange = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color FgDark = Color.FromRgb(0x22, 0x22, 0x22);
-        private static readonly Color FgSubtle = Color.FromRgb(0x77, 0x77, 0x77);
-        private static readonly Color BorderLight = Color.FromRgb(0xD0, 0xD0, 0xD0);
-        private static readonly Color CardBg = Color.FromRgb(0xFF, 0xFF, 0xFF);
-        private static readonly Color CardHover = Color.FromRgb(0xFD, 0xF0, 0xE0);
-
+        // ── Theme-routed palette ─────────────────────────────────────────
+        // All colours come from ThemeManager so the dashboard follows the
+        // active theme (Corporate by default — navy header, orange accent).
         private static SolidColorBrush FZ(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
-        private static readonly SolidColorBrush BrBgLight = FZ(BgLight);
-        private static readonly SolidColorBrush BrBgWhite = FZ(BgWhite);
-        private static readonly SolidColorBrush BrBgHeader = FZ(BgHeader);
-        private static readonly SolidColorBrush BrAccent = FZ(AccentOrange);
-        private static readonly SolidColorBrush BrFgDark = FZ(FgDark);
-        private static readonly SolidColorBrush BrFgSubtle = FZ(FgSubtle);
-        private static readonly SolidColorBrush BrBorder = FZ(BorderLight);
-        private static readonly SolidColorBrush BrCardBg = FZ(CardBg);
-        private static readonly SolidColorBrush BrCardHover = FZ(CardHover);
-        private static readonly SolidColorBrush BrWhite = FZ(Colors.White);
-        private static readonly SolidColorBrush BrHeaderFg = FZ(Color.FromRgb(0xA0, 0xA0, 0xA0));
+
+        private static SolidColorBrush BrBgLight   => ThemeManager.GetBrush("AltRowBg");
+        private static SolidColorBrush BrBgWhite   => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrBgHeader  => ThemeManager.GetBrush("HeaderBg");
+        private static SolidColorBrush BrAccent    => ThemeManager.GetBrush("AccentBrush");
+        private static SolidColorBrush BrFgDark    => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush BrFgSubtle  => ThemeManager.GetBrush("SubtleFg");
+        private static SolidColorBrush BrBorder    => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush BrCardBg    => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrCardHover => ThemeManager.GetBrush("RowHover");
+        private static SolidColorBrush BrWhite     => ThemeManager.GetBrush("HeaderFg");
+        private static SolidColorBrush BrHeaderFg  => ThemeManager.GetBrush("HeaderFg");
 
         /// <summary>
         /// Show the Revision Manager Dashboard and return the user's selection.

--- a/StingTools/UI/SchedulingCostDashboard.cs
+++ b/StingTools/UI/SchedulingCostDashboard.cs
@@ -35,37 +35,27 @@ namespace StingTools.UI
     /// </summary>
     internal static class SchedulingCostDashboard
     {
-        // ── Theme colours (light corporate theme) ───────────────────────
-        private static readonly Color BgLight      = Color.FromRgb(0xF5, 0xF5, 0xF5);
-        private static readonly Color BgWhite      = Colors.White;
-        private static readonly Color HeaderBg     = Color.FromRgb(0x1A, 0x23, 0x7E);
-        private static readonly Color AccentOrange = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color FgDark       = Color.FromRgb(0x22, 0x22, 0x22);
-        private static readonly Color FgSubtle     = Color.FromRgb(0x77, 0x77, 0x77);
-        private static readonly Color BorderLight  = Color.FromRgb(0xD0, 0xD0, 0xD0);
-        private static readonly Color CardBg       = Colors.White;
-        private static readonly Color CardHover    = Color.FromRgb(0xFD, 0xF0, 0xE0);
-        private static readonly Color SectionBg    = Color.FromRgb(0xF0, 0xF0, 0xF0);
-        private static readonly Color InfoBg       = Color.FromRgb(0xE8, 0xF0, 0xFE);
-        private static readonly Color InfoBorder   = Color.FromRgb(0xB0, 0xC8, 0xE8);
-        private static readonly Color TabDefault   = Color.FromRgb(0xE0, 0xE0, 0xE0);
-
+        // ── Theme-routed palette ─────────────────────────────────────────
+        // All colours come from ThemeManager so the dashboard follows the
+        // active theme (Corporate by default — navy header, orange accent).
         private static SolidColorBrush FZ(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
 
-        private static readonly SolidColorBrush BrBgLight     = FZ(BgLight);
-        private static readonly SolidColorBrush BrBgWhite     = FZ(BgWhite);
-        private static readonly SolidColorBrush BrHeaderBg    = FZ(HeaderBg);
-        private static readonly SolidColorBrush BrAccent      = FZ(AccentOrange);
-        private static readonly SolidColorBrush BrFgDark      = FZ(FgDark);
-        private static readonly SolidColorBrush BrFgSubtle    = FZ(FgSubtle);
-        private static readonly SolidColorBrush BrBorder      = FZ(BorderLight);
-        private static readonly SolidColorBrush BrCardBg      = FZ(CardBg);
-        private static readonly SolidColorBrush BrCardHover   = FZ(CardHover);
-        private static readonly SolidColorBrush BrSectionBg   = FZ(SectionBg);
-        private static readonly SolidColorBrush BrInfoBg      = FZ(InfoBg);
-        private static readonly SolidColorBrush BrInfoBorder  = FZ(InfoBorder);
-        private static readonly SolidColorBrush BrWhiteFg     = FZ(Colors.White);
-        private static readonly SolidColorBrush BrTabDefault  = FZ(TabDefault);
+        private static SolidColorBrush BrBgLight    => ThemeManager.GetBrush("AltRowBg");
+        private static SolidColorBrush BrBgWhite    => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrHeaderBg   => ThemeManager.GetBrush("HeaderBg");
+        private static SolidColorBrush BrAccent     => ThemeManager.GetBrush("AccentBrush");
+        private static SolidColorBrush BrFgDark     => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush BrFgSubtle   => ThemeManager.GetBrush("SubtleFg");
+        private static SolidColorBrush BrBorder     => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush BrCardBg     => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrCardHover  => ThemeManager.GetBrush("RowHover");
+        private static SolidColorBrush BrSectionBg  => ThemeManager.GetBrush("SecondaryBg");
+        private static SolidColorBrush BrWhiteFg    => ThemeManager.GetBrush("HeaderFg");
+        private static SolidColorBrush BrTabDefault => ThemeManager.GetBrush("TabBg");
+
+        // Light info/highlight box (BIM info banner) — fixed corporate blue tint
+        private static readonly SolidColorBrush BrInfoBg     = FZ(Color.FromRgb(0xE8, 0xF0, 0xFE));
+        private static readonly SolidColorBrush BrInfoBorder = FZ(Color.FromRgb(0xB0, 0xC8, 0xE8));
 
         // ── State ───────────────────────────────────────────────────────
         private static Window _win;

--- a/StingTools/UI/SheetManagerDialog.cs
+++ b/StingTools/UI/SheetManagerDialog.cs
@@ -41,7 +41,7 @@ namespace StingTools.UI
         // ── Theme colours ───────────────────────────────────────────────
         private static readonly SolidColorBrush BrBgLight = new(Color.FromRgb(0xF5, 0xF5, 0xF5));
         private static readonly SolidColorBrush BrBgWhite = new(Color.FromRgb(0xFF, 0xFF, 0xFF));
-        private static readonly SolidColorBrush BrBgHeader = new(Color.FromRgb(0x2D, 0x2D, 0x30));
+        private static readonly SolidColorBrush BrBgHeader = new(Color.FromRgb(0x1A, 0x23, 0x7E));
         private static readonly SolidColorBrush BrAccent = new(Color.FromRgb(0xE8, 0x91, 0x2D));
         private static readonly SolidColorBrush BrFgDark = new(Color.FromRgb(0x22, 0x22, 0x22));
         private static readonly SolidColorBrush BrFgWhite = new(Color.FromRgb(0xFF, 0xFF, 0xFF));

--- a/StingTools/UI/StickyDashboardDialog.cs
+++ b/StingTools/UI/StickyDashboardDialog.cs
@@ -70,7 +70,7 @@ namespace StingTools.UI
             Width = 900;
             Height = 600;
             WindowStartupLocation = WindowStartupLocation.CenterScreen;
-            Background = new SolidColorBrush(Color.FromRgb(0xF5, 0xF5, 0xF5));
+            Background = ThemeManager.GetBrush("AltRowBg");
 
             try
             {
@@ -89,7 +89,7 @@ namespace StingTools.UI
             // ── Header ──
             var header = new Border
             {
-                Background = new SolidColorBrush(Color.FromRgb(0x6A, 0x1B, 0x9A)),
+                Background = ThemeManager.GetBrush("HeaderBg"),
                 Padding = new Thickness(12, 8, 12, 8)
             };
             header.Child = new TextBlock

--- a/StingTools/UI/TemplateManagerDashboard.cs
+++ b/StingTools/UI/TemplateManagerDashboard.cs
@@ -29,30 +29,20 @@ namespace StingTools.UI
     /// </summary>
     internal static class TemplateManagerDashboard
     {
-        // ── Theme colours (light corporate) ─────────────────────────────
-        private static readonly Color BgColor      = Color.FromRgb(0xF5, 0xF5, 0xF5);
-        private static readonly Color PanelBg      = Colors.White;
-        private static readonly Color HeaderBg     = Color.FromRgb(0x1A, 0x23, 0x7E);
-        private static readonly Color AccentOrange = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color FgDark       = Color.FromRgb(0x22, 0x22, 0x22);
-        private static readonly Color FgDim        = Color.FromRgb(0x88, 0x88, 0x88);
-        private static readonly Color BorderClr    = Color.FromRgb(0xD0, 0xD0, 0xD0);
-        private static readonly Color GreenAccent  = Color.FromRgb(0x4C, 0xAF, 0x50);
-        private static readonly Color HoverBg      = Color.FromRgb(0xFD, 0xF0, 0xDD);
-
-        private static SolidColorBrush FZ(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
-
-        private static readonly SolidColorBrush BrBg      = FZ(BgColor);
-        private static readonly SolidColorBrush BrPanel    = FZ(PanelBg);
-        private static readonly SolidColorBrush BrHeader   = FZ(HeaderBg);
-        private static readonly SolidColorBrush BrAccent   = FZ(AccentOrange);
-        private static readonly SolidColorBrush BrFg       = FZ(FgDark);
-        private static readonly SolidColorBrush BrFgDim    = FZ(FgDim);
-        private static readonly SolidColorBrush BrBorder   = FZ(BorderClr);
-        private static readonly SolidColorBrush BrWhite    = FZ(PanelBg);
-        private static readonly SolidColorBrush BrGreen    = FZ(GreenAccent);
-        private static readonly SolidColorBrush BrHover    = FZ(HoverBg);
-        private static readonly SolidColorBrush BrHeaderFg = FZ(Color.FromRgb(0xBB, 0xBB, 0xBB));
+        // ── Theme-routed palette ─────────────────────────────────────────
+        // All colours come from ThemeManager so the dashboard follows the
+        // active theme (Corporate by default — navy header, orange accent).
+        private static SolidColorBrush BrBg       => ThemeManager.GetBrush("AltRowBg");
+        private static SolidColorBrush BrPanel    => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrHeader   => ThemeManager.GetBrush("HeaderBg");
+        private static SolidColorBrush BrAccent   => ThemeManager.GetBrush("AccentBrush");
+        private static SolidColorBrush BrFg       => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush BrFgDim    => ThemeManager.GetBrush("SubtleFg");
+        private static SolidColorBrush BrBorder   => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush BrWhite    => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrGreen    => ThemeManager.GetBrush("SuccessColor");
+        private static SolidColorBrush BrHover    => ThemeManager.GetBrush("RowHover");
+        private static SolidColorBrush BrHeaderFg => ThemeManager.GetBrush("HeaderFg");
 
         // ── Operation definition ────────────────────────────────────────
         private class OpDef
@@ -258,7 +248,7 @@ namespace StingTools.UI
                 Cursor = Cursors.Hand
             };
             // Left accent border via the 4px left BorderThickness
-            card.BorderBrush = new SolidColorBrush(BorderClr);
+            card.BorderBrush = BrBorder;
 
             // Use a Grid to overlay the left accent colour
             var outerGrid = new Grid();

--- a/StingTools/UI/ThemeManager.cs
+++ b/StingTools/UI/ThemeManager.cs
@@ -107,18 +107,20 @@ namespace StingTools.UI
                     }
                 },
                 {
-                    // Corporate — light professional grey header
+                    // Corporate — light professional grey body + StingTools brand
+                    // navy header (#1A237E) + orange accent (#E8912D) — matches
+                    // the BCC and Document Management Centre.
                     "Corporate", new Dictionary<string, string>
                     {
                         { "PrimaryBg", "#FAFAFA" },
                         { "SecondaryBg", "#F3F3F3" },
                         { "PanelFg", "#37474F" },
-                        { "AccentBrush", "#1976D2" },   // Corporate blue headers
+                        { "AccentBrush", "#E8912D" },   // STING orange (primary accent)
                         { "ButtonBg", "#E8E8E8" },
                         { "ButtonFg", "#37474F" },
-                        { "HoverBg", "#D5D5D5" },
-                        { "HeaderBg", "#ECEFF1" },       // Light slate header
-                        { "HeaderFg", "#263238" },
+                        { "HoverBg", "#FDF0E0" },
+                        { "HeaderBg", "#1A237E" },       // STING navy header
+                        { "HeaderFg", "#FFFFFF" },       // white on navy
                         { "BorderColor", "#CFD8DC" },
                         { "SuccessColor", "#2E7D32" },
                         { "WarningColor", "#E65100" },
@@ -127,6 +129,14 @@ namespace StingTools.UI
                         { "TabFg", "#455A64" },
                         { "TabSelectedBg", "#FAFAFA" },
                         { "TabSelectedFg", "#37474F" },
+                        // Brand + dashboard extras (used by GetBrush callers)
+                        { "NavyHeader", "#1A237E" },
+                        { "OrangeAccent", "#E8912D" },
+                        { "CardBg", "#FFFFFF" },
+                        { "AltRowBg", "#F5F5F5" },
+                        { "SubtleFg", "#607D8B" },
+                        { "InfoBlue", "#1976D2" },
+                        { "RowHover", "#FDF0E0" },
                     }
                 },
             };
@@ -236,5 +246,49 @@ namespace StingTools.UI
 
         /// <summary>Get all available theme names.</summary>
         public static string[] GetThemeNames() => ThemeOrder;
+
+        /// <summary>
+        /// Resolve a theme key to a frozen <see cref="SolidColorBrush"/>
+        /// for code-behind use (where <see cref="DynamicResource"/> isn't
+        /// convenient). Looks up the active theme's palette, falls back
+        /// to the Corporate map for unknown keys, and finally returns a
+        /// safe slate brush so callers never get null. Adding this single
+        /// helper lets every dashboard route its palette through the
+        /// ThemeManager instead of hardcoding hex values inline.
+        /// </summary>
+        public static SolidColorBrush GetBrush(string key)
+        {
+            if (string.IsNullOrEmpty(key)) return _fallbackBrush;
+            try
+            {
+                var name = Themes.ContainsKey(CurrentTheme) ? CurrentTheme : "Corporate";
+                if (Themes[name].TryGetValue(key, out string hex)
+                    || Themes["Corporate"].TryGetValue(key, out hex))
+                {
+                    var color = (Color)ColorConverter.ConvertFromString(hex);
+                    if (name.Equals("Corporate", StringComparison.OrdinalIgnoreCase)
+                        && _corporateOverrides.TryGetValue(key, out string ovHex))
+                    {
+                        try { color = (Color)ColorConverter.ConvertFromString(ovHex); }
+                        catch { /* keep base colour */ }
+                    }
+                    var b = new SolidColorBrush(color);
+                    b.Freeze();
+                    return b;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"ThemeManager.GetBrush('{key}'): {ex.Message}"); }
+            return _fallbackBrush;
+        }
+
+        private static readonly SolidColorBrush _fallbackBrush =
+            CreateFrozen(Color.FromRgb(0x37, 0x47, 0x4F));
+
+        private static SolidColorBrush CreateFrozen(Color c)
+        {
+            var b = new SolidColorBrush(c);
+            b.Freeze();
+            return b;
+        }
     }
 }

--- a/StingTools/UI/WarningsDashboardDialog.cs
+++ b/StingTools/UI/WarningsDashboardDialog.cs
@@ -35,38 +35,26 @@ namespace StingTools.UI
     /// </summary>
     internal static class WarningsDashboardDialog
     {
-        // ── Theme colours (light corporate theme) ───────────────────────
-        private static readonly Color BgLight       = Color.FromRgb(0xF5, 0xF5, 0xF5);
-        private static readonly Color BgWhite       = Colors.White;
-        private static readonly Color BgHeader      = Color.FromRgb(0x1A, 0x23, 0x7E);
-        private static readonly Color AccentOrange  = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color FgDark        = Color.FromRgb(0x22, 0x22, 0x22);
-        private static readonly Color FgSubtle      = Color.FromRgb(0x77, 0x77, 0x77);
-        private static readonly Color FgWhite       = Colors.White;
-        private static readonly Color BorderLight   = Color.FromRgb(0xD0, 0xD0, 0xD0);
-        private static readonly Color CardBg        = Colors.White;
-        private static readonly Color CardHover     = Color.FromRgb(0xFD, 0xF0, 0xE0);
-        private static readonly Color CardSelected  = Color.FromRgb(0xFB, 0xE4, 0xC8);
-        private static readonly Color TabSelected   = Color.FromRgb(0xE8, 0x91, 0x2D);
-        private static readonly Color TabDefault    = Color.FromRgb(0xE0, 0xE0, 0xE0);
-        private static readonly Color InfoBg        = Color.FromRgb(0xEE, 0xF2, 0xF7);
-        private static readonly Color InfoBorder    = Color.FromRgb(0xB0, 0xC4, 0xDE);
-
+        // ── Theme-routed palette ─────────────────────────────────────────
+        // All colours come from ThemeManager so the dashboard follows the
+        // active theme (Corporate by default — navy header, orange accent).
         private static SolidColorBrush FZ(Color c) { var b = new SolidColorBrush(c); b.Freeze(); return b; }
 
-        private static readonly SolidColorBrush BrBgLight      = FZ(BgLight);
-        private static readonly SolidColorBrush BrBgWhite      = FZ(BgWhite);
-        private static readonly SolidColorBrush BrBgHeader     = FZ(BgHeader);
-        private static readonly SolidColorBrush BrAccent       = FZ(AccentOrange);
-        private static readonly SolidColorBrush BrFgDark       = FZ(FgDark);
-        private static readonly SolidColorBrush BrFgSubtle     = FZ(FgSubtle);
-        private static readonly SolidColorBrush BrFgWhite      = FZ(FgWhite);
-        private static readonly SolidColorBrush BrBorder       = FZ(BorderLight);
-        private static readonly SolidColorBrush BrCardBg       = FZ(CardBg);
-        private static readonly SolidColorBrush BrCardHover    = FZ(CardHover);
-        private static readonly SolidColorBrush BrCardSelected = FZ(CardSelected);
-        private static readonly SolidColorBrush BrInfoBg       = FZ(InfoBg);
-        private static readonly SolidColorBrush BrInfoBorder   = FZ(InfoBorder);
+        private static SolidColorBrush BrBgLight      => ThemeManager.GetBrush("AltRowBg");
+        private static SolidColorBrush BrBgWhite      => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrBgHeader     => ThemeManager.GetBrush("HeaderBg");
+        private static SolidColorBrush BrAccent       => ThemeManager.GetBrush("AccentBrush");
+        private static SolidColorBrush BrFgDark       => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush BrFgSubtle     => ThemeManager.GetBrush("SubtleFg");
+        private static SolidColorBrush BrFgWhite      => ThemeManager.GetBrush("HeaderFg");
+        private static SolidColorBrush BrBorder       => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush BrCardBg       => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrCardHover    => ThemeManager.GetBrush("RowHover");
+
+        // Selection / info / RAG-tinted boxes — fixed brand-paired tints
+        private static readonly SolidColorBrush BrCardSelected = FZ(Color.FromRgb(0xFB, 0xE4, 0xC8));
+        private static readonly SolidColorBrush BrInfoBg       = FZ(Color.FromRgb(0xEE, 0xF2, 0xF7));
+        private static readonly SolidColorBrush BrInfoBorder   = FZ(Color.FromRgb(0xB0, 0xC4, 0xDE));
 
         // ── State ───────────────────────────────────────────────────────
         private static string _selectedOperation;
@@ -1229,7 +1217,7 @@ namespace StingTools.UI
             return new TabItem
             {
                 Header = tb,
-                Background = FZ(TabDefault),
+                Background = ThemeManager.GetBrush("TabBg"),
                 Foreground = BrFgDark
             };
         }


### PR DESCRIPTION
## Summary
This PR consolidates the fragmented STING project folder structure into a single unified root directory per project, eliminating sibling folders scattered next to the .rvt file. It introduces auto-bootstrapping of default ProjectSetup configurations and migrates legacy metadata buckets (_BIM_COORD, _bim_manager, STING_BIM_MANAGER, etc.) into a centralized _data folder.

## Key Changes

### Folder Structure Consolidation
- **ProjectFolderEngine**: Modified `GetRootPath()` to name the root folder after the project code (e.g., `FIRESTONE_LIBERIA/`) instead of generic `STING_Project`, making each project visually distinct
- **Auto-bootstrap**: Added `LoadOrBootstrapSetup()` method that automatically creates a default BIM ProjectSetup if none exists, allowing subsystems to write into the unified structure without requiring explicit user setup
- **Metadata consolidation**: New `GetMetaPath()` helper resolves metadata bucket paths inside `<root>/_data/` instead of as sibling folders

### Legacy Migration
- **MigrateFromLegacy()** enhanced to move legacy folders into the unified root:
  - `_BIM_COORD`, `_bim_manager`, `STING_BIM_MANAGER` → `_data/<bucket>/`
  - `.bimmanager` (hidden clash detection folder) → `_data/.bimmanager/`
  - `STING_WORKFLOW_LOG.json*` → `_data/workflow_log.*`
  - `STING_BOQ_RateHeatMap/` → `COMPLIANCE/RateHeatMap/`
  - `*_Briefcase_*` folders → `BRIEFCASE/`
- Fixed directory enumeration to check for files only (not empty subdirectories) before deletion

### ProjectSetup Enhancements
- Added four new folder definitions: `BRIEFCASE`, `PHOTOS`, `CORRESPONDENCE`, `MISC` (folders 17–20)
- Folder names now get suffixed with project code at setup time (e.g., `01_WIP_FIRESTONE_LIBERIA`) for unique identification when copied/zipped
- Added `WithCodeSuffix()` helper to apply code suffixes consistently

### Theme & UI Consolidation
- **ThemeManager**: Updated Corporate theme with navy header (#1A237E) and orange accent (#E8912D) to match BCC branding; added new palette keys (`NavyHeader`, `OrangeAccent`, `CardBg`, `AltRowBg`, `SubtleFg`, `InfoBlue`, `RowHover`)
- **GetBrush()** helper: New method to resolve theme keys to frozen SolidColorBrush for code-behind use, allowing dashboards to route colors through ThemeManager instead of hardcoding hex values
- **Dashboard refactoring**: Updated WarningsDashboard, SchedulingCostDashboard, TemplateManagerDashboard, RevisionManagerDashboard, IssueTrackerDashboard, BEPDashboard, COBieExportDashboard, and BIMCoordinationCenter to use ThemeManager.GetBrush() for dynamic theme support

### Output & Logging
- **OutputLocationHelper**: Changed to prefer `LoadOrBootstrapSetup()` and route exports to `20_MISC_<code>` folder; removed legacy `STING_Exports/` fallbacks
- **WorkflowEngine**: Moved workflow log from project directory sibling to `_data/workflow_log.jsonl`
- **DocumentOpened handler**: Now auto-bootstraps ProjectSetup and silently migrates legacy folders on document open

### Subsystem Updates
- Updated all metadata-writing subsystems (DocumentIndex, DeliverableLifecycle, DocumentIdentityGenerator, EmbeddedTemplates, TemplateEngine, TransmittalOrchestrator, AuditLog, DistributionGroups, WorkflowEngine, WorkflowRegistry) to use consolidated `_data/` paths
- **BIMManagerCommands**: Briefcase exports now route to unified BRIEFCASE folder
- **BOQRateSource

https://claude.ai/code/session_0144hFtJ4cT6TJAKT1ARqCBE