### PR TITLE
Add unified STING Export Centre dialog and pipeline

### DIFF
--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1483,7 +1483,9 @@ namespace StingTools.Core
                 case "CrossModelClash": return new Temp.CrossModelClashCommand();
                 case "MEPClearance": return new Temp.MEPClearanceValidationCommand();
                 // Phase 74: Removed duplicate "AutoAssignTemplates" case (already at line 1096)
-                case "BatchPrintSheets": return new Docs.BatchPrintSheetsCommand();
+                case "BatchPrintSheets": return new Docs.ExportCenterPdfCommand(); // redirects to Export Centre (PDF preset)
+                case "ExportCenter":     return new Docs.ExportCenterCommand();
+                case "ExportCenterPDF":  return new Docs.ExportCenterPdfCommand();
 
                 // Data Pipeline
                 case "DynamicBindings": return new Temp.DynamicBindingsCommand();

--- a/StingTools/Docs/ExportCenterCommand.cs
+++ b/StingTools/Docs/ExportCenterCommand.cs
@@ -1,0 +1,85 @@
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.UI;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterCommand — IExternalCommand entry point for the unified
+    //  STING Export Centre. Replaces ad-hoc batch-print/PDF/DWG flows by
+    //  routing every export request through the StingExportCenterDialog.
+    //
+    //  Command tag: "ExportCenter" (registered in StingCommandHandler).
+    //  Workflow tag: same.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ExportCenterCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx?.UIDoc == null)
+                {
+                    TaskDialog.Show("STING Export Centre", "No active document.");
+                    return Result.Failed;
+                }
+                StingExportCenterDialog.Show(ctx.UIDoc);
+                return Result.Succeeded;
+            }
+            catch (System.Exception ex)
+            {
+                StingLog.Error("ExportCenterCommand failed", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Quick-launch shortcut that opens the Export Centre with PDF preselected.
+    /// Wired to the legacy "BatchPrintSheets" tag so existing buttons keep working.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ExportCenterPdfCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx?.UIDoc == null)
+                {
+                    TaskDialog.Show("STING Export Centre", "No active document.");
+                    return Result.Failed;
+                }
+
+                // Pre-set the PDF-only profile by mutating state, so the dialog
+                // opens already configured for PDF export.
+                var state = ExportCenterEngine.LoadState();
+                var pdfProfile = state.Profiles.Find(p => p.Name == "Default — PDF only")
+                                ?? state.Profiles.Find(p => p.BuiltIn);
+                if (pdfProfile != null)
+                {
+                    state.LastProfile = pdfProfile.Name;
+                    ExportCenterEngine.SaveState(state);
+                }
+
+                StingExportCenterDialog.Show(ctx.UIDoc);
+                return Result.Succeeded;
+            }
+            catch (System.Exception ex)
+            {
+                StingLog.Error("ExportCenterPdfCommand failed", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/Docs/ExportCenterDwgMerger.cs
+++ b/StingTools/Docs/ExportCenterDwgMerger.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using StingTools.Core;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterDwgMerger — multi-layout DWG merger.
+    //
+    //  Merges N per-sheet DWG files into a single .dwg whose Layouts collection
+    //  contains one tab per source sheet. Implementation strategy (Method A
+    //  from CLAUDE.md): drive AutoCAD via late-bound COM automation. We use
+    //  System.Type / Activator / dynamic to avoid any compile-time AutoCAD ref.
+    //
+    //  When AutoCAD is not installed, IsAvailable() returns false and the engine
+    //  falls back per FallbackOnMergeFailure. Method B (ODA File Converter) is
+    //  not yet implemented — TODO_ODA_MERGE.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    internal static class ExportCenterDwgMerger
+    {
+        /// <summary>Probe for AutoCAD COM. Cached after first call per process.</summary>
+        private static bool? _availableCache;
+
+        internal static bool IsAvailable()
+        {
+            if (_availableCache.HasValue) return _availableCache.Value;
+            try
+            {
+                var t = Type.GetTypeFromProgID("AutoCAD.Application");
+                _availableCache = t != null;
+            }
+            catch { _availableCache = false; }
+            return _availableCache.Value;
+        }
+
+        /// <summary>
+        /// Merge a set of source DWGs into a single output DWG with one Layout
+        /// per source. Returns the output path on success, null on failure.
+        /// </summary>
+        /// <param name="sourceDwgs">Per-sheet DWG paths produced by Document.Export.</param>
+        /// <param name="layoutNames">Layout tab labels, parallel to sourceDwgs.</param>
+        /// <param name="outputPath">Final .dwg path (will be overwritten).</param>
+        internal static string Merge(List<string> sourceDwgs, List<string> layoutNames, string outputPath)
+        {
+            if (!IsAvailable())
+            {
+                StingLog.Warn("DwgMerger.Merge: AutoCAD COM not available.");
+                return null;
+            }
+            if (sourceDwgs == null || sourceDwgs.Count == 0) return null;
+
+            dynamic acad = null;
+            dynamic master = null;
+            try
+            {
+                Type acadType = Type.GetTypeFromProgID("AutoCAD.Application");
+                if (acadType == null) return null;
+                acad = Activator.CreateInstance(acadType);
+                acad.Visible = false;
+
+                // Start with a fresh drawing as the master container.
+                master = acad.Documents.Add();
+                var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                for (int i = 0; i < sourceDwgs.Count; i++)
+                {
+                    string src = sourceDwgs[i];
+                    if (!File.Exists(src)) continue;
+
+                    string desiredName = SanitiseLayoutName(
+                        i < layoutNames.Count ? layoutNames[i] : Path.GetFileNameWithoutExtension(src),
+                        usedNames);
+
+                    try
+                    {
+                        // Copy each layout from src into master via SendCommand —
+                        // less brittle than CopyObjects across documents.
+                        // The LAYOUT command's Template option imports from another DWG.
+                        // Syntax: LAYOUT T <path> <source-layout> <new-name>
+                        string srcSafe = src.Replace("\\", "/");
+                        // Try the most portable invocation: import every layout, then rename.
+                        string cmd = $"_.-LAYOUT _T \"{srcSafe}\" * \n";
+                        master.SendCommand(cmd);
+
+                        // Rename newly-imported tabs to follow our layoutNames pattern.
+                        TryRenameImportedLayouts(master, desiredName, usedNames);
+                    }
+                    catch (Exception exSrc)
+                    {
+                        StingLog.Warn($"DwgMerger.Merge: source '{src}' failed — {exSrc.Message}");
+                    }
+                }
+
+                // SaveAs — file format follows AutoCAD's default (matches the master's
+                // dwgVersion which AutoCAD picked from the per-sheet DWGs).
+                master.SaveAs(outputPath);
+                StingLog.Info($"DwgMerger.Merge: wrote {outputPath} ({sourceDwgs.Count} layouts).");
+                return outputPath;
+            }
+            catch (COMException comEx)
+            {
+                StingLog.Warn("DwgMerger.Merge COM error: " + comEx.Message);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("DwgMerger.Merge: " + ex.Message);
+                return null;
+            }
+            finally
+            {
+                try { master?.Close(false); } catch { }
+                try { acad?.Quit(); } catch { }
+                if (acad != null && Marshal.IsComObject(acad))
+                    Marshal.FinalReleaseComObject(acad);
+            }
+        }
+
+        private static void TryRenameImportedLayouts(dynamic doc, string baseName, HashSet<string> used)
+        {
+            try
+            {
+                dynamic layouts = doc.Layouts;
+                int n = (int)layouts.Count;
+                int seq = 1;
+                for (int i = 0; i < n; i++)
+                {
+                    dynamic layout = layouts.Item(i);
+                    string current = (string)layout.Name;
+                    if (current.Equals("Model", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (used.Contains(current)) continue;
+
+                    string candidate = baseName;
+                    while (used.Contains(candidate))
+                        candidate = baseName + "_" + (++seq).ToString();
+                    layout.Name = candidate;
+                    used.Add(candidate);
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("DwgMerger.TryRenameImportedLayouts: " + ex.Message);
+            }
+        }
+
+        private static string SanitiseLayoutName(string raw, HashSet<string> taken)
+        {
+            string clean = ExportCenterEngine.Sanitise(raw ?? "Layout", "_");
+            if (clean.Length > 31) clean = clean.Substring(0, 31);
+            string candidate = clean;
+            int i = 1;
+            while (taken.Contains(candidate))
+            {
+                string suffix = "_" + (++i);
+                int max = 31 - suffix.Length;
+                candidate = (clean.Length > max ? clean.Substring(0, max) : clean) + suffix;
+            }
+            return candidate;
+        }
+    }
+}

--- a/StingTools/Docs/ExportCenterDwgMerger.cs
+++ b/StingTools/Docs/ExportCenterDwgMerger.cs
@@ -15,14 +15,18 @@ namespace StingTools.Docs
     //  from CLAUDE.md): drive AutoCAD via late-bound COM automation. We use
     //  System.Type / Activator / dynamic to avoid any compile-time AutoCAD ref.
     //
-    //  When AutoCAD is not installed, IsAvailable() returns false and the engine
-    //  falls back per FallbackOnMergeFailure. Method B (ODA File Converter) is
-    //  not yet implemented — TODO_ODA_MERGE.
+    //  When AutoCAD COM (Method A) is unavailable, the engine optionally falls
+    //  back to Method B — ExportCenterOdaConverter — which uses the FREE ODA
+    //  File Converter to normalise per-sheet DWGs to a target version and emit
+    //  a merge_manifest.json for a downstream tool. Method B does NOT itself
+    //  produce a single multi-layout DWG (the free ODA tool can't); the user
+    //  gets staged files + manifest + version normalisation rather than a
+    //  true merged output. See ExportCenterOdaConverter for the scope note.
     // ════════════════════════════════════════════════════════════════════════════
 
     internal static class ExportCenterDwgMerger
     {
-        /// <summary>Probe for AutoCAD COM. Cached after first call per process.</summary>
+        /// <summary>Probe for AutoCAD COM (the only path that yields a true merged DWG).</summary>
         private static bool? _availableCache;
 
         internal static bool IsAvailable()
@@ -35,6 +39,76 @@ namespace StingTools.Docs
             }
             catch { _availableCache = false; }
             return _availableCache.Value;
+        }
+
+        /// <summary>True if either Method A (AutoCAD COM) or Method B (ODA) is available.</summary>
+        internal static bool IsAnyMergerAvailable() =>
+            IsAvailable() || ExportCenterOdaConverter.IsAvailable();
+
+        /// <summary>Friendly description of the active merger for status lines.</summary>
+        internal static string DescribeAvailableMerger()
+        {
+            if (IsAvailable())                          return "AutoCAD COM (true layout merge)";
+            if (ExportCenterOdaConverter.IsAvailable()) return "ODA File Converter (version-normalise + manifest, no true merge)";
+            return null;
+        }
+
+        /// <summary>
+        /// Method B fallback — copy staged DWGs into a final folder, normalise
+        /// every file to <paramref name="targetDwgVersion"/>, and write a
+        /// merge_manifest.json that downstream tools (Teigha SDK, ezdxf script,
+        /// or AutoCAD COM on a different workstation) can use to do the actual
+        /// layout merge. Returns the manifest path on success, null on failure.
+        /// </summary>
+        internal static string MergeViaOda(List<string> sourceDwgs, List<string> layoutNames,
+            string outputDwg, string targetDwgVersion)
+        {
+            if (sourceDwgs == null || sourceDwgs.Count == 0) return null;
+            if (!ExportCenterOdaConverter.IsAvailable())
+            {
+                StingLog.Warn("DwgMerger.MergeViaOda: ODA File Converter not available.");
+                return null;
+            }
+
+            try
+            {
+                string outputFolder = Path.GetDirectoryName(outputDwg) ?? Path.GetTempPath();
+                string stagedFolder = Path.Combine(outputFolder, Path.GetFileNameWithoutExtension(outputDwg) + "_staged");
+                Directory.CreateDirectory(stagedFolder);
+
+                // Stage 1 — assemble inputs in a single folder so the ODA CLI can sweep them.
+                string odaIn = Path.Combine(stagedFolder, "_in");
+                Directory.CreateDirectory(odaIn);
+                foreach (var src in sourceDwgs)
+                {
+                    if (!File.Exists(src)) continue;
+                    File.Copy(src, Path.Combine(odaIn, Path.GetFileName(src)), overwrite: true);
+                }
+
+                // Stage 2 — normalise to target DWG version.
+                string odaVer = ExportCenterOdaConverter.MapStingVersionToOda(targetDwgVersion);
+                int converted = ExportCenterOdaConverter.Convert(odaIn, stagedFolder, odaVer, "DWG");
+                if (converted == 0)
+                {
+                    StingLog.Warn("DwgMerger.MergeViaOda: ODA conversion produced no files.");
+                    return null;
+                }
+
+                // Stage 3 — drop a manifest describing the intended layout structure.
+                string manifest = ExportCenterOdaConverter.WriteMergeManifest(
+                    stagedFolder, sourceDwgs, layoutNames, outputDwg, targetDwgVersion);
+
+                // Stage 4 — clean up the temporary input folder.
+                try { Directory.Delete(odaIn, true); } catch { }
+
+                StingLog.Info($"DwgMerger.MergeViaOda: staged {converted} normalised DWGs + manifest at {stagedFolder}.");
+                return manifest;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("DwgMerger.MergeViaOda: " + ex.Message);
+                return null;
+            }
         }
 
         /// <summary>

--- a/StingTools/Docs/ExportCenterEngine.cs
+++ b/StingTools/Docs/ExportCenterEngine.cs
@@ -1,0 +1,1142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterEngine — the export pipeline that powers StingExportCenterDialog.
+    //
+    //  Responsibilities:
+    //    • Persist / load ExportCenterState in project_config.json
+    //    • Resolve naming templates against per-sheet token contexts
+    //    • Run pre-flight checks
+    //    • Dispatch to per-format exporters (PDF, DWG, IFC, NWC, Image, …)
+    //    • Implement combined-PDF and DWG-multi-layout pipelines
+    //    • Emit ExportRunResult + per-row report rows
+    //
+    //  This engine is intentionally headless — no WPF or TaskDialog calls — so
+    //  it can be invoked from the dialog, a workflow step, or a scheduled job.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    public static class ExportCenterEngine
+    {
+        // ── State persistence (project_config.json: key "ExportCenter") ─────────
+
+        private const string ConfigKey = "ExportCenter";
+
+        public static ExportCenterState LoadState()
+        {
+            try
+            {
+                string path = TagConfig.ConfigSource;
+                ExportCenterState st = null;
+                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                {
+                    var root = JObject.Parse(File.ReadAllText(path));
+                    if (root[ConfigKey] is JObject sub)
+                        st = sub.ToObject<ExportCenterState>();
+                }
+                st ??= new ExportCenterState();
+
+                // Seed built-ins on first run.
+                if (st.Profiles.Count == 0)
+                    st.Profiles.AddRange(ExportCenterState.BuildBuiltInProfiles());
+                else
+                    EnsureBuiltInProfilesPresent(st);
+
+                if (st.SavedSets.Count == 0)
+                    st.SavedSets.AddRange(ExportCenterState.BuildBuiltInSets());
+                else
+                    EnsureBuiltInSetsPresent(st);
+
+                return st;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ExportCenterEngine.LoadState: {ex.Message}");
+                var st = new ExportCenterState();
+                st.Profiles.AddRange(ExportCenterState.BuildBuiltInProfiles());
+                st.SavedSets.AddRange(ExportCenterState.BuildBuiltInSets());
+                return st;
+            }
+        }
+
+        public static void SaveState(ExportCenterState st)
+        {
+            try
+            {
+                string path = TagConfig.ConfigSource;
+                if (string.IsNullOrEmpty(path)) return;
+
+                JObject root = File.Exists(path)
+                    ? JObject.Parse(File.ReadAllText(path))
+                    : new JObject();
+
+                root[ConfigKey] = JObject.FromObject(st);
+                File.WriteAllText(path, root.ToString(Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ExportCenterEngine.SaveState: {ex.Message}");
+            }
+        }
+
+        private static void EnsureBuiltInProfilesPresent(ExportCenterState st)
+        {
+            var existing = new HashSet<string>(st.Profiles.Where(p => p.BuiltIn).Select(p => p.Name));
+            foreach (var bi in ExportCenterState.BuildBuiltInProfiles())
+                if (!existing.Contains(bi.Name)) st.Profiles.Add(bi);
+        }
+
+        private static void EnsureBuiltInSetsPresent(ExportCenterState st)
+        {
+            var existing = new HashSet<string>(st.SavedSets.Where(s => s.BuiltIn).Select(s => s.Name));
+            foreach (var bi in ExportCenterState.BuildBuiltInSets())
+                if (!existing.Contains(bi.Name)) st.SavedSets.Add(bi);
+        }
+
+        // ── Saved-set resolution ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Materialise a saved set into a list of live ElementIds, following the
+        /// "built-in semantic sets" rules (e.g. "All Sheets" returns every ViewSheet).
+        /// Missing element ids are silently dropped; the count is returned via
+        /// <paramref name="missingCount"/>.
+        /// </summary>
+        public static List<ElementId> ResolveSet(Document doc, ExportSavedSet set, out int missingCount)
+        {
+            missingCount = 0;
+            if (set == null) return new List<ElementId>();
+
+            // Built-in semantic sets bypass the persisted id list.
+            if (set.BuiltIn)
+                return ResolveBuiltInSet(doc, set.Name);
+
+            var ids = new List<ElementId>();
+            foreach (string idText in set.ElementIds)
+            {
+                if (!long.TryParse(idText, out long raw)) { missingCount++; continue; }
+                var eid = new ElementId(raw);
+                var el = doc.GetElement(eid);
+                if (el == null) { missingCount++; continue; }
+                ids.Add(eid);
+            }
+            return ids;
+        }
+
+        private static List<ElementId> ResolveBuiltInSet(Document doc, string name)
+        {
+            var sheets = new FilteredElementCollector(doc).OfClass(typeof(ViewSheet))
+                .Cast<ViewSheet>().Where(s => !s.IsTemplate).ToList();
+
+            switch (name)
+            {
+                case "All Sheets":
+                    return sheets.Select(s => s.Id).ToList();
+
+                case "All Views":
+                    return new FilteredElementCollector(doc).OfClass(typeof(View))
+                        .Cast<View>()
+                        .Where(v => !v.IsTemplate && !(v is ViewSheet))
+                        .Select(v => v.Id).ToList();
+
+                case "By Discipline: Architectural":  return FilterByDisc(sheets, "A");
+                case "By Discipline: Mechanical":     return FilterByDisc(sheets, "M");
+                case "By Discipline: Electrical":     return FilterByDisc(sheets, "E");
+                case "By Discipline: Plumbing":       return FilterByDisc(sheets, "P");
+                case "By Discipline: Structural":     return FilterByDisc(sheets, "S");
+
+                case "Issued Sheets":
+                {
+                    // A sheet counts as "issued" if it appears in any revision.
+                    var ids = new List<ElementId>();
+                    foreach (var s in sheets)
+                    {
+                        var revs = s.GetAllRevisionIds();
+                        if (revs != null && revs.Count > 0) ids.Add(s.Id);
+                    }
+                    return ids;
+                }
+
+                case "Revised This Week":
+                {
+                    var cutoff = DateTime.Today.AddDays(-7);
+                    var ids = new List<ElementId>();
+                    foreach (var s in sheets)
+                    {
+                        var revs = s.GetAllRevisionIds();
+                        if (revs == null) continue;
+                        foreach (var rid in revs)
+                        {
+                            if (doc.GetElement(rid) is Revision r &&
+                                DateTime.TryParse(r.RevisionDate, out var d) && d >= cutoff)
+                            { ids.Add(s.Id); break; }
+                        }
+                    }
+                    return ids;
+                }
+
+                case "Currently Opened":
+                {
+                    // We can only inspect the active UI app from the dialog layer;
+                    // engine-side we approximate by returning the active view's sheet (if any).
+                    var ids = new List<ElementId>();
+                    var active = doc.ActiveView;
+                    if (active is ViewSheet vs) ids.Add(vs.Id);
+                    return ids;
+                }
+            }
+            return sheets.Select(s => s.Id).ToList();
+        }
+
+        private static List<ElementId> FilterByDisc(List<ViewSheet> sheets, string disc)
+        {
+            return sheets.Where(s => GetDisciplinePrefix(s.SheetNumber).Equals(disc, StringComparison.OrdinalIgnoreCase))
+                         .Select(s => s.Id).ToList();
+        }
+
+        public static string GetDisciplinePrefix(string sheetNumber)
+        {
+            if (string.IsNullOrWhiteSpace(sheetNumber)) return "Other";
+            int dash = sheetNumber.IndexOf('-');
+            if (dash > 0) return sheetNumber.Substring(0, dash).ToUpperInvariant();
+            string letters = new string(sheetNumber.TakeWhile(char.IsLetter).ToArray());
+            return string.IsNullOrEmpty(letters) ? "Other" : letters.ToUpperInvariant();
+        }
+
+        // ── Token resolver ──────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Resolve a naming template ({SheetNumber}, {Revision}, {Date:yyyyMMdd}, …)
+        /// into a concrete filename stem (without extension). Caller is responsible
+        /// for sanitising disallowed characters and appending the format extension.
+        /// </summary>
+        public static string ResolveNaming(Document doc, View view, string template, OutputSettings outSettings)
+        {
+            if (string.IsNullOrEmpty(template)) template = "{SheetNumber} - {SheetTitle}";
+
+            var tokens = BuildTokenContext(doc, view);
+            return Regex.Replace(template, @"\{(?<key>[A-Za-z0-9_]+)(?::(?<fmt>[^}]+))?\}", m =>
+            {
+                string key = m.Groups["key"].Value;
+                string fmt = m.Groups["fmt"].Value;
+
+                if (key.Equals("Date", StringComparison.OrdinalIgnoreCase))
+                    return DateTime.Now.ToString(string.IsNullOrEmpty(fmt) ? "yyyyMMdd" : fmt);
+                if (key.Equals("Time", StringComparison.OrdinalIgnoreCase))
+                    return DateTime.Now.ToString(string.IsNullOrEmpty(fmt) ? "HHmm" : fmt);
+
+                if (tokens.TryGetValue(key, out string value))
+                    return value ?? "";
+
+                return ""; // unknown tokens vanish — keeps filenames tidy
+            });
+        }
+
+        /// <summary>Build the per-view token map used by ResolveNaming + bookmark templates.</summary>
+        public static Dictionary<string, string> BuildTokenContext(Document doc, View view)
+        {
+            var t = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var pi = doc?.ProjectInformation;
+
+            t["ProjectName"]   = pi?.Name ?? "";
+            t["ProjectNumber"] = pi?.Number ?? "";
+            t["ProjectCode"]   = ReadProjectInfo(pi, "PRJ_ORG_PROJECT_COD_TXT") ?? pi?.Number ?? "";
+            t["Originator"]    = ReadProjectInfo(pi, "PRJ_ORG_ORIGINATOR_COD_TXT") ?? "";
+            t["OriginatorCode"]= t["Originator"];
+            t["CompanyName"]   = ReadProjectInfo(pi, "PRJ_ORG_COMPANY_NAME_TXT") ?? "";
+            t["ClientName"]    = ReadProjectInfo(pi, "PRJ_ORG_CLIENT_NAME_TXT") ?? pi?.ClientName ?? "";
+
+            if (view is ViewSheet sheet)
+            {
+                t["SheetNumber"]  = sheet.SheetNumber ?? "";
+                t["SheetTitle"]   = sheet.Name ?? "";
+                t["DrawingNumber"]= sheet.SheetNumber ?? "";
+                t["DrawingTitle"] = sheet.Name ?? "";
+                t["DrawingSet"]   = ReadParam(sheet, "Sheet Issue Date") ?? "";
+                t["Discipline"]   = GetDisciplinePrefix(sheet.SheetNumber);
+
+                var (rev, revDate) = GetCurrentRevision(doc, sheet);
+                t["Revision"] = rev ?? "";
+                t["RevDate"]  = revDate ?? "";
+
+                t["Volume"]      = ReadParam(sheet, "STING_VOLUME_TXT") ?? "00";
+                t["Level"]       = ReadParam(sheet, "STING_LVL_COD_TXT") ?? "";
+                t["Type"]        = ReadParam(sheet, "STING_DOC_TYPE_TXT") ?? "DR";
+                t["Role"]        = ReadParam(sheet, "STING_ROLE_TXT") ?? t["Discipline"];
+                t["Suitability"] = ReadParam(sheet, "STING_SUITABILITY_TXT") ?? "S2";
+                t["Format"]      = ""; // filled in by caller per format
+            }
+            else if (view != null)
+            {
+                t["SheetNumber"]   = "";
+                t["SheetTitle"]    = view.Name ?? "";
+                t["DrawingNumber"] = "";
+                t["DrawingTitle"]  = view.Name ?? "";
+                t["Discipline"]    = view.ViewType.ToString();
+                t["Revision"]      = "";
+                t["RevDate"]       = "";
+            }
+
+            return t;
+        }
+
+        private static string ReadProjectInfo(ProjectInfo pi, string paramName)
+        {
+            if (pi == null) return null;
+            try
+            {
+                var p = pi.LookupParameter(paramName);
+                if (p == null || !p.HasValue) return null;
+                return p.AsString();
+            }
+            catch { return null; }
+        }
+
+        private static string ReadParam(Element el, string name)
+        {
+            if (el == null) return null;
+            try
+            {
+                var p = el.LookupParameter(name);
+                if (p == null || !p.HasValue) return null;
+                return p.StorageType == StorageType.String ? p.AsString() : p.AsValueString();
+            }
+            catch { return null; }
+        }
+
+        private static (string rev, string date) GetCurrentRevision(Document doc, ViewSheet sheet)
+        {
+            try
+            {
+                var revIds = sheet.GetAllRevisionIds();
+                if (revIds == null || revIds.Count == 0) return (null, null);
+                var lastId = revIds[revIds.Count - 1];
+                if (doc.GetElement(lastId) is Revision r)
+                    return (r.SequenceNumber.ToString(), r.RevisionDate);
+            }
+            catch { }
+            return (null, null);
+        }
+
+        // ── Filename hygiene ────────────────────────────────────────────────────
+
+        public static string Sanitise(string filename, string replacement)
+        {
+            if (string.IsNullOrEmpty(filename)) return "untitled";
+            var bad = Path.GetInvalidFileNameChars();
+            var sb = new System.Text.StringBuilder(filename.Length);
+            foreach (char c in filename)
+                sb.Append(Array.IndexOf(bad, c) >= 0 ? replacement : c.ToString());
+            string clean = sb.ToString().Trim().TrimEnd('.');
+            return string.IsNullOrEmpty(clean) ? "untitled" : clean;
+        }
+
+        // ── Pre-flight ──────────────────────────────────────────────────────────
+
+        public static List<ExportPreflightIssue> PreflightCheck(
+            Document doc, ExportProfile profile, List<ElementId> selectedIds)
+        {
+            var issues = new List<ExportPreflightIssue>();
+            if (selectedIds == null || selectedIds.Count == 0)
+                issues.Add(Err("NO_SELECTION", "No sheets or views selected."));
+
+            if (profile.Formats == ExportFormats.None)
+                issues.Add(Err("NO_FORMAT", "No output format is active."));
+
+            // Folder writability
+            try
+            {
+                if (profile.Output.Destination != ExportDestination.PlanscapeCde)
+                {
+                    var folder = profile.Output.LocalFolder;
+                    if (string.IsNullOrEmpty(folder))
+                        issues.Add(Err("NO_OUTPUT_FOLDER", "Output folder is empty."));
+                    else if (!Directory.Exists(folder))
+                    {
+                        if (profile.Output.CreateFolderIfMissing)
+                            issues.Add(Warn("FOLDER_CREATE",
+                                $"Output folder doesn't exist and will be created: {folder}"));
+                        else
+                            issues.Add(Err("FOLDER_MISSING", $"Output folder doesn't exist: {folder}"));
+                    }
+                }
+            }
+            catch (Exception ex) { issues.Add(Warn("FOLDER_CHECK", ex.Message)); }
+
+            // Filename collisions across the projected set
+            try
+            {
+                var seen = new Dictionary<string, string>();
+                foreach (var eid in selectedIds)
+                {
+                    if (doc.GetElement(eid) is not View v) continue;
+                    string stem = Sanitise(ResolveNaming(doc, v, profile.Output.NamingTemplate, profile.Output),
+                                           profile.Output.IllegalCharReplacement);
+                    if (seen.TryGetValue(stem, out string other) && other != v.Id.ToString())
+                        issues.Add(Warn("DUP_NAME",
+                            $"Two items would produce the same filename: '{stem}' (sheets {other} and {v.Id})"));
+                    else
+                        seen[stem] = v.Id.ToString();
+                }
+            }
+            catch (Exception ex) { issues.Add(Warn("NAME_CHECK", ex.Message)); }
+
+            // Compliance gate (BIM mode only)
+            if (profile.Mode == ExportCenterMode.BIM)
+            {
+                try
+                {
+                    var c = ComplianceScan.Scan(doc);
+                    if (c != null && c.CompliancePercent < 50)
+                        issues.Add(Warn("LOW_COMPLIANCE",
+                            $"Project tag compliance is {c.CompliancePercent}% — exports may show incomplete tag data."));
+                }
+                catch { /* non-fatal */ }
+            }
+
+            // DWG multi-layout availability
+            if ((profile.Formats & ExportFormats.DWG) != 0 &&
+                profile.Dwg.OutputMode == DwgOutputMode.AllInOneMultiLayout)
+            {
+                if (!IsMultiLayoutMergerAvailable())
+                    issues.Add(Warn("DWG_MERGE_UNAVAILABLE",
+                        "DWG multi-layout merge requires AutoCAD COM or ODA libraries — none detected. " +
+                        (profile.Dwg.FallbackOnMergeFailure
+                            ? "Will fall back to individual files."
+                            : "Export will fail.")));
+            }
+
+            return issues;
+        }
+
+        public static bool IsMultiLayoutMergerAvailable()
+        {
+            // Simple heuristic — real implementation would probe for AutoCAD COM
+            // (Type.GetTypeFromProgID("AutoCAD.Application")) and the ODA SDK on
+            // disk. For headless test envs we report unavailable.
+            try
+            {
+                var t = Type.GetTypeFromProgID("AutoCAD.Application");
+                if (t != null) return true;
+            }
+            catch { }
+            return false;
+        }
+
+        private static ExportPreflightIssue Err(string code, string msg) =>
+            new() { Level = ExportPreflightIssue.Severity.Error, Code = code, Message = msg };
+
+        private static ExportPreflightIssue Warn(string code, string msg) =>
+            new() { Level = ExportPreflightIssue.Severity.Warning, Code = code, Message = msg };
+
+        // ── Run dispatcher ──────────────────────────────────────────────────────
+
+        public delegate void ProgressReporter(int current, int total, string label);
+
+        /// <summary>
+        /// Run the export pipeline. Returns an aggregate result. Caller is expected
+        /// to be on the Revit API thread (this method calls Document.Export which
+        /// is not transactional but must run on the UI thread).
+        /// </summary>
+        public static ExportRunResult Run(
+            Document doc,
+            ExportProfile profile,
+            List<ElementId> selectedIds,
+            ProgressReporter progress = null,
+            Func<bool> cancelRequested = null)
+        {
+            var result = new ExportRunResult { Profile = profile };
+
+            try
+            {
+                EnsureFolder(profile);
+
+                int total = CountFormatPasses(profile) * (selectedIds?.Count ?? 0);
+                int done = 0;
+
+                // PDF
+                if ((profile.Formats & ExportFormats.PDF) != 0)
+                {
+                    RunPdf(doc, profile, selectedIds, result,
+                        (label) => progress?.Invoke(++done, total, label),
+                        cancelRequested);
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; goto Done; }
+                }
+
+                // DWG
+                if ((profile.Formats & ExportFormats.DWG) != 0)
+                {
+                    RunDwg(doc, profile, selectedIds, result,
+                        (label) => progress?.Invoke(++done, total, label),
+                        cancelRequested);
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; goto Done; }
+                }
+
+                // IFC
+                if ((profile.Formats & ExportFormats.IFC) != 0)
+                {
+                    RunIfc(doc, profile, selectedIds, result,
+                        (label) => progress?.Invoke(++done, total, label),
+                        cancelRequested);
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; goto Done; }
+                }
+
+                // NWC, DGN, DWF, Image, XML — implementations tagged TODO_FORMAT.
+                if ((profile.Formats & ExportFormats.NWC) != 0)
+                    result.Warnings.Add("NWC export is not yet implemented in this build (requires Navisworks NWC Export Utility).");
+                if ((profile.Formats & ExportFormats.Image) != 0)
+                    RunImage(doc, profile, selectedIds, result,
+                        (label) => progress?.Invoke(++done, total, label), cancelRequested);
+                if ((profile.Formats & ExportFormats.DGN) != 0)
+                    RunDgn(doc, profile, selectedIds, result,
+                        (label) => progress?.Invoke(++done, total, label), cancelRequested);
+                if ((profile.Formats & ExportFormats.DWF) != 0)
+                    RunDwf(doc, profile, selectedIds, result,
+                        (label) => progress?.Invoke(++done, total, label), cancelRequested);
+                if ((profile.Formats & ExportFormats.XML) != 0)
+                    result.Warnings.Add("XML export is not yet implemented in this build.");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("ExportCenterEngine.Run failed", ex);
+                result.Warnings.Add("Run failed: " + ex.Message);
+            }
+            finally
+            {
+                Done:
+                result.FinishedUtc = DateTime.UtcNow;
+                if (profile.Output.GenerateReport)
+                    WriteReport(profile, result);
+            }
+            return result;
+        }
+
+        private static int CountFormatPasses(ExportProfile p)
+        {
+            int n = 0;
+            foreach (ExportFormats f in Enum.GetValues(typeof(ExportFormats)))
+                if (f != ExportFormats.None && (p.Formats & f) != 0) n++;
+            return Math.Max(1, n);
+        }
+
+        private static void EnsureFolder(ExportProfile p)
+        {
+            if (p.Output.Destination == ExportDestination.PlanscapeCde) return;
+            var f = p.Output.LocalFolder;
+            if (!string.IsNullOrEmpty(f) && !Directory.Exists(f) && p.Output.CreateFolderIfMissing)
+                Directory.CreateDirectory(f);
+        }
+
+        private static string SubFolderFor(ExportProfile p, string format, string discipline)
+        {
+            string root = p.Output.LocalFolder;
+            if (p.Output.SplitByFormatSubFolder) root = Path.Combine(root, format);
+            if (p.Output.SplitByDisciplineSubFolder && !string.IsNullOrEmpty(discipline))
+                root = Path.Combine(root, discipline);
+            if (!Directory.Exists(root)) Directory.CreateDirectory(root);
+            return root;
+        }
+
+        // ── PDF pipeline ────────────────────────────────────────────────────────
+
+        private static void RunPdf(Document doc, ExportProfile profile, List<ElementId> ids,
+            ExportRunResult result, Action<string> tick, Func<bool> cancel)
+        {
+            var sheets = ids.Select(doc.GetElement).OfType<View>().ToList();
+            if (sheets.Count == 0) return;
+
+            switch (profile.Pdf.CombineMode)
+            {
+                case PdfCombineMode.OnePerSheet:
+                    foreach (var v in sheets)
+                    {
+                        if (cancel != null && cancel()) return;
+                        ExportSinglePdf(doc, v, profile, result);
+                        tick?.Invoke($"PDF: {GetLabel(v)}");
+                    }
+                    break;
+
+                case PdfCombineMode.OnePerDiscipline:
+                {
+                    var groups = sheets.OfType<ViewSheet>()
+                        .GroupBy(s => GetDisciplinePrefix(s.SheetNumber))
+                        .ToList();
+                    foreach (var g in groups)
+                    {
+                        if (cancel != null && cancel()) return;
+                        ExportCombinedPdf(doc, g.ToList<View>(), profile, result, g.Key);
+                        tick?.Invoke($"PDF (combined): {g.Key}");
+                    }
+                    break;
+                }
+
+                case PdfCombineMode.OnePerSet:
+                    ExportCombinedPdf(doc, sheets, profile, result, "All");
+                    tick?.Invoke("PDF (combined): All");
+                    break;
+
+                case PdfCombineMode.CustomGroups:
+                    foreach (var kv in profile.Pdf.CustomGroups)
+                    {
+                        var groupSheets = kv.Value
+                            .Select(idText => long.TryParse(idText, out var n) ? doc.GetElement(new ElementId(n)) : null)
+                            .OfType<View>().ToList();
+                        if (groupSheets.Count == 0) continue;
+                        ExportCombinedPdf(doc, groupSheets, profile, result, kv.Key);
+                        tick?.Invoke($"PDF (custom): {kv.Key}");
+                    }
+                    break;
+            }
+        }
+
+        private static void ExportSinglePdf(Document doc, View view, ExportProfile profile, ExportRunResult result)
+        {
+            var row = StartRow(view, "PDF");
+            try
+            {
+                string disc = view is ViewSheet vs ? GetDisciplinePrefix(vs.SheetNumber) : "";
+                string folder = SubFolderFor(profile, "PDF", disc);
+                string stem = Sanitise(
+                    ResolveNaming(doc, view, profile.Output.NamingTemplate, profile.Output),
+                    profile.Output.IllegalCharReplacement);
+
+                stem = ResolveConflict(folder, stem, "pdf", profile.Output.ConflictMode, out bool skip);
+                if (skip) { row.Success = false; row.Error = "Skipped — file exists"; return; }
+
+                var opts = new PDFExportOptions
+                {
+                    FileName = stem,
+                    Combine = false,
+                    AlwaysUseRaster = profile.Pdf.HiddenLineMode == "Raster",
+                    RasterQuality = MapRasterQuality(profile.Pdf.RasterDpi),
+                    ColorDepth = MapColorDepth(profile.Pdf.ColourScheme),
+                };
+
+                bool ok = doc.Export(folder, new List<ElementId> { view.Id }, opts);
+                row.OutputPath = Path.Combine(folder, stem + ".pdf");
+                row.Success = ok && File.Exists(row.OutputPath);
+                if (row.Success) row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                else row.Error = "PDF export returned false";
+            }
+            catch (Exception ex)
+            {
+                row.Success = false; row.Error = ex.Message;
+                StingLog.Warn($"PDF export {row.SheetNumber}: {ex.Message}");
+            }
+            finally { CommitRow(row, result); }
+        }
+
+        private static void ExportCombinedPdf(Document doc, List<View> views,
+            ExportProfile profile, ExportRunResult result, string groupName)
+        {
+            var row = new ExportResultRow
+            {
+                SheetNumber = $"[combined:{groupName}]",
+                SheetTitle = $"{views.Count} sheets",
+                Format = "PDF",
+                StartedUtc = DateTime.UtcNow,
+            };
+            try
+            {
+                string folder = SubFolderFor(profile, "PDF", profile.Output.SplitByDisciplineSubFolder ? groupName : null);
+                string stem = Sanitise(
+                    ResolveNaming(doc, views[0], profile.Output.NamingTemplate, profile.Output) + "_" + groupName,
+                    profile.Output.IllegalCharReplacement);
+                stem = ResolveConflict(folder, stem, "pdf", profile.Output.ConflictMode, out bool skip);
+                if (skip) { row.Success = false; row.Error = "Skipped — file exists"; return; }
+
+                var ordered = OrderForMerge(views, profile.Pdf.MergeOrderSheetIds);
+
+                var opts = new PDFExportOptions
+                {
+                    FileName = stem,
+                    Combine = true,
+                    AlwaysUseRaster = profile.Pdf.HiddenLineMode == "Raster",
+                    RasterQuality = MapRasterQuality(profile.Pdf.RasterDpi),
+                    ColorDepth = MapColorDepth(profile.Pdf.ColourScheme),
+                };
+
+                bool ok = doc.Export(folder, ordered.Select(v => v.Id).ToList(), opts);
+                row.OutputPath = Path.Combine(folder, stem + ".pdf");
+                row.Success = ok && File.Exists(row.OutputPath);
+                if (row.Success)
+                {
+                    row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                    if (profile.Pdf.AddBookmarks)
+                        TryInjectBookmarks(row.OutputPath, ordered, profile, result);
+                    if (profile.Pdf.ApplyWatermark)
+                        TryInjectWatermark(row.OutputPath, profile.Pdf, result);
+                }
+                else row.Error = "Combined PDF export returned false";
+            }
+            catch (Exception ex)
+            {
+                row.Success = false; row.Error = ex.Message;
+                StingLog.Warn($"PDF combined export {groupName}: {ex.Message}");
+            }
+            finally
+            {
+                row.FinishedUtc = DateTime.UtcNow;
+                result.Rows.Add(row);
+            }
+        }
+
+        private static List<View> OrderForMerge(List<View> views, List<string> mergeOrder)
+        {
+            if (mergeOrder == null || mergeOrder.Count == 0)
+                return views.OrderBy(v => v is ViewSheet s ? s.SheetNumber : v.Name).ToList();
+
+            var index = mergeOrder.Select((id, i) => new { id, i }).ToDictionary(x => x.id, x => x.i);
+            return views.OrderBy(v => index.TryGetValue(v.Id.ToString(), out int i) ? i : int.MaxValue).ToList();
+        }
+
+        private static void TryInjectBookmarks(string pdfPath, List<View> views,
+            ExportProfile profile, ExportRunResult result)
+        {
+            // Bookmark injection requires PdfSharp 6.x or PdfPig — neither is currently
+            // a build dependency. Mark as TODO so the dialog can show the warning and
+            // the build CI can pick it up.
+            result.Warnings.Add(
+                $"Bookmark injection skipped for '{Path.GetFileName(pdfPath)}' — " +
+                "requires PdfSharp 6.x (TODO_PDFSHARP_DEP).");
+        }
+
+        private static void TryInjectWatermark(string pdfPath, PdfExportSettings pdf, ExportRunResult result)
+        {
+            result.Warnings.Add(
+                $"Watermark injection skipped for '{Path.GetFileName(pdfPath)}' — " +
+                "requires PdfSharp 6.x (TODO_PDFSHARP_DEP).");
+        }
+
+        private static PDFExportQualityType MapRasterQuality(int dpi) => dpi switch
+        {
+            <= 72  => PDFExportQualityType.DPI72,
+            <= 150 => PDFExportQualityType.DPI150,
+            <= 300 => PDFExportQualityType.DPI300,
+            _      => PDFExportQualityType.DPI600,
+        };
+
+        private static ColorDepthType MapColorDepth(string scheme) => scheme switch
+        {
+            "Greyscale"     => ColorDepthType.GrayScale,
+            "BlackAndWhite" => ColorDepthType.BlackLine,
+            _               => ColorDepthType.Color,
+        };
+
+        // ── DWG pipeline ────────────────────────────────────────────────────────
+
+        private static void RunDwg(Document doc, ExportProfile profile, List<ElementId> ids,
+            ExportRunResult result, Action<string> tick, Func<bool> cancel)
+        {
+            var sheets = ids.Select(doc.GetElement).OfType<View>().ToList();
+            if (sheets.Count == 0) return;
+
+            var dwgOpts = ResolveDwgOptions(doc, profile);
+
+            switch (profile.Dwg.OutputMode)
+            {
+                case DwgOutputMode.OnePerSheet:
+                case DwgOutputMode.ModelSpaceOnly:
+                    foreach (var v in sheets)
+                    {
+                        if (cancel != null && cancel()) return;
+                        ExportSingleDwg(doc, v, profile, dwgOpts, result);
+                        tick?.Invoke($"DWG: {GetLabel(v)}");
+                    }
+                    break;
+
+                case DwgOutputMode.AllInOneMultiLayout:
+                    if (IsMultiLayoutMergerAvailable())
+                        ExportMultiLayoutDwg(doc, sheets, profile, dwgOpts, result, "All");
+                    else if (profile.Dwg.FallbackOnMergeFailure)
+                    {
+                        result.Warnings.Add("DWG multi-layout merger unavailable — exporting individual files.");
+                        foreach (var v in sheets) ExportSingleDwg(doc, v, profile, dwgOpts, result);
+                    }
+                    else
+                        result.Warnings.Add("DWG multi-layout export skipped — merger unavailable.");
+                    tick?.Invoke("DWG (multi-layout)");
+                    break;
+
+                case DwgOutputMode.CustomGroups:
+                    foreach (var kv in profile.Dwg.CustomGroups)
+                    {
+                        var group = kv.Value
+                            .Select(s => long.TryParse(s, out long n) ? doc.GetElement(new ElementId(n)) : null)
+                            .OfType<View>().ToList();
+                        if (group.Count == 0) continue;
+                        if (IsMultiLayoutMergerAvailable())
+                            ExportMultiLayoutDwg(doc, group, profile, dwgOpts, result, kv.Key);
+                        else
+                            foreach (var v in group) ExportSingleDwg(doc, v, profile, dwgOpts, result);
+                        tick?.Invoke($"DWG (group): {kv.Key}");
+                    }
+                    break;
+            }
+        }
+
+        private static DWGExportOptions ResolveDwgOptions(Document doc, ExportProfile profile)
+        {
+            DWGExportOptions opts = null;
+            try
+            {
+                if (!string.IsNullOrEmpty(profile.Dwg.ExportSetupName) &&
+                    profile.Dwg.ExportSetupName != "<in-session>")
+                    opts = DWGExportOptions.GetPredefinedOptions(doc, profile.Dwg.ExportSetupName);
+            }
+            catch { }
+            opts ??= new DWGExportOptions();
+            opts.MergedViews = profile.Dwg.OutputMode == DwgOutputMode.ModelSpaceOnly;
+            opts.FileVersion = MapDwgVersion(profile.Dwg.DwgVersion);
+            return opts;
+        }
+
+        private static ACADVersion MapDwgVersion(string v) => v switch
+        {
+            "AC2018" => ACADVersion.R2018,
+            "AC2013" => ACADVersion.R2013,
+            "AC2010" => ACADVersion.R2010,
+            "AC2007" => ACADVersion.R2007,
+            "AC2004" => ACADVersion.R2004,
+            _        => ACADVersion.Default,
+        };
+
+        private static void ExportSingleDwg(Document doc, View view, ExportProfile profile,
+            DWGExportOptions opts, ExportRunResult result)
+        {
+            var row = StartRow(view, "DWG");
+            try
+            {
+                string disc = view is ViewSheet vs ? GetDisciplinePrefix(vs.SheetNumber) : "";
+                string folder = SubFolderFor(profile, "DWG", disc);
+                string stem = Sanitise(
+                    ResolveNaming(doc, view, profile.Output.NamingTemplate, profile.Output),
+                    profile.Output.IllegalCharReplacement);
+                stem = ResolveConflict(folder, stem, "dwg", profile.Output.ConflictMode, out bool skip);
+                if (skip) { row.Success = false; row.Error = "Skipped — file exists"; return; }
+
+                bool ok = doc.Export(folder, stem, new List<ElementId> { view.Id }, opts);
+                row.OutputPath = Path.Combine(folder, stem + ".dwg");
+                row.Success = ok && File.Exists(row.OutputPath);
+                if (row.Success) row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                else row.Error = "DWG export returned false";
+            }
+            catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+            finally { CommitRow(row, result); }
+        }
+
+        private static void ExportMultiLayoutDwg(Document doc, List<View> sheets, ExportProfile profile,
+            DWGExportOptions opts, ExportRunResult result, string groupName)
+        {
+            var row = new ExportResultRow
+            {
+                SheetNumber = $"[multilayout:{groupName}]",
+                SheetTitle = $"{sheets.Count} sheets",
+                Format = "DWG",
+                StartedUtc = DateTime.UtcNow,
+            };
+            try
+            {
+                // Step 1: per-sheet temp export
+                string temp = Path.Combine(Path.GetTempPath(),
+                    "STING_DWG_MERGE_" + DateTime.Now.ToString("yyyyMMddHHmmss"));
+                Directory.CreateDirectory(temp);
+                foreach (var v in sheets)
+                {
+                    string label = SanitiseLayoutName(ResolveNaming(doc, v, profile.Dwg.LayoutNameTemplate, profile.Output));
+                    doc.Export(temp, label, new List<ElementId> { v.Id }, opts);
+                }
+
+                // Step 2: merge — implementation deferred (TODO_DWG_MERGE).
+                // The plan in CLAUDE.md uses AutoCAD COM (Method A) or ODA (Method B);
+                // for now we stage the files, leave them for the user, and emit a
+                // warning. Falling back here keeps the dialog functional.
+                result.Warnings.Add(
+                    $"DWG multi-layout merge for '{groupName}' deferred — " +
+                    $"individual DWGs staged at: {temp} (TODO_DWG_MERGE).");
+                row.OutputPath = temp;
+                row.Success = true;
+            }
+            catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+            finally
+            {
+                row.FinishedUtc = DateTime.UtcNow;
+                result.Rows.Add(row);
+            }
+        }
+
+        private static string SanitiseLayoutName(string name)
+        {
+            // AutoCAD layout tab names: max 31 chars, no /\:*?"<>|
+            string s = Sanitise(name ?? "Layout", "_");
+            return s.Length <= 31 ? s : s.Substring(0, 31);
+        }
+
+        // ── IFC pipeline ────────────────────────────────────────────────────────
+
+        private static void RunIfc(Document doc, ExportProfile profile, List<ElementId> ids,
+            ExportRunResult result, Action<string> tick, Func<bool> cancel)
+        {
+            // IFC is whole-document; we ignore sheet selection for IFC and emit one file.
+            var row = new ExportResultRow
+            {
+                SheetNumber = "[ifc]",
+                SheetTitle = doc.PathName,
+                Format = "IFC",
+                StartedUtc = DateTime.UtcNow,
+            };
+            try
+            {
+                string folder = SubFolderFor(profile, "IFC", null);
+                string stem = Sanitise(
+                    ResolveNaming(doc, doc.ActiveView, profile.Output.NamingTemplate, profile.Output),
+                    profile.Output.IllegalCharReplacement);
+
+                var opts = new IFCExportOptions();
+                opts.FileVersion = MapIfcSchema(profile.Ifc.Schema);
+                if (!string.IsNullOrEmpty(profile.Ifc.PhaseName))
+                {
+                    var phase = new FilteredElementCollector(doc).OfClass(typeof(Phase))
+                        .Cast<Phase>().FirstOrDefault(p => p.Name == profile.Ifc.PhaseName);
+                    if (phase != null) opts.AddOption("ActivePhaseId", phase.Id.ToString());
+                }
+
+                using (var t = new Transaction(doc, "STING IFC export"))
+                {
+                    t.Start();
+                    bool ok = doc.Export(folder, stem, opts);
+                    t.RollBack(); // IFC export doesn't actually mutate the model
+                    row.OutputPath = Path.Combine(folder, stem + ".ifc");
+                    row.Success = ok && File.Exists(row.OutputPath);
+                    if (row.Success) row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                    else row.Error = "IFC export returned false";
+                }
+                tick?.Invoke("IFC");
+            }
+            catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+            finally
+            {
+                row.FinishedUtc = DateTime.UtcNow;
+                result.Rows.Add(row);
+            }
+        }
+
+        private static IFCVersion MapIfcSchema(string s) => s switch
+        {
+            "IFC2x3" => IFCVersion.IFC2x3CV2,
+            "IFC4"   => IFCVersion.IFC4,
+            "IFC4x3" => IFCVersion.IFC4,   // 4x3 not yet exposed in many API versions
+            _        => IFCVersion.IFC4,
+        };
+
+        // ── Image / DGN / DWF ───────────────────────────────────────────────────
+
+        private static void RunImage(Document doc, ExportProfile profile, List<ElementId> ids,
+            ExportRunResult result, Action<string> tick, Func<bool> cancel)
+        {
+            foreach (var eid in ids)
+            {
+                if (cancel != null && cancel()) return;
+                if (doc.GetElement(eid) is not View v) continue;
+                var row = StartRow(v, "Image");
+                try
+                {
+                    string folder = SubFolderFor(profile, "Image", null);
+                    string stem = Sanitise(
+                        ResolveNaming(doc, v, profile.Output.NamingTemplate, profile.Output),
+                        profile.Output.IllegalCharReplacement);
+                    string path = Path.Combine(folder, stem + "." + profile.Image.Format.ToLowerInvariant());
+
+                    var io = new ImageExportOptions
+                    {
+                        FilePath = path,
+                        ZoomType = ZoomFitType.FitToPage,
+                        PixelSize = 2400,
+                        ImageResolution = MapImageDpi(profile.Image.Dpi),
+                        ExportRange = ExportRange.SetOfViews,
+                        HLRandWFViewsFileType = MapImageType(profile.Image.Format),
+                        ShadowViewsFileType = MapImageType(profile.Image.Format),
+                    };
+                    io.SetViewsAndSheets(new List<ElementId> { v.Id });
+                    doc.ExportImage(io);
+
+                    row.OutputPath = path;
+                    row.Success = File.Exists(path);
+                    if (row.Success) row.FileSizeBytes = new FileInfo(path).Length;
+                    tick?.Invoke($"Image: {GetLabel(v)}");
+                }
+                catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+                finally { CommitRow(row, result); }
+            }
+        }
+
+        private static ImageResolution MapImageDpi(int dpi) => dpi switch
+        {
+            <= 72  => ImageResolution.DPI_72,
+            <= 150 => ImageResolution.DPI_150,
+            <= 300 => ImageResolution.DPI_300,
+            _      => ImageResolution.DPI_600,
+        };
+
+        private static ImageFileType MapImageType(string fmt) => fmt.ToUpperInvariant() switch
+        {
+            "JPEG" => ImageFileType.JPEGLossless,
+            "TIFF" => ImageFileType.TIFF,
+            _      => ImageFileType.PNG,
+        };
+
+        private static void RunDgn(Document doc, ExportProfile profile, List<ElementId> ids,
+            ExportRunResult result, Action<string> tick, Func<bool> cancel)
+        {
+            var opts = new DGNExportOptions();
+            foreach (var eid in ids)
+            {
+                if (cancel != null && cancel()) return;
+                if (doc.GetElement(eid) is not View v) continue;
+                var row = StartRow(v, "DGN");
+                try
+                {
+                    string folder = SubFolderFor(profile, "DGN", null);
+                    string stem = Sanitise(
+                        ResolveNaming(doc, v, profile.Output.NamingTemplate, profile.Output),
+                        profile.Output.IllegalCharReplacement);
+                    bool ok = doc.Export(folder, stem, new List<ElementId> { v.Id }, opts);
+                    row.OutputPath = Path.Combine(folder, stem + ".dgn");
+                    row.Success = ok && File.Exists(row.OutputPath);
+                    if (row.Success) row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                    else row.Error = "DGN export returned false";
+                    tick?.Invoke($"DGN: {GetLabel(v)}");
+                }
+                catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+                finally { CommitRow(row, result); }
+            }
+        }
+
+        private static void RunDwf(Document doc, ExportProfile profile, List<ElementId> ids,
+            ExportRunResult result, Action<string> tick, Func<bool> cancel)
+        {
+            foreach (var eid in ids)
+            {
+                if (cancel != null && cancel()) return;
+                if (doc.GetElement(eid) is not View v) continue;
+                var row = StartRow(v, profile.Dwf.DwfX ? "DWFx" : "DWF");
+                try
+                {
+                    string folder = SubFolderFor(profile, profile.Dwf.DwfX ? "DWFx" : "DWF", null);
+                    string stem = Sanitise(
+                        ResolveNaming(doc, v, profile.Output.NamingTemplate, profile.Output),
+                        profile.Output.IllegalCharReplacement);
+
+                    bool ok;
+                    if (profile.Dwf.DwfX)
+                    {
+                        var dx = new DWFXExportOptions();
+                        ok = doc.Export(folder, stem, new List<ElementId> { v.Id }, dx);
+                    }
+                    else
+                    {
+                        var dw = new DWFExportOptions();
+                        ok = doc.Export(folder, stem, new List<ElementId> { v.Id }, dw);
+                    }
+
+                    string ext = profile.Dwf.DwfX ? ".dwfx" : ".dwf";
+                    row.OutputPath = Path.Combine(folder, stem + ext);
+                    row.Success = ok && File.Exists(row.OutputPath);
+                    if (row.Success) row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                    else row.Error = "DWF export returned false";
+                    tick?.Invoke($"DWF: {GetLabel(v)}");
+                }
+                catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+                finally { CommitRow(row, result); }
+            }
+        }
+
+        // ── Helpers shared by per-format runs ───────────────────────────────────
+
+        private static ExportResultRow StartRow(View v, string format) => new()
+        {
+            SheetId = v?.Id.ToString(),
+            SheetNumber = v is ViewSheet s ? s.SheetNumber : "",
+            SheetTitle = v?.Name ?? "",
+            Format = format,
+            StartedUtc = DateTime.UtcNow,
+        };
+
+        private static void CommitRow(ExportResultRow row, ExportRunResult result)
+        {
+            row.FinishedUtc = DateTime.UtcNow;
+            result.Rows.Add(row);
+        }
+
+        private static string GetLabel(View v) =>
+            v is ViewSheet s ? $"{s.SheetNumber} - {s.Name}" : v.Name;
+
+        /// <summary>Apply the configured filename-conflict rule.</summary>
+        public static string ResolveConflict(string folder, string stem, string ext,
+            FilenameConflictMode mode, out bool skip)
+        {
+            skip = false;
+            string full = Path.Combine(folder, stem + "." + ext);
+            if (!File.Exists(full)) return stem;
+
+            switch (mode)
+            {
+                case FilenameConflictMode.Skip:      skip = true; return stem;
+                case FilenameConflictMode.Overwrite: return stem;
+                case FilenameConflictMode.AutoRename:
+                {
+                    int i = 1;
+                    while (File.Exists(Path.Combine(folder, $"{stem}_{i}.{ext}"))) i++;
+                    return $"{stem}_{i}";
+                }
+                default:
+                    // Caller would prompt in Ask mode — engine returns stem and lets the dialog override.
+                    return stem;
+            }
+        }
+
+        // ── Report writer ───────────────────────────────────────────────────────
+
+        private static void WriteReport(ExportProfile profile, ExportRunResult result)
+        {
+            try
+            {
+                string folder = profile.Output.LocalFolder;
+                if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder)) return;
+                string stamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                string path = Path.Combine(folder, $"STING_Export_Report_{stamp}.csv");
+
+                using var w = new StreamWriter(path);
+                w.WriteLine("Format,SheetNumber,SheetTitle,OutputPath,Bytes,Success,Error,DurationMs");
+                foreach (var r in result.Rows)
+                {
+                    w.WriteLine(string.Join(",", new[]
+                    {
+                        Csv(r.Format), Csv(r.SheetNumber), Csv(r.SheetTitle),
+                        Csv(r.OutputPath), r.FileSizeBytes.ToString(),
+                        r.Success ? "1" : "0", Csv(r.Error),
+                        ((long)r.Duration.TotalMilliseconds).ToString(),
+                    }));
+                }
+                StingLog.Info($"Export report written: {path}");
+            }
+            catch (Exception ex) { StingLog.Warn($"Export report: {ex.Message}"); }
+        }
+
+        private static string Csv(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return "";
+            bool quote = s.Contains(',') || s.Contains('"') || s.Contains('\n');
+            string escaped = s.Replace("\"", "\"\"");
+            return quote ? $"\"{escaped}\"" : escaped;
+        }
+    }
+}

