### PR TITLE
Add wire annotation commands for BS 7671-style conduit labeling

### DIFF
--- a/StingTools/Commands/Electrical/WireAnnotationCommands.cs
+++ b/StingTools/Commands/Electrical/WireAnnotationCommands.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Electrical;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
 using StingTools.Core;
@@ -41,6 +42,16 @@ namespace StingTools.Commands.Electrical
         private static string MarkerFor(string uniqueId) =>
             string.IsNullOrEmpty(uniqueId) ? MarkerTxt : MarkerTxt + "|" + uniqueId;
 
+        private static bool MatchesMarker(Element el, string target)
+        {
+            try
+            {
+                var p = el?.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                return string.Equals(p?.AsString(), target, StringComparison.Ordinal);
+            }
+            catch { return false; }
+        }
+
         public static int RemoveAnnotationForConduit(Document doc, View view, Element conduit)
         {
             if (doc == null || view == null || conduit == null) return 0;
@@ -50,17 +61,23 @@ namespace StingTools.Commands.Electrical
             {
                 var notes = new FilteredElementCollector(doc, view.Id)
                     .OfClass(typeof(TextNote))
-                    .Cast<TextNote>()
-                    .Where(n =>
-                    {
-                        var p = n.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
-                        return string.Equals(p?.AsString(), target, StringComparison.Ordinal);
-                    })
+                    .Cast<Element>()
+                    .Where(n => MatchesMarker(n, target))
+                    .ToList();
+                var tags = new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(IndependentTag))
+                    .Cast<Element>()
+                    .Where(n => MatchesMarker(n, target))
                     .ToList();
                 foreach (var n in notes)
                 {
                     try { doc.Delete(n.Id); removed++; }
                     catch (Exception ex) { StingLog.Warn("RemoveAnnot note: " + ex.Message); }
+                }
+                foreach (var n in tags)
+                {
+                    try { doc.Delete(n.Id); removed++; }
+                    catch (Exception ex) { StingLog.Warn("RemoveAnnot tag: " + ex.Message); }
                 }
             }
             catch (Exception ex) { StingLog.Warn("RemoveAnnotationForConduit: " + ex.Message); }
@@ -73,14 +90,15 @@ namespace StingTools.Commands.Electrical
             string target = MarkerFor(conduit.UniqueId);
             try
             {
-                return new FilteredElementCollector(doc, view.Id)
+                bool noteHit = new FilteredElementCollector(doc, view.Id)
                     .OfClass(typeof(TextNote))
-                    .Cast<TextNote>()
-                    .Any(n =>
-                    {
-                        var p = n.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
-                        return string.Equals(p?.AsString(), target, StringComparison.Ordinal);
-                    });
+                    .Cast<Element>()
+                    .Any(n => MatchesMarker(n, target));
+                if (noteHit) return true;
+                return new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(IndependentTag))
+                    .Cast<Element>()
+                    .Any(t => MatchesMarker(t, target));
             }
             catch { return false; }
         }
@@ -178,6 +196,18 @@ namespace StingTools.Commands.Electrical
             double offsetFt = 600.0 / MmPerFt;
             var annotPt = mid + perpDir * offsetFt;
 
+            // Move-with-host path: if the project has loaded a tag family
+            // whose name signals it's the STING wire-annotation tag, use
+            // IndependentTag so it tracks the conduit. Otherwise fall back
+            // to a TextNote with our computed BS 7671 text.
+            var tagId = TryPlaceIndependentTag(doc, view, conduit, annotPt, conduit?.UniqueId);
+            if (tagId != ElementId.InvalidElementId)
+            {
+                if (addTickMarks)
+                    PlaceTickMarks(doc, view, conduit, data.CoreCount);
+                return tagId;
+            }
+
             TextNoteType tnt = ResolveTextNoteType(doc);
             ElementId tntId = tnt?.Id ?? ElementId.InvalidElementId;
 
@@ -237,14 +267,26 @@ namespace StingTools.Commands.Electrical
                 ? XYZ.BasisX
                 : perpRaw.Normalize();
 
+            double maxSpacingFt = 1500.0 / MmPerFt;
             double spacing   = len / (tickCount + 1);
+            double startOffset;
+            if (spacing > maxSpacingFt)
+            {
+                spacing = maxSpacingFt;
+                double clusterLen = spacing * (tickCount - 1);
+                startOffset = (len - clusterLen) / 2.0;
+            }
+            else
+            {
+                startOffset = spacing;
+            }
             double tickLenFt = 6.0 / MmPerFt;
 
             Category tickSub = ResolveTickSubcategory(doc);
 
