### PR TITLE
Refactor tag migration to use canonical TagPipelineHelper

### DIFF
--- a/StingTools/Tags/BatchTagCommand.cs
+++ b/StingTools/Tags/BatchTagCommand.cs
@@ -517,101 +517,28 @@ namespace StingTools.Tags
                 {
                     tx.Start();
 
-                    foreach (var (el, currentTag) in mfBatch)
+                    foreach (var (el, _) in mfBatch)
                     {
                         if (mfProgress != null) mfProgress.Increment($"Migrating {el.Id}");
                         try
                         {
-                            // FIX-V01-C: Re-derive tokens before format rebuild so stale/wrong
-                            // tokens are corrected, not just reformatted
-                            if (mfPopCtx != null)
-                            {
-                                try
-                                {
-                                    TokenAutoPopulator.TypeTokenInherit(doc, el);
-                                    TokenAutoPopulator.PopulateAll(doc, el, mfPopCtx, overwrite: false);
-                                }
-                                catch (Exception popEx)
-                                {
-                                    StingLog.Warn($"TagFormatMigration Populate for {el.Id}: {popEx.Message}");
-                                }
-                            }
-
-                            // FIX-V01-C: Bridge native params before tag format migration
-                            try { NativeParamMapper.MapAll(doc, el); }
-                            catch (Exception nmEx) { StingLog.Warn($"TagFormatMigration NativeMapper for {el.Id}: {nmEx.Message}"); }
-
-                            // FIX-V01-C: Evaluate formulas after populate + native mapping
-                            if (mfFormulas != null && mfFormulas.Count > 0)
-                            {
-                                try
-                                {
-                                    foreach (var formula in mfFormulas)
-                                    {
-                                        try
-                                        {
-                                            Parameter fp = el.LookupParameter(formula.ParameterName);
-                                            if (fp == null || fp.IsReadOnly) continue;
-                                            var fCtx = Temp.FormulaEngine.BuildContext(el, formula);
-                                            if (fCtx == null) continue;
-                                            if (formula.DataType == "TEXT")
-                                            {
-                                                string fResult = Temp.FormulaEngine.EvaluateText(formula.Expression, fCtx);
-                                                if (fResult != null && fp.StorageType == StorageType.String
-                                                    && string.IsNullOrEmpty(fp.AsString()))
-                                                    fp.Set(fResult);
-                                            }
-                                            else
-                                            {
-                                                double? fResult = Temp.FormulaEngine.EvaluateNumeric(formula.Expression, fCtx);
-                                                if (fResult.HasValue && !double.IsNaN(fResult.Value)
-                                                    && !double.IsInfinity(fResult.Value))
-                                                    Temp.FormulaEngine.WriteNumericResult(fp, fResult.Value);
-                                            }
-                                        }
-                                        catch (Exception frmEx) { StingLog.Warn($"Formula eval for element {el.Id}: {frmEx.Message}"); }
-                                    }
-                                }
-                                catch (Exception fExMf)
-                                {
-                                    StingLog.Warn($"TagFormatMigration formula eval for {el.Id}: {fExMf.Message}");
-                                }
-                            }
-
-                            TagConfig.BuildAndWriteTag(doc, el, seqCounters,
+                            // Route migration through the canonical pipeline so the
+                            // cached RoomIndex feeds NativeParamMapper, the type-cached
+                            // formula filter avoids the 199-formula-per-element scan,
+                            // and BuildAndWriteTag's internal container write replaces
+                            // the previous external WriteTag7All + WriteContainers
+                            // double-write. overwrite=false preserves existing tokens
+                            // (this is a format rebuild, not a re-derivation);
+                            // collisionMode=Overwrite forces TAG1 to be rewritten with
+                            // current Separator/NumPad even when tag is "complete".
+                            bool pipelineOk = TagPipelineHelper.RunFullPipeline(
+                                doc, el, mfPopCtx, tagIndex, seqCounters,
+                                mfFormulas, mfGridLines,
+                                overwrite: false,
                                 skipComplete: false,
-                                existingTags: tagIndex,
                                 collisionMode: TagCollisionMode.Overwrite,
                                 stats: stats);
-
-                            // Write TAG7 + containers with migrated tag
-                            try
-                            {
-                                string catName = ParameterHelpers.GetCategoryName(el);
-                                string[] tokenVals = ParamRegistry.ReadTokenValues(el);
-                                TagConfig.WriteTag7All(doc, el, catName, tokenVals, overwrite: true);
-                                // NP3: Write containers after format migration
-                                ParamRegistry.WriteContainers(el, tokenVals, catName, overwrite: true,
-                                    skipParam: ParamRegistry.TAG1);
-                            }
-                            catch (Exception tag7Ex)
-                            {
-                                StingLog.Warn($"Migration TAG7+containers for {el.Id}: {tag7Ex.Message}");
-                            }
-
-                            // FIX-R06: Write GridRef per element
-                            if (mfGridLines != null && mfGridLines.Count > 0)
-                            {
-                                try
-                                {
-                                    string gridRef = SpatialAutoDetect.GetGridRef(el, mfGridLines);
-                                    if (!string.IsNullOrEmpty(gridRef))
-                                        ParameterHelpers.SetIfEmpty(el, ParamRegistry.GRID_REF, gridRef);
-                                }
-                                catch (Exception grEx) { StingLog.Warn($"Migration GridRef for {el.Id}: {grEx.Message}"); }
-                            }
-
-                            migrated++;
+                            if (pipelineOk) migrated++;
                         }
                         catch (Exception ex)
                         {

--- a/StingTools/Tags/RepairDuplicateSeqCommand.cs
+++ b/StingTools/Tags/RepairDuplicateSeqCommand.cs
@@ -84,72 +84,20 @@ namespace StingTools.Tags
                         Element el = kvp.Value[i];
                         try
                         {
-                            // FIX-05: Pre-enrich tokens before rebuild to ensure
-                            // spatial/system data is current before SEQ reassignment
-                            TokenAutoPopulator.TypeTokenInherit(doc, el);
-                            if (popCtx != null)
-                                TokenAutoPopulator.PopulateAll(doc, el, popCtx, overwrite: false);
-                            try { NativeParamMapper.MapAll(doc, el); }
-                            catch (Exception nmEx) { StingLog.Warn($"RepairDuplicateSeq NativeMapper for {el.Id}: {nmEx.Message}"); }
-
-                            // FIX-R04: Evaluate formulas after native mapper
-                            if (rdFormulas != null && rdFormulas.Count > 0)
-                            {
-                                try
-                                {
-                                    foreach (var formula in rdFormulas)
-                                    {
-                                        Parameter fp = el.LookupParameter(formula.ParameterName);
-                                        if (fp == null || fp.IsReadOnly) continue;
-                                        var fCtx = Temp.FormulaEngine.BuildContext(el, formula);
-                                        if (fCtx == null) continue;
-                                        if (formula.DataType == "TEXT")
-                                        {
-                                            string fResult = Temp.FormulaEngine.EvaluateText(formula.Expression, fCtx);
-                                            if (fResult != null && fp.StorageType == StorageType.String)
-                                                fp.Set(fResult);
-                                        }
-                                        else
-                                        {
-                                            double? fResult = Temp.FormulaEngine.EvaluateNumeric(formula.Expression, fCtx);
-                                            if (fResult.HasValue && !double.IsNaN(fResult.Value) && !double.IsInfinity(fResult.Value))
-                                                Temp.FormulaEngine.WriteNumericResult(fp, fResult.Value);
-                                        }
-                                    }
-                                }
-                                catch (Exception fEx) { StingLog.Warn($"RepairDuplicateSeq formula eval for {el.Id}: {fEx.Message}"); }
-                            }
-
-                            TagConfig.BuildAndWriteTag(doc, el, seqCounters,
-                                skipComplete: false, existingTags,
-                                TagCollisionMode.AutoIncrement, null);
-
-                            // NP5: Write TAG7 + containers after SEQ repair
-                            try
-                            {
-                                string repairCat = ParameterHelpers.GetCategoryName(el);
-                                string[] repairToks = ParamRegistry.ReadTokenValues(el);
-                                TagConfig.WriteTag7All(doc, el, repairCat, repairToks, overwrite: true);
-                                ParamRegistry.WriteContainers(el, repairToks, repairCat, overwrite: true,
-                                    skipParam: ParamRegistry.TAG1);
-                            }
-                            catch (Exception repEx)
-                            {
-                                StingLog.Warn($"RepairDuplicateSeq TAG7+containers for {el.Id}: {repEx.Message}");
-                            }
-
-                            // FIX-R04: Write GridRef per element
-                            if (rdGridLines != null && rdGridLines.Count > 0)
-                            {
-                                try
-                                {
-                                    string gridRef = SpatialAutoDetect.GetGridRef(el, rdGridLines);
-                                    if (!string.IsNullOrEmpty(gridRef))
-                                        ParameterHelpers.SetIfEmpty(el, ParamRegistry.GRID_REF, gridRef);
-                                }
-                                catch (Exception grEx) { StingLog.Warn($"RepairDuplicateSeq GridRef for {el.Id}: {grEx.Message}"); }
-                            }
-                            retagged++;
+                            // Route the re-tagging step through the canonical pipeline so all
+                            // 11 steps (skip list, audit trail, type inherit, locked-token
+                            // snapshot, PopulateAll, force-SYS, token overrides, native mapper
+                            // with cached RoomIndex, type-cached formulas, BuildAndWriteTag
+                            // which writes containers internally, TAG7, and GridRef) run
+                            // consistently. AutoIncrement assigns a new collision-free SEQ;
+                            // overwrite=false preserves the already-correct non-SEQ tokens.
+                            bool pipelineOk = TagPipelineHelper.RunFullPipeline(
+                                doc, el, popCtx, existingTags, seqCounters,
+                                rdFormulas, rdGridLines,
+                                overwrite: false,
+                                skipComplete: false,
+                                collisionMode: TagCollisionMode.AutoIncrement);
+                            if (pipelineOk) retagged++;
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
## Summary
Consolidated tag processing logic in `BatchTagCommand` and `RepairDuplicateSeqCommand` to use a new canonical `TagPipelineHelper.RunFullPipeline()` method, eliminating code duplication and ensuring consistent behavior across all tagging operations.

## Key Changes
- **BatchTagCommand**: Replaced 73 lines of inline token population, native mapping, formula evaluation, and TAG7/container writing with a single `TagPipelineHelper.RunFullPipeline()` call
- **RepairDuplicateSeqCommand**: Replaced 52 lines of similar inline processing logic with the same pipeline helper
- **Pipeline consolidation**: The new helper encapsulates all 11 processing steps:
  - Skip list and audit trail checks
  - Type token inheritance
  - Locked-token snapshot
  - Token population (PopulateAll)
  - Force-SYS token handling
  - Token overrides
  - Native parameter mapping with cached RoomIndex
  - Type-cached formula evaluation
  - BuildAndWriteTag with internal container writes
  - TAG7 writing
  - GridRef spatial detection

## Implementation Details
- Both commands now pass `overwrite: false` to preserve existing non-SEQ tokens (format rebuild, not re-derivation)
- `BatchTagCommand` uses `TagCollisionMode.Overwrite` to force TAG1 rewrite with current Separator/NumPad settings
- `RepairDuplicateSeqCommand` uses `TagCollisionMode.AutoIncrement` to assign collision-free SEQ values
- Removed unused `currentTag` variable in BatchTagCommand loop
- Success tracking simplified to check `pipelineOk` boolean return value
- Cached RoomIndex and type-cached formulas eliminate redundant per-element scans

https://claude.ai/code/session_01AK6Md7PNckNY9xbwsBbnR2