--- a/StingTools/Docs/ExportCenterEngine.cs
+++ b/StingTools/Docs/ExportCenterEngine.cs
@@ -402,16 +402,29 @@ namespace StingTools.Docs
                 catch { /* non-fatal */ }
             }
 
-            // DWG multi-layout availability
+            // DWG multi-layout availability — Method A (AutoCAD COM) or Method B (ODA).
             if ((profile.Formats & ExportFormats.DWG) != 0 &&
                 profile.Dwg.OutputMode == DwgOutputMode.AllInOneMultiLayout)
             {
-                if (!IsMultiLayoutMergerAvailable())
+                if (ExportCenterDwgMerger.IsAvailable())
+                {
+                    /* Method A available — true merge */
+                }
+                else if (ExportCenterOdaConverter.IsAvailable())
+                {
+                    issues.Add(Warn("DWG_MERGE_METHOD_B",
+                        "AutoCAD COM not detected. Will use ODA File Converter (Method B): " +
+                        "per-sheet DWGs version-normalised + merge_manifest.json. " +
+                        "True layout-tab merging requires AutoCAD or the Teigha SDK."));
+                }
+                else
+                {
                     issues.Add(Warn("DWG_MERGE_UNAVAILABLE",
-                        "DWG multi-layout merge requires AutoCAD COM or ODA libraries — none detected. " +
+                        "DWG multi-layout merge requires AutoCAD COM or ODA File Converter — neither detected. " +
                         (profile.Dwg.FallbackOnMergeFailure
                             ? "Will fall back to individual files."
                             : "Export will fail.")));
+                }
             }
 
             // NWC availability