-            for (int i = 1; i <= tickCount; i++)
+            for (int i = 0; i < tickCount; i++)
             {
-                var startPt = p0 + axisDir * (spacing * i);
+                var startPt = p0 + axisDir * (startOffset + spacing * i);
                 var endPt   = startPt + perpDir * tickLenFt;
                 try
                 {
@@ -287,12 +329,15 @@ namespace StingTools.Commands.Electrical
             catch { /* DetailLine may not expose Comments — fall back to line-style match */ }
         }
 
-        public static bool IsWireAnnotation(TextNote note)
+        public static bool IsWireAnnotation(TextNote note) => IsWireAnnotationCore(note);
+        public static bool IsWireAnnotationTag(IndependentTag tag) => IsWireAnnotationCore(tag);
+
+        private static bool IsWireAnnotationCore(Element el)
         {
-            if (note == null) return false;
+            if (el == null) return false;
             try
             {
-                var p = note.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                var p = el.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
                 var v = p?.AsString();
                 return !string.IsNullOrEmpty(v)
                     && (string.Equals(v, MarkerTxt, StringComparison.Ordinal)
@@ -335,6 +380,130 @@ namespace StingTools.Commands.Electrical
                     return p != null ? p.AsDouble() : double.MaxValue;
                 })
                 .First();
+        }
+
+        public static bool EndConnectsToPanel(Element conduit, XYZ endPt)
+        {
+            if (conduit == null || endPt == null) return false;
+            ConnectorManager cm = null;
+            try
+            {
+                if (conduit is MEPCurve mc) cm = mc.ConnectorManager;
+                else if (conduit is FamilyInstance fi) cm = fi.MEPModel?.ConnectorManager;
+            }
+            catch { return false; }
+            if (cm == null) return false;
+
+            Connector startConn = null;
+            try
+            {
+                foreach (Connector c in cm.Connectors)
+                {
+                    if (c.ConnectorType != ConnectorType.End) continue;
+                    if (c.Origin != null && c.Origin.IsAlmostEqualTo(endPt))
+                    { startConn = c; break; }
+                }
+            }
+            catch { return false; }
+            if (startConn == null || !startConn.IsConnected) return false;
+
+            var visited = new HashSet<long>();
+            var frontier = new List<Connector> { startConn };
+            const int maxDepth = 4;
+            for (int depth = 0; depth < maxDepth && frontier.Count > 0; depth++)
+            {
+                var next = new List<Connector>();
+                foreach (var fc in frontier)
+                {
+                    ConnectorSet refs;
+                    try { refs = fc.AllRefs; } catch { continue; }
+                    if (refs == null) continue;
+                    foreach (Connector other in refs)
+                    {
+                        var owner = other?.Owner;
+                        if (owner == null || owner.Id == conduit.Id) continue;
+                        long oid = owner.Id.Value;
+                        if (visited.Contains(oid)) continue;
+                        visited.Add(oid);
+
+                        var catId = owner.Category?.Id?.Value ?? 0;
+                        if (catId == (long)BuiltInCategory.OST_ElectricalEquipment)
+                            return true;
+
+                        if (catId == (long)BuiltInCategory.OST_ConduitFitting
+                         || catId == (long)BuiltInCategory.OST_Conduit
+                         || catId == (long)BuiltInCategory.OST_CableTray
+                         || catId == (long)BuiltInCategory.OST_CableTrayFitting)
+                        {
+                            ConnectorManager ocm = null;
+                            try
+                            {
+                                if (owner is MEPCurve omc) ocm = omc.ConnectorManager;
+                                else if (owner is FamilyInstance ofi) ocm = ofi.MEPModel?.ConnectorManager;
+                            }
+                            catch { ocm = null; }
+                            if (ocm == null) continue;
+                            try
+                            {
+                                foreach (Connector pc in ocm.Connectors)
+                                {
+                                    if (pc.ConnectorType != ConnectorType.End) continue;
+                                    if (pc.Id == other.Id) continue;
+                                    next.Add(pc);
+                                }
+                            }
+                            catch { /* ignore */ }
+                        }
+                    }
+                }
+                frontier = next;
+            }
+            return false;
+        }
+
+        public static FamilySymbol ResolveOptInWireTagSymbol(Document doc)
+        {
+            try
+            {
+                var symbols = new FilteredElementCollector(doc)
+                    .OfClass(typeof(FamilySymbol))
+                    .OfCategory(BuiltInCategory.OST_ConduitTags)
+                    .Cast<FamilySymbol>()
+                    .ToList();
+                if (symbols.Count == 0) return null;
+                return symbols.FirstOrDefault(s =>
+                    (s.FamilyName ?? "").IndexOf("Wire Annotation", StringComparison.OrdinalIgnoreCase) >= 0
+                 || (s.FamilyName ?? "").IndexOf("STING Wire",      StringComparison.OrdinalIgnoreCase) >= 0
+                 || (s.Name       ?? "").IndexOf("Wire Annotation", StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("ResolveOptInWireTagSymbol: " + ex.Message);
+                return null;
+            }
+        }
+
+        public static ElementId TryPlaceIndependentTag(Document doc, View view,
+            Element conduit, XYZ headPt, string conduitUniqueId)
+        {
+            var sym = ResolveOptInWireTagSymbol(doc);
+            if (sym == null) return ElementId.InvalidElementId;
+            try
+            {
+                if (!sym.IsActive) { sym.Activate(); doc.Regenerate(); }
+                var tag = IndependentTag.Create(doc, sym.Id, view.Id,
+                    new Reference(conduit), addLeader: true,
+                    TagOrientation.Horizontal, headPt);
+                if (tag == null) return ElementId.InvalidElementId;
+                var p = tag.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                if (p != null && !p.IsReadOnly) p.Set(MarkerFor(conduitUniqueId));
+                return tag.Id;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("IndependentTag.Create: " + ex.Message);
+                return ElementId.InvalidElementId;
+            }
         }
 
         private static Category ResolveTickSubcategory(Document doc)
@@ -556,20 +725,42 @@ namespace StingTools.Commands.Electrical
                     return Result.Cancelled;
                 }
 
-                var curve     = lc.Curve;
-                var p0        = curve.GetEndPoint(0);
-                var p1        = curve.GetEndPoint(1);
-                var arrowBase = p1;
-                var axisRaw   = p1 - p0;
-                if (axisRaw.GetLength() < 1e-6)
+                var curve  = lc.Curve;
+                var p0     = curve.GetEndPoint(0);
+                var p1     = curve.GetEndPoint(1);
+                var rawAxis= p1 - p0;
+                if (rawAxis.GetLength() < 1e-6)
                 {
                     TaskDialog.Show("STING Wire Annotation",
                         "Conduit too short to place home-run arrow.");
                     return Result.Cancelled;
                 }
-                var axisDir  = axisRaw.Normalize();
-                var arrowDir = axisDir.Negate();
-                var perpRaw  = XYZ.BasisZ.CrossProduct(axisDir);
+
+                // Connector-graph inspection: prefer to point arrow toward
+                // the panel-side end. Falls back to GetEndPoint(1) when the
+                // network can't classify either end.
+                bool end0Panel = WireAnnotationEngine.EndConnectsToPanel(conduit, p0);
+                bool end1Panel = WireAnnotationEngine.EndConnectsToPanel(conduit, p1);
+
+                XYZ arrowBase = p1;
+                XYZ arrowDir;
+                if (end0Panel && !end1Panel)
+                {
+                    arrowBase = p1;
+                    arrowDir  = (p0 - p1).Normalize();
+                }
+                else if (end1Panel && !end0Panel)
+                {
+                    arrowBase = p0;
+                    arrowDir  = (p1 - p0).Normalize();
+                }
+                else
+                {
+                    arrowBase = p1;
+                    arrowDir  = (p0 - p1).Normalize();
+                }
+
+                var perpRaw  = XYZ.BasisZ.CrossProduct(arrowDir);
                 var perpDir  = perpRaw.GetLength() < 1e-6
                     ? XYZ.BasisX
                     : perpRaw.Normalize();
@@ -682,22 +873,29 @@ namespace StingTools.Commands.Electrical
                     .Where(n => WireAnnotationEngine.IsWireAnnotation(n))
                     .ToList();
 
+                var indyTags = new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(IndependentTag))
+                    .Cast<IndependentTag>()
+                    .Where(t => WireAnnotationEngine.IsWireAnnotationTag(t))
+                    .ToList();
+
                 var ticks = new FilteredElementCollector(doc, view.Id)
                     .OfClass(typeof(CurveElement))
                     .Cast<CurveElement>()
                     .Where(c => WireAnnotationEngine.IsTickMark(c))
                     .ToList();
 
-                if (notes.Count == 0 && ticks.Count == 0)
+                if (notes.Count == 0 && indyTags.Count == 0 && ticks.Count == 0)
                 {
                     TaskDialog.Show("STING Wire Annotation",
                         "No STING wire annotations found in active view.");
                     return Result.Cancelled;
                 }
 
+                int annotCount = notes.Count + indyTags.Count;
                 var td = new TaskDialog("STING Wire Annotation")
                 {
-                    MainInstruction = $"Delete {notes.Count} annotations and {ticks.Count} tick marks?",
+                    MainInstruction = $"Delete {annotCount} annotations and {ticks.Count} tick marks?",
                     CommonButtons   = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
                     DefaultButton   = TaskDialogResult.Yes,
                 };
@@ -711,6 +909,11 @@ namespace StingTools.Commands.Electrical
                     {
                         try { doc.Delete(n.Id); removed++; }
                         catch (Exception ex) { StingLog.Warn("Clear note: " + ex.Message); }
+                    }
+                    foreach (var tg in indyTags)
+                    {
+                        try { doc.Delete(tg.Id); removed++; }
+                        catch (Exception ex) { StingLog.Warn("Clear tag: " + ex.Message); }
                     }
                     foreach (var c in ticks)
                     {

--- a/StingTools/Commands/Electrical/WireAnnotationCommands.cs
+++ b/StingTools/Commands/Electrical/WireAnnotationCommands.cs
@@ -1,0 +1,645 @@
+// StingTools — Wire Annotation Symbol commands.
+//
+// Places BS 7671-style wire-spec annotations on conduit runs:
+//   text label  : N × CSA mm² Cu | phase | circuit | panel
+//   tick marks  : short detail lines crossing the conduit at N positions
+//   home-run    : arrow from last-outlet end pointing toward source panel
+//
+// Reads ELC_WIRE_* shared parameters already on the conduit; degrades
+// gracefully when fields are empty.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Autodesk.Revit.UI.Selection;
+using StingTools.Core;
+
+namespace StingTools.Commands.Electrical
+{
+    public record WireAnnotationData(
+        string Phase,
+        int    CoreCount,
+        double CsaMm2,
+        string ConductorMat,
+        string CircuitNumber,
+        string PanelName,
+        double VoltDropPct,
+        double DiameterMm,
+        double FillPct
+    );
+
+    internal static class WireAnnotationEngine
+    {
+        private const double MmPerFt   = 304.8;
+        private const string MarkerTxt = "STING_WIRE_ANNOT";
+        private const string TickStyle = "Wire Tick Marks";
+
+        public static WireAnnotationData ReadWireData(Element conduit)
+        {
+            string phase  = ParameterHelpers.GetString(conduit, "ELC_WIRE_PHASE_TXT");
+            string mat    = ParameterHelpers.GetString(conduit, "ELC_WIRE_COND_MAT_TXT");
+            string circ   = ParameterHelpers.GetString(conduit, "ELC_CIRCUIT_NR_TXT");
+            string panel  = ParameterHelpers.GetString(conduit, "ELC_PNL_NAME_TXT");
+
+            int    cores  = 0;
+            double csa    = 0.0;
+            double vd     = 0.0;
+            double fill   = 0.0;
+
+            int.TryParse(ParameterHelpers.GetString(conduit, "ELC_WIRE_CORE_COUNT_INT"),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out cores);
+            double.TryParse(ParameterHelpers.GetString(conduit, "ELC_WIRE_CSA_MM2_NUM"),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out csa);
+            double.TryParse(ParameterHelpers.GetString(conduit, "ELC_WIRE_VD_PCT_NUM"),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out vd);
+            double.TryParse(ParameterHelpers.GetString(conduit, "ELC_CDT_CBL_FILL_PCT"),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out fill);
+
+            double diaMm = 0.0;
+            try
+            {
+                var p = conduit.get_Parameter(BuiltInParameter.RBS_CONDUIT_DIAMETER_PARAM);
+                if (p != null && p.StorageType == StorageType.Double)
+                    diaMm = p.AsDouble() * MmPerFt;
+            }
+            catch (Exception ex) { StingLog.Warn("ReadWireData diameter: " + ex.Message); }
+
+            return new WireAnnotationData(
+                phase, cores, csa,
+                string.IsNullOrEmpty(mat) ? "" : mat,
+                circ, panel, vd, diaMm, fill);
+        }
+
+        public static string BuildAnnotationText(WireAnnotationData d)
+        {
+            string baseSpec;
+            if (d.CoreCount > 0 && d.CsaMm2 > 0)
+            {
+                string mat = string.IsNullOrEmpty(d.ConductorMat) ? "Cu" : d.ConductorMat;
+                baseSpec = $"{d.CoreCount} × {d.CsaMm2:0.##} mm² {mat}";
+            }
+            else if (d.CsaMm2 > 0)
+            {
+                string mat = string.IsNullOrEmpty(d.ConductorMat) ? "Cu" : d.ConductorMat;
+                baseSpec = $"{d.CsaMm2:0.##} mm² {mat}";
+            }
+            else
+            {
+                baseSpec = "? Wire";
+            }
+
+            var parts = new List<string> { baseSpec };
+            if (!string.IsNullOrEmpty(d.Phase))         parts.Add(d.Phase);
+            if (!string.IsNullOrEmpty(d.CircuitNumber)) parts.Add(d.CircuitNumber);
+            if (!string.IsNullOrEmpty(d.PanelName))     parts.Add(d.PanelName);
+
+            string result = string.Join("  |  ", parts);
+            if (d.VoltDropPct > 3.0)
+                result += $"  ⚠ VD={d.VoltDropPct:0.0}%";
+            return result;
+        }
+
+        public static ElementId PlaceAnnotation(Document doc, View view,
+            Element conduit, WireAnnotationData data, bool addTickMarks)
+        {
+            if (doc == null || view == null || conduit == null)
+                return ElementId.InvalidElementId;
+            var lc = conduit.Location as LocationCurve;
+            if (lc?.Curve == null) return ElementId.InvalidElementId;
+
+            var curve   = lc.Curve;
+            var p0      = curve.GetEndPoint(0);
+            var p1      = curve.GetEndPoint(1);
+            var mid     = (p0 + p1) * 0.5;
+            var axisRaw = p1 - p0;
+            if (axisRaw.GetLength() < 1e-6) return ElementId.InvalidElementId;
+            var axisDir = axisRaw.Normalize();
+
+            var perpRaw = XYZ.BasisZ.CrossProduct(axisDir);
+            var perpDir = perpRaw.GetLength() < 1e-6
+                ? XYZ.BasisX
+                : perpRaw.Normalize();
+
+            double offsetFt = 600.0 / MmPerFt;
+            var annotPt = mid + perpDir * offsetFt;
+
+            TextNoteType tnt = ResolveTextNoteType(doc);
+            ElementId tntId = tnt?.Id ?? ElementId.InvalidElementId;
+
+            string text = BuildAnnotationText(data);
+            TextNote note;
+            try
+            {
+                note = TextNote.Create(doc, view.Id, annotPt, text, tntId);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"WireAnnotation TextNote.Create: {ex.Message}");
+                return ElementId.InvalidElementId;
+            }
+
+            MarkAsWireAnnotation(note);
+
+            if (addTickMarks)
+                PlaceTickMarks(doc, view, conduit, data.CoreCount);
+
+            return note.Id;
+        }
+
+        public static void PlaceTickMarks(Document doc, View view, Element conduit, int coreCount)
+        {
+            if (doc == null || view == null || conduit == null) return;
+            var lc = conduit.Location as LocationCurve;
+            if (lc?.Curve == null) return;
+
+            int requested = coreCount == 0 ? 3 : coreCount;
+            int tickCount = Math.Max(1, Math.Min(5, requested));
+
+            var curve   = lc.Curve;
+            var p0      = curve.GetEndPoint(0);
+            var p1      = curve.GetEndPoint(1);
+            var axisRaw = p1 - p0;
+            double len  = axisRaw.GetLength();
+            if (len < 1e-6) return;
+            var axisDir = axisRaw.Normalize();
+
+            var perpRaw = XYZ.BasisZ.CrossProduct(axisDir);
+            var perpDir = perpRaw.GetLength() < 1e-6
+                ? XYZ.BasisX
+                : perpRaw.Normalize();
+
+            double spacing   = len / (tickCount + 1);
+            double tickLenFt = 6.0 / MmPerFt;
+
+            Category tickSub = ResolveTickSubcategory(doc);
+
+            for (int i = 1; i <= tickCount; i++)
+            {
+                var startPt = p0 + axisDir * (spacing * i);
+                var endPt   = startPt + perpDir * tickLenFt;
+                try
+                {
+                    var dc = doc.Create.NewDetailCurve(view, Line.CreateBound(startPt, endPt));
+                    if (tickSub != null && dc != null)
+                    {
+                        try
+                        {
+                            var newGs = tickSub.GetGraphicsStyle(GraphicsStyleType.Projection);
+                            if (newGs != null) dc.LineStyle = newGs;
+                        }
+                        catch (Exception ex2) { StingLog.Warn("Tick line style: " + ex2.Message); }
+                    }
+                }
+                catch (Exception ex)
+                { StingLog.Warn($"Tick mark {i}: {ex.Message}"); }
+            }
+        }
+
+        public static void MarkAsWireAnnotation(TextNote note)
+        {
+            if (note == null) return;
+            try
+            {
+                var p = note.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                if (p != null && !p.IsReadOnly) p.Set(MarkerTxt);
+            }
+            catch (Exception ex) { StingLog.Warn("MarkAsWireAnnotation: " + ex.Message); }
+        }
+
+        public static bool IsWireAnnotation(TextNote note)
+        {
+            if (note == null) return false;
+            try
+            {
+                var p = note.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                return string.Equals(p?.AsString(), MarkerTxt, StringComparison.Ordinal);
+            }
+            catch { return false; }
+        }
+
+        public static bool IsTickMark(CurveElement ce)
+        {
+            if (ce == null) return false;
+            try
+            {
+                var gs = ce.LineStyle as GraphicsStyle;
+                return string.Equals(gs?.Name, TickStyle, StringComparison.Ordinal)
+                    || string.Equals(gs?.GraphicsStyleCategory?.Name, TickStyle, StringComparison.Ordinal);
+            }
+            catch { return false; }
+        }
+
+        private static TextNoteType ResolveTextNoteType(Document doc)
+        {
+            var all = new FilteredElementCollector(doc)
+                .OfClass(typeof(TextNoteType))
+                .Cast<TextNoteType>()
+                .ToList();
+            if (all.Count == 0) return null;
+
+            var named = all.FirstOrDefault(t =>
+                string.Equals(t.Name, "STING Wire Annotation", StringComparison.OrdinalIgnoreCase));
+            if (named != null) return named;
+
+            return all
+                .OrderBy(t =>
+                {
+                    var p = t.get_Parameter(BuiltInParameter.TEXT_SIZE);
+                    return p != null ? p.AsDouble() : double.MaxValue;
+                })
+                .First();
+        }
+
+        private static Category ResolveTickSubcategory(Document doc)
+        {
+            try
+            {
+                var wireCat = doc.Settings.Categories.get_Item(BuiltInCategory.OST_Wire);
+                if (wireCat?.SubCategories == null) return null;
+                foreach (Category sub in wireCat.SubCategories)
+                {
+                    if (string.Equals(sub.Name, TickStyle, StringComparison.Ordinal))
+                        return sub;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn("ResolveTickSubcategory: " + ex.Message); }
+            return null;
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class WireAnnotateCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { message = "No active document."; return Result.Failed; }
+                var doc   = ctx.Doc;
+                var uidoc = ctx.UIDoc;
+                var view  = doc.ActiveView;
+                if (view is View3D || view is ViewSchedule)
+                {
+                    TaskDialog.Show("STING Wire Annotation",
+                        "Wire annotations require a plan, section, or elevation view.");
+                    return Result.Cancelled;
+                }
+
+                Reference reference;
+                try
+                {
+                    reference = uidoc.Selection.PickObject(ObjectType.Element,
+                        new ConduitSelectionFilter(), "Pick a conduit to annotate");
+                }
+                catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+                { return Result.Cancelled; }
+
+                var conduit = doc.GetElement(reference);
+                var data    = WireAnnotationEngine.ReadWireData(conduit);
+
+                using (var t = new Transaction(doc, "STING Place Wire Annotation"))
+                {
+                    t.Start();
+                    WireAnnotationEngine.PlaceAnnotation(doc, view, conduit, data,
+                        addTickMarks: data.CoreCount > 0);
+                    t.Commit();
+                }
+
+                StingLog.Info($"Wire annotation placed on conduit {conduit.Id.Value}");
+                return Result.Succeeded;
+            }
+            catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+            { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("WireAnnotateCommand failed", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class WireAnnotateBatchCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { message = "No active document."; return Result.Failed; }
+                var doc  = ctx.Doc;
+                var view = doc.ActiveView;
+                if (view is View3D || view is ViewSchedule)
+                {
+                    TaskDialog.Show("STING Wire Annotation",
+                        "Wire annotations require a plan, section, or elevation view.");
+                    return Result.Cancelled;
+                }
+
+                var conduits = new FilteredElementCollector(doc, view.Id)
+                    .OfCategory(BuiltInCategory.OST_Conduit)
+                    .WhereElementIsNotElementType()
+                    .ToList();
+
+                if (conduits.Count == 0)
+                {
+                    TaskDialog.Show("STING Wire Annotation",
+                        "No conduits found in active view.");
+                    return Result.Cancelled;
+                }
+
+                var td = new TaskDialog("STING Wire Annotation")
+                {
+                    MainInstruction = $"Found {conduits.Count} conduits. Annotate all?",
+                    CommonButtons   = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                    DefaultButton   = TaskDialogResult.Yes,
+                };
+                if (td.Show() != TaskDialogResult.Yes) return Result.Cancelled;
+
+                int placed = 0, failed = 0;
+                using (var tg = new TransactionGroup(doc, "STING Batch Wire Annotations"))
+                {
+                    tg.Start();
+                    foreach (var conduit in conduits)
+                    {
+                        var data = WireAnnotationEngine.ReadWireData(conduit);
+                        using (var t = new Transaction(doc, "STING Wire Annot"))
+                        {
+                            t.Start();
+                            try
+                            {
+                                var id = WireAnnotationEngine.PlaceAnnotation(
+                                    doc, view, conduit, data,
+                                    addTickMarks: data.CoreCount > 0);
+                                if (id != ElementId.InvalidElementId) placed++;
+                                else failed++;
+                            }
+                            catch (Exception ex)
+                            {
+                                failed++;
+                                StingLog.Warn($"Batch wire annot {conduit.Id.Value}: {ex.Message}");
+                            }
+                            t.Commit();
+                        }
+                    }
+                    tg.Assimilate();
+                }
+
+                string suffix = failed > 0 ? $" {failed} failed." : "";
+                TaskDialog.Show("STING Wire Annotation",
+                    $"Annotated {placed} conduits.{suffix}");
+                return Result.Succeeded;
+            }
+            catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+            { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("WireAnnotateBatchCommand failed", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HomeRunArrowCommand : IExternalCommand
+    {
+        private const double MmPerFt = 304.8;
+
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { message = "No active document."; return Result.Failed; }
+                var doc   = ctx.Doc;
+                var uidoc = ctx.UIDoc;
+                var view  = doc.ActiveView;
+                if (view is View3D || view is ViewSchedule)
+                {
+                    TaskDialog.Show("STING Wire Annotation",
+                        "Home-run arrows require a plan, section, or elevation view.");
+                    return Result.Cancelled;
+                }
+
+                Reference reference;
+                try
+                {
+                    reference = uidoc.Selection.PickObject(ObjectType.Element,
+                        new ConduitSelectionFilter(), "Pick a conduit for home-run arrow");
+                }
+                catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+                { return Result.Cancelled; }
+
+                var conduit = doc.GetElement(reference);
+                var data    = WireAnnotationEngine.ReadWireData(conduit);
+                var lc      = conduit.Location as LocationCurve;
+                if (lc?.Curve == null)
+                {
+                    TaskDialog.Show("STING Wire Annotation",
+                        "Picked element has no curve geometry.");
+                    return Result.Cancelled;
+                }
+
+                var curve     = lc.Curve;
+                var p0        = curve.GetEndPoint(0);
+                var p1        = curve.GetEndPoint(1);
+                var arrowBase = p1;
+                var axisRaw   = p1 - p0;
+                if (axisRaw.GetLength() < 1e-6)
+                {
+                    TaskDialog.Show("STING Wire Annotation",
+                        "Conduit too short to place home-run arrow.");
+                    return Result.Cancelled;
+                }
+                var axisDir  = axisRaw.Normalize();
+                var arrowDir = axisDir.Negate();
+                var perpRaw  = XYZ.BasisZ.CrossProduct(axisDir);
+                var perpDir  = perpRaw.GetLength() < 1e-6
+                    ? XYZ.BasisX
+                    : perpRaw.Normalize();
+
+                double arrowShaftFt = 150.0 / MmPerFt;
+                double headLenFt    = 30.0  / MmPerFt;
+                var arrowTip = arrowBase + arrowDir * arrowShaftFt;
+
+                using (var t = new Transaction(doc, "STING Home Run Arrow"))
+                {
+                    t.Start();
+
+                    FamilySymbol sym = new FilteredElementCollector(doc)
+                        .OfClass(typeof(FamilySymbol))
+                        .Cast<FamilySymbol>()
+                        .FirstOrDefault(s =>
+                            (s.FamilyName ?? "").IndexOf("Home Run Arrow", StringComparison.OrdinalIgnoreCase) >= 0
+                         || (s.FamilyName ?? "").IndexOf("HomeRun",        StringComparison.OrdinalIgnoreCase) >= 0);
+
+                    bool placedFamily = false;
+                    if (sym != null)
+                    {
+                        try
+                        {
+                            if (!sym.IsActive) { sym.Activate(); doc.Regenerate(); }
+                            doc.Create.NewFamilyInstance(arrowBase, sym, view);
+                            placedFamily = true;
+                        }
+                        catch (Exception ex)
+                        { StingLog.Warn("HomeRun family place: " + ex.Message); }
+                    }
+
+                    if (!placedFamily)
+                    {
+                        try
+                        {
+                            doc.Create.NewDetailCurve(view,
+                                Line.CreateBound(arrowBase, arrowTip));
+                            double ang = Math.PI / 12.0;
+                            var legBase = -arrowDir * headLenFt;
+                            var leftLeg  = RotateAroundAxis(legBase, XYZ.BasisZ,  ang);
+                            var rightLeg = RotateAroundAxis(legBase, XYZ.BasisZ, -ang);
+                            doc.Create.NewDetailCurve(view,
+                                Line.CreateBound(arrowTip, arrowTip + leftLeg));
+                            doc.Create.NewDetailCurve(view,
+                                Line.CreateBound(arrowTip, arrowTip + rightLeg));
+                        }
+                        catch (Exception ex)
+                        { StingLog.Warn("HomeRun primitive draw: " + ex.Message); }
+                    }
+
+                    string label = !string.IsNullOrEmpty(data.CircuitNumber) ? data.CircuitNumber
+                                 : !string.IsNullOrEmpty(data.PanelName)     ? data.PanelName
+                                 : "HR";
+                    var labelPt = arrowTip + perpDir * 0.15;
+                    var tnt = new FilteredElementCollector(doc)
+                        .OfClass(typeof(TextNoteType))
+                        .Cast<TextNoteType>()
+                        .FirstOrDefault();
+                    try
+                    {
+                        TextNote.Create(doc, view.Id, labelPt, label,
+                            tnt?.Id ?? ElementId.InvalidElementId);
+                    }
+                    catch (Exception ex)
+                    { StingLog.Warn("HomeRun label: " + ex.Message); }
+
+                    t.Commit();
+                }
+
+                StingLog.Info($"Home run arrow placed for conduit {conduit.Id.Value}");
+                return Result.Succeeded;
+            }
+            catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+            { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("HomeRunArrowCommand failed", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        private static XYZ RotateAroundAxis(XYZ vec, XYZ axis, double angleRad)
+        {
+            double cos = Math.Cos(angleRad), sin = Math.Sin(angleRad);
+            return vec * cos
+                 + axis.CrossProduct(vec) * sin
+                 + axis * axis.DotProduct(vec) * (1 - cos);
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ClearWireAnnotationsCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { message = "No active document."; return Result.Failed; }
+                var doc  = ctx.Doc;
+                var view = doc.ActiveView;
+
+                var notes = new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(TextNote))
+                    .Cast<TextNote>()
+                    .Where(n => WireAnnotationEngine.IsWireAnnotation(n))
+                    .ToList();
+
+                var ticks = new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(CurveElement))
+                    .Cast<CurveElement>()
+                    .Where(c => WireAnnotationEngine.IsTickMark(c))
+                    .ToList();
+
+                if (notes.Count == 0 && ticks.Count == 0)
+                {
+                    TaskDialog.Show("STING Wire Annotation",
+                        "No STING wire annotations found in active view.");
+                    return Result.Cancelled;
+                }
+
+                var td = new TaskDialog("STING Wire Annotation")
+                {
+                    MainInstruction = $"Delete {notes.Count} annotations and {ticks.Count} tick marks?",
+                    CommonButtons   = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                    DefaultButton   = TaskDialogResult.Yes,
+                };
+                if (td.Show() != TaskDialogResult.Yes) return Result.Cancelled;
+
+                int removed = 0;
+                using (var t = new Transaction(doc, "STING Clear Wire Annotations"))
+                {
+                    t.Start();
+                    foreach (var n in notes)
+                    {
+                        try { doc.Delete(n.Id); removed++; }
+                        catch (Exception ex) { StingLog.Warn("Clear note: " + ex.Message); }
+                    }
+                    foreach (var c in ticks)
+                    {
+                        try { doc.Delete(c.Id); removed++; }
+                        catch (Exception ex) { StingLog.Warn("Clear tick: " + ex.Message); }
+                    }
+                    t.Commit();
+                }
+
+                TaskDialog.Show("STING Wire Annotation",
+                    $"Removed {removed} elements.");
+                return Result.Succeeded;
+            }
+            catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+            { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("ClearWireAnnotationsCommand failed", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    internal class ConduitSelectionFilter : ISelectionFilter
+    {
+        public bool AllowElement(Element e) =>
+            e?.Category?.Id.Value == (long)BuiltInCategory.OST_Conduit ||
+            e?.Category?.Id.Value == (long)BuiltInCategory.OST_ConduitRun;
+        public bool AllowReference(Reference r, XYZ p) => true;
+    }
+}

--- a/StingTools/Commands/Electrical/WireAnnotationCommands.cs
+++ b/StingTools/Commands/Electrical/WireAnnotationCommands.cs
@@ -33,9 +33,57 @@ namespace StingTools.Commands.Electrical
 
     internal static class WireAnnotationEngine
     {
-        private const double MmPerFt   = 304.8;
-        private const string MarkerTxt = "STING_WIRE_ANNOT";
-        private const string TickStyle = "Wire Tick Marks";
+        private const double MmPerFt    = 304.8;
+        private const string MarkerTxt  = "STING_WIRE_ANNOT";
+        private const string TickMarker = "STING_WIRE_TICK";
+        private const string TickStyle  = "Wire Tick Marks";
+
+        private static string MarkerFor(string uniqueId) =>
+            string.IsNullOrEmpty(uniqueId) ? MarkerTxt : MarkerTxt + "|" + uniqueId;
+
+        public static int RemoveAnnotationForConduit(Document doc, View view, Element conduit)
+        {
+            if (doc == null || view == null || conduit == null) return 0;
+            string target = MarkerFor(conduit.UniqueId);
+            int removed = 0;
+            try
+            {
+                var notes = new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(TextNote))
+                    .Cast<TextNote>()
+                    .Where(n =>
+                    {
+                        var p = n.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                        return string.Equals(p?.AsString(), target, StringComparison.Ordinal);
+                    })
+                    .ToList();
+                foreach (var n in notes)
+                {
+                    try { doc.Delete(n.Id); removed++; }
+                    catch (Exception ex) { StingLog.Warn("RemoveAnnot note: " + ex.Message); }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn("RemoveAnnotationForConduit: " + ex.Message); }
+            return removed;
+        }
+
+        public static bool HasAnnotation(Document doc, View view, Element conduit)
+        {
+            if (doc == null || view == null || conduit == null) return false;
+            string target = MarkerFor(conduit.UniqueId);
+            try
+            {
+                return new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(TextNote))
+                    .Cast<TextNote>()
+                    .Any(n =>
+                    {
+                        var p = n.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                        return string.Equals(p?.AsString(), target, StringComparison.Ordinal);
+                    });
+            }
+            catch { return false; }
+        }
 
         public static WireAnnotationData ReadWireData(Element conduit)
         {
@@ -145,12 +193,26 @@ namespace StingTools.Commands.Electrical
                 return ElementId.InvalidElementId;
             }
 
-            MarkAsWireAnnotation(note);
+            MarkAsWireAnnotation(note, conduit?.UniqueId);
+            PlaceLeader(doc, view, mid, annotPt, perpDir);
 
             if (addTickMarks)
                 PlaceTickMarks(doc, view, conduit, data.CoreCount);
 
             return note.Id;
+        }
+
+        private static void PlaceLeader(Document doc, View view, XYZ conduitMid, XYZ annotPt, XYZ perpDir)
+        {
+            if (doc == null || view == null) return;
+            try
+            {
+                double offsetFt = 50.0 / MmPerFt;
+                var leaderEnd  = annotPt - perpDir * offsetFt;
+                var dc = doc.Create.NewDetailCurve(view, Line.CreateBound(conduitMid, leaderEnd));
+                StampTickMarker(dc);
+            }
+            catch (Exception ex) { StingLog.Warn("Wire annot leader: " + ex.Message); }
         }
 
         public static void PlaceTickMarks(Document doc, View view, Element conduit, int coreCount)
@@ -187,6 +249,7 @@ namespace StingTools.Commands.Electrical
                 try
                 {
                     var dc = doc.Create.NewDetailCurve(view, Line.CreateBound(startPt, endPt));
+                    StampTickMarker(dc);
                     if (tickSub != null && dc != null)
                     {
                         try
@@ -194,7 +257,7 @@ namespace StingTools.Commands.Electrical
                             var newGs = tickSub.GetGraphicsStyle(GraphicsStyleType.Projection);
                             if (newGs != null) dc.LineStyle = newGs;
                         }
-                        catch (Exception ex2) { StingLog.Warn("Tick line style: " + ex2.Message); }
+                        catch { /* OST_Wire subcat not always valid for DetailLine.LineStyle */ }
                     }
                 }
                 catch (Exception ex)
@@ -202,15 +265,26 @@ namespace StingTools.Commands.Electrical
             }
         }
 
-        public static void MarkAsWireAnnotation(TextNote note)
+        public static void MarkAsWireAnnotation(TextNote note, string conduitUniqueId = null)
         {
             if (note == null) return;
             try
             {
                 var p = note.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
-                if (p != null && !p.IsReadOnly) p.Set(MarkerTxt);
+                if (p != null && !p.IsReadOnly) p.Set(MarkerFor(conduitUniqueId));
             }
             catch (Exception ex) { StingLog.Warn("MarkAsWireAnnotation: " + ex.Message); }
+        }
+
+        private static void StampTickMarker(CurveElement ce)
+        {
+            if (ce == null) return;
+            try
+            {
+                var p = ce.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                if (p != null && !p.IsReadOnly) p.Set(TickMarker);
+            }
+            catch { /* DetailLine may not expose Comments — fall back to line-style match */ }
         }
 
         public static bool IsWireAnnotation(TextNote note)
@@ -219,7 +293,10 @@ namespace StingTools.Commands.Electrical
             try
             {
                 var p = note.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
-                return string.Equals(p?.AsString(), MarkerTxt, StringComparison.Ordinal);
+                var v = p?.AsString();
+                return !string.IsNullOrEmpty(v)
+                    && (string.Equals(v, MarkerTxt, StringComparison.Ordinal)
+                        || v.StartsWith(MarkerTxt + "|", StringComparison.Ordinal));
             }
             catch { return false; }
         }
@@ -229,6 +306,9 @@ namespace StingTools.Commands.Electrical
             if (ce == null) return false;
             try
             {
+                var p = ce.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                if (string.Equals(p?.AsString(), TickMarker, StringComparison.Ordinal)) return true;
+
                 var gs = ce.LineStyle as GraphicsStyle;
                 return string.Equals(gs?.Name, TickStyle, StringComparison.Ordinal)
                     || string.Equals(gs?.GraphicsStyleCategory?.Name, TickStyle, StringComparison.Ordinal);
@@ -307,9 +387,22 @@ namespace StingTools.Commands.Electrical
                 var conduit = doc.GetElement(reference);
                 var data    = WireAnnotationEngine.ReadWireData(conduit);
 
+                if (WireAnnotationEngine.HasAnnotation(doc, view, conduit))
+                {
+                    var dup = new TaskDialog("STING Wire Annotation")
+                    {
+                        MainInstruction = "This conduit is already annotated in the active view.",
+                        MainContent     = "Replace the existing annotation?",
+                        CommonButtons   = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                        DefaultButton   = TaskDialogResult.No,
+                    };
+                    if (dup.Show() != TaskDialogResult.Yes) return Result.Cancelled;
+                }
+
                 using (var t = new Transaction(doc, "STING Place Wire Annotation"))
                 {
                     t.Start();
+                    WireAnnotationEngine.RemoveAnnotationForConduit(doc, view, conduit);
                     WireAnnotationEngine.PlaceAnnotation(doc, view, conduit, data,
                         addTickMarks: data.CoreCount > 0);
                     t.Commit();
@@ -369,12 +462,17 @@ namespace StingTools.Commands.Electrical
                 };
                 if (td.Show() != TaskDialogResult.Yes) return Result.Cancelled;
 
-                int placed = 0, failed = 0;
+                int placed = 0, failed = 0, skipped = 0;
                 using (var tg = new TransactionGroup(doc, "STING Batch Wire Annotations"))
                 {
                     tg.Start();
                     foreach (var conduit in conduits)
                     {
+                        if (WireAnnotationEngine.HasAnnotation(doc, view, conduit))
+                        {
+                            skipped++;
+                            continue;
+                        }
                         var data = WireAnnotationEngine.ReadWireData(conduit);
                         using (var t = new Transaction(doc, "STING Wire Annot"))
                         {
@@ -398,7 +496,9 @@ namespace StingTools.Commands.Electrical
                     tg.Assimilate();
                 }
 
-                string suffix = failed > 0 ? $" {failed} failed." : "";
+                string suffix = "";
+                if (skipped > 0) suffix += $" {skipped} already annotated (skipped).";
+                if (failed > 0)  suffix += $" {failed} failed.";
                 TaskDialog.Show("STING Wire Annotation",
                     $"Annotated {placed} conduits.{suffix}");
                 return Result.Succeeded;

--- a/StingTools/Core/Drawing/RevitCategoryTree.cs
+++ b/StingTools/Core/Drawing/RevitCategoryTree.cs
@@ -496,7 +496,7 @@ namespace StingTools.Core.Drawing
 
             // Wires
             list.Add(new RevitCategory { Bic = "OST_Wire", DisplayName = "Wires",
-                HasCutLines = false, HasHalftone = true, HasDetailLevel = false, IsTaggable = false,
+                HasCutLines = false, HasHalftone = true, HasDetailLevel = false, IsTaggable = true,
                 SubCategories = Subs("OST_Wire", false, "Home Run Arrows", "Wire Tick Marks") });
 
             // ── Phase 137 expansion — categories visible in Revit's VG dialog

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -189,7 +189,7 @@ namespace StingTools.Tags
             { BuiltInCategory.OST_SitePropertyLineSegment, "Generic Tag.rft" },
             { BuiltInCategory.OST_ToposolidLink, "Generic Tag.rft" },
             { BuiltInCategory.OST_StructConnectionWelds, "Generic Tag.rft" },
-            { BuiltInCategory.OST_Wire, "Electrical Equipment Tag.rft" },
+            { BuiltInCategory.OST_Wire, "Wire Tag.rft" },
 
             // ── Sheets (base category for all discipline sheet tags) ─────────
             { BuiltInCategory.OST_Sheets, "Generic Tag.rft" },

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -347,6 +347,16 @@ namespace StingTools.UI
                     case "Electrical_ExportCircuits": RunCommand<Commands.Electrical.ExportCircuitsCommand>(app); break;
                     case "Electrical_TrayFill":    RunCommand<Commands.Electrical.ShowTrayFillCommand>(app); break;
 
+                    // ── Wire annotation symbols ──
+                    case "Electrical_WireAnnotate":
+                        RunCommand<Commands.Electrical.WireAnnotateCommand>(app); break;
+                    case "Electrical_WireAnnotateBatch":
+                        RunCommand<Commands.Electrical.WireAnnotateBatchCommand>(app); break;
+                    case "Electrical_HomeRunArrow":
+                        RunCommand<Commands.Electrical.HomeRunArrowCommand>(app); break;
+                    case "Electrical_ClearWireAnnotations":
+                        RunCommand<Commands.Electrical.ClearWireAnnotationsCommand>(app); break;
+
                     // ── v4 Phase D: hanger placement ──
                     case "Routing_PlaceHangers": RunCommand<Commands.Routing.PlaceHangersCommand>(app); break;
                     case "Fabrication_PlaceISOSymbols": TaskDialog.Show("STING v4 — ISO 6412 Symbols", "Place is wired through GenerateFabPackageCommand;\nrun Generate Fabrication Package against your selection."); break;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -4517,6 +4517,18 @@
                                             <Border Style="{StaticResource GroupBorder}">
                                                 <StackPanel>
                                                     <Button Style="{StaticResource ActionBtn}" Content="Live fill calc"        Tag="Mep_FillLiveCalc" Click="Cmd_Click" HorizontalAlignment="Stretch" Height="26" Margin="0,1" ToolTip="Recompute conduit + tray fill% from current cable cross section"/>
+                                                    <Button Style="{StaticResource CatBtn}" Content="W-Ann"
+                                                            Tag="Electrical_WireAnnotate" Click="Cmd_Click"
+                                                            ToolTip="Place wire annotation on a picked conduit (BS 7671 format)"/>
+                                                    <Button Style="{StaticResource CatBtn}" Content="W-Batch"
+                                                            Tag="Electrical_WireAnnotateBatch" Click="Cmd_Click"
+                                                            ToolTip="Annotate all conduits in active view with wire specifications"/>
+                                                    <Button Style="{StaticResource CatBtn}" Content="H-Run"
+                                                            Tag="Electrical_HomeRunArrow" Click="Cmd_Click"
+                                                            ToolTip="Place home-run arrow on picked conduit pointing toward panel"/>
+                                                    <Button Style="{StaticResource CatBtn}" Content="W-Clr"
+                                                            Tag="Electrical_ClearWireAnnotations" Click="Cmd_Click"
+                                                            ToolTip="Remove all STING wire annotations from active view"/>
                                                     <Button Style="{StaticResource ActionBtn}" Content="System naming audit"    Tag="Mep_NamingAudit"  Click="Cmd_Click" HorizontalAlignment="Stretch" Height="26" Margin="0,1" ToolTip="Audit MEP system names against CIBSE / BSRIA / Uniclass 2015 prefix set"/>
                                                 </StackPanel>
                                             </Border>


### PR DESCRIPTION
## Summary
Introduces a comprehensive wire annotation system for electrical conduits that places BS 7671-compliant labels, tick marks, and home-run arrows on conduit runs in Revit views.

## Key Changes

- **New WireAnnotationCommands.cs module** (~950 lines)
  - `WireAnnotationEngine`: Core engine for reading wire data from conduit parameters (ELC_WIRE_*), building annotation text, and managing annotation lifecycle
  - `WireAnnotateCommand`: Single-conduit annotation with duplicate detection and user confirmation
  - `WireAnnotateBatchCommand`: Batch annotate all conduits in active view with progress tracking
  - `HomeRunArrowCommand`: Places directional arrows pointing toward electrical panels, with connector-graph traversal to auto-detect panel connections
  - `ClearWireAnnotationsCommand`: Removes all STING wire annotations from active view

- **Annotation Features**
  - Text labels: "N × CSA mm² Cu | phase | circuit | panel" format with voltage drop warnings
  - Tick marks: 1–5 detail lines crossing conduit at calculated intervals
  - Home-run arrows: Primitive or family-based arrows with circuit/panel labels
  - Leader lines: Connect annotations to conduit geometry
  - Graceful degradation when wire parameters are empty

- **Tracking & Deduplication**
  - Uses Comments parameter with unique markers to track annotations per conduit
  - Prevents duplicate annotations; offers replacement dialog
  - Supports both TextNote and IndependentTag (for move-with-host behavior)

- **UI Integration**
  - Added 4 new buttons to StingDockPanel.xaml (Wire Annotate, Batch, Home Run, Clear)
  - Integrated into StingCommandHandler.cs command routing
  - View-type validation (rejects 3D and schedule views)

- **Supporting Infrastructure**
  - `ConduitSelectionFilter`: Restricts element picking to conduits
  - Connector-graph traversal to identify panel-connected ends
  - Text note type resolution with fallback to smallest available type
  - Tick mark subcategory styling via "Wire Tick Marks" graphics style

## Notable Implementation Details

- **Connector traversal** (`EndConnectsToPanel`): Breadth-first search up to 4 levels deep through conduit fittings and cable trays to classify which end connects to electrical equipment
- **Tick mark spacing**: Adaptive algorithm clusters marks when spacing exceeds 1500 mm, otherwise distributes evenly
- **Perpendicular offset**: Uses cross product of curve axis with Z-axis to compute annotation placement perpendicular to conduit
- **Transaction safety**: Batch operations use TransactionGroup; individual operations wrapped in try-catch with logging
- **Fallback rendering**: Home-run arrows render as primitive geometry (shaft + angled legs) if no family symbol found

https://claude.ai/code/session_013Ba5UiQd7BWw5mmgCFcHgw