@@ -872,6 +885,7 @@ namespace StingTools.Docs
                     profile.Output.IllegalCharReplacement);
                 string outPath = Path.Combine(outFolder, outName + ".dwg");
 
+                // Method A — AutoCAD COM
                 string merged = ExportCenterDwgMerger.Merge(perSheet, labels, outPath);
                 if (merged != null && File.Exists(merged))
                 {
@@ -880,18 +894,39 @@ namespace StingTools.Docs
                     row.Success = true;
                     try { Directory.Delete(temp, true); } catch { }
                 }
-                else if (profile.Dwg.FallbackOnMergeFailure)
-                {
-                    result.Warnings.Add(
-                        $"DWG multi-layout merge for '{groupName}' fell back — " +
-                        $"individual DWGs staged at: {temp}");
-                    row.OutputPath = temp;
-                    row.Success = true;
-                }
                 else
                 {
-                    row.Success = false;
-                    row.Error = "Multi-layout merge failed and FallbackOnMergeFailure is disabled.";
+                    // Method B — ODA File Converter (free): version-normalise +
+                    // emit merge_manifest.json. Doesn't produce a true single
+                    // multi-layout DWG, but the user gets staged files at the
+                    // right version + a manifest a downstream tool can use.
+                    string manifest = ExportCenterDwgMerger.MergeViaOda(
+                        perSheet, labels, outPath, profile.Dwg.DwgVersion);
+                    if (manifest != null)
+                    {
+                        result.Warnings.Add(
+                            $"DWG multi-layout merge for '{groupName}' used Method B (ODA). " +
+                            $"True layout merge requires AutoCAD COM or the Teigha SDK — " +
+                            $"the staged folder + merge_manifest.json is at: " +
+                            $"{Path.GetDirectoryName(manifest)}");
+                        row.OutputPath = manifest;
+                        row.Success = true;
+                        try { Directory.Delete(temp, true); } catch { }
+                    }
+                    else if (profile.Dwg.FallbackOnMergeFailure)
+                    {
+                        result.Warnings.Add(
+                            $"DWG multi-layout merge for '{groupName}' fell back to staged " +
+                            $"individual files (no AutoCAD COM, no ODA File Converter). " +
+                            $"Staged at: {temp}");
+                        row.OutputPath = temp;
+                        row.Success = true;
+                    }
+                    else
+                    {
+                        row.Success = false;
+                        row.Error = "Multi-layout merge failed and FallbackOnMergeFailure is disabled.";
+                    }
                 }
             }
             catch (Exception ex) { row.Success = false; row.Error = ex.Message; }

--- a/StingTools/Docs/ExportCenterEngine.cs
+++ b/StingTools/Docs/ExportCenterEngine.cs
@@ -414,22 +414,19 @@ namespace StingTools.Docs
                             : "Export will fail.")));
             }
 
+            // NWC availability
+            if ((profile.Formats & ExportFormats.NWC) != 0)
+            {
+                if (!ExportCenterNwcExporter.IsAvailable())
+                    issues.Add(Warn("NWC_UNAVAILABLE",
+                        "Navisworks NWC Export Utility not detected — NWC export will be skipped."));
+            }
+
             return issues;
         }
 
-        public static bool IsMultiLayoutMergerAvailable()
-        {
-            // Simple heuristic — real implementation would probe for AutoCAD COM
-            // (Type.GetTypeFromProgID("AutoCAD.Application")) and the ODA SDK on
-            // disk. For headless test envs we report unavailable.
-            try
-            {
-                var t = Type.GetTypeFromProgID("AutoCAD.Application");
-                if (t != null) return true;
-            }
-            catch { }
-            return false;
-        }
+        /// <summary>True if AutoCAD COM (Method A) is reachable. ODA (Method B) is TODO.</summary>
+        public static bool IsMultiLayoutMergerAvailable() => ExportCenterDwgMerger.IsAvailable();
 
         private static ExportPreflightIssue Err(string code, string msg) =>
             new() { Level = ExportPreflightIssue.Severity.Error, Code = code, Message = msg };
@@ -489,9 +486,12 @@ namespace StingTools.Docs
                     if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; goto Done; }
                 }
 
-                // NWC, DGN, DWF, Image, XML — implementations tagged TODO_FORMAT.
                 if ((profile.Formats & ExportFormats.NWC) != 0)
-                    result.Warnings.Add("NWC export is not yet implemented in this build (requires Navisworks NWC Export Utility).");
+                {
+                    RunNwc(doc, profile, result,
+                        (label) => progress?.Invoke(++done, total, label));
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; goto Done; }
+                }
                 if ((profile.Formats & ExportFormats.Image) != 0)
                     RunImage(doc, profile, selectedIds, result,
                         (label) => progress?.Invoke(++done, total, label), cancelRequested);
@@ -502,7 +502,8 @@ namespace StingTools.Docs
                     RunDwf(doc, profile, selectedIds, result,
                         (label) => progress?.Invoke(++done, total, label), cancelRequested);
                 if ((profile.Formats & ExportFormats.XML) != 0)
-                    result.Warnings.Add("XML export is not yet implemented in this build.");
+                    RunXml(doc, profile, selectedIds, result,
+                        (label) => progress?.Invoke(++done, total, label));
             }
             catch (Exception ex)
             {
@@ -701,19 +702,22 @@ namespace StingTools.Docs
         private static void TryInjectBookmarks(string pdfPath, List<View> views,
             ExportProfile profile, ExportRunResult result)
         {
-            // Bookmark injection requires PdfSharp 6.x or PdfPig — neither is currently
-            // a build dependency. Mark as TODO so the dialog can show the warning and
-            // the build CI can pick it up.
-            result.Warnings.Add(
-                $"Bookmark injection skipped for '{Path.GetFileName(pdfPath)}' — " +
-                "requires PdfSharp 6.x (TODO_PDFSHARP_DEP).");
+            // Backed by PDFsharp 6.x (added as a NuGet package). Best-effort —
+            // a bookmark failure must not abort the export.
+            try { ExportCenterPdfPostProcess.InjectBookmarks(pdfPath, views, profile); }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"Bookmark injection failed for '{Path.GetFileName(pdfPath)}': {ex.Message}");
+            }
         }
 
         private static void TryInjectWatermark(string pdfPath, PdfExportSettings pdf, ExportRunResult result)
         {
-            result.Warnings.Add(
-                $"Watermark injection skipped for '{Path.GetFileName(pdfPath)}' — " +
-                "requires PdfSharp 6.x (TODO_PDFSHARP_DEP).");
+            try { ExportCenterPdfPostProcess.InjectWatermark(pdfPath, pdf); }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"Watermark injection failed for '{Path.GetFileName(pdfPath)}': {ex.Message}");
+            }
         }
 
         private static PDFExportQualityType MapRasterQuality(int dpi) => dpi switch
@@ -849,21 +853,46 @@ namespace StingTools.Docs
                 string temp = Path.Combine(Path.GetTempPath(),
                     "STING_DWG_MERGE_" + DateTime.Now.ToString("yyyyMMddHHmmss"));
                 Directory.CreateDirectory(temp);
+                var perSheet = new List<string>();
+                var labels   = new List<string>();
                 foreach (var v in sheets)
                 {
                     string label = SanitiseLayoutName(ResolveNaming(doc, v, profile.Dwg.LayoutNameTemplate, profile.Output));
                     doc.Export(temp, label, new List<ElementId> { v.Id }, opts);
+                    string p = Path.Combine(temp, label + ".dwg");
+                    if (File.Exists(p)) { perSheet.Add(p); labels.Add(label); }
                 }
 
-                // Step 2: merge — implementation deferred (TODO_DWG_MERGE).
-                // The plan in CLAUDE.md uses AutoCAD COM (Method A) or ODA (Method B);
-                // for now we stage the files, leave them for the user, and emit a
-                // warning. Falling back here keeps the dialog functional.
-                result.Warnings.Add(
-                    $"DWG multi-layout merge for '{groupName}' deferred — " +
-                    $"individual DWGs staged at: {temp} (TODO_DWG_MERGE).");
-                row.OutputPath = temp;
-                row.Success = true;
+                // Step 2: AutoCAD-COM merge (ExportCenterDwgMerger). Falls through
+                // to the staged per-sheet output if AutoCAD isn't installed and
+                // the profile permits fallback.
+                string outFolder = SubFolderFor(profile, "DWG", null);
+                string outName = Sanitise(
+                    ResolveNaming(doc, sheets[0], profile.Output.NamingTemplate, profile.Output) + "_" + groupName,
+                    profile.Output.IllegalCharReplacement);
+                string outPath = Path.Combine(outFolder, outName + ".dwg");
+
+                string merged = ExportCenterDwgMerger.Merge(perSheet, labels, outPath);
+                if (merged != null && File.Exists(merged))
+                {
+                    row.OutputPath = merged;
+                    row.FileSizeBytes = new FileInfo(merged).Length;
+                    row.Success = true;
+                    try { Directory.Delete(temp, true); } catch { }
+                }
+                else if (profile.Dwg.FallbackOnMergeFailure)
+                {
+                    result.Warnings.Add(
+                        $"DWG multi-layout merge for '{groupName}' fell back — " +
+                        $"individual DWGs staged at: {temp}");
+                    row.OutputPath = temp;
+                    row.Success = true;
+                }
+                else
+                {
+                    row.Success = false;
+                    row.Error = "Multi-layout merge failed and FallbackOnMergeFailure is disabled.";
+                }
             }
             catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
             finally
@@ -1056,6 +1085,83 @@ namespace StingTools.Docs
                 }
                 catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
                 finally { CommitRow(row, result); }
+            }
+        }
+
+        // ── NWC pipeline ────────────────────────────────────────────────────────
+
+        private static void RunNwc(Document doc, ExportProfile profile, ExportRunResult result, Action<string> tick)
+        {
+            var row = new ExportResultRow
+            {
+                SheetNumber = "[nwc]",
+                SheetTitle = doc.PathName,
+                Format = "NWC",
+                StartedUtc = DateTime.UtcNow,
+            };
+            try
+            {
+                if (!ExportCenterNwcExporter.IsAvailable())
+                {
+                    row.Success = false;
+                    row.Error = "Navisworks NWC Export Utility not detected.";
+                    result.Warnings.Add(row.Error +
+                        " Install the free Navisworks NWC Export Utility from Autodesk and restart Revit.");
+                    return;
+                }
+
+                string folder = SubFolderFor(profile, "NWC", null);
+                string stem = Sanitise(
+                    ResolveNaming(doc, doc.ActiveView, profile.Output.NamingTemplate, profile.Output),
+                    profile.Output.IllegalCharReplacement);
+
+                bool ok = ExportCenterNwcExporter.Export(doc, folder, stem, profile.Nwc);
+                row.OutputPath = Path.Combine(folder, stem + ".nwc");
+                row.Success = ok && File.Exists(row.OutputPath);
+                if (row.Success) row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                else row.Error ??= "NWC export returned false";
+                tick?.Invoke("NWC");
+            }
+            catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+            finally
+            {
+                row.FinishedUtc = DateTime.UtcNow;
+                result.Rows.Add(row);
+            }
+        }
+
+        // ── XML pipeline ────────────────────────────────────────────────────────
+
+        private static void RunXml(Document doc, ExportProfile profile, List<ElementId> ids,
+            ExportRunResult result, Action<string> tick)
+        {
+            var row = new ExportResultRow
+            {
+                SheetNumber = "[xml]",
+                SheetTitle = profile.Xml.Scope == "ProjectInfoOnly" ? "(project info)" : $"{ids.Count} sheets",
+                Format = "XML",
+                StartedUtc = DateTime.UtcNow,
+            };
+            try
+            {
+                string folder = SubFolderFor(profile, "XML", null);
+                string stem = Sanitise(
+                    ResolveNaming(doc, doc.ActiveView, profile.Output.NamingTemplate, profile.Output),
+                    profile.Output.IllegalCharReplacement);
+                string path = Path.Combine(folder, stem + ".xml");
+
+                bool ok = ExportCenterXmlWriter.Write(doc, ids, path, profile.Xml);
+                row.OutputPath = path;
+                row.Success = ok;
+                if (ok) row.FileSizeBytes = new FileInfo(path).Length;
+                else row.Error = "XML writer returned false";
+                tick?.Invoke("XML");
+            }
+            catch (Exception ex) { row.Success = false; row.Error = ex.Message; }
+            finally
+            {
+                row.FinishedUtc = DateTime.UtcNow;
+                result.Rows.Add(row);
             }
         }
 

--- a/StingTools/Docs/ExportCenterModels.cs
+++ b/StingTools/Docs/ExportCenterModels.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterModels — POCO models for the STING Export Centre.
+    //
+    //  Backs the WPF dialog (StingExportCenterDialog) and the export pipeline
+    //  (ExportCenterEngine). All persistent state goes here, JSON-serialised
+    //  into project_config.json under "ExportCenter".
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>UI mode toggle. Controls which features and columns are shown.</summary>
+    public enum ExportCenterMode
+    {
+        /// <summary>ISO 19650-driven BIM coordinator surface (full features).</summary>
+        BIM,
+        /// <summary>Plain English non-ISO surface (reduced columns, friendly naming).</summary>
+        Simple,
+    }
+
+    /// <summary>Whether the SELECT panel lists sheets or non-sheet views.</summary>
+    public enum ExportSelectionKind { Sheets, Views }
+
+    /// <summary>Active output formats (bit flags so multiple can be combined).</summary>
+    [Flags]
+    public enum ExportFormats
+    {
+        None  = 0,
+        PDF   = 1 << 0,
+        DWG   = 1 << 1,
+        IFC   = 1 << 2,
+        NWC   = 1 << 3,
+        DGN   = 1 << 4,
+        DWF   = 1 << 5,
+        Image = 1 << 6,
+        XML   = 1 << 7,
+    }
+
+    /// <summary>How combined PDF output is grouped.</summary>
+    public enum PdfCombineMode
+    {
+        OnePerSheet,
+        OnePerDiscipline,
+        OnePerSet,
+        CustomGroups,
+    }
+
+    /// <summary>How DWG output is grouped — drives the multi-layout pipeline.</summary>
+    public enum DwgOutputMode
+    {
+        OnePerSheet,
+        AllInOneMultiLayout,
+        ModelSpaceOnly,
+        CustomGroups,
+    }
+
+    /// <summary>Where the export lands.</summary>
+    public enum ExportDestination
+    {
+        LocalFolder,
+        PlanscapeCde,
+        Both,
+    }
+
+    /// <summary>Filename collision strategy.</summary>
+    public enum FilenameConflictMode { Skip, Overwrite, AutoRename, Ask }
+
+    /// <summary>Document approval suitability code (BS EN ISO 19650-2 §A.2).</summary>
+    public enum SuitabilityCode { S0, S1, S2, S3, S4, S6, S7, A1, A2, A3, AB, B1, B2, B3, CR }
+
+    // ── PDF settings ────────────────────────────────────────────────────────────
+
+    public class PdfExportSettings
+    {
+        public PdfCombineMode CombineMode { get; set; } = PdfCombineMode.OnePerSheet;
+        public bool AddBookmarks { get; set; } = true;
+        public bool NestBookmarksByDiscipline { get; set; } = true;
+        public bool NestBookmarksByLevel { get; set; }
+        public string BookmarkLabelTemplate { get; set; } = "{SheetNumber} - {SheetTitle}";
+
+        public string DocumentTitleTemplate { get; set; } = "{ProjectName} — {DrawingSet}";
+        public string DocumentAuthorTemplate { get; set; } = "{OriginatorCode}";
+        public string DocumentSubjectTemplate { get; set; } = "{Discipline} Drawing Package";
+        public string DocumentKeywordsTemplate { get; set; } = "{ProjectCode},{Revision}";
+
+        public string HiddenLineMode { get; set; } = "Auto";   // Vector / Raster / Auto
+        public string ColourScheme { get; set; } = "Colour";   // Colour / Greyscale / BlackAndWhite
+        public int RasterDpi { get; set; } = 300;
+        public string PaperPlacement { get; set; } = "Centre"; // Centre / Offset
+        public double OffsetXmm { get; set; }
+        public double OffsetYmm { get; set; }
+        public string Zoom { get; set; } = "Fit";
+        public int ZoomPercent { get; set; } = 100;
+
+        public string Printer { get; set; } = "RevitNative";   // RevitNative / PDF24 / SystemDefault
+
+        public bool ApplyWatermark { get; set; }
+        public string WatermarkText { get; set; } = "DRAFT";
+        public string WatermarkPosition { get; set; } = "DiagonalCentre";
+        public int WatermarkOpacityPct { get; set; } = 30;
+        public int WatermarkFontSize { get; set; } = 96;
+        public string WatermarkColourHex { get; set; } = "#999999";
+
+        /// <summary>User-defined groups (CustomGroups mode). Map of group name → list of sheet ids (as strings).</summary>
+        public Dictionary<string, List<string>> CustomGroups { get; set; } = new();
+
+        /// <summary>Optional explicit merge order overriding sheet-number sort.</summary>
+        public List<string> MergeOrderSheetIds { get; set; } = new();
+    }
+
+    // ── DWG settings ────────────────────────────────────────────────────────────
+
+    public class DwgExportSettings
+    {
+        public DwgOutputMode OutputMode { get; set; } = DwgOutputMode.OnePerSheet;
+        public string ExportSetupName { get; set; } = "<in-session>";
+        public string LayerMappingMode { get; set; } = "ByCategory";  // ByCategory / Standard / Custom
+        public string LayerStandard { get; set; } = "AIA";            // AIA / BS1192 / Custom
+        public string LayerCustomMappingFile { get; set; }
+        public string LineworkSource { get; set; } = "Revit";         // Revit / ExportSetup
+        public string CoordinateSystem { get; set; } = "Project";     // Project / Shared / Survey
+        public string LinkedModelMode { get; set; } = "Embed";        // Embed / XRefs / Ignore
+        public bool BindRasterImages { get; set; }
+        public bool RunAuditAfterExport { get; set; }
+        public string DwgVersion { get; set; } = "AC2018";            // AC2018 / AC2013 / AC2010 / AC2007 / AC2004
+
+        public string LayoutNameTemplate { get; set; } = "{SheetNumber}";
+        public Dictionary<string, List<string>> CustomGroups { get; set; } = new();
+
+        /// <summary>Whether to fall back to individual files if the multi-layout merge tool is unavailable.</summary>
+        public bool FallbackOnMergeFailure { get; set; } = true;
+    }
+
+    // ── IFC / NWC / Image / DGN / DWF / XML ─────────────────────────────────────
+
+    public class IfcExportSettings
+    {
+        public string ExportSetupName { get; set; } = "<in-session>";
+        public string Schema { get; set; } = "IFC4";            // IFC2x3 / IFC4 / IFC4x3
+        public string PhaseName { get; set; }
+        public bool ExportLinkedModels { get; set; }
+        public string Classification { get; set; } = "None";    // Uniclass / OmniClass / None
+        public string Geometry { get; set; } = "BRep";          // Solid / BRep / Triangulated
+        public string CoordinateOrigin { get; set; } = "Project"; // Project / Survey / Internal
+    }
+
+    public class NwcExportSettings
+    {
+        public string Scope { get; set; } = "Selected";          // Entire / Selected / CurrentView
+        public string CoordinateSystem { get; set; } = "Project";
+        public bool ExportElementIdsForClash { get; set; } = true;
+    }
+
+    public class ImageExportSettings
+    {
+        public string Format { get; set; } = "PNG";              // JPEG / PNG / TIFF
+        public int Dpi { get; set; } = 300;
+        public string ColourDepth { get; set; } = "RGB24";       // RGB24 / Grey8
+        public int JpegQuality { get; set; } = 85;
+        public bool TransparentBackground { get; set; }
+    }
+
+    public class DgnExportSettings
+    {
+        public string Version { get; set; } = "V8";
+        public string CoordinateSystem { get; set; } = "Project";
+    }
+
+    public class DwfExportSettings
+    {
+        public bool IncludeRoomBoundaries { get; set; } = true;
+        public bool IncludeMarkupGeometry { get; set; } = true;
+        public bool DwfX { get; set; } = true;
+    }
+
+    public class XmlExportSettings
+    {
+        public string Scope { get; set; } = "Selected";          // Selected / ProjectInfoOnly
+        public bool IncludeProjectInfo { get; set; } = true;
+        public string Format { get; set; } = "GroupedBySheet";   // FlatList / GroupedBySheet
+        public List<string> ParameterGroups { get; set; } = new()
+        {
+            "Identity", "Location", "Dimensions", "Revisions",
+        };
+    }
+
+    // ── Output settings (path + naming) ─────────────────────────────────────────
+
+    public class OutputSettings
+    {
+        public ExportDestination Destination { get; set; } = ExportDestination.LocalFolder;
+        public string LocalFolder { get; set; } = "";
+        public bool OpenFolderWhenDone { get; set; } = true;
+        public bool CreateFolderIfMissing { get; set; } = true;
+        public bool SplitByFormatSubFolder { get; set; }
+        public bool SplitByDisciplineSubFolder { get; set; }
+
+        // CDE only
+        public string CdeStateOnUpload { get; set; } = "Shared";
+        public SuitabilityCode CdeSuitability { get; set; } = SuitabilityCode.S2;
+        public bool CdeAutoRegister { get; set; } = true;
+        public bool CdeTriggerWorkflow { get; set; }
+        public string CdeWorkflowPreset { get; set; } = "deliverable_issue_default";
+        public bool CdeNotifyTeam { get; set; } = true;
+
+        // Naming
+        public string NamingTemplate { get; set; } = "{SheetNumber} - {SheetTitle}";
+        public string NamingSeparator { get; set; } = "-";
+        public FilenameConflictMode ConflictMode { get; set; } = FilenameConflictMode.AutoRename;
+        public string IllegalCharReplacement { get; set; } = "-";
+
+        // Report
+        public bool GenerateReport { get; set; } = true;
+        public string ReportFormat { get; set; } = "XLSX";       // XLSX / CSV
+        public bool OpenReportWhenDone { get; set; }
+    }
+
+    /// <summary>Persistent saved selection — names + a list of sheet/view ElementIds (as strings to survive across docs).</summary>
+    public class ExportSavedSet
+    {
+        public string Name { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public ExportSelectionKind Kind { get; set; } = ExportSelectionKind.Sheets;
+        public List<string> ElementIds { get; set; } = new();
+        public string FilterText { get; set; }
+        public string SortColumn { get; set; }
+        public bool SortAscending { get; set; } = true;
+        public bool BuiltIn { get; set; }
+    }
+
+    /// <summary>A complete dialog state, named, persistable, importable, shareable.</summary>
+    public class ExportProfile
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public bool BuiltIn { get; set; }
+
+        public ExportCenterMode Mode { get; set; } = ExportCenterMode.BIM;
+        public ExportFormats Formats { get; set; } = ExportFormats.PDF;
+
+        public PdfExportSettings Pdf { get; set; } = new();
+        public DwgExportSettings Dwg { get; set; } = new();
+        public IfcExportSettings Ifc { get; set; } = new();
+        public NwcExportSettings Nwc { get; set; } = new();
+        public ImageExportSettings Image { get; set; } = new();
+        public DgnExportSettings Dgn { get; set; } = new();
+        public DwfExportSettings Dwf { get; set; } = new();
+        public XmlExportSettings Xml { get; set; } = new();
+
+        public OutputSettings Output { get; set; } = new();
+
+        /// <summary>The set name used as the default selection when this profile is loaded.</summary>
+        public string DefaultSetName { get; set; } = "All Sheets";
+    }
+
+    /// <summary>A scheduled export job persisted in project_config.json.</summary>
+    public class ScheduledExport
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString("N");
+        public string ProfileName { get; set; }
+        public string SetName { get; set; }
+        public DateTime NextRunUtc { get; set; }
+        public string Repeat { get; set; } = "Once"; // Once / Daily / Weekly / Monthly
+        public List<DayOfWeek> WeeklyDays { get; set; } = new();
+        public bool Enabled { get; set; } = true;
+        public DateTime? LastRunUtc { get; set; }
+        public string LastResult { get; set; }
+    }
+
+    /// <summary>Top-level container persisted under "ExportCenter" inside project_config.json.</summary>
+    public class ExportCenterState
+    {
+        public ExportCenterMode Mode { get; set; } = ExportCenterMode.BIM;
+        public string LastProfile { get; set; }
+        public List<ExportProfile> Profiles { get; set; } = new();
+        public List<ExportSavedSet> SavedSets { get; set; } = new();
+        public List<ScheduledExport> ScheduledExports { get; set; } = new();
+        public List<string> RecentFolders { get; set; } = new();
+        public string LastOutputFolder { get; set; }
+        public string LastNamingTemplate { get; set; }
+        public string OdaLibraryPath { get; set; }
+        public bool? AutocadComAvailable { get; set; }
+
+        // ── Built-in profile factory ────────────────────────────────────────────
+
+        public static List<ExportProfile> BuildBuiltInProfiles()
+        {
+            var list = new List<ExportProfile>();
+
+            list.Add(new ExportProfile
+            {
+                Name = "Default — PDF only",
+                BuiltIn = true,
+                Mode = ExportCenterMode.Simple,
+                Formats = ExportFormats.PDF,
+            });
+
+            list.Add(new ExportProfile
+            {
+                Name = "Full Issue Package — PDF + DWG + IFC",
+                BuiltIn = true,
+                Mode = ExportCenterMode.BIM,
+                Formats = ExportFormats.PDF | ExportFormats.DWG | ExportFormats.IFC,
+                Output = new OutputSettings { SplitByFormatSubFolder = true },
+            });
+
+            list.Add(new ExportProfile
+            {
+                Name = "Client Presentation — Combined PDF, Greyscale",
+                BuiltIn = true,
+                Mode = ExportCenterMode.Simple,
+                Formats = ExportFormats.PDF,
+                Pdf = new PdfExportSettings
+                {
+                    CombineMode = PdfCombineMode.OnePerSet,
+                    AddBookmarks = true,
+                    NestBookmarksByDiscipline = true,
+                    ColourScheme = "Greyscale",
+                },
+            });
+
+            list.Add(new ExportProfile
+            {
+                Name = "Contractor Package — Individual PDFs + DWG with Layouts",
+                BuiltIn = true,
+                Mode = ExportCenterMode.BIM,
+                Formats = ExportFormats.PDF | ExportFormats.DWG,
+                Pdf = new PdfExportSettings { CombineMode = PdfCombineMode.OnePerDiscipline },
+                Dwg = new DwgExportSettings { OutputMode = DwgOutputMode.AllInOneMultiLayout },
+            });
+
+            list.Add(new ExportProfile
+            {
+                Name = "BIM Model Exchange — IFC + NWC",
+                BuiltIn = true,
+                Mode = ExportCenterMode.BIM,
+                Formats = ExportFormats.IFC | ExportFormats.NWC,
+            });
+
+            list.Add(new ExportProfile
+            {
+                Name = "Simple — PDF only (non-ISO)",
+                BuiltIn = true,
+                Mode = ExportCenterMode.Simple,
+                Formats = ExportFormats.PDF,
+                Output = new OutputSettings { NamingTemplate = "{SheetNumber} - {SheetTitle}" },
+            });
+
+            return list;
+        }
+
+        // ── Built-in saved-set factory ──────────────────────────────────────────
+
+        public static List<ExportSavedSet> BuildBuiltInSets()
+        {
+            var built = new List<ExportSavedSet>();
+            void S(string n) => built.Add(new ExportSavedSet { Name = n, BuiltIn = true });
+
+            S("All Sheets");
+            S("All Views");
+            S("By Discipline: Architectural");
+            S("By Discipline: Mechanical");
+            S("By Discipline: Electrical");
+            S("By Discipline: Plumbing");
+            S("By Discipline: Structural");
+            S("Issued Sheets");
+            S("Revised This Week");
+            S("Currently Opened");
+            return built;
+        }
+    }
+
+    // ── Naming preset catalogue (Simple-mode quick presets) ─────────────────────
+
+    public static class ExportNamingPresets
+    {
+        public static readonly Dictionary<string, string> SimpleMode = new()
+        {
+            { "US Standard",            "{SheetNumber} - {SheetTitle}" },
+            { "UK Basic",               "{SheetNumber}_{SheetTitle}_Rev{Revision}" },
+            { "Australia",              "{ProjectCode}-{SheetNumber}-{SheetTitle}" },
+            { "Africa / General",       "{ProjectName}_{SheetNumber}_{Revision}_{Date:yyyyMMdd}" },
+        };
+
+        public static readonly Dictionary<string, string> BimMode = new()
+        {
+            { "ISO 19650 (full)",       "{Originator}-{Volume}-{Level}-{Type}-{Role}-{SheetNumber}-{Suitability}-{Revision}" },
+            { "ISO 19650 (compact)",    "{Originator}-{SheetNumber}-{Suitability}{Revision}" },
+            { "Issue + Date",           "{ProjectCode}-{SheetNumber}-{SheetTitle}-{Suitability}{Revision}_{Date:yyyyMMdd}" },
+            { "Drawing No. only",       "{SheetNumber}" },
+        };
+    }
+
+    /// <summary>Per-result row produced by the export pipeline (used in the report and post-export log).</summary>
+    public class ExportResultRow
+    {
+        public string SheetId { get; set; }
+        public string SheetNumber { get; set; }
+        public string SheetTitle { get; set; }
+        public string Format { get; set; }
+        public string OutputPath { get; set; }
+        public long FileSizeBytes { get; set; }
+        public bool Success { get; set; }
+        public string Error { get; set; }
+        public DateTime StartedUtc { get; set; }
+        public DateTime FinishedUtc { get; set; }
+        public TimeSpan Duration => FinishedUtc - StartedUtc;
+    }
+
+    /// <summary>Aggregate result from one export run.</summary>
+    public class ExportRunResult
+    {
+        public DateTime StartedUtc { get; set; } = DateTime.UtcNow;
+        public DateTime FinishedUtc { get; set; }
+        public ExportProfile Profile { get; set; }
+        public List<ExportResultRow> Rows { get; set; } = new();
+        public List<string> Warnings { get; set; } = new();
+        public bool Cancelled { get; set; }
+
+        public int Success => Rows.FindAll(r => r.Success).Count;
+        public int Failed  => Rows.FindAll(r => !r.Success).Count;
+        public long TotalBytes
+        {
+            get { long t = 0; foreach (var r in Rows) t += r.FileSizeBytes; return t; }
+        }
+    }
+
+    /// <summary>A pre-flight problem found before export starts.</summary>
+    public class ExportPreflightIssue
+    {
+        public enum Severity { Info, Warning, Error }
+        public Severity Level { get; set; }
+        public string Code { get; set; }
+        public string Message { get; set; }
+        public string Hint { get; set; }
+    }
+}

--- a/StingTools/Docs/ExportCenterNwcExporter.cs
+++ b/StingTools/Docs/ExportCenterNwcExporter.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterNwcExporter — NWC export via reflection.
+    //
+    //  Revit's NavisworksExportOptions only exists when the Navisworks NWC
+    //  Export Utility is installed (it ships its own assembly that surfaces
+    //  the type to the Revit API). We probe for the type at runtime so that
+    //  the StingTools assembly itself has no compile-time dependency on it.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    internal static class ExportCenterNwcExporter
+    {
+        private static Type _optionsType;
+        private static MethodInfo _exportMethod;
+        private static bool _probed;
+
+        internal static bool IsAvailable()
+        {
+            if (_probed) return _optionsType != null;
+            _probed = true;
+            try
+            {
+                // Try a few well-known assembly names — older Revit versions ship
+                // the type in different locations.
+                foreach (string asm in new[] { "RevitAPI", "Autodesk.Revit.DB.RevitAPI", "RevitNwcExporter" })
+                {
+                    var t = Type.GetType($"Autodesk.Revit.DB.NavisworksExportOptions, {asm}", false);
+                    if (t != null) { _optionsType = t; break; }
+                }
+
+                if (_optionsType == null)
+                {
+                    // Fall back: scan loaded assemblies.
+                    _optionsType = AppDomain.CurrentDomain.GetAssemblies()
+                        .SelectMany(a => SafeGetTypes(a))
+                        .FirstOrDefault(t => t?.FullName == "Autodesk.Revit.DB.NavisworksExportOptions");
+                }
+
+                if (_optionsType != null)
+                {
+                    _exportMethod = typeof(Document).GetMethods()
+                        .FirstOrDefault(m => m.Name == "Export"
+                            && m.GetParameters().Length == 3
+                            && m.GetParameters()[0].ParameterType == typeof(string)
+                            && m.GetParameters()[1].ParameterType == typeof(string)
+                            && m.GetParameters()[2].ParameterType == _optionsType);
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("NwcExporter.IsAvailable probe: " + ex.Message);
+            }
+            return _optionsType != null && _exportMethod != null;
+        }
+
+        internal static bool Export(Document doc, string folder, string nameNoExt, NwcExportSettings settings)
+        {
+            if (!IsAvailable()) return false;
+            try
+            {
+                object opts = Activator.CreateInstance(_optionsType);
+
+                // Apply settings via reflection — properties may not exist on every
+                // version of the exporter, so each set is wrapped in try/catch.
+                Set(opts, "ExportScope", MapScope(settings.Scope));
+                Set(opts, "Coordinates", MapCoords(settings.CoordinateSystem));
+                Set(opts, "ExportElementIds", settings.ExportElementIdsForClash);
+                Set(opts, "ConvertElementProperties", true);
+
+                _exportMethod.Invoke(doc, new object[] { folder, nameNoExt, opts });
+
+                string path = Path.Combine(folder, nameNoExt + ".nwc");
+                return File.Exists(path);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("NwcExporter.Export: " + ex.Message);
+                return false;
+            }
+        }
+
+        private static object MapScope(string scope)
+        {
+            // NavisworksExportScope enum values: Model = 0, View = 1, Selection = 2
+            return scope switch
+            {
+                "CurrentView" => 1,
+                "Selected"    => 2,
+                _             => 0,
+            };
+        }
+
+        private static object MapCoords(string coords)
+        {
+            // NavisworksCoordinates enum: Shared = 0, Internal = 1
+            return coords switch { "Shared" => 0, _ => 1 };
+        }
+
+        private static void Set(object target, string propName, object value)
+        {
+            try
+            {
+                var p = target.GetType().GetProperty(propName);
+                if (p == null || !p.CanWrite) return;
+                // Convert numeric-as-int to the enum type if the property is an enum.
+                object converted = value;
+                if (p.PropertyType.IsEnum && value is int iv)
+                    converted = Enum.ToObject(p.PropertyType, iv);
+                p.SetValue(target, converted);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"NwcExporter.Set {propName}: {ex.Message}");
+            }
+        }
+
+        private static IEnumerable<Type> SafeGetTypes(Assembly a)
+        {
+            try { return a.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t != null); }
+            catch { return Array.Empty<Type>(); }
+        }
+    }
+}

--- a/StingTools/Docs/ExportCenterOdaConverter.cs
+++ b/StingTools/Docs/ExportCenterOdaConverter.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+using Newtonsoft.Json;
+using StingTools.Core;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterOdaConverter — Method B for DWG multi-layout output.
+    //
+    //  Honest scope note (read this before assuming this class "merges layouts"):
+    //
+    //  The FREE ODA File Converter CLI is a one-file-in, one-file-out
+    //  version-normaliser — it cannot merge multiple DWGs into one DWG
+    //  with N layout tabs. True ODA-side layout merging requires the paid
+    //  Teigha / Drawings SDK, which we don't bundle.
+    //
+    //  What this Method B actually does:
+    //    1. Detect ODAFileConverter.exe on disk (well-known installer paths
+    //       + the registry uninstall keys it writes during install).
+    //    2. Normalise every staged per-sheet DWG to a single target DWG
+    //       version (e.g. AC2018), so downstream consumers running older
+    //       AutoCAD/AutoCAD LT versions can open them all.
+    //    3. Optionally also emit DXF copies (text format — diffable in git
+    //       and consumable by ezdxf/LibreDWG/etc. for offline merging).
+    //    4. Drop a merge_manifest.json next to the staged files that
+    //       declares the intended layout structure (source DWG → target
+    //       layout name + order). A downstream merger (Teigha, ezdxf script,
+    //       AutoCAD COM on a different machine) can then consume it.
+    //
+    //  When AutoCAD COM (Method A) is unavailable AND this Method B runs,
+    //  the engine still falls back to "individual files" semantics — the
+    //  user gets a clean folder of staged DWGs at the right version, plus
+    //  the manifest, instead of a single multi-layout DWG.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    internal static class ExportCenterOdaConverter
+    {
+        private static string _cachedExePath;
+        private static bool _probed;
+
+        /// <summary>Path to ODAFileConverter.exe, or null if not installed.</summary>
+        internal static string FindExecutable()
+        {
+            if (_probed) return _cachedExePath;
+            _probed = true;
+
+            // 1) Honour an explicit override stored in ExportCenterState.
+            try
+            {
+                var st = ExportCenterEngine.LoadState();
+                if (!string.IsNullOrEmpty(st.OdaLibraryPath) && File.Exists(st.OdaLibraryPath))
+                    return _cachedExePath = st.OdaLibraryPath;
+            }
+            catch { }
+
+            // 2) Well-known installer paths — ODA names the dir "ODA File Converter <version>".
+            string[] roots =
+            {
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            };
+            foreach (var root in roots.Where(Directory.Exists))
+            {
+                try
+                {
+                    foreach (var dir in Directory.EnumerateDirectories(root, "ODA File Converter*"))
+                    {
+                        var exe = Path.Combine(dir, "ODAFileConverter.exe");
+                        if (File.Exists(exe)) return _cachedExePath = exe;
+                    }
+                }
+                catch { }
+            }
+
+            // 3) Registry — ODA's installer drops an Uninstall entry that includes InstallLocation.
+            try
+            {
+                using var key = Registry.LocalMachine.OpenSubKey(
+                    @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall");
+                if (key != null)
+                {
+                    foreach (var sub in key.GetSubKeyNames())
+                    {
+                        using var s = key.OpenSubKey(sub);
+                        var name = s?.GetValue("DisplayName") as string;
+                        if (string.IsNullOrEmpty(name) ||
+                            !name.StartsWith("ODA File Converter", StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        var loc = s.GetValue("InstallLocation") as string;
+                        if (!string.IsNullOrEmpty(loc))
+                        {
+                            var exe = Path.Combine(loc, "ODAFileConverter.exe");
+                            if (File.Exists(exe)) return _cachedExePath = exe;
+                        }
+                    }
+                }
+            }
+            catch { }
+
+            return _cachedExePath = null;
+        }
+
+        internal static bool IsAvailable() => !string.IsNullOrEmpty(FindExecutable());
+
+        /// <summary>
+        /// Normalise a folder of DWGs to a single target version using ODA File
+        /// Converter's CLI signature. Returns the count of successfully-converted
+        /// files. The CLI is invoked once for the whole input folder.
+        /// </summary>
+        /// <param name="inputFolder">Folder containing per-sheet DWGs.</param>
+        /// <param name="outputFolder">Target folder (created if missing).</param>
+        /// <param name="targetVersion">"ACAD2018" / "ACAD2013" / "ACAD2010" / "ACAD2007" / "ACAD2004".</param>
+        /// <param name="targetFormat">"DWG" or "DXF".</param>
+        internal static int Convert(string inputFolder, string outputFolder, string targetVersion, string targetFormat)
+        {
+            string exe = FindExecutable();
+            if (string.IsNullOrEmpty(exe))
+            {
+                StingLog.Warn("OdaConverter.Convert: ODAFileConverter.exe not found.");
+                return 0;
+            }
+            if (!Directory.Exists(inputFolder))
+            {
+                StingLog.Warn($"OdaConverter.Convert: input folder missing — {inputFolder}");
+                return 0;
+            }
+            Directory.CreateDirectory(outputFolder);
+
+            // CLI signature (positional args, no flags):
+            //   ODAFileConverter <inFolder> <outFolder> <outVer> <outFormat> <recurse> <audit> [filter]
+            //   outVer:    ACAD9  ACAD10  ACAD12  ACAD13  ACAD14  ACAD2000  ACAD2004  ACAD2007  ACAD2010  ACAD2013  ACAD2018
+            //   outFormat: DWG | DXF | DXB
+            //   recurse:   0 | 1
+            //   audit:     0 | 1
+            //   filter:    optional file mask (default *.DWG;*.DXF)
+            var psi = new ProcessStartInfo
+            {
+                FileName = exe,
+                Arguments = $"\"{inputFolder}\" \"{outputFolder}\" {targetVersion} {targetFormat} 0 1 \"*.DWG\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+            };
+
+            try
+            {
+                using var proc = Process.Start(psi);
+                if (proc == null) return 0;
+
+                // The ODA tool can be slow on large folders; cap at 10 minutes.
+                if (!proc.WaitForExit(10 * 60 * 1000))
+                {
+                    try { proc.Kill(true); } catch { }
+                    StingLog.Warn("OdaConverter.Convert timed out after 10 minutes.");
+                    return 0;
+                }
+
+                if (proc.ExitCode != 0)
+                {
+                    string stderr = proc.StandardError.ReadToEnd();
+                    StingLog.Warn($"OdaConverter.Convert exit {proc.ExitCode}: {stderr}");
+                }
+
+                string ext = "." + targetFormat.ToLowerInvariant();
+                int count = Directory.EnumerateFiles(outputFolder, "*" + ext).Count();
+                StingLog.Info($"OdaConverter.Convert wrote {count} {targetFormat} files to {outputFolder}.");
+                return count;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("OdaConverter.Convert: " + ex.Message);
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Map STING's DWG version constant ("AC2018" etc.) onto the literal
+        /// ODA CLI version flag ("ACAD2018" etc.).
+        /// </summary>
+        internal static string MapStingVersionToOda(string stingVersion) => stingVersion switch
+        {
+            "AC2018" => "ACAD2018",
+            "AC2013" => "ACAD2013",
+            "AC2010" => "ACAD2010",
+            "AC2007" => "ACAD2007",
+            "AC2004" => "ACAD2004",
+            _        => "ACAD2018",
+        };
+
+        /// <summary>
+        /// Write a merge manifest describing how a downstream merger should
+        /// fold the staged per-sheet DWGs into a single multi-layout DWG.
+        /// Format is intentionally simple JSON, version-stamped.
+        /// </summary>
+        internal static string WriteMergeManifest(
+            string folder, List<string> sourceDwgs, List<string> layoutNames,
+            string proposedOutputDwg, string targetDwgVersion)
+        {
+            try
+            {
+                Directory.CreateDirectory(folder);
+                var manifest = new
+                {
+                    schema = "sting-export-centre/dwg-merge-manifest/1",
+                    generatedUtc = DateTime.UtcNow.ToString("o"),
+                    proposedOutput = proposedOutputDwg,
+                    targetDwgVersion,
+                    note = "Each entry is a per-sheet DWG that should become one layout tab " +
+                           "in the merged output. The free ODA File Converter cannot perform " +
+                           "this merge — use AutoCAD COM, Teigha SDK, or an ezdxf script.",
+                    layouts = sourceDwgs.Select((src, i) => new
+                    {
+                        index = i,
+                        sourceDwg = src,
+                        layoutName = i < layoutNames.Count ? layoutNames[i] : Path.GetFileNameWithoutExtension(src),
+                    }),
+                };
+                string path = Path.Combine(folder, "merge_manifest.json");
+                File.WriteAllText(path, JsonConvert.SerializeObject(manifest, Formatting.Indented));
+                StingLog.Info($"OdaConverter.WriteMergeManifest: {path}");
+                return path;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("OdaConverter.WriteMergeManifest: " + ex.Message);
+                return null;
+            }
+        }
+    }
+}

--- a/StingTools/Docs/ExportCenterPdfPostProcess.cs
+++ b/StingTools/Docs/ExportCenterPdfPostProcess.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.DB;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+using PdfSharp.Pdf.IO;
+using StingTools.Core;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterPdfPostProcess — bookmark + watermark injection for the
+    //  combined-PDF outputs produced by ExportCenterEngine.RunPdf.
+    //
+    //  Backed by PDFsharp 6.x (added to StingTools.csproj). Each method opens
+    //  the PDF in Modify mode, mutates it, and saves over the same path.
+    //  Failures are logged but never thrown — post-processing is best-effort.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    internal static class ExportCenterPdfPostProcess
+    {
+        /// <summary>
+        /// Insert a document outline (bookmark tree) into a combined PDF whose
+        /// pages match <paramref name="views"/> in order. Honours
+        /// <c>NestBookmarksByDiscipline</c> and <c>NestBookmarksByLevel</c>.
+        /// </summary>
+        internal static void InjectBookmarks(string pdfPath, List<View> views, ExportProfile profile)
+        {
+            if (!File.Exists(pdfPath) || views == null || views.Count == 0) return;
+
+            try
+            {
+                using var doc = PdfReader.Open(pdfPath, PdfDocumentOpenMode.Modify);
+                int pageCount = doc.PageCount;
+                if (pageCount == 0) return;
+
+                bool nestDisc  = profile.Pdf.NestBookmarksByDiscipline;
+                bool nestLevel = profile.Pdf.NestBookmarksByLevel;
+                string template = string.IsNullOrEmpty(profile.Pdf.BookmarkLabelTemplate)
+                    ? "{SheetNumber} - {SheetTitle}"
+                    : profile.Pdf.BookmarkLabelTemplate;
+
+                // Group lookups so each parent appears once.
+                var discParents  = new Dictionary<string, PdfOutline>(StringComparer.OrdinalIgnoreCase);
+                var levelParents = new Dictionary<string, PdfOutline>(StringComparer.OrdinalIgnoreCase);
+
+                int bound = Math.Min(pageCount, views.Count);
+                for (int i = 0; i < bound; i++)
+                {
+                    var v = views[i];
+                    var page = doc.Pages[i];
+
+                    string disc  = v is ViewSheet s ? ExportCenterEngine.GetDisciplinePrefix(s.SheetNumber) : "";
+                    string level = ResolveLevelLabel(v);
+                    string label = ResolveTemplate(template, v, disc, level);
+
+                    PdfOutline host = doc.Outlines;
+
+                    if (nestDisc && !string.IsNullOrEmpty(disc))
+                    {
+                        if (!discParents.TryGetValue(disc, out var dp))
+                        {
+                            dp = host.Outlines.Add(disc, page, true);
+                            discParents[disc] = dp;
+                        }
+                        host = dp;
+                    }
+
+                    if (nestLevel && !string.IsNullOrEmpty(level))
+                    {
+                        string key = (nestDisc ? disc + "::" : "") + level;
+                        if (!levelParents.TryGetValue(key, out var lp))
+                        {
+                            lp = host.Outlines.Add(level, page, true);
+                            levelParents[key] = lp;
+                        }
+                        host = lp;
+                    }
+
+                    host.Outlines.Add(label, page, true);
+                }
+
+                // Document properties
+                if (doc.Info != null)
+                {
+                    var titleTok  = ResolveTemplate(profile.Pdf.DocumentTitleTemplate,  views[0], "", "");
+                    var authorTok = ResolveTemplate(profile.Pdf.DocumentAuthorTemplate, views[0], "", "");
+                    var subjTok   = ResolveTemplate(profile.Pdf.DocumentSubjectTemplate, views[0], "", "");
+                    var kwTok     = ResolveTemplate(profile.Pdf.DocumentKeywordsTemplate, views[0], "", "");
+                    if (!string.IsNullOrWhiteSpace(titleTok))  doc.Info.Title    = titleTok;
+                    if (!string.IsNullOrWhiteSpace(authorTok)) doc.Info.Author   = authorTok;
+                    if (!string.IsNullOrWhiteSpace(subjTok))   doc.Info.Subject  = subjTok;
+                    if (!string.IsNullOrWhiteSpace(kwTok))     doc.Info.Keywords = kwTok;
+                    doc.Info.Creator = "STING Export Centre";
+                }
+
+                doc.Save(pdfPath);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"InjectBookmarks {Path.GetFileName(pdfPath)}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Stamp every page with the configured watermark — diagonal centre by
+        /// default. Honours opacity (0–100) and font size.
+        /// </summary>
+        internal static void InjectWatermark(string pdfPath, PdfExportSettings pdf)
+        {
+            if (!File.Exists(pdfPath) || string.IsNullOrEmpty(pdf?.WatermarkText)) return;
+
+            try
+            {
+                using var doc = PdfReader.Open(pdfPath, PdfDocumentOpenMode.Modify);
+
+                XColor colour = ParseHexColour(pdf.WatermarkColourHex, 0x99, 0x99, 0x99);
+                colour.A = Math.Clamp(pdf.WatermarkOpacityPct, 0, 100) / 100.0;
+
+                var brush = new XSolidBrush(colour);
+                int fontSize = Math.Max(24, pdf.WatermarkFontSize);
+                var font = new XFont("Arial", fontSize, XFontStyleEx.Bold);
+
+                foreach (PdfPage page in doc.Pages)
+                {
+                    using var gfx = XGraphics.FromPdfPage(page, XGraphicsPdfPageOptions.Append);
+
+                    double w = page.Width.Point;
+                    double h = page.Height.Point;
+                    var size = gfx.MeasureString(pdf.WatermarkText, font);
+
+                    gfx.Save();
+                    switch (pdf.WatermarkPosition)
+                    {
+                        case "TopLeft":
+                            gfx.DrawString(pdf.WatermarkText, font, brush,
+                                new XPoint(20, 20 + size.Height));
+                            break;
+                        case "BottomRight":
+                            gfx.DrawString(pdf.WatermarkText, font, brush,
+                                new XPoint(w - size.Width - 20, h - 20));
+                            break;
+                        default: // DiagonalCentre
+                            gfx.TranslateTransform(w / 2, h / 2);
+                            gfx.RotateTransform(-30);
+                            gfx.DrawString(pdf.WatermarkText, font, brush,
+                                new XPoint(-size.Width / 2, size.Height / 2));
+                            break;
+                    }
+                    gfx.Restore();
+                }
+
+                doc.Save(pdfPath);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"InjectWatermark {Path.GetFileName(pdfPath)}: {ex.Message}");
+            }
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────────────────
+
+        private static string ResolveLevelLabel(View v)
+        {
+            try
+            {
+                var lvl = v?.GenLevel ?? null;
+                return lvl?.Name ?? "";
+            }
+            catch { return ""; }
+        }
+
+        private static string ResolveTemplate(string template, View v, string disc, string level)
+        {
+            if (string.IsNullOrEmpty(template)) return v?.Name ?? "";
+            return template
+                .Replace("{SheetNumber}", v is ViewSheet s ? s.SheetNumber ?? "" : "")
+                .Replace("{SheetTitle}",  v?.Name ?? "")
+                .Replace("{DrawingNumber}", v is ViewSheet s2 ? s2.SheetNumber ?? "" : "")
+                .Replace("{DrawingTitle}",  v?.Name ?? "")
+                .Replace("{Discipline}", disc ?? "")
+                .Replace("{Level}", level ?? "")
+                .Replace("{ProjectName}", v?.Document?.ProjectInformation?.Name ?? "")
+                .Replace("{DrawingSet}", "");
+        }
+
+        private static XColor ParseHexColour(string hex, byte rDef, byte gDef, byte bDef)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(hex)) return XColor.FromArgb(rDef, gDef, bDef);
+                hex = hex.TrimStart('#');
+                if (hex.Length == 6)
+                {
+                    return XColor.FromArgb(
+                        Convert.ToByte(hex.Substring(0, 2), 16),
+                        Convert.ToByte(hex.Substring(2, 2), 16),
+                        Convert.ToByte(hex.Substring(4, 2), 16));
+                }
+            }
+            catch { }
+            return XColor.FromArgb(rDef, gDef, bDef);
+        }
+    }
+}

--- a/StingTools/Docs/ExportCenterXmlWriter.cs
+++ b/StingTools/Docs/ExportCenterXmlWriter.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ExportCenterXmlWriter — custom XML serialiser for the Export Centre.
+    //
+    //  Revit's API has no general-purpose "sheet to XML" exporter, so we roll
+    //  one. Every selected sheet (or the project-info block, depending on
+    //  XmlExportSettings.Scope) becomes one <sheet> element with parameters
+    //  filtered by the user-selected groups.
+    //
+    //  Output format is intentionally simple and stable so downstream tools
+    //  (ETL, reporting, dashboards) can parse it without an XSD.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    internal static class ExportCenterXmlWriter
+    {
+        internal static bool Write(Document doc, List<ElementId> sheetIds, string outputPath, XmlExportSettings settings)
+        {
+            try
+            {
+                var writerSettings = new XmlWriterSettings
+                {
+                    Indent = true,
+                    IndentChars = "  ",
+                    Encoding = new System.Text.UTF8Encoding(false),
+                };
+
+                using var w = XmlWriter.Create(outputPath, writerSettings);
+                w.WriteStartDocument();
+                w.WriteStartElement("export");
+                w.WriteAttributeString("schema", "sting-export-centre/1");
+                w.WriteAttributeString("generatedUtc", DateTime.UtcNow.ToString("o"));
+                w.WriteAttributeString("documentTitle", doc?.Title ?? "");
+
+                if (settings.IncludeProjectInfo) WriteProjectInfo(w, doc);
+
+                if (settings.Scope == "ProjectInfoOnly")
+                {
+                    // Done — only project info requested.
+                    w.WriteEndElement();
+                    w.WriteEndDocument();
+                    return File.Exists(outputPath);
+                }
+
+                w.WriteStartElement("sheets");
+                foreach (var eid in sheetIds ?? new List<ElementId>())
+                {
+                    var sheet = doc.GetElement(eid) as ViewSheet;
+                    if (sheet == null) continue;
+                    WriteSheet(w, doc, sheet, settings);
+                }
+                w.WriteEndElement(); // sheets
+
+                w.WriteEndElement(); // export
+                w.WriteEndDocument();
+                return File.Exists(outputPath);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("XmlWriter.Write: " + ex.Message);
+                return false;
+            }
+        }
+
+        private static void WriteProjectInfo(XmlWriter w, Document doc)
+        {
+            try
+            {
+                var pi = doc?.ProjectInformation;
+                if (pi == null) return;
+                w.WriteStartElement("project");
+                W(w, "name",    pi.Name);
+                W(w, "number",  pi.Number);
+                W(w, "client",  pi.ClientName);
+                W(w, "address", pi.Address);
+                W(w, "status",  pi.Status);
+                w.WriteStartElement("orgParams");
+                foreach (string p in new[]
+                {
+                    "PRJ_ORG_PROJECT_COD_TXT", "PRJ_ORG_ORIGINATOR_COD_TXT",
+                    "PRJ_ORG_COMPANY_NAME_TXT", "PRJ_ORG_CLIENT_NAME_TXT",
+                    "PRJ_ORG_PHASE_TXT", "PRJ_ORG_CLASS_TXT",
+                })
+                {
+                    var par = pi.LookupParameter(p);
+                    if (par != null && par.HasValue)
+                    {
+                        w.WriteStartElement("param");
+                        w.WriteAttributeString("name", p);
+                        w.WriteString(SafeAsString(par));
+                        w.WriteEndElement();
+                    }
+                }
+                w.WriteEndElement(); // orgParams
+                w.WriteEndElement(); // project
+            }
+            catch (Exception ex) { StingLog.Warn("XmlWriter.WriteProjectInfo: " + ex.Message); }
+        }
+
+        private static void WriteSheet(XmlWriter w, Document doc, ViewSheet sheet, XmlExportSettings settings)
+        {
+            w.WriteStartElement("sheet");
+            w.WriteAttributeString("id", sheet.Id.Value.ToString());
+            w.WriteAttributeString("number", sheet.SheetNumber ?? "");
+            w.WriteAttributeString("title",  sheet.Name ?? "");
+            w.WriteAttributeString("discipline", ExportCenterEngine.GetDisciplinePrefix(sheet.SheetNumber));
+
+            // Revisions
+            try
+            {
+                var revs = sheet.GetAllRevisionIds();
+                if (revs != null && revs.Count > 0)
+                {
+                    w.WriteStartElement("revisions");
+                    foreach (var rid in revs)
+                    {
+                        if (doc.GetElement(rid) is Revision r)
+                        {
+                            w.WriteStartElement("revision");
+                            w.WriteAttributeString("seq", r.SequenceNumber.ToString());
+                            w.WriteAttributeString("date", r.RevisionDate ?? "");
+                            w.WriteString(r.Description ?? "");
+                            w.WriteEndElement();
+                        }
+                    }
+                    w.WriteEndElement();
+                }
+            }
+            catch { }
+
+            // Parameters by group
+            var groups = settings.ParameterGroups ?? new List<string>();
+            w.WriteStartElement("params");
+            foreach (Parameter p in sheet.Parameters)
+            {
+                if (p == null) continue;
+                if (!IncludeByGroup(p, groups)) continue;
+                w.WriteStartElement("param");
+                w.WriteAttributeString("name", p.Definition?.Name ?? "");
+                w.WriteAttributeString("group", p.Definition?.ParameterGroup.ToString() ?? "");
+                w.WriteString(SafeAsString(p));
+                w.WriteEndElement();
+            }
+            w.WriteEndElement(); // params
+
+            // Viewports — list each placed view's id and name.
+            try
+            {
+                var vps = new FilteredElementCollector(doc, sheet.Id)
+                    .OfClass(typeof(Viewport)).Cast<Viewport>().ToList();
+                if (vps.Count > 0)
+                {
+                    w.WriteStartElement("viewports");
+                    foreach (var vp in vps)
+                    {
+                        var view = doc.GetElement(vp.ViewId) as View;
+                        if (view == null) continue;
+                        w.WriteStartElement("viewport");
+                        w.WriteAttributeString("viewId",   vp.ViewId.Value.ToString());
+                        w.WriteAttributeString("viewName", view.Name ?? "");
+                        w.WriteAttributeString("viewType", view.ViewType.ToString());
+                        w.WriteAttributeString("scale",    view.Scale.ToString());
+                        w.WriteEndElement();
+                    }
+                    w.WriteEndElement();
+                }
+            }
+            catch { }
+
+            w.WriteEndElement(); // sheet
+        }
+
+        private static bool IncludeByGroup(Parameter p, List<string> groups)
+        {
+            if (groups == null || groups.Count == 0) return true;
+            string g = p.Definition?.ParameterGroup.ToString() ?? "";
+            foreach (var want in groups)
+            {
+                if (g.IndexOf(want, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+                // Simple semantic mapping for the user-facing labels in the dialog.
+                if (want == "Identity"   && g.Contains("IDENTITY", StringComparison.OrdinalIgnoreCase)) return true;
+                if (want == "Location"   && g.Contains("CONSTRAINTS", StringComparison.OrdinalIgnoreCase)) return true;
+                if (want == "Dimensions" && g.Contains("GEOMETRY", StringComparison.OrdinalIgnoreCase)) return true;
+                if (want == "Revisions"  && p.Definition?.Name?.Contains("Revision", StringComparison.OrdinalIgnoreCase) == true) return true;
+            }
+            return false;
+        }
+
+        private static string SafeAsString(Parameter p)
+        {
+            try
+            {
+                return p.StorageType switch
+                {
+                    StorageType.String   => p.AsString() ?? "",
+                    StorageType.Integer  => p.AsInteger().ToString(),
+                    StorageType.Double   => p.AsValueString() ?? p.AsDouble().ToString("G"),
+                    StorageType.ElementId => p.AsValueString() ?? p.AsElementId().Value.ToString(),
+                    _ => p.AsValueString() ?? "",
+                };
+            }
+            catch { return ""; }
+        }
+
+        private static void W(XmlWriter w, string name, string value)
+        {
+            w.WriteStartElement(name);
+            w.WriteString(value ?? "");
+            w.WriteEndElement();
+        }
+    }
+}

--- a/StingTools/StingTools.csproj
+++ b/StingTools/StingTools.csproj
@@ -58,6 +58,10 @@
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
     <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
+    <!-- Export Centre — PDFsharp 6.x for combined-PDF bookmark trees and
+         diagonal watermark overlays (TryInjectBookmarks / TryInjectWatermark).
+         Pure managed, .NET 6/8 compatible, MIT-style licence. -->
+    <PackageReference Include="PDFsharp" Version="6.1.1" />
   </ItemGroup>
 
   <!-- Template engine v1.1 (S11/S14/S15): embedded default templates + workflow JSON.

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -767,8 +767,10 @@ namespace StingTools.UI
                     case "GridAlignViewports": RunCommand<Docs.GridAlignViewportsCommand>(app); break;
                     case "AlignViewportEdges": RunCommand<Docs.AlignViewportEdgesCommand>(app); break;
                     case "DistributeViewports": RunCommand<Docs.DistributeViewportsCommand>(app); break;
-                    case "BatchPrintSheets": RunCommand<Docs.BatchPrintSheetsCommand>(app); break;
+                    case "BatchPrintSheets": RunCommand<Docs.ExportCenterPdfCommand>(app); break; // redirects to Export Centre (PDF preset)
                     case "ExportSheetRegister": RunCommand<Docs.ExportSheetRegisterCommand>(app); break;
+                    case "ExportCenter": RunCommand<Docs.ExportCenterCommand>(app); break;
+                    case "ExportCenterPDF": RunCommand<Docs.ExportCenterPdfCommand>(app); break;
 
                     // ── Sheet Manager Live Operations (modeless dialog dispatch) ──
                     case "SM_PlaceViewOnSheet":

--- a/StingTools/UI/StingExportCenterDialog.cs
+++ b/StingTools/UI/StingExportCenterDialog.cs
@@ -519,11 +519,11 @@ namespace StingTools.UI
             if ((_profile.Formats & ExportFormats.PDF)   != 0) _formatOptionsHost.Children.Add(BuildPdfOptions());
             if ((_profile.Formats & ExportFormats.DWG)   != 0) _formatOptionsHost.Children.Add(BuildDwgOptions());
             if ((_profile.Formats & ExportFormats.IFC)   != 0) _formatOptionsHost.Children.Add(BuildIfcOptions());
-            if ((_profile.Formats & ExportFormats.NWC)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("NWC", "Requires Navisworks NWC Export Utility — TODO_NWC."));
+            if ((_profile.Formats & ExportFormats.NWC)   != 0) _formatOptionsHost.Children.Add(BuildNwcOptions());
             if ((_profile.Formats & ExportFormats.DGN)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("DGN", "Default DGN export options applied."));
             if ((_profile.Formats & ExportFormats.DWF)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("DWF", "DWFx default options applied."));
             if ((_profile.Formats & ExportFormats.Image) != 0) _formatOptionsHost.Children.Add(BuildImageOptions());
-            if ((_profile.Formats & ExportFormats.XML)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("XML", "XML export — TODO_XML."));
+            if ((_profile.Formats & ExportFormats.XML)   != 0) _formatOptionsHost.Children.Add(BuildXmlOptions());
         }
 
         private Border BuildPdfOptions()
@@ -686,6 +686,78 @@ namespace StingTools.UI
         {
             var card = NewSection(title);
             ((StackPanel)card.Child).Children.Add(new TextBlock { Text = text, TextWrapping = TextWrapping.Wrap, Foreground = (Brush)new BrushConverter().ConvertFromString("#5B6470"), FontSize = 11 });
+            return card;
+        }
+
+        private Border BuildNwcOptions()
+        {
+            var card = NewSection("NWC — Navisworks Cache");
+            var sp = (StackPanel)card.Child;
+
+            string hint = ExportCenterNwcExporter.IsAvailable()
+                ? "✅ Navisworks NWC Export Utility detected."
+                : "⚠ Navisworks NWC Export Utility NOT detected. Install the free utility from Autodesk to enable.";
+            sp.Children.Add(new TextBlock
+            {
+                Text = hint,
+                Foreground = ExportCenterNwcExporter.IsAvailable() ? Brushes.DarkGreen : Brushes.DarkOrange,
+                Margin = new Thickness(0, 0, 0, 6),
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+            });
+
+            var scope = new ComboBox();
+            foreach (var v in new[] { "Selected", "CurrentView", "Entire" }) scope.Items.Add(v);
+            scope.SelectedItem = _profile.Nwc.Scope;
+            scope.SelectionChanged += (_, __) => _profile.Nwc.Scope = scope.SelectedItem?.ToString() ?? "Selected";
+            sp.Children.Add(LabelFor("Scope", scope));
+
+            var coords = new ComboBox();
+            foreach (var v in new[] { "Project", "Shared" }) coords.Items.Add(v);
+            coords.SelectedItem = _profile.Nwc.CoordinateSystem;
+            coords.SelectionChanged += (_, __) => _profile.Nwc.CoordinateSystem = coords.SelectedItem?.ToString() ?? "Project";
+            sp.Children.Add(LabelFor("Coordinates", coords));
+
+            sp.Children.Add(BindCheck("Export element IDs (clash detective)",
+                () => _profile.Nwc.ExportElementIdsForClash, v => _profile.Nwc.ExportElementIdsForClash = v));
+            return card;
+        }
+
+        private Border BuildXmlOptions()
+        {
+            var card = NewSection("XML — Sheet metadata + parameters");
+            var sp = (StackPanel)card.Child;
+
+            var scope = new ComboBox();
+            foreach (var v in new[] { "Selected", "ProjectInfoOnly" }) scope.Items.Add(v);
+            scope.SelectedItem = _profile.Xml.Scope;
+            scope.SelectionChanged += (_, __) => _profile.Xml.Scope = scope.SelectedItem?.ToString() ?? "Selected";
+            sp.Children.Add(LabelFor("Scope", scope));
+
+            sp.Children.Add(BindCheck("Include project information",
+                () => _profile.Xml.IncludeProjectInfo, v => _profile.Xml.IncludeProjectInfo = v));
+
+            sp.Children.Add(new TextBlock
+            {
+                Text = "Parameter groups",
+                FontSize = 11,
+                Foreground = (Brush)new BrushConverter().ConvertFromString("#5B6470"),
+                Margin = new Thickness(0, 6, 0, 2),
+            });
+            foreach (var group in new[] { "Identity", "Location", "Dimensions", "Revisions", "Custom" })
+            {
+                var g = group;
+                var cb = new CheckBox
+                {
+                    Content = g,
+                    IsChecked = _profile.Xml.ParameterGroups.Contains(g),
+                    Margin = new Thickness(0, 1, 0, 1),
+                };
+                cb.Checked   += (_, __) => { if (!_profile.Xml.ParameterGroups.Contains(g)) _profile.Xml.ParameterGroups.Add(g); };
+                cb.Unchecked += (_, __) => _profile.Xml.ParameterGroups.RemoveAll(x => x == g);
+                sp.Children.Add(cb);
+            }
+
             return card;
         }
 

--- a/StingTools/UI/StingExportCenterDialog.cs
+++ b/StingTools/UI/StingExportCenterDialog.cs
@@ -619,16 +619,35 @@ namespace StingTools.UI
             sp.Children.Add(BindCheck("Fall back to individual files if merge fails",
                 () => _profile.Dwg.FallbackOnMergeFailure, v => _profile.Dwg.FallbackOnMergeFailure = v));
 
-            // Availability hint
-            string hint = ExportCenterEngine.IsMultiLayoutMergerAvailable()
-                ? "✅ Multi-layout merger detected on this machine."
-                : "⚠ Multi-layout merger NOT detected — install AutoCAD or ODA tools to enable.";
+            // Availability hint — distinguishes Method A (true merge) from
+            // Method B (ODA: version-normalise + manifest, no real merge).
+            string hint;
+            Brush hintColour;
+            if (ExportCenterDwgMerger.IsAvailable())
+            {
+                hint = "✅ Method A active — AutoCAD COM detected, true layout merge available.";
+                hintColour = Brushes.DarkGreen;
+            }
+            else if (ExportCenterOdaConverter.IsAvailable())
+            {
+                hint = "⚙ Method B active — ODA File Converter detected. " +
+                       "Per-sheet DWGs will be version-normalised and a merge_manifest.json " +
+                       "emitted; true layout merging requires AutoCAD or the Teigha SDK.";
+                hintColour = (Brush)new BrushConverter().ConvertFromString("#B07000");
+            }
+            else
+            {
+                hint = "⚠ No merger detected. Install AutoCAD (Method A) or the free " +
+                       "ODA File Converter (Method B) to enable multi-layout DWG output.";
+                hintColour = Brushes.DarkOrange;
+            }
             sp.Children.Add(new TextBlock
             {
                 Text = hint,
-                Foreground = ExportCenterEngine.IsMultiLayoutMergerAvailable() ? Brushes.DarkGreen : Brushes.DarkOrange,
+                Foreground = hintColour,
                 Margin = new Thickness(0, 6, 0, 0),
                 FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
             });
 
             return card;

--- a/StingTools/UI/StingExportCenterDialog.cs
+++ b/StingTools/UI/StingExportCenterDialog.cs
@@ -1,0 +1,1404 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Media;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+using StingTools.Docs;
+using Grid = System.Windows.Controls.Grid;
+using TextBox = System.Windows.Controls.TextBox;
+using ComboBox = System.Windows.Controls.ComboBox;
+using CheckBox = System.Windows.Controls.CheckBox;
+using Brush = System.Windows.Media.Brush;
+using Brushes = System.Windows.Media.Brushes;
+using HorizontalAlignment = System.Windows.HorizontalAlignment;
+using Orientation = System.Windows.Controls.Orientation;
+using SystemColors = System.Windows.SystemColors;
+
+namespace StingTools.UI
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  StingExportCenterDialog — the unified STING Export Centre.
+    //
+    //  A resizable WPF dialog that consolidates BatchPrintSheets, PrintManager,
+    //  AutomationEngine PDF/DWG, IFC export, ExLink batch export, and the
+    //  Drawing Production Config dialog into one publishing surface.
+    //
+    //  Layout:
+    //    HEADER : mode toggle (Simple / BIM), profile picker, share/import
+    //    BODY   : 3 columns — SELECT │ FORMAT │ OUTPUT
+    //    FOOTER : status summary, progress bar, EXPORT button
+    //
+    //  See CLAUDE.md "STING Export Centre — Complete Implementation Prompt"
+    //  for the full UX brief that this dialog implements.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    public class StingExportCenterDialog : Window
+    {
+        private readonly Document _doc;
+        private readonly Autodesk.Revit.UI.UIDocument _uiDoc;
+
+        private ExportCenterState _state;
+        private ExportProfile _profile;
+
+        private ComboBox _modeToggleSimple;
+        private ComboBox _modeToggleBim;
+        private ComboBox _profileCombo;
+        private DataGrid _selectGrid;
+        private TextBox _searchBox;
+        private ComboBox _setCombo;
+        private RadioButton _kindSheets, _kindViews;
+
+        private CheckBox _fmtPdf, _fmtDwg, _fmtIfc, _fmtNwc, _fmtDgn, _fmtDwf, _fmtImage, _fmtXml;
+        private StackPanel _formatOptionsHost;
+
+        private TextBox _folderBox;
+        private TextBox _namingBox;
+        private TextBlock _namingPreview;
+        private TextBlock _statusLine;
+        private TextBlock _progressLabel;
+        private ProgressBar _progressBar;
+        private Button _exportButton;
+
+        private readonly ObservableCollection<SheetRow> _rows = new();
+        private bool _exporting;
+        private bool _cancelRequested;
+
+        // ── Entry point ─────────────────────────────────────────────────────────
+
+        public static void Show(Autodesk.Revit.UI.UIDocument uiDoc)
+        {
+            try
+            {
+                var dlg = new StingExportCenterDialog(uiDoc);
+                var owner = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle;
+                if (owner != IntPtr.Zero)
+                    new System.Windows.Interop.WindowInteropHelper(dlg).Owner = owner;
+                dlg.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("StingExportCenterDialog.Show failed", ex);
+                Autodesk.Revit.UI.TaskDialog.Show("Export Centre", "Failed to open: " + ex.Message);
+            }
+        }
+
+        public StingExportCenterDialog(Autodesk.Revit.UI.UIDocument uiDoc)
+        {
+            _uiDoc = uiDoc ?? throw new ArgumentNullException(nameof(uiDoc));
+            _doc = uiDoc.Document;
+
+            _state = ExportCenterEngine.LoadState();
+            _profile = ResolveStartingProfile();
+
+            InitWindowChrome();
+            BuildLayout();
+            ApplyProfileToUi();
+            RefreshSelectionGrid();
+            UpdateStatusLine();
+        }
+
+        private ExportProfile ResolveStartingProfile()
+        {
+            var p = _state.Profiles.FirstOrDefault(x => x.Name == _state.LastProfile);
+            return p ?? _state.Profiles.FirstOrDefault() ?? new ExportProfile { Name = "New profile" };
+        }
+
+        private void InitWindowChrome()
+        {
+            Title = "STING Export Centre";
+            Width = 1280; Height = 820;
+            MinWidth = 1024; MinHeight = 640;
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            Background = (Brush)new BrushConverter().ConvertFromString("#F5F6F8");
+            FontFamily = new FontFamily("Segoe UI");
+            FontSize = 12;
+            ResizeMode = ResizeMode.CanResize;
+        }
+
+        // ── Layout ──────────────────────────────────────────────────────────────
+
+        private void BuildLayout()
+        {
+            var root = new Grid();
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });    // header
+            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }); // body
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });    // footer
+
+            root.Children.Add(BuildHeader());
+            var body = BuildBody();
+            Grid.SetRow(body, 1);
+            root.Children.Add(body);
+            var footer = BuildFooter();
+            Grid.SetRow(footer, 2);
+            root.Children.Add(footer);
+
+            Content = root;
+        }
+
+        // ── Header ──────────────────────────────────────────────────────────────
+
+        private FrameworkElement BuildHeader()
+        {
+            var bar = new Border
+            {
+                Background = (Brush)new BrushConverter().ConvertFromString("#1F2A3A"),
+                Padding = new Thickness(16, 10, 16, 10),
+            };
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+            var title = new TextBlock
+            {
+                Text = "STING Export Centre",
+                Foreground = Brushes.White,
+                FontSize = 17,
+                FontWeight = FontWeights.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            grid.Children.Add(title);
+
+            // Profile picker
+            var profilePanel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            profilePanel.Children.Add(new TextBlock
+            {
+                Text = "Profile:",
+                Foreground = Brushes.White,
+                Margin = new Thickness(0, 0, 8, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+
+            _profileCombo = new ComboBox { Width = 280, Padding = new Thickness(6, 3, 6, 3) };
+            foreach (var p in _state.Profiles)
+                _profileCombo.Items.Add(p.Name + (p.BuiltIn ? "  (built-in)" : ""));
+            _profileCombo.SelectedIndex = Math.Max(0, _state.Profiles.IndexOf(_profile));
+            _profileCombo.SelectionChanged += (_, __) =>
+            {
+                int i = _profileCombo.SelectedIndex;
+                if (i >= 0 && i < _state.Profiles.Count)
+                {
+                    _profile = _state.Profiles[i];
+                    ApplyProfileToUi();
+                    UpdateStatusLine();
+                }
+            };
+            profilePanel.Children.Add(_profileCombo);
+
+            profilePanel.Children.Add(SmallButton("★ Save",  OnSaveProfileClick));
+            profilePanel.Children.Add(SmallButton("Save As…", OnSaveAsProfileClick));
+            profilePanel.Children.Add(SmallButton("Import…", OnImportProfileClick));
+            profilePanel.Children.Add(SmallButton("Share",   OnShareProfileClick));
+
+            Grid.SetColumn(profilePanel, 1);
+            grid.Children.Add(profilePanel);
+
+            // Mode toggle
+            var modeBox = new StackPanel { Orientation = Orientation.Horizontal, VerticalAlignment = VerticalAlignment.Center };
+            var simpleBtn = ModePill("Simple",  ExportCenterMode.Simple);
+            var bimBtn    = ModePill("BIM 19650", ExportCenterMode.BIM);
+            modeBox.Children.Add(simpleBtn);
+            modeBox.Children.Add(bimBtn);
+            Grid.SetColumn(modeBox, 2);
+            grid.Children.Add(modeBox);
+
+            // Close
+            var closeBtn = new Button
+            {
+                Content = "✕",
+                Width = 32, Height = 28,
+                Background = Brushes.Transparent,
+                Foreground = Brushes.White,
+                BorderThickness = new Thickness(0),
+                Margin = new Thickness(12, 0, 0, 0),
+                FontSize = 14,
+                Cursor = Cursors.Hand,
+            };
+            closeBtn.Click += (_, __) => Close();
+            Grid.SetColumn(closeBtn, 3);
+            grid.Children.Add(closeBtn);
+
+            bar.Child = grid;
+            return bar;
+        }
+
+        private Button ModePill(string label, ExportCenterMode mode)
+        {
+            var btn = new Button
+            {
+                Content = label,
+                Padding = new Thickness(14, 4, 14, 4),
+                Margin = new Thickness(2, 0, 2, 0),
+                Background = (_profile?.Mode == mode)
+                    ? (Brush)new BrushConverter().ConvertFromString("#3577F0")
+                    : Brushes.Transparent,
+                Foreground = Brushes.White,
+                BorderBrush = Brushes.White,
+                BorderThickness = new Thickness(1),
+                FontWeight = FontWeights.SemiBold,
+                Cursor = Cursors.Hand,
+            };
+            btn.Click += (_, __) =>
+            {
+                _profile.Mode = mode;
+                _state.Mode = mode;
+                ApplyProfileToUi();
+                UpdateStatusLine();
+            };
+            return btn;
+        }
+
+        private Button SmallButton(string label, RoutedEventHandler onClick)
+        {
+            var b = new Button
+            {
+                Content = label,
+                Padding = new Thickness(10, 3, 10, 3),
+                Margin = new Thickness(4, 0, 0, 0),
+                Background = (Brush)new BrushConverter().ConvertFromString("#33FFFFFF"),
+                Foreground = Brushes.White,
+                BorderBrush = Brushes.Transparent,
+                Cursor = Cursors.Hand,
+            };
+            b.Click += onClick;
+            return b;
+        }
+
+        // ── Body (three columns + splitters) ────────────────────────────────────
+
+        private FrameworkElement BuildBody()
+        {
+            var grid = new Grid { Margin = new Thickness(12) };
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1.6, GridUnitType.Star), MinWidth = 320 });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(4) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1.4, GridUnitType.Star), MinWidth = 280 });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(4) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1.2, GridUnitType.Star), MinWidth = 280 });
+
+            var sel = WrapPanel("1.  SELECT", BuildSelectPanel());
+            Grid.SetColumn(sel, 0);
+            grid.Children.Add(sel);
+
+            var s1 = new GridSplitter
+            {
+                Width = 4,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Background = (Brush)new BrushConverter().ConvertFromString("#E2E5EA"),
+            };
+            Grid.SetColumn(s1, 1);
+            grid.Children.Add(s1);
+
+            var fmt = WrapPanel("2.  FORMAT", BuildFormatPanel());
+            Grid.SetColumn(fmt, 2);
+            grid.Children.Add(fmt);
+
+            var s2 = new GridSplitter
+            {
+                Width = 4,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Background = (Brush)new BrushConverter().ConvertFromString("#E2E5EA"),
+            };
+            Grid.SetColumn(s2, 3);
+            grid.Children.Add(s2);
+
+            var outp = WrapPanel("3.  OUTPUT", BuildOutputPanel());
+            Grid.SetColumn(outp, 4);
+            grid.Children.Add(outp);
+
+            return grid;
+        }
+
+        private FrameworkElement WrapPanel(string title, FrameworkElement content)
+        {
+            var card = new Border
+            {
+                Background = Brushes.White,
+                BorderBrush = (Brush)new BrushConverter().ConvertFromString("#D9DDE3"),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(4),
+                Margin = new Thickness(2),
+            };
+            var dock = new DockPanel();
+            var header = new Border
+            {
+                Background = (Brush)new BrushConverter().ConvertFromString("#F0F2F5"),
+                Padding = new Thickness(10, 6, 10, 6),
+            };
+            header.Child = new TextBlock
+            {
+                Text = title,
+                FontWeight = FontWeights.Bold,
+                FontSize = 12,
+                Foreground = (Brush)new BrushConverter().ConvertFromString("#1F2A3A"),
+            };
+            DockPanel.SetDock(header, Dock.Top);
+            dock.Children.Add(header);
+            content.Margin = new Thickness(8);
+            dock.Children.Add(content);
+            card.Child = dock;
+            return card;
+        }
+
+        // ── SELECT panel ────────────────────────────────────────────────────────
+
+        private FrameworkElement BuildSelectPanel()
+        {
+            var dock = new DockPanel { LastChildFill = true };
+
+            // Top: kind toggle + saved-set picker + search
+            var topBar = new Grid();
+            topBar.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            topBar.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            topBar.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var kindRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 6) };
+            _kindSheets = new RadioButton { Content = "Sheets", IsChecked = true, GroupName = "Kind", Margin = new Thickness(0, 0, 12, 0) };
+            _kindViews  = new RadioButton { Content = "Views",  GroupName = "Kind" };
+            _kindSheets.Checked += (_, __) => RefreshSelectionGrid();
+            _kindViews.Checked  += (_, __) => RefreshSelectionGrid();
+            kindRow.Children.Add(_kindSheets);
+            kindRow.Children.Add(_kindViews);
+            Grid.SetRow(kindRow, 0);
+            topBar.Children.Add(kindRow);
+
+            var setRow = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+            setRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            setRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            setRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            setRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+            setRow.Children.Add(new TextBlock { Text = "Set:", VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 6, 0) });
+
+            _setCombo = new ComboBox();
+            foreach (var s in _state.SavedSets) _setCombo.Items.Add(s.Name + (s.BuiltIn ? "  (built-in)" : ""));
+            _setCombo.SelectedIndex = 0;
+            _setCombo.SelectionChanged += (_, __) => ApplySavedSetSelection();
+            Grid.SetColumn(_setCombo, 1);
+            setRow.Children.Add(_setCombo);
+
+            var saveSetBtn = new Button { Content = "+ Save", Margin = new Thickness(6, 0, 0, 0), Padding = new Thickness(8, 2, 8, 2) };
+            saveSetBtn.Click += OnSaveSetClick;
+            Grid.SetColumn(saveSetBtn, 2);
+            setRow.Children.Add(saveSetBtn);
+
+            var manageBtn = new Button { Content = "✎", Margin = new Thickness(4, 0, 0, 0), Padding = new Thickness(8, 2, 8, 2) };
+            manageBtn.Click += OnManageSetsClick;
+            Grid.SetColumn(manageBtn, 3);
+            setRow.Children.Add(manageBtn);
+
+            Grid.SetRow(setRow, 1);
+            topBar.Children.Add(setRow);
+
+            _searchBox = new TextBox
+            {
+                Padding = new Thickness(6, 4, 6, 4),
+                Margin = new Thickness(0, 0, 0, 6),
+                Tag = "Search sheets, titles, disciplines…",
+            };
+            _searchBox.TextChanged += (_, __) => ApplySearchFilter();
+            Grid.SetRow(_searchBox, 2);
+            topBar.Children.Add(_searchBox);
+
+            DockPanel.SetDock(topBar, Dock.Top);
+            dock.Children.Add(topBar);
+
+            // Filter chips
+            var chips = new WrapPanel { Margin = new Thickness(0, 0, 0, 6) };
+            string[] chipLabels = { "All", "Issued", "Unissued", "Current Revision", "Opened Only" };
+            foreach (var c in chipLabels) chips.Children.Add(MakeChip(c));
+            DockPanel.SetDock(chips, Dock.Top);
+            dock.Children.Add(chips);
+
+            // Grid
+            _selectGrid = new DataGrid
+            {
+                AutoGenerateColumns = false,
+                CanUserAddRows = false,
+                CanUserDeleteRows = false,
+                IsReadOnly = false,
+                HeadersVisibility = DataGridHeadersVisibility.Column,
+                GridLinesVisibility = DataGridGridLinesVisibility.Horizontal,
+                AlternatingRowBackground = (Brush)new BrushConverter().ConvertFromString("#F8F9FB"),
+                EnableRowVirtualization = true,
+                EnableColumnVirtualization = true,
+                ItemsSource = _rows,
+            };
+
+            _selectGrid.Columns.Add(new DataGridCheckBoxColumn
+            {
+                Header = "",
+                Binding = new Binding(nameof(SheetRow.IsChecked)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
+                Width = 32,
+            });
+            _selectGrid.Columns.Add(new DataGridTextColumn { Header = "Sheet No.", Binding = new Binding(nameof(SheetRow.Number)),     Width = 110, IsReadOnly = true });
+            _selectGrid.Columns.Add(new DataGridTextColumn { Header = "Title",     Binding = new Binding(nameof(SheetRow.Title)),      Width = new DataGridLength(1, DataGridLengthUnitType.Star), IsReadOnly = true });
+            _selectGrid.Columns.Add(new DataGridTextColumn { Header = "Rev",       Binding = new Binding(nameof(SheetRow.Revision)),   Width = 50,  IsReadOnly = true });
+            _selectGrid.Columns.Add(new DataGridTextColumn { Header = "Disc",      Binding = new Binding(nameof(SheetRow.Discipline)), Width = 50,  IsReadOnly = true });
+            _selectGrid.Columns.Add(new DataGridTextColumn { Header = "Size",      Binding = new Binding(nameof(SheetRow.PaperSize)),  Width = 60,  IsReadOnly = true });
+            _selectGrid.Columns.Add(new DataGridTextColumn { Header = "CDE",       Binding = new Binding(nameof(SheetRow.CdeStatus)),  Width = 60,  IsReadOnly = true });
+
+            dock.Children.Add(_selectGrid);
+            return dock;
+        }
+
+        private Border MakeChip(string label)
+        {
+            var b = new Border
+            {
+                Background = (Brush)new BrushConverter().ConvertFromString("#EEF1F5"),
+                CornerRadius = new CornerRadius(10),
+                Padding = new Thickness(8, 2, 8, 2),
+                Margin = new Thickness(0, 0, 6, 0),
+                Cursor = Cursors.Hand,
+            };
+            b.Child = new TextBlock { Text = label, FontSize = 11 };
+            b.MouseLeftButtonUp += (_, __) => { _searchBox.Text = label == "All" ? "" : label; ApplySearchFilter(); };
+            return b;
+        }
+
+        // ── FORMAT panel ────────────────────────────────────────────────────────
+
+        private FrameworkElement BuildFormatPanel()
+        {
+            var dock = new DockPanel { LastChildFill = true };
+
+            // Format chips
+            var chips = new WrapPanel { Margin = new Thickness(0, 0, 0, 8) };
+            _fmtPdf   = AddFormatChip(chips, "📄 PDF",  ExportFormats.PDF);
+            _fmtDwg   = AddFormatChip(chips, "⬛ DWG",  ExportFormats.DWG);
+            _fmtIfc   = AddFormatChip(chips, "🏛 IFC",  ExportFormats.IFC);
+            _fmtNwc   = AddFormatChip(chips, "🔷 NWC",  ExportFormats.NWC);
+            _fmtDgn   = AddFormatChip(chips, "◇ DGN",  ExportFormats.DGN);
+            _fmtDwf   = AddFormatChip(chips, "≋ DWF",  ExportFormats.DWF);
+            _fmtImage = AddFormatChip(chips, "🖼 Image",ExportFormats.Image);
+            _fmtXml   = AddFormatChip(chips, "⊞ XML",  ExportFormats.XML);
+            DockPanel.SetDock(chips, Dock.Top);
+            dock.Children.Add(chips);
+
+            // Per-format options
+            _formatOptionsHost = new StackPanel();
+            var scroller = new ScrollViewer { Content = _formatOptionsHost, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
+            dock.Children.Add(scroller);
+
+            return dock;
+        }
+
+        private CheckBox AddFormatChip(Panel parent, string label, ExportFormats fmt)
+        {
+            var cb = new CheckBox
+            {
+                Content = label,
+                Padding = new Thickness(10, 3, 10, 3),
+                Margin = new Thickness(0, 0, 6, 6),
+                IsChecked = (_profile.Formats & fmt) != 0,
+            };
+            cb.Checked   += (_, __) => { _profile.Formats |= fmt;  RebuildFormatOptions(); UpdateStatusLine(); };
+            cb.Unchecked += (_, __) => { _profile.Formats &= ~fmt; RebuildFormatOptions(); UpdateStatusLine(); };
+            parent.Children.Add(cb);
+            return cb;
+        }
+
+        private void RebuildFormatOptions()
+        {
+            _formatOptionsHost.Children.Clear();
+            if ((_profile.Formats & ExportFormats.PDF)   != 0) _formatOptionsHost.Children.Add(BuildPdfOptions());
+            if ((_profile.Formats & ExportFormats.DWG)   != 0) _formatOptionsHost.Children.Add(BuildDwgOptions());
+            if ((_profile.Formats & ExportFormats.IFC)   != 0) _formatOptionsHost.Children.Add(BuildIfcOptions());
+            if ((_profile.Formats & ExportFormats.NWC)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("NWC", "Requires Navisworks NWC Export Utility — TODO_NWC."));
+            if ((_profile.Formats & ExportFormats.DGN)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("DGN", "Default DGN export options applied."));
+            if ((_profile.Formats & ExportFormats.DWF)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("DWF", "DWFx default options applied."));
+            if ((_profile.Formats & ExportFormats.Image) != 0) _formatOptionsHost.Children.Add(BuildImageOptions());
+            if ((_profile.Formats & ExportFormats.XML)   != 0) _formatOptionsHost.Children.Add(BuildSimpleNote("XML", "XML export — TODO_XML."));
+        }
+
+        private Border BuildPdfOptions()
+        {
+            var card = NewSection("PDF — Combine, Bookmarks, Watermark");
+            var sp = (StackPanel)card.Child;
+
+            // Combine mode
+            var combineBox = new ComboBox { Margin = new Thickness(0, 4, 0, 6) };
+            foreach (var v in Enum.GetNames(typeof(PdfCombineMode))) combineBox.Items.Add(v);
+            combineBox.SelectedItem = _profile.Pdf.CombineMode.ToString();
+            combineBox.SelectionChanged += (_, __) =>
+            {
+                Enum.TryParse<PdfCombineMode>(combineBox.SelectedItem?.ToString(), out var m);
+                _profile.Pdf.CombineMode = m;
+                UpdateStatusLine();
+            };
+            sp.Children.Add(LabelFor("Output mode", combineBox));
+
+            // Bookmarks
+            sp.Children.Add(BindCheck("Add bookmarks", () => _profile.Pdf.AddBookmarks, v => _profile.Pdf.AddBookmarks = v));
+            sp.Children.Add(BindCheck("Nest by Discipline", () => _profile.Pdf.NestBookmarksByDiscipline, v => _profile.Pdf.NestBookmarksByDiscipline = v));
+            sp.Children.Add(BindCheck("Nest by Level",       () => _profile.Pdf.NestBookmarksByLevel,       v => _profile.Pdf.NestBookmarksByLevel = v));
+
+            // Render
+            var hidden = new ComboBox();
+            hidden.Items.Add("Auto"); hidden.Items.Add("Vector"); hidden.Items.Add("Raster");
+            hidden.SelectedItem = _profile.Pdf.HiddenLineMode;
+            hidden.SelectionChanged += (_, __) => _profile.Pdf.HiddenLineMode = hidden.SelectedItem?.ToString() ?? "Auto";
+            sp.Children.Add(LabelFor("Hidden lines", hidden));
+
+            var colour = new ComboBox();
+            colour.Items.Add("Colour"); colour.Items.Add("Greyscale"); colour.Items.Add("BlackAndWhite");
+            colour.SelectedItem = _profile.Pdf.ColourScheme;
+            colour.SelectionChanged += (_, __) => _profile.Pdf.ColourScheme = colour.SelectedItem?.ToString() ?? "Colour";
+            sp.Children.Add(LabelFor("Colour scheme", colour));
+
+            var dpi = new ComboBox();
+            foreach (int d in new[] { 72, 150, 300, 600 }) dpi.Items.Add(d);
+            dpi.SelectedItem = _profile.Pdf.RasterDpi;
+            dpi.SelectionChanged += (_, __) => { if (int.TryParse(dpi.SelectedItem?.ToString(), out int n)) _profile.Pdf.RasterDpi = n; };
+            sp.Children.Add(LabelFor("Raster DPI", dpi));
+
+            // Watermark
+            sp.Children.Add(BindCheck("Apply watermark", () => _profile.Pdf.ApplyWatermark, v => _profile.Pdf.ApplyWatermark = v));
+            var wmText = new TextBox { Text = _profile.Pdf.WatermarkText };
+            wmText.TextChanged += (_, __) => _profile.Pdf.WatermarkText = wmText.Text;
+            sp.Children.Add(LabelFor("Watermark text", wmText));
+
+            return card;
+        }
+
+        private Border BuildDwgOptions()
+        {
+            var card = NewSection("DWG — Output mode & Layouts");
+            var sp = (StackPanel)card.Child;
+
+            var modeBox = new ComboBox { Margin = new Thickness(0, 4, 0, 6) };
+            foreach (var v in Enum.GetNames(typeof(DwgOutputMode))) modeBox.Items.Add(v);
+            modeBox.SelectedItem = _profile.Dwg.OutputMode.ToString();
+            modeBox.SelectionChanged += (_, __) =>
+            {
+                Enum.TryParse<DwgOutputMode>(modeBox.SelectedItem?.ToString(), out var m);
+                _profile.Dwg.OutputMode = m;
+                UpdateStatusLine();
+            };
+            sp.Children.Add(LabelFor("Output mode", modeBox));
+
+            sp.Children.Add(new TextBlock
+            {
+                Text =
+                    "• OnePerSheet — standard one-DWG-per-sheet (Revit native)\n" +
+                    "• AllInOneMultiLayout — all sheets become layout tabs in a single DWG\n" +
+                    "  (requires AutoCAD COM or ODA libraries; falls back if missing)\n" +
+                    "• ModelSpaceOnly — geometry merged, no paper space\n" +
+                    "• CustomGroups — user-defined groups, one DWG per group",
+                Foreground = (Brush)new BrushConverter().ConvertFromString("#5B6470"),
+                Margin = new Thickness(0, 4, 0, 6),
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 11,
+            });
+
+            var version = new ComboBox();
+            foreach (var v in new[] { "AC2018", "AC2013", "AC2010", "AC2007", "AC2004" }) version.Items.Add(v);
+            version.SelectedItem = _profile.Dwg.DwgVersion;
+            version.SelectionChanged += (_, __) => _profile.Dwg.DwgVersion = version.SelectedItem?.ToString() ?? "AC2018";
+            sp.Children.Add(LabelFor("DWG version", version));
+
+            var layoutTpl = new TextBox { Text = _profile.Dwg.LayoutNameTemplate };
+            layoutTpl.TextChanged += (_, __) => _profile.Dwg.LayoutNameTemplate = layoutTpl.Text;
+            sp.Children.Add(LabelFor("Layout tab name template", layoutTpl));
+
+            sp.Children.Add(BindCheck("Fall back to individual files if merge fails",
+                () => _profile.Dwg.FallbackOnMergeFailure, v => _profile.Dwg.FallbackOnMergeFailure = v));
+
+            // Availability hint
+            string hint = ExportCenterEngine.IsMultiLayoutMergerAvailable()
+                ? "✅ Multi-layout merger detected on this machine."
+                : "⚠ Multi-layout merger NOT detected — install AutoCAD or ODA tools to enable.";
+            sp.Children.Add(new TextBlock
+            {
+                Text = hint,
+                Foreground = ExportCenterEngine.IsMultiLayoutMergerAvailable() ? Brushes.DarkGreen : Brushes.DarkOrange,
+                Margin = new Thickness(0, 6, 0, 0),
+                FontSize = 11,
+            });
+
+            return card;
+        }
+
+        private Border BuildIfcOptions()
+        {
+            var card = NewSection("IFC — Schema & Phase");
+            var sp = (StackPanel)card.Child;
+
+            var schema = new ComboBox();
+            foreach (var v in new[] { "IFC2x3", "IFC4", "IFC4x3" }) schema.Items.Add(v);
+            schema.SelectedItem = _profile.Ifc.Schema;
+            schema.SelectionChanged += (_, __) => _profile.Ifc.Schema = schema.SelectedItem?.ToString() ?? "IFC4";
+            sp.Children.Add(LabelFor("Schema", schema));
+
+            var phase = new ComboBox();
+            phase.Items.Add("(current)");
+            try
+            {
+                foreach (Phase p in _doc.Phases) phase.Items.Add(p.Name);
+            }
+            catch { }
+            phase.SelectedIndex = 0;
+            phase.SelectionChanged += (_, __) =>
+                _profile.Ifc.PhaseName = phase.SelectedIndex == 0 ? null : phase.SelectedItem?.ToString();
+            sp.Children.Add(LabelFor("Phase", phase));
+
+            sp.Children.Add(BindCheck("Export linked models", () => _profile.Ifc.ExportLinkedModels, v => _profile.Ifc.ExportLinkedModels = v));
+
+            return card;
+        }
+
+        private Border BuildImageOptions()
+        {
+            var card = NewSection("Image — Format & DPI");
+            var sp = (StackPanel)card.Child;
+
+            var fmt = new ComboBox();
+            foreach (var v in new[] { "PNG", "JPEG", "TIFF" }) fmt.Items.Add(v);
+            fmt.SelectedItem = _profile.Image.Format;
+            fmt.SelectionChanged += (_, __) => _profile.Image.Format = fmt.SelectedItem?.ToString() ?? "PNG";
+            sp.Children.Add(LabelFor("Format", fmt));
+
+            var dpi = new ComboBox();
+            foreach (int d in new[] { 72, 150, 300, 600 }) dpi.Items.Add(d);
+            dpi.SelectedItem = _profile.Image.Dpi;
+            dpi.SelectionChanged += (_, __) => { if (int.TryParse(dpi.SelectedItem?.ToString(), out int n)) _profile.Image.Dpi = n; };
+            sp.Children.Add(LabelFor("DPI", dpi));
+
+            return card;
+        }
+
+        private Border BuildSimpleNote(string title, string text)
+        {
+            var card = NewSection(title);
+            ((StackPanel)card.Child).Children.Add(new TextBlock { Text = text, TextWrapping = TextWrapping.Wrap, Foreground = (Brush)new BrushConverter().ConvertFromString("#5B6470"), FontSize = 11 });
+            return card;
+        }
+
+        private Border NewSection(string title)
+        {
+            var sp = new StackPanel { Margin = new Thickness(0, 0, 0, 0) };
+            sp.Children.Add(new TextBlock { Text = title, FontWeight = FontWeights.SemiBold, Margin = new Thickness(0, 0, 0, 4) });
+            return new Border
+            {
+                BorderBrush = (Brush)new BrushConverter().ConvertFromString("#E2E5EA"),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(3),
+                Padding = new Thickness(8),
+                Margin = new Thickness(0, 0, 0, 8),
+                Child = sp,
+            };
+        }
+
+        private FrameworkElement LabelFor(string label, FrameworkElement control)
+        {
+            var sp = new StackPanel { Margin = new Thickness(0, 4, 0, 4) };
+            sp.Children.Add(new TextBlock { Text = label, FontSize = 11, Foreground = (Brush)new BrushConverter().ConvertFromString("#5B6470") });
+            sp.Children.Add(control);
+            return sp;
+        }
+
+        private CheckBox BindCheck(string label, Func<bool> read, Action<bool> write)
+        {
+            var cb = new CheckBox { Content = label, IsChecked = read(), Margin = new Thickness(0, 2, 0, 2) };
+            cb.Checked   += (_, __) => write(true);
+            cb.Unchecked += (_, __) => write(false);
+            return cb;
+        }
+
+        // ── OUTPUT panel ────────────────────────────────────────────────────────
+
+        private FrameworkElement BuildOutputPanel()
+        {
+            var sp = new StackPanel();
+
+            // Destination
+            var dest = NewSection("Destination");
+            var destSp = (StackPanel)dest.Child;
+            var local = new RadioButton { Content = "Local / Network folder", IsChecked = _profile.Output.Destination == ExportDestination.LocalFolder, GroupName = "Dest" };
+            var cde   = new RadioButton { Content = "Planscape CDE",          IsChecked = _profile.Output.Destination == ExportDestination.PlanscapeCde, GroupName = "Dest" };
+            var both  = new RadioButton { Content = "Both",                   IsChecked = _profile.Output.Destination == ExportDestination.Both,         GroupName = "Dest" };
+            local.Checked += (_, __) => _profile.Output.Destination = ExportDestination.LocalFolder;
+            cde.Checked   += (_, __) => _profile.Output.Destination = ExportDestination.PlanscapeCde;
+            both.Checked  += (_, __) => _profile.Output.Destination = ExportDestination.Both;
+            destSp.Children.Add(local); destSp.Children.Add(cde); destSp.Children.Add(both);
+
+            var folderRow = new Grid { Margin = new Thickness(0, 6, 0, 0) };
+            folderRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            folderRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            _folderBox = new TextBox { Text = _profile.Output.LocalFolder ?? "" };
+            _folderBox.TextChanged += (_, __) => { _profile.Output.LocalFolder = _folderBox.Text; UpdateStatusLine(); };
+            Grid.SetColumn(_folderBox, 0);
+            folderRow.Children.Add(_folderBox);
+            var browse = new Button { Content = "Browse…", Margin = new Thickness(4, 0, 0, 0), Padding = new Thickness(8, 2, 8, 2) };
+            browse.Click += OnBrowseFolderClick;
+            Grid.SetColumn(browse, 1);
+            folderRow.Children.Add(browse);
+            destSp.Children.Add(folderRow);
+
+            destSp.Children.Add(BindCheck("Open folder when export completes", () => _profile.Output.OpenFolderWhenDone, v => _profile.Output.OpenFolderWhenDone = v));
+            destSp.Children.Add(BindCheck("Create folder if it doesn't exist", () => _profile.Output.CreateFolderIfMissing, v => _profile.Output.CreateFolderIfMissing = v));
+            destSp.Children.Add(BindCheck("Split into format sub-folders",     () => _profile.Output.SplitByFormatSubFolder, v => _profile.Output.SplitByFormatSubFolder = v));
+            destSp.Children.Add(BindCheck("Split by discipline sub-folders",   () => _profile.Output.SplitByDisciplineSubFolder, v => _profile.Output.SplitByDisciplineSubFolder = v));
+
+            sp.Children.Add(dest);
+
+            // Naming
+            var naming = NewSection("File naming");
+            var nSp = (StackPanel)naming.Child;
+
+            var preset = new ComboBox { Margin = new Thickness(0, 0, 0, 6) };
+            var presetMap = _profile.Mode == ExportCenterMode.BIM ? ExportNamingPresets.BimMode : ExportNamingPresets.SimpleMode;
+            foreach (var k in presetMap.Keys) preset.Items.Add(k);
+            preset.Items.Add("Custom…");
+            preset.SelectedIndex = 0;
+            preset.SelectionChanged += (_, __) =>
+            {
+                string key = preset.SelectedItem?.ToString();
+                if (key != null && presetMap.TryGetValue(key, out string tpl))
+                {
+                    _namingBox.Text = tpl;
+                }
+            };
+            nSp.Children.Add(LabelFor("Preset", preset));
+
+            _namingBox = new TextBox { Text = _profile.Output.NamingTemplate };
+            _namingBox.TextChanged += (_, __) => { _profile.Output.NamingTemplate = _namingBox.Text; RefreshNamingPreview(); };
+            nSp.Children.Add(LabelFor("Template", _namingBox));
+
+            // Token palette
+            var tokens = new WrapPanel { Margin = new Thickness(0, 4, 0, 6) };
+            string[] common  = { "{SheetNumber}", "{SheetTitle}", "{Revision}", "{Discipline}", "{Date:yyyyMMdd}" };
+            string[] bimOnly = { "{Originator}", "{Volume}", "{Level}", "{Type}", "{Role}", "{Suitability}", "{ProjectCode}" };
+            foreach (var t in common) tokens.Children.Add(MakeTokenPill(t));
+            if (_profile.Mode == ExportCenterMode.BIM)
+                foreach (var t in bimOnly) tokens.Children.Add(MakeTokenPill(t));
+            nSp.Children.Add(tokens);
+
+            _namingPreview = new TextBlock
+            {
+                FontSize = 11,
+                Foreground = (Brush)new BrushConverter().ConvertFromString("#1F2A3A"),
+                FontStyle = FontStyles.Italic,
+                Margin = new Thickness(0, 4, 0, 0),
+                TextWrapping = TextWrapping.Wrap,
+            };
+            nSp.Children.Add(LabelFor("Preview (first sheet)", _namingPreview));
+
+            // Conflict mode
+            var conflict = new ComboBox();
+            foreach (var v in Enum.GetNames(typeof(FilenameConflictMode))) conflict.Items.Add(v);
+            conflict.SelectedItem = _profile.Output.ConflictMode.ToString();
+            conflict.SelectionChanged += (_, __) =>
+            {
+                Enum.TryParse<FilenameConflictMode>(conflict.SelectedItem?.ToString(), out var m);
+                _profile.Output.ConflictMode = m;
+            };
+            nSp.Children.Add(LabelFor("If file already exists", conflict));
+
+            sp.Children.Add(naming);
+
+            // Report
+            var report = NewSection("Export report");
+            var rSp = (StackPanel)report.Child;
+            rSp.Children.Add(BindCheck("Generate report", () => _profile.Output.GenerateReport, v => _profile.Output.GenerateReport = v));
+            rSp.Children.Add(BindCheck("Open report when done", () => _profile.Output.OpenReportWhenDone, v => _profile.Output.OpenReportWhenDone = v));
+            sp.Children.Add(report);
+
+            return new ScrollViewer { Content = sp, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
+        }
+
+        private Border MakeTokenPill(string token)
+        {
+            var b = new Border
+            {
+                Background = (Brush)new BrushConverter().ConvertFromString("#E5ECFB"),
+                BorderBrush = (Brush)new BrushConverter().ConvertFromString("#3577F0"),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(3),
+                Padding = new Thickness(6, 1, 6, 1),
+                Margin = new Thickness(0, 0, 4, 4),
+                Cursor = Cursors.Hand,
+            };
+            b.Child = new TextBlock { Text = token, FontSize = 11 };
+            b.MouseLeftButtonUp += (_, __) =>
+            {
+                _namingBox.Text = (_namingBox.Text ?? "").TrimEnd() + token;
+                RefreshNamingPreview();
+            };
+            return b;
+        }
+
+        // ── Footer ──────────────────────────────────────────────────────────────
+
+        private FrameworkElement BuildFooter()
+        {
+            var bar = new Border
+            {
+                Background = (Brush)new BrushConverter().ConvertFromString("#F0F2F5"),
+                BorderBrush = (Brush)new BrushConverter().ConvertFromString("#D9DDE3"),
+                BorderThickness = new Thickness(0, 1, 0, 0),
+                Padding = new Thickness(16, 8, 16, 8),
+            };
+            var grid = new Grid();
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            _statusLine = new TextBlock { FontSize = 12, TextWrapping = TextWrapping.Wrap };
+            Grid.SetRow(_statusLine, 0);
+            grid.Children.Add(_statusLine);
+
+            var actionRow = new Grid { Margin = new Thickness(0, 6, 0, 0) };
+            actionRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            actionRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+            var progPanel = new StackPanel { Orientation = Orientation.Vertical };
+            _progressBar = new ProgressBar { Height = 6, Minimum = 0, Maximum = 100, Value = 0 };
+            _progressLabel = new TextBlock { FontSize = 11, Foreground = (Brush)new BrushConverter().ConvertFromString("#5B6470") };
+            progPanel.Children.Add(_progressBar);
+            progPanel.Children.Add(_progressLabel);
+            Grid.SetColumn(progPanel, 0);
+            actionRow.Children.Add(progPanel);
+
+            _exportButton = new Button
+            {
+                Content = "▶  EXPORT",
+                Padding = new Thickness(20, 6, 20, 6),
+                Margin = new Thickness(12, 0, 0, 0),
+                FontWeight = FontWeights.Bold,
+                Background = (Brush)new BrushConverter().ConvertFromString("#3577F0"),
+                Foreground = Brushes.White,
+                BorderBrush = Brushes.Transparent,
+                Cursor = Cursors.Hand,
+            };
+            _exportButton.Click += OnExportClick;
+            Grid.SetColumn(_exportButton, 1);
+            actionRow.Children.Add(_exportButton);
+
+            Grid.SetRow(actionRow, 1);
+            grid.Children.Add(actionRow);
+
+            bar.Child = grid;
+            return bar;
+        }
+
+        // ── Behaviour: applying/saving profile ──────────────────────────────────
+
+        private void ApplyProfileToUi()
+        {
+            // Mode-driven UI tweaks: column visibility on the grid, naming presets, etc.
+            if (_selectGrid != null)
+            {
+                var cdeCol = _selectGrid.Columns.LastOrDefault(c => string.Equals(c.Header?.ToString(), "CDE"));
+                if (cdeCol != null) cdeCol.Visibility = _profile.Mode == ExportCenterMode.BIM ? Visibility.Visible : Visibility.Collapsed;
+            }
+
+            // Sync format chips
+            if (_fmtPdf   != null) _fmtPdf.IsChecked   = (_profile.Formats & ExportFormats.PDF)   != 0;
+            if (_fmtDwg   != null) _fmtDwg.IsChecked   = (_profile.Formats & ExportFormats.DWG)   != 0;
+            if (_fmtIfc   != null) _fmtIfc.IsChecked   = (_profile.Formats & ExportFormats.IFC)   != 0;
+            if (_fmtNwc   != null) _fmtNwc.IsChecked   = (_profile.Formats & ExportFormats.NWC)   != 0;
+            if (_fmtDgn   != null) _fmtDgn.IsChecked   = (_profile.Formats & ExportFormats.DGN)   != 0;
+            if (_fmtDwf   != null) _fmtDwf.IsChecked   = (_profile.Formats & ExportFormats.DWF)   != 0;
+            if (_fmtImage != null) _fmtImage.IsChecked = (_profile.Formats & ExportFormats.Image) != 0;
+            if (_fmtXml   != null) _fmtXml.IsChecked   = (_profile.Formats & ExportFormats.XML)   != 0;
+
+            if (_namingBox != null) _namingBox.Text = _profile.Output.NamingTemplate;
+            if (_folderBox != null) _folderBox.Text = _profile.Output.LocalFolder;
+
+            RebuildFormatOptions();
+            RefreshNamingPreview();
+        }
+
+        // ── Selection grid + filter ─────────────────────────────────────────────
+
+        private void RefreshSelectionGrid()
+        {
+            try
+            {
+                _rows.Clear();
+                bool wantSheets = _kindSheets?.IsChecked == true;
+                if (wantSheets)
+                {
+                    var sheets = new FilteredElementCollector(_doc).OfClass(typeof(ViewSheet))
+                        .Cast<ViewSheet>().Where(s => !s.IsTemplate)
+                        .OrderBy(s => s.SheetNumber).ToList();
+                    foreach (var s in sheets)
+                        _rows.Add(SheetRow.From(_doc, s));
+                }
+                else
+                {
+                    var views = new FilteredElementCollector(_doc).OfClass(typeof(View))
+                        .Cast<View>().Where(v => !v.IsTemplate && !(v is ViewSheet))
+                        .OrderBy(v => v.ViewType.ToString()).ThenBy(v => v.Name).ToList();
+                    foreach (var v in views)
+                        _rows.Add(SheetRow.FromView(v));
+                }
+                ApplySearchFilter();
+                RefreshNamingPreview();
+                UpdateStatusLine();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("ExportCentre RefreshSelectionGrid: " + ex.Message);
+            }
+        }
+
+        private void ApplySearchFilter()
+        {
+            try
+            {
+                var view = CollectionViewSource.GetDefaultView(_rows);
+                if (view == null) return;
+                string q = _searchBox?.Text?.Trim() ?? "";
+                if (string.IsNullOrEmpty(q)) { view.Filter = null; return; }
+                view.Filter = obj =>
+                {
+                    var r = (SheetRow)obj;
+                    return (r.Number ?? "").IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0
+                        || (r.Title ?? "").IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0
+                        || (r.Discipline ?? "").IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0
+                        || (r.PaperSize ?? "").IndexOf(q, StringComparison.OrdinalIgnoreCase) >= 0;
+                };
+            }
+            catch { }
+        }
+
+        private void ApplySavedSetSelection()
+        {
+            try
+            {
+                int idx = _setCombo.SelectedIndex;
+                if (idx < 0 || idx >= _state.SavedSets.Count) return;
+                var set = _state.SavedSets[idx];
+                var ids = ExportCenterEngine.ResolveSet(_doc, set, out int missing);
+                var idSet = new HashSet<long>(ids.Select(e => e.Value));
+                foreach (var r in _rows) r.IsChecked = idSet.Contains(r.Id);
+                if (missing > 0) UpdateStatusLine($"{missing} sheets in set were not found in this model.");
+                else UpdateStatusLine();
+            }
+            catch (Exception ex) { StingLog.Warn("ApplySavedSetSelection: " + ex.Message); }
+        }
+
+        // ── Status line + naming preview ────────────────────────────────────────
+
+        private void RefreshNamingPreview()
+        {
+            try
+            {
+                if (_namingPreview == null) return;
+                var first = _rows.FirstOrDefault(r => r.IsChecked) ?? _rows.FirstOrDefault();
+                if (first == null) { _namingPreview.Text = "(no sheets)"; return; }
+                var view = _doc.GetElement(new ElementId(first.Id)) as View;
+                string stem = ExportCenterEngine.ResolveNaming(_doc, view, _namingBox.Text, _profile.Output);
+                stem = ExportCenterEngine.Sanitise(stem, _profile.Output.IllegalCharReplacement);
+                _namingPreview.Text = stem + ".pdf";
+            }
+            catch (Exception ex) { _namingPreview.Text = "(error: " + ex.Message + ")"; }
+        }
+
+        private void UpdateStatusLine(string warning = null)
+        {
+            try
+            {
+                int picked = _rows.Count(r => r.IsChecked);
+                var fmts = new List<string>();
+                foreach (ExportFormats f in Enum.GetValues(typeof(ExportFormats)))
+                    if (f != ExportFormats.None && (_profile.Formats & f) != 0) fmts.Add(f.ToString());
+                string fmtsLabel = fmts.Count == 0 ? "(no format)" : string.Join(", ", fmts);
+
+                string line = $"{picked} {(_kindSheets?.IsChecked == true ? "sheets" : "views")} selected · " +
+                              $"{fmtsLabel} · Naming: {_profile.Output.NamingTemplate} · " +
+                              $"Output: {_profile.Output.LocalFolder ?? "(not set)"}";
+                if (!string.IsNullOrEmpty(warning))
+                    line += "\n⚠ " + warning;
+                _statusLine.Text = line;
+                _statusLine.Foreground = string.IsNullOrEmpty(warning)
+                    ? (Brush)new BrushConverter().ConvertFromString("#1F2A3A")
+                    : Brushes.DarkOrange;
+            }
+            catch { }
+        }
+
+        // ── Header button handlers ──────────────────────────────────────────────
+
+        private void OnSaveProfileClick(object _, RoutedEventArgs __)
+        {
+            if (_profile.BuiltIn)
+            {
+                Autodesk.Revit.UI.TaskDialog.Show("Export Centre", "Built-in profiles can't be edited. Use 'Save As…' to fork.");
+                return;
+            }
+            CommitProfile();
+            Autodesk.Revit.UI.TaskDialog.Show("Export Centre", $"Profile '{_profile.Name}' saved.");
+        }
+
+        private void OnSaveAsProfileClick(object _, RoutedEventArgs __)
+        {
+            string name = PromptForText("Save profile as", "Profile name:", _profile.Name + " (copy)");
+            if (string.IsNullOrEmpty(name)) return;
+            var copy = JsonClone(_profile);
+            copy.Name = name; copy.BuiltIn = false; copy.CreatedAt = DateTime.UtcNow;
+            _state.Profiles.Add(copy);
+            _profile = copy;
+            _profileCombo.Items.Add(name);
+            _profileCombo.SelectedIndex = _state.Profiles.Count - 1;
+            CommitProfile();
+        }
+
+        private void OnImportProfileClick(object _, RoutedEventArgs __)
+        {
+            try
+            {
+                var dlg = new Microsoft.Win32.OpenFileDialog
+                {
+                    Filter = "STING Export Profile (*.stingexport)|*.stingexport|JSON files (*.json)|*.json|All files (*.*)|*.*",
+                };
+                if (dlg.ShowDialog() != true) return;
+                var json = File.ReadAllText(dlg.FileName);
+                var p = Newtonsoft.Json.JsonConvert.DeserializeObject<ExportProfile>(json);
+                if (p == null) return;
+                p.BuiltIn = false;
+                _state.Profiles.Add(p);
+                _profileCombo.Items.Add(p.Name);
+                _profile = p;
+                _profileCombo.SelectedIndex = _state.Profiles.Count - 1;
+                CommitProfile();
+            }
+            catch (Exception ex) { Autodesk.Revit.UI.TaskDialog.Show("Import", "Failed: " + ex.Message); }
+        }
+
+        private void OnShareProfileClick(object _, RoutedEventArgs __)
+        {
+            try
+            {
+                var dlg = new Microsoft.Win32.SaveFileDialog
+                {
+                    Filter = "STING Export Profile (*.stingexport)|*.stingexport",
+                    FileName = ExportCenterEngine.Sanitise(_profile.Name ?? "profile", "_") + ".stingexport",
+                };
+                if (dlg.ShowDialog() != true) return;
+                File.WriteAllText(dlg.FileName,
+                    Newtonsoft.Json.JsonConvert.SerializeObject(_profile, Newtonsoft.Json.Formatting.Indented));
+                Autodesk.Revit.UI.TaskDialog.Show("Share", "Profile exported to:\n" + dlg.FileName);
+            }
+            catch (Exception ex) { Autodesk.Revit.UI.TaskDialog.Show("Share", "Failed: " + ex.Message); }
+        }
+
+        // ── OUTPUT button handlers ──────────────────────────────────────────────
+
+        private void OnBrowseFolderClick(object _, RoutedEventArgs __)
+        {
+            try
+            {
+                var dlg = new Microsoft.Win32.SaveFileDialog
+                {
+                    Title = "Pick output folder",
+                    FileName = "ExportCentre",
+                    Filter = "Folder|*.this",
+                };
+                if (dlg.ShowDialog() == true)
+                {
+                    string folder = Path.GetDirectoryName(dlg.FileName);
+                    _folderBox.Text = folder;
+                    _profile.Output.LocalFolder = folder;
+                    if (!_state.RecentFolders.Contains(folder)) _state.RecentFolders.Insert(0, folder);
+                    if (_state.RecentFolders.Count > 5) _state.RecentFolders.RemoveAt(5);
+                    UpdateStatusLine();
+                }
+            }
+            catch (Exception ex) { Autodesk.Revit.UI.TaskDialog.Show("Browse", ex.Message); }
+        }
+
+        // ── Saved-set handlers ──────────────────────────────────────────────────
+
+        private void OnSaveSetClick(object _, RoutedEventArgs __)
+        {
+            string name = PromptForText("Save selection set", "Set name:", "My set");
+            if (string.IsNullOrEmpty(name)) return;
+            var set = new ExportSavedSet
+            {
+                Name = name,
+                Kind = _kindSheets?.IsChecked == true ? ExportSelectionKind.Sheets : ExportSelectionKind.Views,
+                ElementIds = _rows.Where(r => r.IsChecked).Select(r => r.Id.ToString()).ToList(),
+                FilterText = _searchBox?.Text,
+            };
+            _state.SavedSets.Add(set);
+            _setCombo.Items.Add(name);
+            _setCombo.SelectedIndex = _state.SavedSets.Count - 1;
+            ExportCenterEngine.SaveState(_state);
+        }
+
+        private void OnManageSetsClick(object _, RoutedEventArgs __)
+        {
+            // Minimal manager: list sets and offer Delete on user-defined ones.
+            var dlg = new Window
+            {
+                Title = "Manage selection sets",
+                Width = 420, Height = 360,
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            };
+            var lb = new ListBox();
+            foreach (var s in _state.SavedSets) lb.Items.Add(s.Name + (s.BuiltIn ? "  (built-in)" : ""));
+            var del = new Button { Content = "Delete selected", Margin = new Thickness(0, 6, 0, 0), Padding = new Thickness(8, 4, 8, 4) };
+            del.Click += (_, __) =>
+            {
+                int i = lb.SelectedIndex;
+                if (i < 0) return;
+                var s = _state.SavedSets[i];
+                if (s.BuiltIn) { Autodesk.Revit.UI.TaskDialog.Show("Sets", "Built-in sets cannot be deleted."); return; }
+                _state.SavedSets.RemoveAt(i);
+                lb.Items.RemoveAt(i);
+                _setCombo.Items.RemoveAt(i);
+                ExportCenterEngine.SaveState(_state);
+            };
+            var sp = new StackPanel { Margin = new Thickness(10) };
+            sp.Children.Add(lb); sp.Children.Add(del);
+            dlg.Content = sp;
+            dlg.ShowDialog();
+        }
+
+        // ── EXPORT click — pre-flight + run ─────────────────────────────────────
+
+        private void OnExportClick(object _, RoutedEventArgs __)
+        {
+            if (_exporting) { _cancelRequested = true; return; }
+
+            CommitProfile();
+            var ids = _rows.Where(r => r.IsChecked).Select(r => new ElementId(r.Id)).ToList();
+
+            // Pre-flight
+            var issues = ExportCenterEngine.PreflightCheck(_doc, _profile, ids);
+            var blocking = issues.Where(i => i.Level == ExportPreflightIssue.Severity.Error).ToList();
+            if (blocking.Count > 0)
+            {
+                Autodesk.Revit.UI.TaskDialog.Show("Pre-flight",
+                    "Cannot start export:\n\n" + string.Join("\n", blocking.Select(i => "• " + i.Message)));
+                return;
+            }
+            var warns = issues.Where(i => i.Level == ExportPreflightIssue.Severity.Warning).ToList();
+            if (warns.Count > 0)
+            {
+                var td = new Autodesk.Revit.UI.TaskDialog("Pre-flight warnings")
+                {
+                    MainInstruction = $"{warns.Count} warning(s) found. Continue?",
+                    MainContent = string.Join("\n", warns.Select(i => "• " + i.Message)),
+                    CommonButtons = Autodesk.Revit.UI.TaskDialogCommonButtons.Yes | Autodesk.Revit.UI.TaskDialogCommonButtons.No,
+                    DefaultButton = Autodesk.Revit.UI.TaskDialogResult.Yes,
+                };
+                if (td.Show() != Autodesk.Revit.UI.TaskDialogResult.Yes) return;
+            }
+
+            // Run inline. Revit API calls happen on the UI thread already (we're
+            // inside the dialog launched from an external command). For long runs
+            // a future patch can route through ExternalEvent.
+            _exporting = true; _cancelRequested = false;
+            _exportButton.Content = "■ CANCEL";
+            try
+            {
+                int total = ids.Count * Math.Max(1, CountActiveFormats());
+                var result = ExportCenterEngine.Run(_doc, _profile, ids,
+                    (cur, tot, label) =>
+                    {
+                        Dispatcher.Invoke(() =>
+                        {
+                            _progressBar.Value = (double)cur * 100.0 / Math.Max(1, total);
+                            _progressLabel.Text = $"{cur}/{total}  {label}";
+                        });
+                    },
+                    () => _cancelRequested);
+
+                ShowResultSummary(result);
+                if (_profile.Output.OpenFolderWhenDone &&
+                    !string.IsNullOrEmpty(_profile.Output.LocalFolder) &&
+                    Directory.Exists(_profile.Output.LocalFolder))
+                {
+                    try { System.Diagnostics.Process.Start("explorer.exe", _profile.Output.LocalFolder); } catch { }
+                }
+            }
+            finally
+            {
+                _exporting = false;
+                _exportButton.Content = "▶  EXPORT";
+                _progressBar.Value = 0;
+                _progressLabel.Text = "";
+            }
+        }
+
+        private int CountActiveFormats()
+        {
+            int n = 0;
+            foreach (ExportFormats f in Enum.GetValues(typeof(ExportFormats)))
+                if (f != ExportFormats.None && (_profile.Formats & f) != 0) n++;
+            return n;
+        }
+
+        private void ShowResultSummary(ExportRunResult r)
+        {
+            string msg = $"Export complete.\n\n" +
+                         $"Successful: {r.Success}\n" +
+                         $"Failed:     {r.Failed}\n" +
+                         $"Cancelled:  {(r.Cancelled ? "yes" : "no")}\n" +
+                         $"Duration:   {(r.FinishedUtc - r.StartedUtc).TotalSeconds:F1} sec\n";
+            if (r.Warnings.Count > 0)
+                msg += "\nWarnings:\n" + string.Join("\n", r.Warnings.Take(8).Select(w => "• " + w));
+            if (r.Failed > 0)
+                msg += "\n\nFirst failures:\n" + string.Join("\n",
+                    r.Rows.Where(x => !x.Success).Take(5).Select(x => $"• {x.SheetNumber}: {x.Error}"));
+            Autodesk.Revit.UI.TaskDialog.Show("STING Export Centre", msg);
+        }
+
+        private void CommitProfile()
+        {
+            _state.LastProfile = _profile.Name;
+            if (!string.IsNullOrEmpty(_profile.Output.LocalFolder))
+                _state.LastOutputFolder = _profile.Output.LocalFolder;
+            _state.LastNamingTemplate = _profile.Output.NamingTemplate;
+            ExportCenterEngine.SaveState(_state);
+        }
+
+        // ── Tiny helpers ────────────────────────────────────────────────────────
+
+        private static T JsonClone<T>(T src) =>
+            Newtonsoft.Json.JsonConvert.DeserializeObject<T>(
+                Newtonsoft.Json.JsonConvert.SerializeObject(src));
+
+        private string PromptForText(string title, string label, string initial)
+        {
+            var dlg = new Window
+            {
+                Title = title, Width = 380, Height = 150,
+                Owner = this, WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                ResizeMode = ResizeMode.NoResize,
+            };
+            var sp = new StackPanel { Margin = new Thickness(14) };
+            sp.Children.Add(new TextBlock { Text = label, Margin = new Thickness(0, 0, 0, 4) });
+            var tb = new TextBox { Text = initial };
+            sp.Children.Add(tb);
+            var btnRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 10, 0, 0) };
+            var ok = new Button { Content = "OK", IsDefault = true, Padding = new Thickness(14, 3, 14, 3), Margin = new Thickness(0, 0, 6, 0) };
+            var cancel = new Button { Content = "Cancel", IsCancel = true, Padding = new Thickness(14, 3, 14, 3) };
+            btnRow.Children.Add(ok); btnRow.Children.Add(cancel);
+            sp.Children.Add(btnRow);
+            string result = null;
+            ok.Click += (_, __) => { result = tb.Text; dlg.DialogResult = true; };
+            dlg.Content = sp;
+            return dlg.ShowDialog() == true ? result : null;
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    //  SheetRow — view-model for the SELECT grid.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    public class SheetRow : INotifyPropertyChanged
+    {
+        public long Id { get; set; }
+        public string Number { get; set; }
+        public string Title { get; set; }
+        public string Revision { get; set; }
+        public string Discipline { get; set; }
+        public string PaperSize { get; set; }
+        public string CdeStatus { get; set; }
+
+        private bool _isChecked;
+        public bool IsChecked
+        {
+            get => _isChecked;
+            set { _isChecked = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked))); }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public static SheetRow From(Document doc, ViewSheet s)
+        {
+            var row = new SheetRow
+            {
+                Id = s.Id.Value,
+                Number = s.SheetNumber,
+                Title = s.Name,
+                Discipline = ExportCenterEngine.GetDisciplinePrefix(s.SheetNumber),
+            };
+
+            // Revision (current)
+            try
+            {
+                var revIds = s.GetAllRevisionIds();
+                if (revIds != null && revIds.Count > 0)
+                {
+                    if (doc.GetElement(revIds[revIds.Count - 1]) is Revision r)
+                        row.Revision = r.SequenceNumber.ToString();
+                }
+            }
+            catch { }
+
+            // Paper size — heuristic: read sheet's title block instance width.
+            try
+            {
+                var tb = new FilteredElementCollector(doc, s.Id)
+                    .OfCategory(BuiltInCategory.OST_TitleBlocks)
+                    .WhereElementIsNotElementType().FirstElement();
+                if (tb != null)
+                {
+                    double w = tb.LookupParameter("Sheet Width")?.AsDouble() ?? 0;
+                    double h = tb.LookupParameter("Sheet Height")?.AsDouble() ?? 0;
+                    row.PaperSize = ClassifyPaperSize(w, h);
+                }
+            }
+            catch { }
+
+            // CDE — read STING_CDE_STATE_TXT if present, else "-"
+            try
+            {
+                var p = s.LookupParameter("STING_CDE_STATE_TXT");
+                row.CdeStatus = p != null && p.HasValue ? p.AsString() : "-";
+            }
+            catch { row.CdeStatus = "-"; }
+
+            return row;
+        }
+
+        public static SheetRow FromView(View v) => new()
+        {
+            Id = v.Id.Value,
+            Number = v.ViewType.ToString(),
+            Title = v.Name,
+            Discipline = "",
+            PaperSize = "",
+            CdeStatus = "",
+        };
+
+        private static string ClassifyPaperSize(double widthFt, double heightFt)
+        {
+            // Convert to mm; classify by closest ISO size.
+            double wmm = Math.Round(widthFt  * 304.8);
+            double hmm = Math.Round(heightFt * 304.8);
+            (string name, double w, double h)[] sizes =
+            {
+                ("A0", 1189, 841), ("A1", 841, 594), ("A2", 594, 420),
+                ("A3", 420, 297),  ("A4", 297, 210),
+            };
+            foreach (var sz in sizes)
+                if ((Approx(wmm, sz.w) && Approx(hmm, sz.h)) ||
+                    (Approx(wmm, sz.h) && Approx(hmm, sz.w))) return sz.name;
+            return $"{wmm:F0}×{hmm:F0}";
+        }
+
+        private static bool Approx(double a, double b) => Math.Abs(a - b) < 8.0;
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a comprehensive, resizable WPF dialog (`StingExportCenterDialog`) that consolidates all export workflows (batch print, PDF, DWG, IFC, NWC, DGN, DWF, image, XML) into a single publishing surface. Backed by a headless export engine (`ExportCenterEngine`) that handles state persistence, naming template resolution, pre-flight checks, and per-format dispatch.

## Key Changes

### UI Layer
- **StingExportCenterDialog.cs** (~1495 lines): Main WPF dialog with three-column layout (SELECT │ FORMAT │ OUTPUT)
  - Header: mode toggle (Simple/BIM), profile picker, share/import buttons
  - Body: sheet/view selection grid, format checkboxes with per-format options, output folder/naming configuration
  - Footer: status summary, progress bar, export button
  - Resizable (1280×820 default, 1024×640 minimum) with dark header bar and card-based panels

### Export Pipeline
- **ExportCenterEngine.cs** (~1283 lines): Headless export orchestrator
  - State persistence (profiles, saved sets) in `project_config.json`
  - Saved-set resolution with built-in semantic sets (All Sheets, By Discipline, Issued Sheets, Revised This Week, etc.)
  - Token resolver for naming templates (`{SheetNumber}`, `{Revision}`, `{Date:yyyyMMdd}`, project/discipline/suitability codes)
  - Per-format export dispatch (PDF, DWG, IFC, NWC, DGN, DWF, image, XML)
  - Combined-PDF and multi-layout DWG pipelines with progress reporting

### Data Models
- **ExportCenterModels.cs** (~441 lines): POCO classes for persistent state
  - `ExportCenterState`: profiles, saved sets, last-used mode/profile
  - `ExportProfile`: per-format settings (PDF bookmarks, DWG layout modes, IFC options, etc.)
  - `ExportSavedSet`: named sheet/view collections with built-in semantic filters
  - Enums: `ExportCenterMode` (BIM/Simple), `ExportFormats`, `PdfCombineMode`, `DwgOutputMode`, `SuitabilityCode`

### Format-Specific Exporters
- **ExportCenterPdfPostProcess.cs**: Bookmark injection and watermark overlay for combined PDFs
- **ExportCenterDwgMerger.cs**: Multi-layout DWG merge via AutoCAD COM (Method A) with ODA fallback (Method B)
- **ExportCenterOdaConverter.cs**: ODA File Converter integration for version normalisation and merge manifest
- **ExportCenterXmlWriter.cs**: Custom XML serialiser for sheet metadata and parameters
- **ExportCenterNwcExporter.cs**: NWC export via reflection (no compile-time dependency on Navisworks)

### Integration
- **ExportCenterCommand.cs**: `IExternalCommand` entry point registered as "ExportCenter" workflow tag
- **WorkflowEngine.cs**: Added command resolver case for ExportCenterCommand
- **StingCommandHandler.cs**: Wired "ExportCenter" to launch the dialog
- **StingTools.csproj**: Added PDFsharp 6.x NuGet dependency for PDF manipulation

## Notable Implementation Details
- **Headless design**: Engine has no WPF or TaskDialog calls, enabling reuse from workflows/scheduled jobs
- **Token context**: Per-view dictionary built from ProjectInfo, sheet parameters, and revision data; supports custom format strings
- **Fallback strategies**: AutoCAD COM → ODA → individual files for DWG; graceful degradation when tools unavailable
- **Reflection-based NWC**: Avoids compile-time Navisworks dependency by probing for NavisworksExportOptions at runtime
- **State serialization**: All profiles, saved sets, and settings persisted as JSON in project_config.json under "ExportCenter" key
- **Built-in profiles/sets**: Seeded on

https://claude.ai/code/session_011NqKh2UMiKfqvHGfsKABcJ