### PR TITLE
Phase 139.27-139.30: Diagnostics, standards validation, and routing support

### DIFF
--- a/StingTools/Commands/Placement/LearnPlacementV4Command.cs
+++ b/StingTools/Commands/Placement/LearnPlacementV4Command.cs
@@ -152,6 +152,57 @@ namespace StingTools.Commands.Placement
                     return Result.Cancelled;
                 }
 
+                // Phase 139.27 (I-02) — validate the learned rules before
+                // they hit disk. Pre-139.27 a malformed cluster could write
+                // a Density rule with PerAreaM2=0 (impossible to derive
+                // here, but kept as a defensive gate) that would then
+                // place 1 fixture per room forever. Run them through the
+                // loader's MergeRules so ValidateRuleSet's same checks fire,
+                // then drop any rule the validator flagged as broken.
+                var droppedRules = new List<string>();
+                try
+                {
+                    // Use MergeRules so LastValidationWarnings populates.
+                    PlacementRuleLoader.MergeRules(rules, null);
+                    var problems = PlacementRuleLoader.LastValidationWarnings ?? new List<string>();
+                    foreach (var p in problems) StingLog.Warn($"LearnPlacementV4: {p}");
+
+                    // Drop any rule whose MergeKey appears in a Density-rate
+                    // warning — those rules will silently place 1 / room.
+                    var bad = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var p in problems)
+                    {
+                        if (p == null) continue;
+                        if (p.IndexOf("declares no PerAreaM2/PerOccupant", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                        // Format: "PlacementRuleLoader: rule '<key>' is RuleKind=Density …"
+                        int s = p.IndexOf('\''), e = s >= 0 ? p.IndexOf('\'', s + 1) : -1;
+                        if (s >= 0 && e > s) bad.Add(p.Substring(s + 1, e - s - 1));
+                    }
+                    if (bad.Count > 0)
+                    {
+                        var keep = new List<PlacementRule>(rules.Count);
+                        foreach (var r in rules)
+                        {
+                            if (r != null && bad.Contains(r.MergeKey))
+                            {
+                                droppedRules.Add(r.MergeKey);
+                                continue;
+                            }
+                            keep.Add(r);
+                        }
+                        rules = keep;
+                    }
+                }
+                catch (Exception vex) { StingLog.Warn($"LearnPlacementV4 validate: {vex.Message}"); }
+
+                if (rules.Count == 0)
+                {
+                    TaskDialog.Show("STING — Learn Placement",
+                        "All learned rules failed validation (typically Density rules without a rate). " +
+                        "Pre-set MountingHeightMm and ensure samples differ by room name before re-running.");
+                    return Result.Cancelled;
+                }
+
                 string dir = Path.GetDirectoryName(doc.PathName);
                 string path = Path.Combine(dir, "STING_PLACEMENT_RULES.learned.json");
                 var set = new PlacementRuleSet
@@ -162,6 +213,10 @@ namespace StingTools.Commands.Placement
                 };
                 File.WriteAllText(path, JsonConvert.SerializeObject(set, Formatting.Indented));
 
+                string droppedNote = droppedRules.Count == 0
+                    ? ""
+                    : $"\n\n⚠ Dropped {droppedRules.Count} invalid rule(s): {string.Join(", ", droppedRules.Take(5))}{(droppedRules.Count > 5 ? "…" : "")}";
+
                 var td = new TaskDialog("STING — Learn Placement")
                 {
                     MainInstruction = $"Wrote {rules.Count} learned rule(s).",
@@ -170,7 +225,10 @@ namespace StingTools.Commands.Placement
                         "Review then either:\n" +
                         "  · Open Placement Centre → Import… and pick this file, or\n" +
                         "  · Rename to STING_PLACEMENT_RULES.project.json to make the rules win automatically.\n\n" +
-                        $"Clusters inspected: {clusters.Count}",
+                        $"Clusters inspected: {clusters.Count}" +
+                        droppedNote +
+                        "\n\nLearned rules persist at Priority=90 — to remove them, delete the .learned.json " +
+                        "file or untick 'Honour learned overrides' in the Placement Centre.",
                     CommonButtons = TaskDialogCommonButtons.Close,
                 };
                 td.Show();

--- a/StingTools/Commands/Placement/PlaceFixturesCommand.cs
+++ b/StingTools/Commands/Placement/PlaceFixturesCommand.cs
@@ -221,6 +221,32 @@ namespace StingTools.Commands.Placement
                 StingLog.Warn($"PlaceFixturesCommand: rule load failed: {ex.Message}");
             }
 
+            // Phase 139.27 (I-04) — pre-flight gate on the project building
+            // profile. Pre-139.27 the loader's FilterByProfile method
+            // existed but wasn't called by this entry point — a project
+            // that disabled BS 7671 would still see every electrical rule
+            // fire because the dock-panel's category checkboxes don't
+            // intersect with profile.ActiveStandards. Apply the filter
+            // and surface a one-shot summary so the user sees what got
+            // dropped and why.
+            ProjectBuildingProfile profile = null;
+            try { profile = ProjectBuildingProfileIO.Load(doc.PathName); } catch { }
+            if (profile != null && rules != null && rules.Count > 0)
+            {
+                int beforeCount = rules.Count;
+                var profileFiltered = PlacementRuleLoader.FilterByProfile(rules, profile);
+                int dropped = beforeCount - (profileFiltered?.Count ?? 0);
+                if (dropped > 0)
+                {
+                    string actLabel = (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0)
+                        ? string.Join(", ", profile.ActiveStandards)
+                        : "(none — all rules pass)";
+                    string btLabel = string.IsNullOrEmpty(profile.BuildingType) ? "(any)" : profile.BuildingType;
+                    StingLog.Info($"PlaceFixturesCommand: ProjectBuildingProfile dropped {dropped} rule(s) — BuildingType={btLabel}, ActiveStandards={actLabel}.");
+                }
+                rules = profileFiltered;
+            }
+
             List<PlacementRule> filtered = null;
             if (rules != null && rules.Count > 0)
             {
@@ -355,6 +381,25 @@ namespace StingTools.Commands.Placement
                 panel.AddSection("PER-RULE COUNTS");
                 foreach (var kv in res.CountsByRule.OrderByDescending(k => k.Value).Take(20))
                     panel.Metric(kv.Key, kv.Value.ToString());
+            }
+
+            // Phase 139.27 (I-03) — per-rule diagnostics. Show every rule
+            // whose Diag was touched, ordered by interest: rules that
+            // generated candidates but placed zero (the "why is my
+            // electrical fixture rule silent?" case) bubble to the top.
+            if (res.Diagnostics != null && res.Diagnostics.Count > 0)
+            {
+                panel.AddSection("PER-RULE DIAGNOSTICS");
+                var ordered = res.Diagnostics.Values
+                    .OrderByDescending(d => d.CandidatesGenerated > 0 && d.CandidatesPlaced == 0)
+                    .ThenByDescending(d => d.CandidatesGenerated)
+                    .Take(40)
+                    .ToList();
+                foreach (var d in ordered) panel.Text(d.OneLineSummary());
+
+                int zeroPlaced = res.Diagnostics.Values.Count(d => d.CandidatesGenerated > 0 && d.CandidatesPlaced == 0);
+                if (zeroPlaced > 0)
+                    panel.Text($"⚠ {zeroPlaced} rule(s) generated candidates but placed nothing — see skip reasons above.");
             }
 
             if (res.Warnings != null && res.Warnings.Count > 0)

--- a/StingTools/Commands/Routing/AutoDropCommand.cs
+++ b/StingTools/Commands/Routing/AutoDropCommand.cs
@@ -34,6 +34,13 @@ namespace StingTools.Commands.Routing
         public static string ConduitInstallMethod { get; set; } = "CLIPPED";
         public static string DuctSeamType       { get; set; } = "A";
         public static string PipeHangerType     { get; set; } = "CLEVIS_ROD";
+
+        // Phase 139.28 — auto-emit physical hangers / clips on the
+        // dropped runs per BS 5572 / MSS SP-58 / SMACNA spacing tables.
+        // Defaults to true so the user gets standards-compliant supports
+        // out of the box; flip to false in the Routing tab when you want
+        // bare drops only and will run Place_Hangers manually later.
+        public static bool   EmitSupports       { get; set; } = true;
     }
 
     [Transaction(TransactionMode.Manual)]
@@ -119,6 +126,68 @@ namespace StingTools.Commands.Routing
                 StingLog.Error("AutoDropCommand failed", ex);
                 message = ex.Message;
                 return Result.Failed;
+            }
+
+            // Phase 139.28 — auto-emit supports per BS 5572 / MSS SP-58.
+            // Each engine returns a DropResult with CreatedIds; we pass
+            // those into RoutingSupportPlacer with a synthetic SUSPENDED
+            // rule so HangerPlacementEngine + HangerFamilyResolver can
+            // place real FamilyInstances inside the same transaction.
+            if (AutoDropOptions.EmitSupports)
+            {
+                using (var sx = new Transaction(doc, "STING v4 Auto-drop supports"))
+                {
+                    try
+                    {
+                        sx.Start();
+                        int totalPlaced = 0, totalMissed = 0;
+                        var aggregateWarnings = new List<string>();
+                        foreach (var dr in allResults)
+                        {
+                            if (dr?.CreatedIds == null || dr.CreatedIds.Count == 0) continue;
+                            var syntheticRule = new StingTools.Core.Placement.PlacementRule
+                            {
+                                RuleId           = "auto-drop-supports",
+                                CategoryFilter   = "",
+                                MountingContext  = "SUSPENDED",
+                                EmitSupports     = true,
+                                // Material / diameter left empty — RoutingSupportPlacer
+                                // falls back to family-side detection in
+                                // HangerPlacementEngine.BuildQuery.
+                            };
+                            var supportRes = StingTools.Core.Calc.RoutingSupportPlacer.PlaceForRoute(
+                                doc, syntheticRule, dr.CreatedIds);
+                            totalPlaced += supportRes.SupportsPlaced;
+                            totalMissed += supportRes.FamilyMissCount;
+                            foreach (var w in supportRes.Warnings)
+                                if (!aggregateWarnings.Contains(w)) aggregateWarnings.Add(w);
+                        }
+                        sx.Commit();
+                        if (totalPlaced > 0 && allResults.Count > 0)
+                        {
+                            allResults[0].Warnings.Add(
+                                $"Auto-drop supports: emitted {totalPlaced} hanger(s) per BS 5572 / MSS SP-58.");
+                        }
+                        if (totalMissed > 0 && allResults.Count > 0)
+                        {
+                            allResults[0].Warnings.Add(
+                                $"Auto-drop supports: {totalMissed} support(s) planned but no hanger family loaded — " +
+                                "load STING_HANGER_GENERIC.rfa or any Anvil/B-Line/Unistrut family.");
+                        }
+                        if (allResults.Count > 0)
+                        {
+                            foreach (var w in aggregateWarnings)
+                                if (!allResults[0].Warnings.Contains(w)) allResults[0].Warnings.Add(w);
+                        }
+                    }
+                    catch (Exception sex)
+                    {
+                        if (sx.HasStarted() && !sx.HasEnded()) sx.RollBack();
+                        StingLog.Warn($"AutoDropCommand support emit: {sex.Message}");
+                        if (allResults.Count > 0)
+                            allResults[0].Warnings.Add($"Auto-drop supports failed: {sex.Message}");
+                    }
+                }
             }
 
             ShowResult(allResults);

--- a/StingTools/Core/Calc/CircuitTopologyEngine.cs
+++ b/StingTools/Core/Calc/CircuitTopologyEngine.cs
@@ -1,0 +1,279 @@
+// Phase 139.30 (X-01) — Circuit topology engine.
+//
+// After fixture placement commits, group placed electrical sockets /
+// switches / electrical fixtures into BS 7671-compliant circuits and
+// stamp each instance with the assigned circuit ID + RCD group.
+//
+// Rules of thumb implemented (BS 7671:2018 + Amendment 2:2022):
+//
+//   * Ring final circuit (regulation 433.1.103, Appendix 15)
+//       - Up to 100 m² floor area per ring
+//       - 32 A protective device (BS 1361 / BS EN 60898)
+//       - 2.5 mm² T+E typical (≈ 106 m total cable length)
+//       - One unfused spur per socket maximum
+//   * Radial final circuit (regulation 433.1.5)
+//       - Up to 75 m² when 32 A; 50 m² when 20 A
+//       - 4.0 mm² T+E for 32 A radial
+//   * RCD requirements (regulation 411.3.3, 415.1, 522.6.202):
+//       - All socket outlets ≤ 32 A — 30 mA RCD
+//       - Bathroom (zones 0/1/2) — 30 mA RCD on every circuit
+//       - Lighting circuits in domestic — 30 mA RCD per Amd 2:2022
+//   * Diversity (Appendix A, Table A1):
+//       - Domestic ring: 100 % of largest + 40 % of remainder
+//       - Kitchen ring: 100 % of largest + 40 % of remainder + 100 % cooker
+//
+// Stamping (silent if the parameter is absent on the family):
+//   STING_CIRCUIT_ID_TXT       e.g. "GF-RING-01"
+//   STING_RCD_GROUP_TXT        e.g. "RCBO-30mA-A"
+//   STING_CIRCUIT_LOAD_VA      derived demand after diversity (VA)
+//   STING_CIRCUIT_RATING_A     32 / 20 / 16 (A)
+//   STING_CIRCUIT_KIND_TXT     RING / RADIAL / DEDICATED
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+
+namespace StingTools.Core.Calc
+{
+    public static class CircuitTopologyEngine
+    {
+        // BS 7671 Appendix 15 — domestic ring final 32 A, max 100 m²,
+        // ~106 m total cable length on 2.5 mm² T+E.
+        private const double RingMaxAreaM2 = 100.0;
+        private const double RadialMaxAreaM2 = 75.0;     // 32 A radial
+        private const int    RingMinSockets = 4;          // < 4 — radial is cheaper
+        private const double DefaultSocketVa = 230.0;     // BS 1363 nominal demand
+        private const double DefaultLightVa  = 100.0;     // typical LED downlight
+        private const double KitchenSocketVa = 350.0;     // higher demand
+
+        /// <summary>
+        /// Walk the placed-element list and assign circuit IDs + RCD
+        /// groups. Idempotent when the parameters already match — only
+        /// stamps when the value changes. Caller owns the transaction.
+        /// </summary>
+        public static void AssignCircuits(Document doc, StingTools.Core.Placement.PlacementResult result)
+        {
+            if (doc == null || result == null || result.PlacedIds.Count == 0) return;
+
+            // Collect electrical instances eligible for circuit assignment.
+            var sockets = new List<(FamilyInstance fi, XYZ p, Room room, double areaM2, bool isWet, double vaPerOutlet)>();
+            foreach (var id in result.PlacedIds)
+            {
+                FamilyInstance fi = null;
+                try { fi = doc.GetElement(id) as FamilyInstance; } catch { }
+                if (fi == null || fi.Category == null) continue;
+                long catId;
+                try { catId = fi.Category.Id.Value; } catch { continue; }
+                BuiltInCategory bic = (BuiltInCategory)catId;
+                if (bic != BuiltInCategory.OST_ElectricalFixtures
+                 && bic != BuiltInCategory.OST_LightingFixtures
+                 && bic != BuiltInCategory.OST_LightingDevices) continue;
+                XYZ p = (fi.Location as LocationPoint)?.Point;
+                if (p == null) continue;
+                Room room = null;
+                try { room = doc.GetRoomAtPoint(p) as Room; } catch { }
+                double areaM2 = 0;
+                if (room != null)
+                {
+                    try { areaM2 = room.Area * 0.3048 * 0.3048; } catch { }
+                }
+                string roomName = room?.Name?.ToLowerInvariant() ?? "";
+                bool isWet = roomName.Contains("bath") || roomName.Contains("shower")
+                          || roomName.Contains("wc")  || roomName.Contains("toilet")
+                          || roomName.Contains("wetroom") || roomName.Contains("ensuite");
+                bool isKitchen = roomName.Contains("kitchen") || roomName.Contains("utility");
+                bool isLight   = bic != BuiltInCategory.OST_ElectricalFixtures;
+                double va = isLight ? DefaultLightVa
+                          : isKitchen ? KitchenSocketVa
+                          : DefaultSocketVa;
+                sockets.Add((fi, p, room, areaM2, isWet, va));
+            }
+            if (sockets.Count == 0) return;
+
+            // Cluster by (level, room kind, kind) so e.g. ground-floor
+            // bedroom sockets cluster separately from ground-floor
+            // kitchen sockets and ground-floor lighting.
+            var groups = sockets
+                .GroupBy(s =>
+                {
+                    string lvl = "";
+                    try { lvl = (doc.GetElement(s.fi.LevelId) as Level)?.Name ?? "X"; } catch { }
+                    string kind;
+                    if (s.fi.Category.Id.Value == (long)BuiltInCategory.OST_LightingFixtures
+                     || s.fi.Category.Id.Value == (long)BuiltInCategory.OST_LightingDevices) kind = "LT";
+                    else if (s.isWet) kind = "BTH";
+                    else if ((s.room?.Name ?? "").ToLowerInvariant().Contains("kitchen")) kind = "KIT";
+                    else kind = "PWR";
+                    return (lvl, kind);
+                })
+                .ToList();
+
+            int circuitsAssigned = 0;
+            int totalStamped = 0;
+            foreach (var grp in groups)
+            {
+                int seq = 1;
+                // Within each (level, kind) group, split into circuits
+                // bounded by max area (100 m² ring / 75 m² radial) and
+                // max sockets-per-circuit (heuristic 24 outlets max
+                // per ring per BS 7671 Appx 15 guidance).
+                var pending = grp.OrderBy(s => s.p.X).ThenBy(s => s.p.Y).ToList();
+                while (pending.Count > 0)
+                {
+                    var bag = new List<(FamilyInstance fi, XYZ p, Room room, double areaM2, bool isWet, double vaPerOutlet)>();
+                    double areaSum = 0; int count = 0;
+                    var roomsTouched = new HashSet<ElementId>();
+                    foreach (var s in pending.ToList())
+                    {
+                        // Don't blow circuit area budget.
+                        if (s.room != null && roomsTouched.Add(s.room.Id))
+                        {
+                            if (areaSum + s.areaM2 > RingMaxAreaM2 && bag.Count > 0) break;
+                            areaSum += s.areaM2;
+                        }
+                        bag.Add(s);
+                        count++;
+                        // Cap per-circuit outlet count to keep the run
+                        // length plausible on 2.5mm² T+E.
+                        if (count >= 24) break;
+                    }
+                    foreach (var b in bag) pending.Remove(b);
+
+                    if (bag.Count == 0) break;
+
+                    string kind = grp.Key.kind;
+                    string circuitKind = "RADIAL";
+                    int rating = 32;
+                    if (kind == "PWR" || kind == "KIT")
+                    {
+                        circuitKind = bag.Count >= RingMinSockets ? "RING" : "RADIAL";
+                        rating = 32;
+                    }
+                    else if (kind == "LT")
+                    {
+                        circuitKind = "RADIAL";
+                        rating = 6; // BS 7671 Type B 6A typical lighting
+                    }
+                    else if (kind == "BTH")
+                    {
+                        circuitKind = "DEDICATED";
+                        rating = 16; // 16A radial typical for bathroom
+                    }
+
+                    // RCD group — Amd 2:2022 wants 30mA on everything in
+                    // a domestic install. Group bathroom and lighting on
+                    // separate RCBOs so a fault in one doesn't take out
+                    // the other.
+                    string rcdGroup;
+                    if (kind == "BTH")        rcdGroup = "RCBO-30mA-BTH";
+                    else if (kind == "LT")    rcdGroup = $"RCBO-30mA-LT-{grp.Key.lvl}";
+                    else if (kind == "KIT")   rcdGroup = $"RCBO-30mA-KIT-{grp.Key.lvl}";
+                    else                       rcdGroup = $"RCBO-30mA-{grp.Key.lvl}-{(seq % 2 == 0 ? "A" : "B")}";
+
+                    // Diversity per Appendix A Table A1: 100 % of largest
+                    // + 40 % of the remainder. Approximation: take max VA
+                    // and apply 0.4 to (n-1) more.
+                    double maxVa = bag.Max(b => b.vaPerOutlet);
+                    double sumOthers = bag.Sum(b => b.vaPerOutlet) - maxVa;
+                    double diversifiedVa = maxVa + 0.40 * sumOthers;
+
+                    string circuitId = $"{grp.Key.lvl}-{kind}-{seq:D2}";
+                    seq++;
+                    circuitsAssigned++;
+
+                    foreach (var s in bag)
+                    {
+                        if (StampOne(s.fi, circuitId, rcdGroup, diversifiedVa, rating, circuitKind))
+                            totalStamped++;
+                    }
+                }
+            }
+
+            if (circuitsAssigned > 0)
+                result.Warnings.Add(
+                    $"Circuit topology: assigned {circuitsAssigned} BS 7671 circuit(s) across " +
+                    $"{totalStamped} placed instance(s). Verify board schedule before issue " +
+                    $"— diversity per Appendix A Table A1, 30 mA RCBO per Amd 2:2022.");
+            if (circuitsAssigned > 0)
+                StingLog.Info($"CircuitTopologyEngine: {circuitsAssigned} circuits, {totalStamped} instances stamped.");
+        }
+
+        private static bool StampOne(FamilyInstance fi, string circuitId, string rcd, double va, int rating, string kind)
+        {
+            bool any = false;
+            try
+            {
+                if (TrySetString(fi, "STING_CIRCUIT_ID_TXT", circuitId))   any = true;
+                if (TrySetString(fi, "STING_RCD_GROUP_TXT",  rcd))         any = true;
+                if (TrySetString(fi, "STING_CIRCUIT_KIND_TXT", kind))      any = true;
+                if (TrySetDouble(fi, "STING_CIRCUIT_LOAD_VA", va))         any = true;
+                if (TrySetInt   (fi, "STING_CIRCUIT_RATING_A", rating))    any = true;
+            }
+            catch { }
+            return any;
+        }
+
+        private static bool TrySetString(Element el, string param, string val)
+        {
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p == null || p.IsReadOnly || p.StorageType != StorageType.String) return false;
+                if ((p.AsString() ?? "") == (val ?? "")) return false; // idempotent
+                p.Set(val ?? "");
+                return true;
+            }
+            catch { return false; }
+        }
+
+        private static bool TrySetDouble(Element el, string param, double val)
+        {
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p == null || p.IsReadOnly) return false;
+                if (p.StorageType == StorageType.Double)
+                {
+                    if (Math.Abs(p.AsDouble() - val) < 1e-6) return false;
+                    p.Set(val);
+                    return true;
+                }
+                if (p.StorageType == StorageType.String)
+                {
+                    string s = val.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+                    if ((p.AsString() ?? "") == s) return false;
+                    p.Set(s);
+                    return true;
+                }
+            }
+            catch { }
+            return false;
+        }
+
+        private static bool TrySetInt(Element el, string param, int val)
+        {
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p == null || p.IsReadOnly) return false;
+                if (p.StorageType == StorageType.Integer)
+                {
+                    if (p.AsInteger() == val) return false;
+                    p.Set(val);
+                    return true;
+                }
+                if (p.StorageType == StorageType.String)
+                {
+                    string s = val.ToString();
+                    if ((p.AsString() ?? "") == s) return false;
+                    p.Set(s);
+                    return true;
+                }
+            }
+            catch { }
+            return false;
+        }
+    }
+}

--- a/StingTools/Core/Calc/ConcreteCoverTable.cs
+++ b/StingTools/Core/Calc/ConcreteCoverTable.cs
@@ -1,0 +1,176 @@
+// Phase 139.28 — Eurocode 2 / UK NA / BS 8500 concrete-cover lookup.
+//
+// Used by InWallChaseRouter when a chased pipe / conduit is to be cast
+// into a concrete element. Returns the minimum nominal cover from the
+// finished concrete face to the pipe's outer surface.
+//
+// Source: BS EN 1992-1-1:2004 §4.4.1 + UK National Annex Table NA.4.4N
+// for structural class S4 (50-year design life). Values are c_nom =
+// c_min,dur + Δc_dev (10 mm allowance per UK NA). For pipework cast
+// into concrete the UK practice is to use the structural-rebar c_nom
+// as a starting point, then add half the pipe outer diameter so the
+// pipe centreline is offset accordingly.
+//
+// Usage:
+//
+//   double cover = ConcreteCoverTable.GetNominalCoverMm(
+//       exposureClass: "XC2",       // typical interior chase
+//       structuralClass: 4,         // 50-year life
+//       fireResistance: "REI60");   // 60-min fire rating
+//
+// Then InWallChaseRouter offsets the route from the wall finish face by
+// (cover + pipeOuterDiameter / 2). Matches Uganda construction
+// practice — UNBS adopts BS EN directly and the UK NA values are the
+// reference used by most consulting engineers in Kampala.
+
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core.Calc
+{
+    public static class ConcreteCoverTable
+    {
+        /// <summary>
+        /// Default exposure class when the rule doesn't specify one —
+        /// XC2 = "wet, rarely dry" — typical for interior wall / slab
+        /// chases below DPC.
+        /// </summary>
+        public const string DefaultExposureClass = "XC2";
+
+        /// <summary>UK NA default structural class (50-year design life).</summary>
+        public const int DefaultStructuralClass = 4;
+
+        /// <summary>
+        /// Δc_dev — UK NA placing-tolerance allowance added to c_min,dur
+        /// to derive c_nom. 10 mm is the BS EN 1992-1-1 §4.4.1.3 default.
+        /// </summary>
+        public const double DeltaDevMm = 10.0;
+
+        // c_min,dur (mm) per UK NA Table NA.4.4N — Structural class S4.
+        // Indexed by exposure class. Values are the durability-driven
+        // minimum cover before the placing-tolerance allowance Δc_dev.
+        private static readonly Dictionary<string, double> CMinDurS4
+            = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Carbonation
+            { "XC1", 15.0 },   // dry / permanently wet (interior)
+            { "XC2", 25.0 },   // wet, rarely dry (foundations, buried)
+            { "XC3", 25.0 },   // moderate humidity (sheltered external)
+            { "XC4", 30.0 },   // cyclic wet/dry (exposed external)
+            // Chloride from de-icing salt
+            { "XD1", 35.0 },
+            { "XD2", 40.0 },
+            { "XD3", 45.0 },
+            // Chloride from sea
+            { "XS1", 35.0 },   // airborne salt (coastal)
+            { "XS2", 40.0 },
+            { "XS3", 45.0 },
+            // Freeze / thaw
+            { "XF1", 30.0 },
+            { "XF2", 35.0 },
+            { "XF3", 35.0 },
+            { "XF4", 40.0 },
+            // Chemical
+            { "XA1", 30.0 },
+            { "XA2", 35.0 },
+            { "XA3", 40.0 },
+        };
+
+        // Adjustment ΔcS per UK NA Table NA.4.3N — structural class.
+        // Class 4 = 0 mm (baseline). Classes 1..3 = -5 mm each step
+        // (shorter design life). Classes 5..6 = +5 mm each step (longer
+        // life e.g. tunnel, bridge).
+        private static double StructuralClassAdjustmentMm(int sClass)
+        {
+            switch (sClass)
+            {
+                case 1: return -15.0;
+                case 2: return -10.0;
+                case 3: return -5.0;
+                case 4: return 0.0;
+                case 5: return 5.0;
+                case 6: return 10.0;
+                default: return 0.0;
+            }
+        }
+
+        // Fire-resistance cover increment per BS EN 1992-1-2 Table 5.5
+        // (slab simply supported, REI 30..240). Conservative — applies
+        // to slab; wall is usually less but we use the slab value as a
+        // safe upper bound for pipe-in-concrete.
+        private static double FireResistanceAdjustmentMm(string fire)
+        {
+            if (string.IsNullOrEmpty(fire)) return 0.0;
+            string f = fire.Trim().ToUpperInvariant().Replace(" ", "");
+            // Match REIxxx / Rxxx / Exxx / xxxMIN
+            int mins = ExtractMinutes(f);
+            if (mins <= 0) return 0.0;
+            if (mins <= 30)  return 5.0;
+            if (mins <= 60)  return 10.0;
+            if (mins <= 90)  return 15.0;
+            if (mins <= 120) return 20.0;
+            if (mins <= 180) return 25.0;
+            return 30.0;
+        }
+
+        private static int ExtractMinutes(string token)
+        {
+            int n = 0;
+            bool any = false;
+            foreach (char c in token)
+            {
+                if (c >= '0' && c <= '9') { n = n * 10 + (c - '0'); any = true; }
+                else if (any) break;
+            }
+            return any ? n : 0;
+        }
+
+        /// <summary>
+        /// Returns the minimum nominal cover c_nom (mm) for a concrete
+        /// element. For pipework cast into the element, callers should
+        /// add half the pipe outer diameter to keep the rebar zone clear.
+        /// Falls back to DefaultExposureClass when the supplied class is
+        /// blank / unknown.
+        /// </summary>
+        public static double GetNominalCoverMm(
+            string exposureClass = DefaultExposureClass,
+            int structuralClass = DefaultStructuralClass,
+            string fireResistance = "")
+        {
+            string key = string.IsNullOrEmpty(exposureClass) ? DefaultExposureClass : exposureClass.Trim();
+            if (!CMinDurS4.TryGetValue(key, out double cMinDur))
+                cMinDur = CMinDurS4[DefaultExposureClass];
+            double adjusted = cMinDur + StructuralClassAdjustmentMm(structuralClass)
+                            + FireResistanceAdjustmentMm(fireResistance);
+            // BS EN 1992-1-1 §4.4.1.2(3) — c_min cannot fall below 10 mm.
+            if (adjusted < 10.0) adjusted = 10.0;
+            return adjusted + DeltaDevMm;
+        }
+
+        /// <summary>
+        /// Pipe-in-concrete effective offset from the concrete finish face
+        /// to the pipe centreline. Equals nominal cover + pipeOuterDiameter / 2.
+        /// </summary>
+        public static double GetPipeOffsetFromFaceMm(
+            double pipeOuterDiameterMm,
+            string exposureClass = DefaultExposureClass,
+            int structuralClass = DefaultStructuralClass,
+            string fireResistance = "")
+        {
+            double cover = GetNominalCoverMm(exposureClass, structuralClass, fireResistance);
+            return cover + Math.Max(0.0, pipeOuterDiameterMm * 0.5);
+        }
+
+        /// <summary>
+        /// Diagnostic — list every exposure class and its nominal cover
+        /// at structural class 4 + no fire rating. Used by the Placement
+        /// Centre's standards-info dialog.
+        /// </summary>
+        public static IReadOnlyDictionary<string, double> AllNominalCoversS4()
+        {
+            var dict = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kv in CMinDurS4) dict[kv.Key] = kv.Value + DeltaDevMm;
+            return dict;
+        }
+    }
+}

--- a/StingTools/Core/Calc/HangerSpacingTable.cs
+++ b/StingTools/Core/Calc/HangerSpacingTable.cs
@@ -69,6 +69,20 @@ namespace StingTools.Core.Calc
             ( 50.0, 1800.0 ), ( 75.0, 2400.0 ), (100.0, 3000.0 ),
             (150.0, 3000.0 ), (200.0, 3000.0 ),
         };
+        // Phase 139.29 — ACO trough / linear drainage support spacing.
+        // Source: ACO Building Drainage technical manual + BS EN 1433
+        // (drainage channels). Channel "diameter" here is the nominal
+        // internal width (slot width) in mm. Hi-Cap channels accept
+        // wider intervals because they're stiffer; standard channels
+        // need closer support to prevent deflection at gully points.
+        private static readonly (double widthMm, double span)[] AcoChannel = new[]
+        {
+            ( 100.0, 1500.0 ),  // ACO Drain S100 — 1.5 m support
+            ( 150.0, 1500.0 ),  // S150
+            ( 200.0, 2000.0 ),  // S200 / Multidrain
+            ( 300.0, 2500.0 ),  // S300 Hi-Cap
+            ( 400.0, 3000.0 ),  // S400+ Hi-Cap
+        };
         // SMACNA rectangular duct hanger spacing by largest dimension.
         private static readonly (double size, double span)[] SmacnaRect = new[]
         {
@@ -109,6 +123,10 @@ namespace StingTools.Core.Calc
                     { tbl = Tr19Plastic; basis = "HVCA TR/19 plastic drainage"; }
                     else if (q.Material.Equals("CAST_IRON", StringComparison.OrdinalIgnoreCase))
                     { tbl = CastIron;    basis = "BS 416 cast iron"; }
+                    else if (q.Material.Equals("ACO", StringComparison.OrdinalIgnoreCase) ||
+                             q.Material.Equals("CHANNEL", StringComparison.OrdinalIgnoreCase) ||
+                             q.Material.Equals("LINEAR_DRAIN", StringComparison.OrdinalIgnoreCase))
+                    { tbl = AcoChannel;  basis = "BS EN 1433 / ACO channel"; }
                     else
                     { tbl = MssSteel;    basis = "MSS SP-58 steel"; }
                     break;

--- a/StingTools/Core/Calc/RoutingSupportPlacer.cs
+++ b/StingTools/Core/Calc/RoutingSupportPlacer.cs
@@ -1,0 +1,238 @@
+// Phase 139.28 — RoutingSupportPlacer.
+//
+// Bridges the placement-side routers (WallFollowerRouter, DropEngineBase,
+// InWallChaseRouter) to the existing HangerPlacementEngine + HangerFamilyResolver
+// pipeline. The placement engine and resolver were authored for the
+// stand-alone PlaceHangersCommand; this class makes them callable
+// from the auto-routing path so a routing rule with EmitSupports=true
+// produces standards-compliant clips / hangers as part of the same
+// transaction that creates the route.
+//
+// Responsibilities:
+//
+//   1. Take the routing rule + the just-created MEP segment IDs.
+//   2. Build a HangerSpacingQuery per run, overriding the engine's
+//      auto-detection with the rule's NominalDiameterMm / Material /
+//      InsulationThicknessMm fields when present (so the rule "wins"
+//      over what was read off the family).
+//   3. Call HangerPlacementEngine.Plan to get HangerCandidates with
+//      anchor types, rod lengths and trapeze grouping.
+//   4. Resolve hanger / clip families via HangerFamilyResolver and
+//      auto-load STING_HANGER_GENERIC.rfa from Families/Hangers/ when
+//      no candidate is loaded (Tier-4 fallback added by 139.28).
+//   5. Create FamilyInstance per candidate and stamp the standard
+//      provenance parameters (HOST_ID / ANCHOR / SPACING / etc.).
+//
+// Caller already owns the active Transaction. RoutingSupportPlacer
+// never creates its own — failures are caught per candidate so a
+// single bad family symbol doesn't tank the whole route.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Structure;
+
+namespace StingTools.Core.Calc
+{
+    public class RoutingSupportPlacementResult
+    {
+        public int SupportsPlaced { get; set; }
+        public int CandidatesGenerated { get; set; }
+        public int FamilyMissCount { get; set; }
+        public List<ElementId> PlacedSupportIds { get; } = new List<ElementId>();
+        public List<string> Warnings { get; } = new List<string>();
+        public List<HangerCandidate> Candidates { get; } = new List<HangerCandidate>();
+    }
+
+    public static class RoutingSupportPlacer
+    {
+        /// <summary>
+        /// Plan + place supports for the freshly-created routing
+        /// segments. Caller owns the Transaction. When the rule has
+        /// EmitSupports=false, returns an empty result with one
+        /// informational warning.
+        /// </summary>
+        public static RoutingSupportPlacementResult PlaceForRoute(
+            Document doc,
+            StingTools.Core.Placement.PlacementRule rule,
+            IList<ElementId> createdSegmentIds)
+        {
+            var r = new RoutingSupportPlacementResult();
+            if (doc == null || rule == null || createdSegmentIds == null || createdSegmentIds.Count == 0) return r;
+            if (!rule.EmitSupports)
+            {
+                r.Warnings.Add($"RoutingSupportPlacer: rule '{rule.MergeKey}' has EmitSupports=false — supports skipped.");
+                return r;
+            }
+
+            // Build the run list, overriding the spacing query with the
+            // rule's NominalDiameterMm / Material / InsulationThicknessMm
+            // when present so rule data beats whatever the family carries.
+            var runs = new List<Element>();
+            foreach (var id in createdSegmentIds)
+            {
+                Element el = null;
+                try { el = doc.GetElement(id); } catch { }
+                if (el == null) continue;
+                runs.Add(el);
+            }
+            if (runs.Count == 0) return r;
+
+            HangerPlacementResult planRes;
+            try
+            {
+                // We'd like to let HangerPlacementEngine.Plan pick up the
+                // rule overrides directly, but that engine reads off the
+                // element. The cleanest hand-off without changing its
+                // public surface: stamp the rule's overrides onto the
+                // run elements as parameters before calling Plan, so
+                // BuildQuery picks them up. PLM_PPE_MAT_TXT and
+                // HVC_DCT_MAT_TXT are already the params it reads.
+                if (!string.IsNullOrEmpty(rule.Material))
+                {
+                    foreach (var el in runs)
+                    {
+                        TrySetString(el, "PLM_PPE_MAT_TXT",   rule.Material);
+                        TrySetString(el, "HVC_DCT_MAT_TXT",   rule.Material);
+                    }
+                }
+                if (rule.InsulationThicknessMm > 0)
+                {
+                    foreach (var el in runs)
+                    {
+                        TrySetDoubleMm(el, "PLM_PPE_INSULATION_THK_MM", rule.InsulationThicknessMm);
+                        TrySetDoubleMm(el, "HVC_DCT_INSULATION_THK_MM", rule.InsulationThicknessMm);
+                    }
+                }
+                planRes = HangerPlacementEngine.Plan(doc, runs);
+            }
+            catch (Exception ex)
+            {
+                r.Warnings.Add($"RoutingSupportPlacer.Plan: {ex.Message}");
+                return r;
+            }
+
+            r.CandidatesGenerated = planRes.CandidatesGenerated;
+            r.Candidates.AddRange(planRes.Candidates);
+            foreach (var w in planRes.Warnings) r.Warnings.Add(w);
+
+            // Resolve families up-front so missing-family is one warning
+            // rather than per-candidate noise.
+            var binding = new Dictionary<string, HangerFamilyBinding>(StringComparer.OrdinalIgnoreCase);
+            foreach (var anchor in new[] { "CONCRETE_ANCHOR", "BEAM_CLAMP", "TRAPEZE", "GENERIC" })
+            {
+                var b = HangerFamilyResolver.Resolve(doc, anchor);
+                if (b?.Symbol != null) binding[anchor] = b;
+            }
+            if (binding.Count == 0)
+            {
+                r.FamilyMissCount = planRes.Candidates.Count;
+                r.Warnings.Add(
+                    "RoutingSupportPlacer: no hanger/clip family loaded in project. The engine planned " +
+                    $"{planRes.Candidates.Count} support(s) per BS 5572 / MSS SP-58 / SMACNA but could not " +
+                    "place them. Load STING_HANGER_GENERIC.rfa (or any Anvil/B-Line/Unistrut family with " +
+                    "'hanger' in its name) and re-run, or run Place_Hangers manually after.");
+                return r;
+            }
+
+            // Place one FamilyInstance per candidate.
+            foreach (var c in planRes.Candidates)
+            {
+                if (c.Point == null) continue;
+                if (!binding.TryGetValue(c.AnchorType ?? "GENERIC", out var b) || b?.Symbol == null)
+                    binding.TryGetValue("GENERIC", out b);
+                if (b?.Symbol == null) { r.FamilyMissCount++; continue; }
+                try
+                {
+                    if (!b.Symbol.IsActive) b.Symbol.Activate();
+                    var fi = doc.Create.NewFamilyInstance(c.Point, b.Symbol, StructuralType.NonStructural);
+                    if (fi == null) { r.FamilyMissCount++; continue; }
+                    StampSupportProvenance(fi, c, rule);
+                    r.PlacedSupportIds.Add(fi.Id);
+                    r.SupportsPlaced++;
+                }
+                catch (Exception ex)
+                {
+                    r.Warnings.Add($"RoutingSupportPlacer NewFamilyInstance @ ({c.Point.X:F2},{c.Point.Y:F2}): {ex.Message}");
+                }
+            }
+
+            if (r.SupportsPlaced > 0)
+                StingLog.Info(
+                    $"RoutingSupportPlacer: rule '{rule.MergeKey}' placed {r.SupportsPlaced} support(s) " +
+                    $"across {runs.Count} run(s); {r.FamilyMissCount} missed for lack of family.");
+            return r;
+        }
+
+        private static void StampSupportProvenance(
+            FamilyInstance fi, HangerCandidate c, StingTools.Core.Placement.PlacementRule rule)
+        {
+            try
+            {
+                TrySetString(fi, "STING_HANGER_HOST_ID",      c.HostRun?.Value.ToString() ?? "");
+                TrySetString(fi, "STING_HANGER_ANCHOR_TXT",   c.AnchorType ?? "GENERIC");
+                TrySetDoubleRaw(fi, "STING_HANGER_STRUT_LEN_MM", c.StrutRodMm);
+                TrySetDoubleRaw(fi, "STING_HANGER_SPACING_MM",   c.MaxSpanMm);
+                TrySetInt   (fi, "STING_HANGER_TRAPEZE_BOOL", c.OnTrapeze ? 1 : 0);
+                TrySetDoubleRaw(fi, "STING_HANGER_POINT_LOAD_KG", c.PointLoadKg);
+                TrySetDoubleRaw(fi, "STING_HANGER_ROD_DIA_MM",   c.RodDiameterMm);
+                TrySetString(fi, "STING_HANGER_ROD_IMPERIAL", c.RodImperial ?? "");
+                TrySetInt   (fi, "STING_HANGER_COUPLER_BOOL", c.RodNeedsCoupler ? 1 : 0);
+                TrySetString(fi, "STING_HANGER_BASIS_TXT",   c.SpacingBasis ?? "");
+                TrySetString(fi, "STING_HANGER_RULE_ID_TXT", rule?.MergeKey ?? "");
+                TrySetString(fi, "STING_HANGER_CONTEXT_TXT", rule?.MountingContext ?? "");
+            }
+            catch (Exception ex) { StingLog.Warn($"RoutingSupportPlacer.StampSupportProvenance: {ex.Message}"); }
+        }
+
+        private static void TrySetString(Element el, string param, string val)
+        {
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p != null && !p.IsReadOnly && p.StorageType == StorageType.String) p.Set(val ?? "");
+            }
+            catch { }
+        }
+
+        private static void TrySetDoubleRaw(Element el, string param, double val)
+        {
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p == null || p.IsReadOnly) return;
+                if (p.StorageType == StorageType.Double) p.Set(val);
+                else if (p.StorageType == StorageType.String)
+                    p.Set(val.ToString("F1", System.Globalization.CultureInfo.InvariantCulture));
+            }
+            catch { }
+        }
+
+        // Length-as-mm setter — converts to internal feet for Length params.
+        private static void TrySetDoubleMm(Element el, string param, double valMm)
+        {
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p == null || p.IsReadOnly) return;
+                if (p.StorageType == StorageType.Double) p.Set(valMm / 304.8);
+                else if (p.StorageType == StorageType.String)
+                    p.Set(valMm.ToString("F1", System.Globalization.CultureInfo.InvariantCulture));
+            }
+            catch { }
+        }
+
+        private static void TrySetInt(Element el, string param, int val)
+        {
+            try
+            {
+                var p = el.LookupParameter(param);
+                if (p == null || p.IsReadOnly) return;
+                if (p.StorageType == StorageType.Integer) p.Set(val);
+                else if (p.StorageType == StorageType.String) p.Set(val.ToString());
+            }
+            catch { }
+        }
+    }
+}

--- a/StingTools/Core/Calc/SlopeValidator.cs
+++ b/StingTools/Core/Calc/SlopeValidator.cs
@@ -142,8 +142,7 @@ namespace StingTools.Core.Calc
         private static string SlopeAsRatio(double pct)
         {
             if (pct <= 0) return "level";
-            double rise = 1.0;
-            double run  = 100.0 / pct;
+            double run = 100.0 / pct;
             return $"1:{run:F0}";
         }
     }

--- a/StingTools/Core/Calc/SlopeValidator.cs
+++ b/StingTools/Core/Calc/SlopeValidator.cs
@@ -1,0 +1,150 @@
+// Phase 139.28 — BS EN 12056-2 / BS 5572 slope validator.
+//
+// Confirms that gravity-drainage and vent-pipe runs are laid at or
+// above the standards-mandated minimum gradient. Used by routing
+// engines after segments are created, both for in-wall chase routes
+// (drainage stacks, branch waste) and for surface / suspended runs
+// (above-ground sanitary).
+//
+// Reference values (BS EN 12056-2 §6, BS 5572 §3):
+//
+//   Soil / waste branch  ≤ 1.5 m   :  1:80   (1.25 %)  System I (UK)
+//                                     1:40   (2.50 %)  short branches & sinks
+//   Vent pipe                       :  any   (no slope required, but pitch
+//                                            toward stack is good practice)
+//   Roof drainage                   :  1:80  (1.25 %)
+//   Foul drainage stack             :  vertical only
+//
+// Caller passes the rule's MinSlopePercent (or the result of a default
+// derivation). The validator inspects each created segment and reports
+// any whose slope is below the threshold.
+
+using System;
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
+
+namespace StingTools.Core.Calc
+{
+    public static class SlopeValidator
+    {
+        /// <summary>
+        /// BS EN 12056-2 default minimum slope (%) for branch waste runs
+        /// up to 1.5 m. Stacks and main runs use double this (2.5 %).
+        /// </summary>
+        public const double DefaultBranchSlopePct = 1.25;
+
+        /// <summary>BS EN 12056-2 default for runs &gt; 1.5 m.</summary>
+        public const double DefaultMainSlopePct = 2.5;
+
+        public class SlopeReport
+        {
+            public int SegmentsChecked { get; set; }
+            public int SegmentsBelowThreshold { get; set; }
+            public int SegmentsAboveThreshold { get; set; }
+            public int VerticalSegments { get; set; }
+            public List<string> Warnings { get; } = new List<string>();
+        }
+
+        /// <summary>
+        /// Walk every supplied MEP-curve segment and check the run's
+        /// slope (rise/run %). Returns a report; never throws.
+        /// </summary>
+        public static SlopeReport CheckSegments(
+            Document doc,
+            IList<ElementId> segmentIds,
+            double minSlopePct,
+            string ruleId = "")
+        {
+            var r = new SlopeReport();
+            if (doc == null || segmentIds == null || segmentIds.Count == 0) return r;
+            if (minSlopePct <= 0) return r; // pressurised — nothing to check
+            foreach (var id in segmentIds)
+            {
+                Element el = null;
+                try { el = doc.GetElement(id); } catch { }
+                if (el == null) continue;
+                var curve = (el.Location as LocationCurve)?.Curve;
+                if (curve == null) continue;
+                XYZ a, b;
+                try
+                {
+                    a = curve.GetEndPoint(0);
+                    b = curve.GetEndPoint(1);
+                }
+                catch { continue; }
+                if (a == null || b == null) continue;
+                double dxFt = b.X - a.X;
+                double dyFt = b.Y - a.Y;
+                double dzFt = b.Z - a.Z;
+                double horizFt = Math.Sqrt(dxFt * dxFt + dyFt * dyFt);
+                double horizMm = horizFt * 304.8;
+                double riseMm  = Math.Abs(dzFt) * 304.8;
+
+                r.SegmentsChecked++;
+
+                // Treat vertical (within 5° of plumb) as exempt — drops
+                // and stacks are inherently OK for gravity flow.
+                if (horizMm < 50.0 && riseMm > 100.0)
+                {
+                    r.VerticalSegments++;
+                    continue;
+                }
+                if (horizMm < 1.0)
+                {
+                    // Degenerate / zero-length — skip.
+                    continue;
+                }
+
+                double slopePct = (riseMm / horizMm) * 100.0;
+                if (slopePct >= minSlopePct)
+                {
+                    r.SegmentsAboveThreshold++;
+                }
+                else
+                {
+                    r.SegmentsBelowThreshold++;
+                    if (r.Warnings.Count < 10)
+                    {
+                        string ratio = SlopeAsRatio(slopePct);
+                        string targetRatio = SlopeAsRatio(minSlopePct);
+                        string ridText = string.IsNullOrEmpty(ruleId) ? "" : $" (rule '{ruleId}')";
+                        r.Warnings.Add(
+                            $"SlopeValidator: segment {id?.Value} slopes at {slopePct:F2}% ({ratio}) " +
+                            $"— below minimum {minSlopePct:F2}% ({targetRatio}) per BS EN 12056-2{ridText}.");
+                    }
+                }
+            }
+
+            if (r.SegmentsBelowThreshold > 10)
+                r.Warnings.Add($"SlopeValidator: +{r.SegmentsBelowThreshold - 10} more segments below threshold (truncated; see StingLog).");
+            return r;
+        }
+
+        /// <summary>
+        /// Derive a sensible default slope for a route segment category
+        /// when the rule didn't set MinSlopePercent. Returns 0 for
+        /// pressurised systems (water supply, gas, vent).
+        /// </summary>
+        public static double DefaultSlopePctFor(string routeSegmentCategory, string systemHint = "")
+        {
+            string sys = (systemHint ?? "").ToUpperInvariant();
+            string cat = (routeSegmentCategory ?? "").ToUpperInvariant();
+            if (cat != "PIPE") return 0.0;
+            if (sys.Contains("WASTE") || sys.Contains("SOIL") || sys.Contains("DRAIN")
+             || sys.Contains("FOUL")  || sys.Contains("STORM") || sys.Contains("RWO"))
+                return DefaultBranchSlopePct;
+            // Heating return: 0.33 % so condensate finds the system low point.
+            if (sys.Contains("HEAT") || sys.Contains("LTHW") || sys.Contains("MTHW"))
+                return 0.33;
+            return 0.0; // CWS / HWS / GAS / VENT — pressurised, no slope.
+        }
+
+        private static string SlopeAsRatio(double pct)
+        {
+            if (pct <= 0) return "level";
+            double rise = 1.0;
+            double run  = 100.0 / pct;
+            return $"1:{run:F0}";
+        }
+    }
+}

--- a/StingTools/Core/Placement/CoverageGridGenerator.cs
+++ b/StingTools/Core/Placement/CoverageGridGenerator.cs
@@ -120,6 +120,79 @@ namespace StingTools.Core.Placement
                 result.CoveragePercent = ComputeCoveragePercent(room, bb, result.Points,
                     rule.CoverageRadiusMm * MmToFt, result.UncoveredSamples);
 
+                // Phase 139.30 (M-08 deep) — iterative densification.
+                // The bbox grid + IsPointInRoom filter is correct but
+                // sparse in narrow legs of L-shaped / T-shaped / U-shaped
+                // rooms. When GuaranteeCoverage is on and coverage is
+                // below 99 %, cluster the uncovered samples and place an
+                // extra point at each cluster centroid; obstruction-test
+                // those extras through the same gate as the base grid.
+                if (rule.GuaranteeCoverage && result.CoveragePercent < 99.0
+                    && result.UncoveredSamples != null && result.UncoveredSamples.Count > 0)
+                {
+                    int densifiedAdded = 0;
+                    for (int pass = 0; pass < 3 && result.CoveragePercent < 99.0; pass++)
+                    {
+                        // Cluster uncovered samples using a coverage-radius
+                        // greedy grouping. Each cluster centroid becomes a
+                        // candidate extra point.
+                        var clusters = ClusterUncoveredSamples(
+                            result.UncoveredSamples, rule.CoverageRadiusMm * MmToFt);
+                        if (clusters.Count == 0) break;
+
+                        int addedThisPass = 0;
+                        foreach (var c in clusters)
+                        {
+                            // Snap Z back to the active anchorZ so the
+                            // extra point lands at mounting height.
+                            var pt = new XYZ(c.X, c.Y, anchorZ);
+                            // Wall + obstruction clearance gates same as
+                            // the base grid.
+                            if (HasObstructionWithin(pt, obstructions, obsClearFt)) continue;
+                            try { if (!room.IsPointInRoom(new XYZ(pt.X, pt.Y, room.Level?.Elevation ?? bb.Min.Z))) continue; }
+                            catch { /* unbounded room — accept */ }
+                            // Reject points too close to the bay edge
+                            // (wall clearance already trimmed the bay,
+                            // but cluster centroids can drift outside).
+                            bool inBay = false;
+                            foreach (var bay in bays)
+                            {
+                                if (pt.X >= bay.minX && pt.X <= bay.maxX
+                                 && pt.Y >= bay.minY && pt.Y <= bay.maxY)
+                                { inBay = true; break; }
+                            }
+                            if (!inBay) continue;
+                            // Don't double-up — skip if an existing point
+                            // is within MinSpacing.
+                            double minSpacingFt = (rule.MinSpacingMm > 0 ? rule.MinSpacingMm : 0.0) * MmToFt;
+                            bool tooClose = false;
+                            if (minSpacingFt > 0)
+                            {
+                                double mssq = minSpacingFt * minSpacingFt;
+                                foreach (var existing in result.Points)
+                                {
+                                    double dx = existing.X - pt.X, dy = existing.Y - pt.Y;
+                                    if (dx * dx + dy * dy < mssq) { tooClose = true; break; }
+                                }
+                            }
+                            if (tooClose) continue;
+                            result.Points.Add(pt);
+                            addedThisPass++;
+                            densifiedAdded++;
+                        }
+                        if (addedThisPass == 0) break;
+                        result.UncoveredSamples.Clear();
+                        result.CoveragePercent = ComputeCoveragePercent(
+                            room, bb, result.Points,
+                            rule.CoverageRadiusMm * MmToFt, result.UncoveredSamples);
+                    }
+                    if (densifiedAdded > 0)
+                        result.Warnings.Add(
+                            $"CoverageGrid: densified +{densifiedAdded} extra point(s) for non-rectangular " +
+                            $"room — bbox grid left {result.UncoveredSamples?.Count ?? 0} uncovered sample(s) " +
+                            $"in narrow leg(s).");
+                }
+
                 if (rule.GuaranteeCoverage && result.CoveragePercent < 99.0)
                 {
                     result.Warnings.Add(
@@ -133,6 +206,39 @@ namespace StingTools.Core.Placement
                 result.Warnings.Add($"CoverageGrid exception: {ex.Message}");
             }
             return result;
+        }
+
+        /// <summary>
+        /// Phase 139.30 (M-08 deep) — group uncovered samples by greedy
+        /// 2× coverage-radius proximity and return cluster centroids.
+        /// Cheap O(n²) for the small uncovered-sample count we expect
+        /// (≤ 100 by ComputeCoveragePercent's cap).
+        /// </summary>
+        private static List<XYZ> ClusterUncoveredSamples(IList<XYZ> samples, double coverageRadiusFt)
+        {
+            var centroids = new List<XYZ>();
+            if (samples == null || samples.Count == 0) return centroids;
+            // 2× radius — points within this distance of each other can
+            // share a single new fixture.
+            double clusterRadiusFt = coverageRadiusFt * 2.0;
+            double rSq = clusterRadiusFt * clusterRadiusFt;
+            var claimed = new bool[samples.Count];
+            for (int i = 0; i < samples.Count; i++)
+            {
+                if (claimed[i] || samples[i] == null) continue;
+                claimed[i] = true;
+                XYZ acc = samples[i];
+                int n = 1;
+                for (int j = i + 1; j < samples.Count; j++)
+                {
+                    if (claimed[j] || samples[j] == null) continue;
+                    double dx = samples[j].X - samples[i].X;
+                    double dy = samples[j].Y - samples[i].Y;
+                    if (dx * dx + dy * dy <= rSq) { acc += samples[j]; n++; claimed[j] = true; }
+                }
+                centroids.Add(acc * (1.0 / n));
+            }
+            return centroids;
         }
 
         private static bool HasObstructionWithin(XYZ pt, List<ExclusionRect> obstructions, double clearFt)

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -513,6 +513,28 @@ namespace StingTools.Core.Placement
                         AuditCableBundleDerating(doc, ordered, result);
                     }
                     catch (Exception cx) { result.Warnings.Add($"Cable bundle audit: {cx.Message}"); }
+
+                    // Phase 139.30 (X-05) — door swing envelope vs switch
+                    // placement. Switches anchored at DOOR_HINGE_SIDE_*
+                    // can sit inside the door's swept arc; opening the
+                    // door hits the switch with the handle. Walks every
+                    // placed switch / electrical fixture and checks
+                    // against every door's swept envelope.
+                    try
+                    {
+                        AuditDoorSwingClearance(doc, ordered, result);
+                    }
+                    catch (Exception dx) { result.Warnings.Add($"Door swing audit: {dx.Message}"); }
+
+                    // Phase 139.30 (X-01) — circuit-aware electrical pass.
+                    // Groups placed sockets / electrical fixtures into
+                    // BS 7671 ring / radial circuits and stamps RCD
+                    // group + circuit ID per element.
+                    try
+                    {
+                        StingTools.Core.Calc.CircuitTopologyEngine.AssignCircuits(doc, result);
+                    }
+                    catch (Exception ex) { result.Warnings.Add($"Circuit topology: {ex.Message}"); }
                 }
 
                 if (!dryRun)
@@ -1904,6 +1926,152 @@ namespace StingTools.Core.Placement
                 return Math.Abs(sa - sb) < 1e-3;
             }
             catch { return true; }
+        }
+
+        /// <summary>
+        /// Phase 139.30 (X-05) — door swing envelope vs switch placement.
+        /// For every placed switch / socket / electrical fixture whose
+        /// rule's AnchorType starts with DOOR_, locate the nearest door
+        /// and check whether the placement falls inside the door's
+        /// swept arc (90° default). When a hit is found, surfaces a
+        /// per-instance warning with a re-anchor recommendation
+        /// (DOOR_LATCH_SIDE / DOOR_STRIKE_SIDE).
+        /// </summary>
+        private static void AuditDoorSwingClearance(
+            Document doc, IList<PlacementRule> rules, PlacementResult result)
+        {
+            if (doc == null || result == null || result.PlacedIds.Count == 0) return;
+
+            // Collect rules that placed switch-like fixtures near doors —
+            // these are the ones at risk.
+            var doorRiskRules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (rules != null)
+            {
+                foreach (var r in rules)
+                {
+                    if (r == null) continue;
+                    string anchor = (r.AnchorType ?? "").ToUpperInvariant();
+                    if (anchor.StartsWith("DOOR_")
+                        || anchor == "WALL_MIDPOINT"
+                        || anchor == "WALL_FACE_OFFSET")
+                        doorRiskRules.Add(r.MergeKey);
+                }
+            }
+            if (doorRiskRules.Count == 0) return;
+
+            // Build a door index: location point + facing + width per door.
+            var doors = new List<DoorEnvelope>();
+            try
+            {
+                foreach (var el in new FilteredElementCollector(doc)
+                    .OfCategory(BuiltInCategory.OST_Doors)
+                    .WhereElementIsNotElementType())
+                {
+                    if (!(el is FamilyInstance fi)) continue;
+                    var loc = (fi.Location as LocationPoint)?.Point;
+                    if (loc == null) continue;
+                    XYZ facing = fi.FacingOrientation ?? XYZ.BasisX;
+                    XYZ hand = fi.HandOrientation   ?? XYZ.BasisY;
+                    double widthFt = 0.85; // ~ 26" door fallback
+                    try
+                    {
+                        var sym = fi.Symbol;
+                        var pW = sym?.LookupParameter("Width") ?? sym?.get_Parameter(BuiltInParameter.DOOR_WIDTH);
+                        if (pW != null && pW.StorageType == StorageType.Double) widthFt = Math.Max(0.5, pW.AsDouble());
+                    }
+                    catch { }
+                    doors.Add(new DoorEnvelope
+                    {
+                        Id      = fi.Id,
+                        Loc     = loc,
+                        Facing  = facing,
+                        Hand    = hand,
+                        WidthFt = widthFt,
+                        HandFlipped   = fi.HandFlipped,
+                        FacingFlipped = fi.FacingFlipped,
+                    });
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"AuditDoorSwingClearance enum doors: {ex.Message}"); }
+            if (doors.Count == 0) return;
+
+            int conflicts = 0;
+            foreach (var id in result.PlacedIds)
+            {
+                FamilyInstance fi = null;
+                try { fi = doc.GetElement(id) as FamilyInstance; } catch { }
+                if (fi == null) continue;
+                XYZ p = (fi.Location as LocationPoint)?.Point;
+                if (p == null) continue;
+
+                DoorEnvelope nearest = null;
+                double bestSq = double.MaxValue;
+                foreach (var d in doors)
+                {
+                    double dx = d.Loc.X - p.X, dy = d.Loc.Y - p.Y;
+                    double sq = dx * dx + dy * dy;
+                    double maxDistFt = d.WidthFt + (300.0 / 304.8);
+                    if (sq < maxDistFt * maxDistFt && sq < bestSq) { bestSq = sq; nearest = d; }
+                }
+                if (nearest == null) continue;
+
+                if (PointInsideSweptArc(nearest, p))
+                {
+                    conflicts++;
+                    if (conflicts <= 10)
+                    {
+                        result.Warnings.Add(
+                            $"Door swing: placed instance {id.Value} at ({p.X:F2},{p.Y:F2}) sits inside the " +
+                            $"swept arc of door {nearest.Id.Value} ({nearest.WidthFt * 304.8:F0}mm). " +
+                            $"The door handle will hit the switch on opening — re-anchor the rule to " +
+                            $"DOOR_LATCH_SIDE or DOOR_STRIKE_SIDE, or move the switch ≥ {nearest.WidthFt * 304.8:F0}mm from the hinge.");
+                    }
+                }
+            }
+            if (conflicts > 10)
+                result.Warnings.Add($"Door swing: {conflicts - 10} additional conflicts truncated — see StingLog.");
+            if (conflicts > 0)
+                StingLog.Warn($"AuditDoorSwingClearance: {conflicts} placed instance(s) inside door swept arc.");
+        }
+
+        private class DoorEnvelope
+        {
+            public ElementId Id;
+            public XYZ       Loc;
+            public XYZ       Facing;
+            public XYZ       Hand;
+            public double    WidthFt;
+            public bool      HandFlipped;
+            public bool      FacingFlipped;
+        }
+
+        /// <summary>
+        /// Approximate "inside swept arc" test. The door hinges on one
+        /// jamb; the leaf swings 90° from closed (along Hand axis) to
+        /// open (along Facing axis, into the room). A switch placed in
+        /// the quarter-circle between those two axes, within door-width
+        /// of the hinge, sits in the swept envelope and will be hit by
+        /// the handle on opening.
+        /// </summary>
+        private static bool PointInsideSweptArc(DoorEnvelope door, XYZ p)
+        {
+            try
+            {
+                double half = door.WidthFt * 0.5;
+                XYZ hinge = door.HandFlipped
+                    ? door.Loc + door.Hand.Multiply(half)
+                    : door.Loc - door.Hand.Multiply(half);
+                XYZ v = p - hinge; v = new XYZ(v.X, v.Y, 0);
+                double r = v.GetLength();
+                if (r < 1e-3) return true;
+                if (r > door.WidthFt + 0.05) return false;
+                XYZ closedDir = door.HandFlipped ? door.Hand.Negate() : door.Hand;
+                XYZ openDir   = door.FacingFlipped ? door.Facing.Negate() : door.Facing;
+                double cosToClosed = v.Normalize().DotProduct(closedDir.Normalize());
+                double cosToOpen   = v.Normalize().DotProduct(openDir.Normalize());
+                return cosToClosed > 0 && cosToOpen > 0;
+            }
+            catch { return false; }
         }
 
         /// <summary>

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -402,21 +402,30 @@ namespace StingTools.Core.Placement
                             ProcessRoomRule(doc, room, rule, scorer,
                                 perCategorySymbol, result, dryRun, roomState);
 
-                            // PC-13 — CoPlaceWith: fire each co-rule at the same XYZ as the primary's last point.
+                            // PC-13 / Phase 139.27 (M-06) — CoPlaceWith fires at
+                            // EVERY placement point of the primary rule, not just
+                            // the last. Pre-139.27 only the last point of a 5-fixture
+                            // primary triggered the co-rule; the other 4 silently
+                            // missed their dependent device (smoke detector under
+                            // luminaire, double-pole isolator next to fan, etc.).
                             if (rule.CoPlaceWith != null && rule.CoPlaceWith.Count > 0
-                                && roomState.LastPointByRule.TryGetValue(rule.MergeKey, out var lastPt))
+                                && roomState.PlacedByRule.TryGetValue(rule.MergeKey, out var primaryPoints)
+                                && primaryPoints != null && primaryPoints.Count > 0)
                             {
                                 foreach (var coId in rule.CoPlaceWith)
                                 {
                                     var coRule = ordered.FirstOrDefault(r => string.Equals(r.MergeKey, coId, StringComparison.OrdinalIgnoreCase));
                                     if (coRule == null) continue;
-                                    try
+                                    foreach (var primaryPt in primaryPoints)
                                     {
-                                        ProcessRoomRuleAtPoint(doc, room, coRule, scorer, perCategorySymbol, result, dryRun, roomState, lastPt);
-                                    }
-                                    catch (Exception cex)
-                                    {
-                                        result.Warnings.Add($"Co-place {coRule.MergeKey} in room {room.Id}: {cex.Message}");
+                                        try
+                                        {
+                                            ProcessRoomRuleAtPoint(doc, room, coRule, scorer, perCategorySymbol, result, dryRun, roomState, primaryPt);
+                                        }
+                                        catch (Exception cex)
+                                        {
+                                            result.Warnings.Add($"Co-place {coRule.MergeKey} in room {room.Id}: {cex.Message}");
+                                        }
                                     }
                                 }
                             }
@@ -466,6 +475,44 @@ namespace StingTools.Core.Placement
                         StampNogginRequirementsFromGrid(doc, scorer, result);
                     }
                     catch (Exception nx) { result.Warnings.Add($"Noggin stamp: {nx.Message}"); }
+
+                    // Phase 139.27 (M-02 deep) — structural-awareness audit.
+                    // Walk each placed instance and warn when the location
+                    // sits inside a beam-junction or column clearance zone
+                    // — drilling there would breach structure. Currently
+                    // advisory-only (no auto-relocation); the warning lands
+                    // in PlacementResult.Warnings so the BIM coordinator
+                    // can resolve before issuing.
+                    try
+                    {
+                        AuditStructuralClearance(doc, ordered, result);
+                    }
+                    catch (Exception sx) { result.Warnings.Add($"Structural audit: {sx.Message}"); }
+
+                    // Phase 139.27 (X-03) — best-effort MEP connector auto-join.
+                    // Walks placed FamilyInstances with MEP connectors and
+                    // tries to connect each open connector to the closest
+                    // unconnected connector on a neighbouring placed
+                    // instance whose system classification matches. Skipped
+                    // when no rule sets RouteSegmentCategory (i.e. not a
+                    // routing rule). All exceptions captured per instance.
+                    try
+                    {
+                        AutoJoinMepConnectors(doc, ordered, result);
+                    }
+                    catch (Exception mx) { result.Warnings.Add($"MEP connector join: {mx.Message}"); }
+
+                    // Phase 139.27 (X-04) — cable / conduit bundle advisory.
+                    // For rules with CableBundleAdvisoryCount > 0, count how
+                    // many same-category instances landed within bundle
+                    // clearance (300 mm default) and warn when the count
+                    // exceeds the BS 7671 Table 4 derating thresholds
+                    // (no auto-resize; advisory only).
+                    try
+                    {
+                        AuditCableBundleDerating(doc, ordered, result);
+                    }
+                    catch (Exception cx) { result.Warnings.Add($"Cable bundle audit: {cx.Message}"); }
                 }
 
                 if (!dryRun)
@@ -1602,6 +1649,234 @@ namespace StingTools.Core.Placement
             {
                 result.Warnings.Add($"Stamped STING_NOGGIN_REQUIRED on {stamped} placed fixture(s) — run Placement_NogginExport to dump the structural fixing schedule.");
                 StingLog.Info($"FixturePlacementEngine: stamped STING_NOGGIN_REQUIRED on {stamped} fixture(s).");
+            }
+        }
+
+        /// <summary>
+        /// Phase 139.27 (M-02 deep) — post-placement structural-clearance
+        /// audit. Each placed instance is checked against
+        /// <see cref="StructuralAwareness.IsNearJunction"/> with a 300mm
+        /// clearance; matches surface as warnings so the coordinator can
+        /// review before drilling. Cheap because StructuralAwareness
+        /// pre-builds the junction set once per document.
+        /// </summary>
+        private static void AuditStructuralClearance(
+            Document doc, IList<PlacementRule> rules, PlacementResult result)
+        {
+            if (doc == null || result == null || result.PlacedIds.Count == 0) return;
+            // Only audit rules whose anchor implies a structural penetration
+            // (ceiling-mounted, soffit-mounted, wall-deep). Surface-mounted
+            // wall fixtures rarely conflict with structure.
+            var auditRuleKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (rules != null)
+            {
+                foreach (var r in rules)
+                {
+                    if (r == null) continue;
+                    string anchor = (r.AnchorType ?? "").ToUpperInvariant();
+                    bool ceilingAnchor = anchor == "CEILING_CENTRE" || anchor == "CEILING_TILE_CENTRE"
+                                       || anchor == "LIGHTING_GRID" || anchor == "LUX_GRID";
+                    bool soffitAnchor = anchor == "SOFFIT_CENTRE" || anchor == "SOFFIT_BESA"
+                                       || anchor == "STRUCTURAL_SOFFIT";
+                    bool deepWallAnchor = (anchor == "WALL_FACE_OFFSET" && r.OffsetXMm > 50.0);
+                    if (ceilingAnchor || soffitAnchor || deepWallAnchor)
+                        auditRuleKeys.Add(r.MergeKey);
+                }
+            }
+            if (auditRuleKeys.Count == 0) return;
+
+            StructuralAwareness sa;
+            try { sa = new StructuralAwareness(doc); }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"AuditStructuralClearance init: {ex.Message}");
+                return;
+            }
+
+            const double clearanceFt = 300.0 / 304.8;
+            int conflicts = 0;
+            foreach (var id in result.PlacedIds)
+            {
+                FamilyInstance fi = null;
+                try { fi = doc.GetElement(id) as FamilyInstance; } catch { }
+                if (fi == null) continue;
+                XYZ p = (fi.Location as LocationPoint)?.Point;
+                if (p == null) continue;
+                bool nearStructure = false;
+                try { nearStructure = sa.IsNearJunction(p, clearanceFt); } catch { }
+                if (!nearStructure) continue;
+                conflicts++;
+                if (conflicts <= 10)
+                    result.Warnings.Add(
+                        $"Structural clearance: placed instance {id.Value} at ({p.X:F2},{p.Y:F2}) " +
+                        $"sits within 300mm of a beam-junction or column. Drilling may breach structure — " +
+                        $"verify with the structural BIM coordinator before issuing.");
+            }
+            if (conflicts > 10)
+                result.Warnings.Add($"Structural clearance: {conflicts - 10} additional conflicts truncated — see StingLog.");
+            if (conflicts > 0)
+                StingLog.Warn($"FixturePlacementEngine.AuditStructuralClearance: {conflicts} placed instance(s) within 300mm of structure.");
+        }
+
+        /// <summary>
+        /// Phase 139.27 (X-03) — best-effort MEP connector auto-join.
+        /// For each placed FamilyInstance with MEP connectors:
+        ///   1. enumerate unconnected connectors;
+        ///   2. find the closest unconnected connector on another placed
+        ///      instance of the same SystemClassification within 600mm;
+        ///   3. attempt a direct connection (no fitting insertion).
+        /// Failures are tallied and surfaced as a single advisory rather
+        /// than per-instance noise. Pre-139.27 placed instances had zero
+        /// connector joins and shipped to COBie / schedules as orphaned.
+        /// </summary>
+        private static void AutoJoinMepConnectors(
+            Document doc, IList<PlacementRule> rules, PlacementResult result)
+        {
+            if (doc == null || result == null || result.PlacedIds.Count == 0) return;
+            // Only run when at least one rule declares a routing target.
+            bool anyRouting = false;
+            if (rules != null)
+            {
+                foreach (var r in rules)
+                {
+                    if (r == null) continue;
+                    if (!string.IsNullOrEmpty(r.RoutingMode)
+                        && !string.Equals(r.RoutingMode, "NONE", StringComparison.OrdinalIgnoreCase))
+                    { anyRouting = true; break; }
+                }
+            }
+            if (!anyRouting) return;
+
+            const double joinRadiusFt = 600.0 / 304.8;
+            double radSq = joinRadiusFt * joinRadiusFt;
+
+            // Index connectors per system classification.
+            var openConns = new Dictionary<string, List<(Connector c, ElementId id)>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var id in result.PlacedIds)
+            {
+                FamilyInstance fi = null;
+                try { fi = doc.GetElement(id) as FamilyInstance; } catch { }
+                if (fi == null) continue;
+                var mgr = fi.MEPModel?.ConnectorManager;
+                if (mgr == null) continue;
+                foreach (Connector c in mgr.Connectors)
+                {
+                    if (c == null || c.IsConnected) continue;
+                    string sysKey = "?";
+                    try { sysKey = c.Domain.ToString() + ":" + (c.MEPSystem?.Name ?? c.PartType.ToString()); } catch { }
+                    if (!openConns.TryGetValue(sysKey, out var list))
+                    {
+                        list = new List<(Connector, ElementId)>();
+                        openConns[sysKey] = list;
+                    }
+                    list.Add((c, id));
+                }
+            }
+
+            int joined = 0, failed = 0;
+            foreach (var kv in openConns)
+            {
+                var list = kv.Value;
+                for (int i = 0; i < list.Count; i++)
+                {
+                    var (a, aid) = list[i];
+                    if (a.IsConnected) continue;
+                    XYZ pa = a.Origin;
+                    if (pa == null) continue;
+                    int bestJ = -1; double bestSq = radSq;
+                    for (int j = i + 1; j < list.Count; j++)
+                    {
+                        var (b, bid) = list[j];
+                        if (b == null || b.IsConnected || bid == aid) continue;
+                        XYZ pb = b.Origin;
+                        if (pb == null) continue;
+                        double dx = pa.X - pb.X, dy = pa.Y - pb.Y, dz = pa.Z - pb.Z;
+                        double sq = dx * dx + dy * dy + dz * dz;
+                        if (sq < bestSq) { bestSq = sq; bestJ = j; }
+                    }
+                    if (bestJ < 0) continue;
+                    var (target, tid) = list[bestJ];
+                    try
+                    {
+                        if (a.IsConnectedTo(target)) continue;
+                        a.ConnectTo(target);
+                        if (a.IsConnected) joined++; else failed++;
+                    }
+                    catch (Exception ex)
+                    {
+                        failed++;
+                        StingLog.Warn($"AutoJoinMepConnectors {aid.Value}->{tid.Value}: {ex.Message}");
+                    }
+                }
+            }
+
+            if (joined > 0)
+                result.Warnings.Add($"MEP auto-join: connected {joined} pair(s) of placed-instance connectors. Verify in Revit before issuing — direct ConnectTo bypasses fitting insertion.");
+            if (failed > 0)
+                result.Warnings.Add($"MEP auto-join: {failed} connector pair(s) within 600mm could not be joined (mismatched flow direction or fitting required). See StingLog.");
+        }
+
+        /// <summary>
+        /// Phase 139.27 (X-04) — BS 7671 Table 4 cable / conduit bundle
+        /// advisory. For rules whose <c>CableBundleAdvisoryCount</c> > 0,
+        /// count placed instances of the same category within 300mm and
+        /// warn when the count crosses the standard derating thresholds
+        /// (4 → 0.80×, 6 → 0.69×, 9+ → 0.50×). Advisory only — does not
+        /// auto-resize cables, this is a check the electrical engineer
+        /// owns. Designed to flag before issue.
+        /// </summary>
+        private static void AuditCableBundleDerating(
+            Document doc, IList<PlacementRule> rules, PlacementResult result)
+        {
+            if (doc == null || rules == null || result == null) return;
+            const double bundleRadiusFt = 300.0 / 304.8;
+            double radSq = bundleRadiusFt * bundleRadiusFt;
+
+            // Group placed ids by rule MergeKey (via CountsByRule diag mapping
+            // is not enough — we need positions). Use document categories
+            // as a proxy.
+            var byCategory = new Dictionary<string, List<(ElementId id, XYZ p)>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var id in result.PlacedIds)
+            {
+                FamilyInstance fi = null;
+                try { fi = doc.GetElement(id) as FamilyInstance; } catch { }
+                if (fi == null) continue;
+                XYZ p = (fi.Location as LocationPoint)?.Point;
+                if (p == null) continue;
+                string cat = "(uncategorised)";
+                try { cat = fi.Category?.Name ?? "(uncategorised)"; } catch { }
+                if (!byCategory.TryGetValue(cat, out var list))
+                {
+                    list = new List<(ElementId, XYZ)>();
+                    byCategory[cat] = list;
+                }
+                list.Add((id, p));
+            }
+
+            // Apply advisory per rule; rules without the field don't trigger.
+            foreach (var rule in rules)
+            {
+                if (rule == null || rule.CableBundleAdvisoryCount <= 0) continue;
+                if (!byCategory.TryGetValue(rule.CategoryFilter ?? "", out var list)) continue;
+                int worstBundle = 0;
+                foreach (var (id, p) in list)
+                {
+                    int near = 0;
+                    foreach (var (id2, p2) in list)
+                    {
+                        if (id == id2) continue;
+                        double dx = p.X - p2.X, dy = p.Y - p2.Y, dz = p.Z - p2.Z;
+                        if (dx * dx + dy * dy + dz * dz <= radSq) near++;
+                    }
+                    if (near > worstBundle) worstBundle = near;
+                }
+                int total = worstBundle + 1; // include self
+                if (total < rule.CableBundleAdvisoryCount) continue;
+
+                double derate = total >= 9 ? 0.50 : total >= 6 ? 0.69 : total >= 4 ? 0.80 : 1.00;
+                result.Warnings.Add(
+                    $"Cable derating: rule '{rule.MergeKey}' has up to {total} same-category instances within 300mm — " +
+                    $"BS 7671 Table 4 derating ≈ {derate:F2}×. Verify cable size with the electrical engineer before issue.");
             }
         }
     }

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -1785,7 +1785,7 @@ namespace StingTools.Core.Placement
                 {
                     if (c == null || c.IsConnected) continue;
                     string sysKey = "?";
-                    try { sysKey = c.Domain.ToString() + ":" + (c.MEPSystem?.Name ?? c.PartType.ToString()); } catch { }
+                    try { sysKey = c.Domain.ToString() + ":" + (c.MEPSystem?.Name ?? c.Description ?? c.Owner?.Category?.Name ?? ""); } catch { }
                     if (!openConns.TryGetValue(sysKey, out var list))
                     {
                         list = new List<(Connector, ElementId)>();

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -1774,6 +1774,7 @@ namespace StingTools.Core.Placement
             }
 
             int joined = 0, failed = 0;
+            int fittingsElbow = 0, fittingsUnion = 0, fittingsTransition = 0, fittingsTee = 0, directJoins = 0;
             foreach (var kv in openConns)
             {
                 var list = kv.Value;
@@ -1799,8 +1800,31 @@ namespace StingTools.Core.Placement
                     try
                     {
                         if (a.IsConnectedTo(target)) continue;
-                        a.ConnectTo(target);
-                        if (a.IsConnected) joined++; else failed++;
+                        // Phase 139.29 — prefer fitting insertion over direct
+                        // ConnectTo. Geometry decides the fitting kind:
+                        //  · same axis, same size  → Union fitting
+                        //  · same axis, ≠ size     → Transition fitting
+                        //  · different axis        → Elbow / Tee fitting
+                        // Falls through to ConnectTo when no fitting matches
+                        // (rare — happens with cable-tray which Revit doesn't
+                        // ship a Union for).
+                        bool insertedFitting = TryInsertFitting(doc, a, target, out int kind);
+                        if (insertedFitting)
+                        {
+                            joined++;
+                            switch (kind)
+                            {
+                                case 1: fittingsElbow++;       break;
+                                case 2: fittingsUnion++;       break;
+                                case 3: fittingsTransition++;  break;
+                                case 4: fittingsTee++;         break;
+                            }
+                        }
+                        else
+                        {
+                            a.ConnectTo(target);
+                            if (a.IsConnected) { joined++; directJoins++; } else failed++;
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -1811,9 +1835,75 @@ namespace StingTools.Core.Placement
             }
 
             if (joined > 0)
-                result.Warnings.Add($"MEP auto-join: connected {joined} pair(s) of placed-instance connectors. Verify in Revit before issuing — direct ConnectTo bypasses fitting insertion.");
+            {
+                var detail = new List<string>();
+                if (fittingsElbow      > 0) detail.Add($"{fittingsElbow} elbow");
+                if (fittingsUnion      > 0) detail.Add($"{fittingsUnion} union");
+                if (fittingsTransition > 0) detail.Add($"{fittingsTransition} transition");
+                if (fittingsTee        > 0) detail.Add($"{fittingsTee} tee");
+                if (directJoins        > 0) detail.Add($"{directJoins} direct");
+                string detailTxt = detail.Count > 0 ? " (" + string.Join(", ", detail) + ")" : "";
+                result.Warnings.Add($"MEP auto-join: connected {joined} pair(s){detailTxt}. Verify fitting orientation in Revit before issue.");
+            }
             if (failed > 0)
-                result.Warnings.Add($"MEP auto-join: {failed} connector pair(s) within 600mm could not be joined (mismatched flow direction or fitting required). See StingLog.");
+                result.Warnings.Add($"MEP auto-join: {failed} connector pair(s) within 600mm could not be joined (mismatched flow direction, incompatible fitting, or missing fitting in family library). See StingLog.");
+        }
+
+        /// <summary>
+        /// Phase 139.29 — try to insert the right fitting between two
+        /// unconnected connectors. Returns true on success and outputs
+        /// the fitting kind (1=elbow, 2=union, 3=transition, 4=tee).
+        /// Falls through quietly when the API call fails so the caller
+        /// can fall back to direct ConnectTo.
+        /// </summary>
+        private static bool TryInsertFitting(Document doc, Connector a, Connector b, out int kind)
+        {
+            kind = 0;
+            if (doc == null || a == null || b == null) return false;
+            try
+            {
+                XYZ pa = a.Origin, pb = b.Origin;
+                if (pa == null || pb == null) return false;
+                XYZ da = (a.CoordinateSystem?.BasisZ) ?? XYZ.BasisZ;
+                XYZ db = (b.CoordinateSystem?.BasisZ) ?? XYZ.BasisZ;
+                bool sameAxis = Math.Abs(Math.Abs(da.DotProduct(db)) - 1.0) < 0.05;
+                bool sameSize = SameSize(a, b);
+
+                if (sameAxis && sameSize)
+                {
+                    var fi = doc.Create.NewUnionFitting(a, b);
+                    if (fi != null) { kind = 2; return true; }
+                }
+                if (sameAxis && !sameSize)
+                {
+                    var fi = doc.Create.NewTransitionFitting(a, b);
+                    if (fi != null) { kind = 3; return true; }
+                }
+                if (!sameAxis)
+                {
+                    var fi = doc.Create.NewElbowFitting(a, b);
+                    if (fi != null) { kind = 1; return true; }
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TryInsertFitting: {ex.Message}");
+            }
+            return false;
+        }
+
+        private static bool SameSize(Connector a, Connector b)
+        {
+            try
+            {
+                // Connector.Radius is set on round connectors;
+                // Connector.Width / Height on rectangular. Use the larger
+                // dimension when one is rect and the other round (rare).
+                double sa = a.Shape == ConnectorProfileType.Round ? a.Radius * 2 : Math.Max(a.Width, a.Height);
+                double sb = b.Shape == ConnectorProfileType.Round ? b.Radius * 2 : Math.Max(b.Width, b.Height);
+                return Math.Abs(sa - sb) < 1e-3;
+            }
+            catch { return true; }
         }
 
         /// <summary>

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -34,6 +34,57 @@ namespace StingTools.Core.Placement
         // Phase 139.2 G — additional fields surfaced from subsystems.
         public List<XYZ> NogginRequiredPoints { get; } = new List<XYZ>();
         public int       TileSnapAdjustments  { get; set; }
+
+        // Phase 139.27 (I-03) — per-rule diagnostics. The Centre's result
+        // panel now shows a row per rule answering: did it fire? how many
+        // candidates? how many were rejected and why? Without this users
+        // who tick "Place Electrical Fixtures" and get zero placements
+        // can't tell whether the rule was filtered out by a room name,
+        // rejected on score, or simply had no matching family symbol.
+        public Dictionary<string, RuleDiagnostic> Diagnostics { get; }
+            = new Dictionary<string, RuleDiagnostic>(StringComparer.OrdinalIgnoreCase);
+
+        internal RuleDiagnostic Diag(string mergeKey)
+        {
+            if (string.IsNullOrEmpty(mergeKey)) return null;
+            if (!Diagnostics.TryGetValue(mergeKey, out var d))
+            {
+                d = new RuleDiagnostic { MergeKey = mergeKey };
+                Diagnostics[mergeKey] = d;
+            }
+            return d;
+        }
+    }
+
+    /// <summary>
+    /// Phase 139.27 (I-03) — one row of per-rule placement diagnostics.
+    /// Filled by FixturePlacementEngine + ProcessRoomRule, surfaced by
+    /// PlaceFixturesCommand.ShowResult.
+    /// </summary>
+    public class RuleDiagnostic
+    {
+        public string MergeKey { get; set; } = "";
+        public int RoomsConsidered { get; set; }
+        public int RoomsFilteredByName { get; set; }
+        public int RoomsFilteredByExclude { get; set; }
+        public int RoomsBlockedByConflict { get; set; }
+        public int RoomsBlockedByDependsOn { get; set; }
+        public int CandidatesGenerated { get; set; }
+        public int CandidatesRejectedDedup { get; set; }
+        public int CandidatesPlaced { get; set; }
+        public int SkippedNoSymbol { get; set; }
+        public int SkippedHostPreflight { get; set; }
+        public int ManufacturerMisses { get; set; }
+        public string FirstSkipReason { get; set; } = "";
+
+        public string OneLineSummary()
+        {
+            return $"{MergeKey}: rooms={RoomsConsidered}/-{RoomsFilteredByName}/-{RoomsFilteredByExclude} " +
+                   $"cand={CandidatesGenerated} placed={CandidatesPlaced} " +
+                   $"skip(host={SkippedHostPreflight}, sym={SkippedNoSymbol}, dedup={CandidatesRejectedDedup}, " +
+                   $"conflict={RoomsBlockedByConflict}, dep={RoomsBlockedByDependsOn}, mfr={ManufacturerMisses})" +
+                   (string.IsNullOrEmpty(FirstSkipReason) ? "" : $" • first: {FirstSkipReason}");
+        }
     }
 
     /// <summary>
@@ -126,11 +177,43 @@ namespace StingTools.Core.Placement
                 }
             }
 
+            // Phase 139.27 (M-05) — surface validation warnings up front.
+            // PlacementRuleLoader.LastValidationWarnings is populated by
+            // every Load/MergeRules call; without this loop they only
+            // landed in the .log file.
+            try
+            {
+                var vw = PlacementRuleLoader.LastValidationWarnings;
+                if (vw != null)
+                    foreach (var w in vw)
+                        if (!string.IsNullOrEmpty(w)) result.Warnings.Add(w);
+            }
+            catch { }
+
+            // Phase 139.27 (N-05) — accessibility / mounting-height validation
+            // against STING_HEIGHT_STANDARDS.json. Silent until 139.27.
+            try
+            {
+                var hsw = HeightStandardsTable.ValidateRulesAgainstStandards(rules);
+                if (hsw != null)
+                    foreach (var w in hsw)
+                        if (!string.IsNullOrEmpty(w)) result.Warnings.Add(w);
+            }
+            catch (Exception hex) { StingLog.Warn($"HeightStandards validation: {hex.Message}"); }
+
             if (rules.Count == 0)
             {
                 result.Warnings.Add("No placement rules found. Ship STING_PLACEMENT_RULES.json or provide a project override.");
                 return result;
             }
+
+            // Phase 139.27 (C-03) — surface a one-shot warning at start
+            // of run when the user enabled "Tag every placement" but
+            // the reflection target is missing. RunFor() warns once per
+            // session via StingLog; mirroring it into result.Warnings
+            // means the run report shows it too.
+            if (PostPlacementHooks.RunDataTagPipeline && PostPlacementHooks.TagPipelineMissing)
+                result.Warnings.Add("Post-placement: 'Tag every placement' is on but TagPipelineHelper.RunFullPipeline could not be resolved by reflection — placed instances will NOT be tagged this session.");
 
             var rooms = CollectRooms(doc, roomIds, result);
             result.RoomsVisited = rooms.Count;
@@ -280,13 +363,24 @@ namespace StingTools.Core.Placement
                     string roomName = SafeRoomName(room);
                     foreach (var rule in ordered)
                     {
+                        var diag = result.Diag(rule.MergeKey);
+                        if (diag != null) diag.RoomsConsidered++;
+
                         // Phase 139.5 Q21 — fast filter using pre-compiled regex
                         // before paying the cost of scorer.Score / RoomMatchesScope
                         // (which reads parameters, level, phase, workset).
                         if (roomFilterRx.TryGetValue(rule.MergeKey, out var rfx)
-                            && !rfx.IsMatch(roomName ?? "")) continue;
+                            && !rfx.IsMatch(roomName ?? ""))
+                        {
+                            if (diag != null) diag.RoomsFilteredByName++;
+                            continue;
+                        }
                         if (excludeFilterRx.TryGetValue(rule.MergeKey, out var efx)
-                            && efx.IsMatch(roomName ?? "")) continue;
+                            && efx.IsMatch(roomName ?? ""))
+                        {
+                            if (diag != null) diag.RoomsFilteredByExclude++;
+                            continue;
+                        }
 
                         try
                         {
@@ -294,12 +388,14 @@ namespace StingTools.Core.Placement
                             if (RuleHasConflict(rule, roomState))
                             {
                                 result.Warnings.Add($"Room {room.Id} / {rule.MergeKey}: skipped — ConflictsWith already fired.");
+                                if (diag != null) diag.RoomsBlockedByConflict++;
                                 continue;
                             }
                             // PC-13 — DependsOn: skip if predecessor produced no placements yet.
                             if (!string.IsNullOrEmpty(rule.DependsOn) && !roomState.PlacedByRule.ContainsKey(rule.DependsOn))
                             {
                                 result.Warnings.Add($"Room {room.Id} / {rule.MergeKey}: skipped — DependsOn '{rule.DependsOn}' has no placement in this room.");
+                                if (diag != null) diag.RoomsBlockedByDependsOn++;
                                 continue;
                             }
 
@@ -356,6 +452,20 @@ namespace StingTools.Core.Placement
                 {
                     try { TwoPhaseBoxPlacer.PlaceSecondFixDevices(doc, roomIds, ordered, firstFixIndex, result); }
                     catch (Exception ex) { result.Warnings.Add($"Two-phase second-fix: {ex.Message}"); }
+                }
+
+                // Phase 139.27 (M-02 partial) — stamp STING_NOGGIN_REQUIRED on
+                // every placed instance whose XY matches a NogginRequiredPoint
+                // from the scorer's lighting-grid cache. Pre-139.27 these
+                // points were computed but discarded; the export command
+                // (NogginRequirementExportCommand) had no parameter to read.
+                if (!dryRun)
+                {
+                    try
+                    {
+                        StampNogginRequirementsFromGrid(doc, scorer, result);
+                    }
+                    catch (Exception nx) { result.Warnings.Add($"Noggin stamp: {nx.Message}"); }
                 }
 
                 if (!dryRun)
@@ -513,6 +623,8 @@ namespace StingTools.Core.Placement
                 candidates = scorer.Score(room, rule, placedPoints, alreadyInRoom);
                 result.CandidatesEvaluated += candidates.Count;
             }
+            var diagRoom = result.Diag(rule.MergeKey);
+            if (diagRoom != null) diagRoom.CandidatesGenerated += candidates.Count;
             if (candidates.Count == 0) return;
 
             // PC-12 — derive the count for Density / Linear rules from the room's
@@ -528,6 +640,7 @@ namespace StingTools.Core.Placement
                 {
                     result.CountsByRule[rule.MergeKey] = result.CountsByRule.TryGetValue(rule.MergeKey, out var n) ? n + 1 : 1;
                     result.CountsByRoom[roomKey] = result.CountsByRoom.TryGetValue(roomKey, out var m) ? m + 1 : 1;
+                    if (diagRoom != null) diagRoom.CandidatesPlaced++;
                     if (state != null)
                     {
                         if (!state.PlacedByRule.TryGetValue(rule.MergeKey, out var lst))
@@ -539,11 +652,50 @@ namespace StingTools.Core.Placement
                         state.LastPointByRule[rule.MergeKey] = c.Position;
                     }
                 }
+
+                // Phase 139.27 (I-01) — dry-run preview of post-placement
+                // hooks. The hooks themselves cannot run in dry-run (no
+                // FamilyInstance to operate on), but the user needs to know
+                // BEFORE they commit whether tagging / COBie seed / MEP
+                // join are configured and resolvable. Surfaced only once
+                // per rule per session, gated by toggles.
+                if (PostPlacementHooks.RunDataTagPipeline && PostPlacementHooks.TagPipelineMissing)
+                {
+                    string warnKey = $"DryRun:{rule.MergeKey}:tagging-missing";
+                    if (!result.Warnings.Any(w => w.Contains(warnKey)))
+                        result.Warnings.Add($"{warnKey} — would-be-tagged in live run, but TagPipelineHelper not resolvable; tagging will silently no-op.");
+                }
                 return;
             }
 
             FamilySymbol symbol = ResolveSymbol(doc, rule.CategoryFilter, rule, perCategorySymbol, result);
-            if (symbol == null) return;
+            if (symbol == null)
+            {
+                if (diagRoom != null)
+                {
+                    diagRoom.SkippedNoSymbol++;
+                    if (string.IsNullOrEmpty(diagRoom.FirstSkipReason))
+                        diagRoom.FirstSkipReason = $"No FamilySymbol for category '{rule.CategoryFilter}'";
+                }
+                return;
+            }
+
+            // Phase 139.27 (M-07) — manufacturer-miss penalty surfaced as a
+            // diagnostic count. PlacementScorer's catalogue scoring is the
+            // proper home for the 0.5 penalty (see PlacementScorer.cs); here
+            // we just record that a rule referenced a catalogue entry the
+            // registry didn't resolve. Surfaced in the result panel so users
+            // know the placement landed without manufacturer-side validation.
+            try
+            {
+                if (!string.IsNullOrEmpty(rule.CatalogueRef) || !string.IsNullOrEmpty(rule.ManufacturerCode))
+                {
+                    bool resolved = false;
+                    try { resolved = ManufacturerCatalogueRegistry.GetForRule(rule) != null; } catch { }
+                    if (!resolved && diagRoom != null) diagRoom.ManufacturerMisses++;
+                }
+            }
+            catch { }
 
             // Phase 139.18 — warn once per (rule, family) when a wall- or
             // ceiling-anchored rule resolves to an un-hosted family. The
@@ -620,6 +772,7 @@ namespace StingTools.Core.Placement
                 if (tooClose)
                 {
                     result.SkippedCount++;
+                    if (diagRoom != null) diagRoom.CandidatesRejectedDedup++;
                     continue;
                 }
                 try
@@ -636,6 +789,12 @@ namespace StingTools.Core.Placement
                     if (pf.Skipped || fi == null)
                     {
                         result.SkippedCount++;
+                        if (diagRoom != null)
+                        {
+                            diagRoom.SkippedHostPreflight++;
+                            if (string.IsNullOrEmpty(diagRoom.FirstSkipReason))
+                                diagRoom.FirstSkipReason = pf.Reason ?? "host preflight skipped";
+                        }
                         if (!string.IsNullOrEmpty(pf.Reason))
                             result.Warnings.Add(pf.Reason);
                         continue;
@@ -667,6 +826,7 @@ namespace StingTools.Core.Placement
                     result.PlacedIds.Add(fi.Id);
                     result.CountsByRule[rule.MergeKey] = result.CountsByRule.TryGetValue(rule.MergeKey, out var n) ? n + 1 : 1;
                     result.CountsByRoom[roomKey] = result.CountsByRoom.TryGetValue(roomKey, out var m) ? m + 1 : 1;
+                    if (diagRoom != null) diagRoom.CandidatesPlaced++;
                     placedPoints.Add(c.Position);
                     existingNearby.Add(c.Position); // Phase 139.25 — live dedup
 
@@ -1331,14 +1491,19 @@ namespace StingTools.Core.Placement
         // Phase 139.4 — resolve a Document.Settings.Categories entry to its
         // BuiltInCategory enum so FilteredElementCollector.OfCategory can
         // pre-filter family symbols. Cached per document on first hit.
-        private static readonly Dictionary<int, Dictionary<string, BuiltInCategory>> _bicByName
-            = new Dictionary<int, Dictionary<string, BuiltInCategory>>();
+        // Phase 139.27 (N-03) — key by PathName|Title not GetHashCode(),
+        // same hash-collision concern as PlacementHostPreflight.ResolveView3D.
+        private static readonly Dictionary<string, Dictionary<string, BuiltInCategory>> _bicByName
+            = new Dictionary<string, Dictionary<string, BuiltInCategory>>(StringComparer.Ordinal);
         private static readonly object _bicByNameLock = new object();
 
         private static BuiltInCategory ResolveBuiltInCategoryByName(Document doc, string categoryName)
         {
             if (doc == null || string.IsNullOrEmpty(categoryName)) return BuiltInCategory.INVALID;
-            int key = doc.GetHashCode();
+            string path = "", title = "";
+            try { path = doc.PathName ?? ""; } catch { }
+            try { title = doc.Title ?? ""; } catch { }
+            string key = path + "|" + title;
             Dictionary<string, BuiltInCategory> map;
             lock (_bicByNameLock)
             {
@@ -1364,6 +1529,80 @@ namespace StingTools.Core.Placement
                 }
             }
             return map.TryGetValue(categoryName, out var hit) ? hit : BuiltInCategory.INVALID;
+        }
+
+        /// <summary>
+        /// Phase 139.27 (M-02 partial) — flow noggin-required points from
+        /// the lighting-grid cache onto placed instances, so structural
+        /// coordination can read them via NogginRequirementExportCommand.
+        ///
+        /// Match radius: 200mm XY. The scorer's grid points are tile-snapped,
+        /// so a placed instance shouldn't be more than half a tile (300mm)
+        /// from its source point — 200mm is a safety buffer.
+        /// </summary>
+        private static void StampNogginRequirementsFromGrid(
+            Document doc, PlacementScorer scorer, PlacementResult result)
+        {
+            if (doc == null || scorer == null || result == null) return;
+            var grids = scorer.GridResults;
+            if (grids == null || grids.Count == 0) return;
+
+            const double matchRadiusFt = 200.0 / 304.8;
+            double matchSq = matchRadiusFt * matchRadiusFt;
+            int stamped = 0;
+
+            // Collect every noggin point across all (room, rule) pairs.
+            var noggins = new List<XYZ>();
+            foreach (var kv in grids)
+            {
+                if (kv.Value?.NogginRequiredPoints == null) continue;
+                foreach (var p in kv.Value.NogginRequiredPoints)
+                {
+                    if (p != null) noggins.Add(p);
+                    result.NogginRequiredPoints.Add(p);
+                }
+            }
+            if (noggins.Count == 0) return;
+
+            foreach (var id in result.PlacedIds)
+            {
+                FamilyInstance fi = null;
+                try { fi = doc.GetElement(id) as FamilyInstance; } catch { }
+                if (fi == null) continue;
+                XYZ p = (fi.Location as LocationPoint)?.Point;
+                if (p == null) continue;
+
+                bool nearNoggin = false;
+                foreach (var n in noggins)
+                {
+                    double dx = n.X - p.X, dy = n.Y - p.Y;
+                    if (dx * dx + dy * dy <= matchSq) { nearNoggin = true; break; }
+                }
+                if (!nearNoggin) continue;
+
+                try
+                {
+                    var pNog = fi.LookupParameter(ParamRegistry.NOGGIN_REQUIRED);
+                    if (pNog == null || pNog.IsReadOnly) continue;
+                    if (pNog.StorageType == StorageType.Integer && pNog.AsInteger() != 1)
+                    {
+                        pNog.Set(1);
+                        stamped++;
+                    }
+                    else if (pNog.StorageType == StorageType.Double && Math.Abs(pNog.AsDouble() - 1) > 1e-6)
+                    {
+                        pNog.Set(1.0);
+                        stamped++;
+                    }
+                }
+                catch (Exception ex) { StingLog.Warn($"StampNogginRequirements {id.Value}: {ex.Message}"); }
+            }
+
+            if (stamped > 0)
+            {
+                result.Warnings.Add($"Stamped STING_NOGGIN_REQUIRED on {stamped} placed fixture(s) — run Placement_NogginExport to dump the structural fixing schedule.");
+                StingLog.Info($"FixturePlacementEngine: stamped STING_NOGGIN_REQUIRED on {stamped} fixture(s).");
+            }
         }
     }
 }

--- a/StingTools/Core/Placement/HeightStandardsTable.cs
+++ b/StingTools/Core/Placement/HeightStandardsTable.cs
@@ -53,6 +53,38 @@ namespace StingTools.Core.Placement
             lock (_lock) { _cache = null; }
         }
 
+        /// <summary>
+        /// Phase 139.27 (N-05) — light validation pass over a rule library.
+        /// For every rule whose <c>HeightStandard</c> field references an
+        /// entry in this table, check that <c>MountingHeightMm</c> falls
+        /// inside MinMm..MaxMm. Returns a list of human-readable warnings;
+        /// callers (engine pre-flight, Placement Centre's audit button)
+        /// surface them in the result panel. Pre-139.27 the table existed
+        /// but no caller consulted it, so accessibility-non-compliant
+        /// rules shipped silently.
+        /// </summary>
+        public static List<string> ValidateRulesAgainstStandards(IEnumerable<PlacementRule> rules)
+        {
+            var warnings = new List<string>();
+            if (rules == null) return warnings;
+            foreach (var r in rules)
+            {
+                if (r == null || string.IsNullOrEmpty(r.HeightStandard)) continue;
+                var entry = Get(r.HeightStandard);
+                if (entry == null)
+                {
+                    warnings.Add($"HeightStandards: rule '{r.MergeKey}' references unknown HeightStandard '{r.HeightStandard}' — add it to STING_HEIGHT_STANDARDS.json or clear the rule field.");
+                    continue;
+                }
+                if (r.MountingHeightMm <= 0) continue; // rule defers to family-side default
+                if (entry.MinMm > 0 && r.MountingHeightMm < entry.MinMm)
+                    warnings.Add($"HeightStandards: rule '{r.MergeKey}' MountingHeightMm={r.MountingHeightMm:F0}mm is BELOW {r.HeightStandard} minimum ({entry.MinMm:F0}mm, {entry.Standard}).");
+                if (entry.MaxMm > 0 && r.MountingHeightMm > entry.MaxMm)
+                    warnings.Add($"HeightStandards: rule '{r.MergeKey}' MountingHeightMm={r.MountingHeightMm:F0}mm is ABOVE {r.HeightStandard} maximum ({entry.MaxMm:F0}mm, {entry.Standard}).");
+            }
+            return warnings;
+        }
+
         private static void EnsureLoaded()
         {
             lock (_lock)

--- a/StingTools/Core/Placement/InWallChaseRouter.cs
+++ b/StingTools/Core/Placement/InWallChaseRouter.cs
@@ -230,6 +230,21 @@ namespace StingTools.Core.Placement
                         }
                     }
                 }
+
+                // Phase 139.28 — slope check for chased gravity drainage.
+                // BS EN 12056-2 §6 minimum 1:80 (1.25 %) for branches up
+                // to 1.5 m, 1:40 (2.5 %) for longer runs / mains.
+                if (rule.MinSlopePercent > 0 && result.CreatedSegments.Count > 0)
+                {
+                    try
+                    {
+                        var slope = StingTools.Core.Calc.SlopeValidator.CheckSegments(
+                            _doc, result.CreatedSegments, rule.MinSlopePercent, rule.RuleId);
+                        foreach (var w in slope.Warnings)
+                            if (!result.Warnings.Contains(w)) result.Warnings.Add(w);
+                    }
+                    catch (Exception slx) { result.Warnings.Add($"InWallChaseRouter slope check: {slx.Message}"); }
+                }
             }
             catch (Exception ex)
             {
@@ -320,10 +335,42 @@ namespace StingTools.Core.Placement
                 if (entry != null && entry.BoxDepthMm > 0) pipeOdMm = entry.BoxDepthMm;
             }
             catch { }
-            if (pipeOdMm == 0) pipeOdMm = rule.BoxDepthMm > 0 ? rule.BoxDepthMm : 22.0; // 22 mm = standard 15 mm copper OD with insulation
-            double insulationMm = rule.ObstructionClearanceMm > 0 ? rule.ObstructionClearanceMm : 10.0;
+            if (pipeOdMm == 0)
+            {
+                // Phase 139.28 — prefer rule.NominalDiameterMm when set
+                // so the rule controls the chase budget rather than the
+                // manufacturer envelope. Falls through to BoxDepthMm and
+                // then to a 22mm default (15mm copper OD + insulation).
+                if (rule.NominalDiameterMm > 0) pipeOdMm = rule.NominalDiameterMm;
+                else if (rule.BoxDepthMm > 0)   pipeOdMm = rule.BoxDepthMm;
+                else                             pipeOdMm = 22.0;
+            }
+            // Phase 139.28 — InsulationThicknessMm is the new dedicated
+            // field; ObstructionClearanceMm survives as a fallback for
+            // older rule packs that overloaded it.
+            double insulationMm = rule.InsulationThicknessMm > 0 ? rule.InsulationThicknessMm
+                                : rule.ObstructionClearanceMm > 0 ? rule.ObstructionClearanceMm
+                                : 10.0;
+
+            // Phase 139.28 — Eurocode 2 / UK NA concrete cover.
+            // Applies only when MountingContext=CHASED. The cover sits
+            // BETWEEN the structural-core face and the pipe outer
+            // surface, so the chase budget on the FINISH side must be
+            // (cover + pipeOd + 2 × insulation + 5mm placing clearance).
             double clearanceMm  = 5.0;
-            double requiredMm   = pipeOdMm + 2 * insulationMm + clearanceMm;
+            double coverMm = 0.0;
+            if (string.Equals(rule.MountingContext, "CHASED", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    coverMm = StingTools.Core.Calc.ConcreteCoverTable.GetNominalCoverMm(
+                        rule.ExposureClass,
+                        StingTools.Core.Calc.ConcreteCoverTable.DefaultStructuralClass,
+                        fireResistance: "");
+                }
+                catch (Exception ex) { StingLog.Warn($"ConcreteCoverTable: {ex.Message}"); }
+            }
+            double requiredMm   = pipeOdMm + 2 * insulationMm + clearanceMm + coverMm;
             return (availableMm, requiredMm);
         }
 

--- a/StingTools/Core/Placement/InWallChaseRouter.cs
+++ b/StingTools/Core/Placement/InWallChaseRouter.cs
@@ -81,10 +81,110 @@ namespace StingTools.Core.Placement
         private readonly Document _doc;
         private readonly StructuralAwareness _structural;
 
+        /// <summary>
+        /// Phase 139.29 — rebar centreline cache built lazily on first
+        /// segment validation. Rebuilt once per Route call (per host
+        /// wall). When the project doesn't model reinforcement the list
+        /// stays empty and the rebar-clash check is a no-op.
+        /// </summary>
+        private List<Curve> _rebarCache;
+
         public InWallChaseRouter(Document doc, StructuralAwareness structural)
         {
             _doc = doc;
             _structural = structural ?? new StructuralAwareness(doc);
+        }
+
+        /// <summary>
+        /// Collect Rebar centreline curves whose bounding box overlaps
+        /// the host wall (plus 200 mm pad). Empty when no reinforcement
+        /// is modelled — typical at MEP stage.
+        /// </summary>
+        private void BuildRebarCache(Wall hostWall)
+        {
+            _rebarCache = new List<Curve>();
+            if (hostWall == null) return;
+            try
+            {
+                var bb = hostWall.get_BoundingBox(null);
+                if (bb == null) return;
+                const double padFt = 200.0 / 304.8;
+                var outline = new Outline(
+                    new XYZ(bb.Min.X - padFt, bb.Min.Y - padFt, bb.Min.Z - padFt),
+                    new XYZ(bb.Max.X + padFt, bb.Max.Y + padFt, bb.Max.Z + padFt));
+                var bbf = new BoundingBoxIntersectsFilter(outline);
+
+                // OST_Rebar covers structural rebar; OST_RebarShape would
+                // be the type-only filter, not what we want.
+                var rebarCol = new FilteredElementCollector(_doc)
+                    .OfCategory(BuiltInCategory.OST_Rebar)
+                    .WhereElementIsNotElementType()
+                    .WherePasses(bbf);
+
+                foreach (var el in rebarCol)
+                {
+                    try
+                    {
+                        // Rebar exposes centreline curves via the API
+                        // method GetCenterlineCurves(false, false, false,
+                        // MultiplanarOption.IncludeOnlyPlanarCurves, 0).
+                        // Some rebar variants throw — catch per element.
+                        var rebar = el as Autodesk.Revit.DB.Structure.Rebar;
+                        if (rebar == null) continue;
+                        var curves = rebar.GetCenterlineCurves(
+                            adjustForSelfIntersection: false,
+                            suppressHooks: false,
+                            suppressBendRadius: false,
+                            multiplanarOption: Autodesk.Revit.DB.Structure.MultiplanarOption.IncludeOnlyPlanarCurves,
+                            barPositionIndex: 0);
+                        if (curves == null) continue;
+                        foreach (var c in curves) if (c != null) _rebarCache.Add(c);
+                    }
+                    catch (Exception ex) { StingLog.Warn($"BuildRebarCache rebar {el?.Id?.Value}: {ex.Message}"); }
+                }
+                if (_rebarCache.Count > 0)
+                    StingLog.Info($"InWallChaseRouter: rebar clash check active — {_rebarCache.Count} rebar curve(s) loaded.");
+            }
+            catch (Exception ex) { StingLog.Warn($"BuildRebarCache: {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// Cheap minimum-distance estimate between line segment a→b and
+        /// an arbitrary curve. Samples the curve at 8 points and returns
+        /// the closest. Good enough for the clash check; not perfect for
+        /// pathological curve shapes.
+        /// </summary>
+        private static double MinSegmentToCurveDistanceFt(XYZ a, XYZ b, Curve curve)
+        {
+            if (a == null || b == null || curve == null) return double.MaxValue;
+            try
+            {
+                double best = double.MaxValue;
+                int samples = 8;
+                for (int i = 0; i <= samples; i++)
+                {
+                    double t = (double)i / samples;
+                    XYZ p;
+                    try { p = curve.Evaluate(t, true); }
+                    catch { continue; }
+                    if (p == null) continue;
+                    double d = DistancePointToSegmentFt(p, a, b);
+                    if (d < best) best = d;
+                }
+                return best;
+            }
+            catch { return double.MaxValue; }
+        }
+
+        private static double DistancePointToSegmentFt(XYZ p, XYZ a, XYZ b)
+        {
+            var ab = b - a;
+            double abLenSq = ab.DotProduct(ab);
+            if (abLenSq < 1e-9) return p.DistanceTo(a);
+            double t = (p - a).DotProduct(ab) / abLenSq;
+            if (t < 0) t = 0; else if (t > 1) t = 1;
+            var proj = a + ab.Multiply(t);
+            return p.DistanceTo(proj);
         }
 
         /// <summary>
@@ -160,6 +260,37 @@ namespace StingTools.Core.Placement
                         result.Warnings.Add(
                             $"InWallChaseRouter: segment {i} crosses load-bearing junction — split run or relocate.");
                         continue;
+                    }
+
+                    // Phase 139.29 — rebar clash check. Only fires when
+                    // reinforcement is actually modelled (typically not at
+                    // MEP stage); silent otherwise. Pipe must clear any
+                    // rebar centreline by at least cover + dia/2 per
+                    // Eurocode 2 §4.4.1.2(2).
+                    if (_rebarCache == null) BuildRebarCache(hostWall);
+                    if (_rebarCache.Count > 0)
+                    {
+                        double pipeOdMm = (rule.NominalDiameterMm > 0 ? rule.NominalDiameterMm
+                                          : rule.BoxDepthMm > 0 ? rule.BoxDepthMm : 22.0);
+                        double coverMm = string.Equals(rule.MountingContext, "CHASED", StringComparison.OrdinalIgnoreCase)
+                            ? StingTools.Core.Calc.ConcreteCoverTable.GetNominalCoverMm(rule.ExposureClass)
+                            : 25.0;
+                        double minClearFt = (coverMm + pipeOdMm * 0.5) / 304.8;
+                        bool rebarClash = false;
+                        foreach (var rebarCurve in _rebarCache)
+                        {
+                            if (rebarCurve == null) continue;
+                            double dist = MinSegmentToCurveDistanceFt(a, b, rebarCurve);
+                            if (dist < minClearFt) { rebarClash = true; break; }
+                        }
+                        if (rebarClash)
+                        {
+                            result.RejectedSegments++;
+                            result.Warnings.Add(
+                                $"InWallChaseRouter: segment {i} clashes with reinforcement (Eurocode 2 cover " +
+                                $"{coverMm:F0}mm + dia/2 from rebar centreline). Adjust mounting height or relocate chase.");
+                            continue;
+                        }
                     }
 
                     // Wall openings (doors, windows): permit the segment to

--- a/StingTools/Core/Placement/LightingGridCalculator.cs
+++ b/StingTools/Core/Placement/LightingGridCalculator.cs
@@ -272,7 +272,11 @@ namespace StingTools.Core.Placement
         {
             try
             {
-                double tileXMm = rule.TileGridSpacingXMm > 0 ? rule.TileGridSpacingXMm : 600.0;
+                // Phase 139.27 (N-06) — default 1200×600 to match CeilingGridSnap
+                // (UK ceiling tile baseline). When the rule pack ships explicit
+                // 600 / 600 (US troffer tiles), TileGridSpacing*Mm carry
+                // the override.
+                double tileXMm = rule.TileGridSpacingXMm > 0 ? rule.TileGridSpacingXMm : 1200.0;
                 double tileYMm = rule.TileGridSpacingYMm > 0 ? rule.TileGridSpacingYMm : 600.0;
 
                 Document doc = room?.Document;
@@ -325,18 +329,71 @@ namespace StingTools.Core.Placement
 
                 double stepX = tileXMm * MmToFt;
                 double stepY = tileYMm * MmToFt;
+                // Phase 139.27 (C-05) — guard against pathological rule
+                // configs (TileGridSpacingXMm / Y < 1mm). The fallback at
+                // the top of this method gates ≤ 0, but a 0.5mm rule slips
+                // through and Math.Round((p.X - origin) / 0.0016) returns
+                // ±Infinity. Re-floor the step to 100mm here so the grid
+                // is at least usable.
+                if (stepX < 100.0 * MmToFt) stepX = 600.0 * MmToFt;
+                if (stepY < 100.0 * MmToFt) stepY = 600.0 * MmToFt;
+
+                // Phase 139.27 (C-05) — snap can push a point outside the
+                // room polygon (corner case: corner tile, tile origin from
+                // an adjacent ceiling). Track points that drift outside
+                // the room AABB and revert them; if reverting still leaves
+                // them out of room, drop them entirely. Without this,
+                // downstream RoomMatchesScope flips the rule's room hit
+                // off post-snap and the engine reports "31 placed" against
+                // a zero-fixture room.
+                BoundingBoxXYZ roomBb = null;
+                try { roomBb = room.get_BoundingBox(null); } catch { }
 
                 int adjustments = 0;
+                int reverted = 0;
+                int dropped  = 0;
+                var snappedList = new List<XYZ>(r.Points.Count);
                 for (int i = 0; i < r.Points.Count; i++)
                 {
                     var p = r.Points[i];
                     double snappedX = tileOrigin.X + Math.Round((p.X - tileOrigin.X) / stepX) * stepX + stepX * 0.5;
                     double snappedY = tileOrigin.Y + Math.Round((p.Y - tileOrigin.Y) / stepY) * stepY + stepY * 0.5;
                     var snapped = new XYZ(snappedX, snappedY, p.Z);
-                    if (snapped.DistanceTo(p) > 50.0 * MmToFt) adjustments++;
-                    r.Points[i] = snapped;
+
+                    bool snappedInBbox = roomBb == null
+                        || (snapped.X >= roomBb.Min.X && snapped.X <= roomBb.Max.X
+                         && snapped.Y >= roomBb.Min.Y && snapped.Y <= roomBb.Max.Y);
+                    bool snappedInRoom = snappedInBbox;
+                    if (snappedInBbox)
+                    {
+                        try { snappedInRoom = room.IsPointInRoom(snapped); }
+                        catch { snappedInRoom = true; }
+                    }
+
+                    if (snappedInRoom)
+                    {
+                        if (snapped.DistanceTo(p) > 50.0 * MmToFt) adjustments++;
+                        snappedList.Add(snapped);
+                    }
+                    else
+                    {
+                        // Try the original (un-snapped) point — it was
+                        // generated from the room's own AABB so it should
+                        // still be inside the polygon.
+                        bool originalInRoom = false;
+                        try { originalInRoom = room.IsPointInRoom(p); } catch { }
+                        if (originalInRoom) { snappedList.Add(p); reverted++; }
+                        else                { dropped++; }
+                    }
                 }
+                r.Points.Clear();
+                r.Points.AddRange(snappedList);
+                r.FixturesPlaced = r.Points.Count;
                 r.TileSnapAdjustments = adjustments;
+                if (reverted > 0)
+                    r.Warnings.Add($"Tile snap: {reverted} luminaire(s) reverted to grid position because the snapped tile centre fell outside the room boundary.");
+                if (dropped > 0)
+                    r.Warnings.Add($"Tile snap: {dropped} luminaire(s) dropped — neither the snapped nor the original position lay inside the room.");
                 if (nameSuggestsTiles)
                     StingLog.Info($"LightingGridCalculator: tile snap applied ({adjustments} adjustments) to room {room.Id}.");
             }

--- a/StingTools/Core/Placement/LightingGridCalculator.cs
+++ b/StingTools/Core/Placement/LightingGridCalculator.cs
@@ -82,6 +82,18 @@ namespace StingTools.Core.Placement
             LoadLuxTargets();
         }
 
+        /// <summary>
+        /// Phase 139.27 (X-02) — minimum acceptable BS EN 12464-1 / CIBSE LG7
+        /// uniformity ratio (Uo = Emin / Eavg). 0.40 is the published
+        /// minimum for general areas; 0.60 for tasks; 0.70 for fine work
+        /// (drawing offices, healthcare, classrooms). Below this floor
+        /// <see cref="LightingGridResult.Warnings"/> reports the rule as
+        /// non-compliant and the engine surfaces it in the run report.
+        /// Tunable per rule via <c>PlacementRule.MinUniformityRatio</c> when
+        /// set (> 0); otherwise this default applies.
+        /// </summary>
+        public double DefaultMinimumUniformity { get; set; } = 0.40;
+
         public LightingGridResult Compute(Room room) => Compute(room, null);
 
         /// <summary>
@@ -628,8 +640,21 @@ namespace StingTools.Core.Placement
                 if (avgE <= 0) return;
                 double uniformity = minE / avgE;
                 r.ActualUniformityRatio = uniformity;
-                if (uniformity < 0.40)
-                    r.Warnings.Add($"Uniformity Uo={uniformity:F2} below BS EN 12464-1 0.40 minimum for general areas.");
+                // Phase 139.27 (X-02) — escalate to a per-rule threshold when
+                // the rule sets MinUniformityRatio (e.g. 0.70 for healthcare,
+                // 0.60 for offices). Falls back to the calculator's
+                // DefaultMinimumUniformity (0.40 = BS EN 12464-1 floor).
+                double minRatio = (rule != null && rule.MinUniformityRatio > 0)
+                    ? rule.MinUniformityRatio
+                    : DefaultMinimumUniformity;
+                if (uniformity < minRatio)
+                {
+                    string standard = minRatio >= 0.60 ? "CIBSE LG7" : "BS EN 12464-1";
+                    r.Warnings.Add(
+                        $"Uniformity Uo={uniformity:F2} below {minRatio:F2} ({standard}) — " +
+                        $"increase fixture count or reduce spacing. " +
+                        $"Required {r.FixturesRequired}, placed {r.FixturesPlaced} in room area {r.RoomAreaM2:F1}m².");
+                }
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/Placement/LightingGridCalculator.cs
+++ b/StingTools/Core/Placement/LightingGridCalculator.cs
@@ -137,7 +137,7 @@ namespace StingTools.Core.Placement
                 if (rule.StructuralFixingCheck) CheckStructuralFixing(room, r, rule);
                 CheckSprinklerSeparation(room, r);   // Phase 139.3 — BS 5306 ≥600mm
                 EnforceMinSpacing(r, rule);          // Phase 139.6 LX-1 — drop points violating MinSpacingMm
-                ComputeUniformityRatio(room, r);
+                ComputeUniformityRatio(room, r, rule);
             }
 
             return r;
@@ -603,7 +603,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"LightingGridCalculator.EnforceMinSpacing: {ex.Message}"); }
         }
 
-        private void ComputeUniformityRatio(Room room, LightingGridResult r)
+        private void ComputeUniformityRatio(Room room, LightingGridResult r, PlacementRule rule)
         {
             try
             {

--- a/StingTools/Core/Placement/ObstructionIndex.cs
+++ b/StingTools/Core/Placement/ObstructionIndex.cs
@@ -61,6 +61,11 @@ namespace StingTools.Core.Placement
         /// Categories to treat as ceiling obstructions for luminaire
         /// placement. Extendable via the <paramref name="extraCats"/>
         /// parameter on <see cref="BuildForRoom"/>.
+        /// Phase 139.27 (M-01) — added Furniture / Casework / GenericModel
+        /// so a luminaire can't be placed inside the swept-volume of a
+        /// suspended cupboard, kitchen island top, or generic ceiling
+        /// rose. The buffer applied around their AABB is the same
+        /// 350 mm CIBSE Guide B4 default.
         /// </summary>
         public static readonly BuiltInCategory[] DefaultCategories = new[]
         {
@@ -71,6 +76,15 @@ namespace StingTools.Core.Placement
             BuiltInCategory.OST_SpecialityEquipment,
             BuiltInCategory.OST_SecurityDevices,
             BuiltInCategory.OST_CommunicationDevices,
+            BuiltInCategory.OST_Furniture,
+            BuiltInCategory.OST_Casework,
+            BuiltInCategory.OST_GenericModel,
+            // Suspended ducts + pipes — a luminaire can't share Z-space
+            // with a 200 mm extract spine. Z-pad on Outline already
+            // covers the swept volume (3 ft above room max Z).
+            BuiltInCategory.OST_DuctCurves,
+            BuiltInCategory.OST_PipeCurves,
+            BuiltInCategory.OST_CableTray,
         };
 
         /// <summary>

--- a/StingTools/Core/Placement/PlacementFailuresPreprocessor.cs
+++ b/StingTools/Core/Placement/PlacementFailuresPreprocessor.cs
@@ -29,12 +29,40 @@ namespace StingTools.Core.Placement
         // Failure definition Ids that the engine recognises as
         // "predictable side-effect — dismiss". Anything else is left
         // alone for Revit's normal failure UI.
-        private static readonly HashSet<string> SuppressGuids = new HashSet<string>
+        // Phase 139.27 — prefer the public BuiltInFailures GUIDs where the
+        // Revit SDK exposes them; fall through to the string match below
+        // for the (many) failures whose GUIDs aren't public. This makes
+        // the dismiss path locale-independent for the GUID-resolved
+        // failures, even if the description is translated.
+        private static readonly HashSet<string> SuppressGuids = BuildSuppressGuidSet();
+
+        private static HashSet<string> BuildSuppressGuidSet()
         {
-            // Revit reports these as informational warnings — string
-            // matched on the failure message because the BuiltInFailureGuids
-            // are not all publicly exposed in the SDK.
-        };
+            // Resolve via reflection so a Revit version that renamed or
+            // removed a particular field doesn't break the build. Each
+            // GUID landing in the set lets the preprocessor dismiss the
+            // failure even when the description is locale-translated.
+            var s = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+            void TryAdd(string typeName, string fieldName)
+            {
+                try
+                {
+                    var t = System.Type.GetType($"Autodesk.Revit.DB.BuiltInFailures+{typeName}, RevitAPI", false);
+                    if (t == null) return;
+                    var f = t.GetField(fieldName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                    if (f == null) return;
+                    var id = f.GetValue(null) as FailureDefinitionId;
+                    if (id != null) s.Add(id.Guid.ToString());
+                }
+                catch { }
+            }
+            // Conservative seed list — each entry is a confirmed-stable
+            // 2024+ GUID. The string match below covers the rest.
+            TryAdd("GeneralFailures",  "CannotMoveToOriginalPosition");
+            TryAdd("OverlapFailures",  "WallsOverlap");
+            TryAdd("OverlapFailures",  "DuplicateInstances");
+            return s;
+        }
 
         public FailureProcessingResult PreprocessFailures(FailuresAccessor accessor)
         {
@@ -42,9 +70,12 @@ namespace StingTools.Core.Placement
             foreach (var f in failures)
             {
                 string desc = "";
+                string guid = "";
                 try { desc = f.GetDescriptionText() ?? ""; } catch { }
-                bool suppress =
-                    desc.IndexOf("Can't rotate element", System.StringComparison.OrdinalIgnoreCase) >= 0
+                try { guid = f.GetFailureDefinitionId()?.Guid.ToString() ?? ""; } catch { }
+                bool suppressByGuid = !string.IsNullOrEmpty(guid) && SuppressGuids.Contains(guid);
+                bool suppress = suppressByGuid
+                 || desc.IndexOf("Can't rotate element", System.StringComparison.OrdinalIgnoreCase) >= 0
                  || desc.IndexOf("identical instances",  System.StringComparison.OrdinalIgnoreCase) >= 0
                  || desc.IndexOf("does not lie on host face", System.StringComparison.OrdinalIgnoreCase) >= 0
                  || desc.IndexOf("origin does not lie",  System.StringComparison.OrdinalIgnoreCase) >= 0
@@ -69,7 +100,7 @@ namespace StingTools.Core.Placement
                 if (suppress)
                 {
                     accessor.DeleteWarning(f);
-                    StingLog.Info($"PlacementFailuresPreprocessor: suppressed '{desc}'");
+                    StingLog.Info($"PlacementFailuresPreprocessor: suppressed '{desc}' (guidMatch={suppressByGuid}, guid={guid})");
                 }
             }
             return FailureProcessingResult.Continue;

--- a/StingTools/Core/Placement/PlacementHostPreflight.cs
+++ b/StingTools/Core/Placement/PlacementHostPreflight.cs
@@ -50,20 +50,36 @@ namespace StingTools.Core.Placement
         // Phase 139.2 — cache the 3-D view used for soffit raycasts so we
         // don't run a FilteredElementCollector for every PlaceOnCeilingSoffit
         // call. Cleared whenever the active document changes.
+        // Phase 139.27 (N-03) — key by PathName + Title rather than
+        // Document.GetHashCode(). Two .rvts opened in sequence with the
+        // same Document hash code (rare but observed when Revit reopens
+        // a file at the same managed-heap address) would otherwise hand
+        // back a stale View3D from the closed document — calls to a
+        // disposed view crash the raycast path.
         private static View3D _cachedView3D;
-        private static int _cachedView3DDocHash;
+        private static string _cachedView3DKey;
+
+        private static string DocCacheKey(Document doc)
+        {
+            if (doc == null) return "";
+            string path = "";
+            string title = "";
+            try { path = doc.PathName ?? ""; } catch { }
+            try { title = doc.Title  ?? ""; } catch { }
+            return path + "|" + title;
+        }
 
         private static View3D ResolveView3D(Document doc)
         {
             if (doc == null) return null;
-            int docHash = doc.GetHashCode();
-            if (_cachedView3D != null && _cachedView3DDocHash == docHash && _cachedView3D.IsValidObject)
+            string docKey = DocCacheKey(doc);
+            if (_cachedView3D != null && _cachedView3DKey == docKey && _cachedView3D.IsValidObject)
                 return _cachedView3D;
             try
             {
                 _cachedView3D = new FilteredElementCollector(doc).OfClass(typeof(View3D))
                     .Cast<View3D>().FirstOrDefault(v => v != null && !v.IsTemplate);
-                _cachedView3DDocHash = docHash;
+                _cachedView3DKey = docKey;
             }
             catch { _cachedView3D = null; }
             return _cachedView3D;

--- a/StingTools/Core/Placement/PlacementParamReader.cs
+++ b/StingTools/Core/Placement/PlacementParamReader.cs
@@ -90,7 +90,25 @@ namespace StingTools.Core.Placement
             {
                 var p = el?.LookupParameter(name);
                 if (p == null || !p.HasValue) return 0;
-                if (p.StorageType == StorageType.Double) return p.AsDouble() * 304.8;
+                if (p.StorageType == StorageType.Double)
+                {
+                    // Revit's internal length unit is feet, but a non-EN /
+                    // metric-template build may report a different display
+                    // unit. UnitUtils honours the document's actual unit
+                    // system; the * 304.8 hard-coded path could be wrong
+                    // when the family parameter is a non-length Number
+                    // double. Fall back to * 304.8 only if the conversion
+                    // throws (e.g. the parameter is not a length).
+                    try
+                    {
+                        return UnitUtils.ConvertFromInternalUnits(
+                            p.AsDouble(), UnitTypeId.Millimeters);
+                    }
+                    catch
+                    {
+                        return p.AsDouble() * 304.8;
+                    }
+                }
                 if (p.StorageType == StorageType.Integer) return p.AsInteger();
             }
             catch { }

--- a/StingTools/Core/Placement/PlacementRule.cs
+++ b/StingTools/Core/Placement/PlacementRule.cs
@@ -330,6 +330,25 @@ namespace StingTools.Core.Placement
 
         public string HeightStandardRef { get; set; } = "";
 
+        // ── Phase 139.27 (X-02) — Per-rule lighting uniformity gate ─
+
+        /// <summary>
+        /// Minimum acceptable BS EN 12464-1 / CIBSE LG7 uniformity ratio
+        /// (Uo = Emin / Eavg). 0 = use calculator default (0.40 — general).
+        /// 0.60 typical for offices; 0.70 for healthcare / classrooms.
+        /// </summary>
+        public double MinUniformityRatio { get; set; } = 0.0;
+
+        // ── Phase 139.27 (X-04) — Cable-derating advisory ───────────
+
+        /// <summary>
+        /// When > 0, the placement engine emits an advisory warning if
+        /// more than this many same-system cables / conduits land within
+        /// the rule's bundle clearance — BS 7671 Table 4 derating
+        /// (e.g. 0.80× at 4 cables, 0.50× at ≥ 9). 0 = no advisory.
+        /// </summary>
+        public int CableBundleAdvisoryCount { get; set; } = 0;
+
         // ── Methods ─────────────────────────────────────────────────
 
         /// <summary>Deep-copy the rule.</summary>
@@ -432,6 +451,8 @@ namespace StingTools.Core.Placement
                 WetZoneExclude       = this.WetZoneExclude,
                 WetZoneClass         = this.WetZoneClass,
                 HeightStandardRef    = this.HeightStandardRef,
+                MinUniformityRatio        = this.MinUniformityRatio,
+                CableBundleAdvisoryCount  = this.CableBundleAdvisoryCount,
             };
         }
 

--- a/StingTools/Core/Placement/PlacementRule.cs
+++ b/StingTools/Core/Placement/PlacementRule.cs
@@ -349,6 +349,61 @@ namespace StingTools.Core.Placement
         /// </summary>
         public int CableBundleAdvisoryCount { get; set; } = 0;
 
+        // ── Phase 139.28 — Routing strategy (chased / surface / suspended)
+
+        /// <summary>
+        /// Which mounting context applies to this rule's route. Drives
+        /// concrete-cover offsets (CHASED), clip emission (SURFACE), and
+        /// hanger emission (SUSPENDED). Empty = legacy NONE-equivalent;
+        /// the engine falls back to RouteOffsetMm without standards lookup.
+        /// </summary>
+        public string MountingContext { get; set; } = ""; // CHASED | SURFACE | SUSPENDED
+
+        /// <summary>
+        /// Nominal pipe / conduit / duct diameter (DN) in mm. Drives both
+        /// the concrete-cover offset (CHASED) and the support-spacing
+        /// table lookup (SURFACE / SUSPENDED). 0 = read from the created
+        /// MEP curve at runtime.
+        /// </summary>
+        public double NominalDiameterMm { get; set; } = 0.0;
+
+        /// <summary>
+        /// Insulation thickness (mm) added to the routing envelope.
+        /// Penalises support span by ×0.90 in HangerSpacingTable.Query.
+        /// </summary>
+        public double InsulationThicknessMm { get; set; } = 0.0;
+
+        /// <summary>
+        /// Eurocode 2 / UK NA exposure class — XC1 / XC2 / XC3 / XC4 /
+        /// XD1 / XD2 / XS1 / XF1. Empty defaults to XC2 (typical
+        /// interior-wall chase) at <see cref="ConcreteCoverTable.Default"/>.
+        /// Drives the cast-in / cast-against cover for CHASED routing.
+        /// </summary>
+        public string ExposureClass { get; set; } = "";
+
+        /// <summary>
+        /// Minimum allowable slope as a percentage (1.25 = 1:80, 2.5 = 1:40).
+        /// 0 = no slope check (pressurised systems). Triggered by
+        /// SlopeValidator after segment creation.
+        /// </summary>
+        public double MinSlopePercent { get; set; } = 0.0;
+
+        /// <summary>
+        /// Pipe / duct material override — STEEL / COPPER / PLASTIC /
+        /// CAST_IRON / GI_SHEET. Empty = read PLM_PPE_MAT_TXT or
+        /// HVC_DCT_MAT_TXT off the created MEP curve. Drives material-
+        /// specific spacing tables (BS 5572 copper vs steel vs CI).
+        /// </summary>
+        public string Material { get; set; } = "";
+
+        /// <summary>
+        /// When true, the engine auto-emits clip / hanger family
+        /// instances after the route is created (SURFACE / SUSPENDED
+        /// only). Defaults to true so a routing rule without explicit
+        /// configuration still gets standards-compliant supports.
+        /// </summary>
+        public bool EmitSupports { get; set; } = true;
+
         // ── Methods ─────────────────────────────────────────────────
 
         /// <summary>Deep-copy the rule.</summary>
@@ -453,6 +508,13 @@ namespace StingTools.Core.Placement
                 HeightStandardRef    = this.HeightStandardRef,
                 MinUniformityRatio        = this.MinUniformityRatio,
                 CableBundleAdvisoryCount  = this.CableBundleAdvisoryCount,
+                MountingContext           = this.MountingContext,
+                NominalDiameterMm         = this.NominalDiameterMm,
+                InsulationThicknessMm     = this.InsulationThicknessMm,
+                ExposureClass             = this.ExposureClass,
+                MinSlopePercent           = this.MinSlopePercent,
+                Material                  = this.Material,
+                EmitSupports              = this.EmitSupports,
             };
         }
 

--- a/StingTools/Core/Placement/PlacementRuleLoader.cs
+++ b/StingTools/Core/Placement/PlacementRuleLoader.cs
@@ -169,6 +169,14 @@ namespace StingTools.Core.Placement
         }
 
         /// <summary>
+        /// Phase 139.27 (M-05) — last validation result, surfaced to the
+        /// engine and result panel so misconfigured rules don't only show
+        /// up in the .log file (where users never look). Cleared and
+        /// rebuilt by every <see cref="MergeRules"/> call.
+        /// </summary>
+        public static List<string> LastValidationWarnings { get; private set; } = new List<string>();
+
+        /// <summary>
         /// Project overrides win on MergeKey match. Rules with a unique
         /// MergeKey are appended. Priority is NOT used for merge — it is
         /// a scoring tie-breaker at placement time.
@@ -178,14 +186,24 @@ namespace StingTools.Core.Placement
             List<PlacementRule> overrides)
         {
             var result = new Dictionary<string, PlacementRule>(StringComparer.OrdinalIgnoreCase);
+            var warnings = new List<string>();
 
             if (defaults != null)
             {
                 foreach (var rule in defaults)
                 {
                     if (rule == null) continue;
-                    if (result.ContainsKey(rule.MergeKey))
-                        StingLog.Warn($"PlacementRuleLoader: duplicate RuleId/MergeKey '{rule.MergeKey}' in baseline pack '{rule.SourcePack}' — later definition wins.");
+                    // Phase 139.27 (M-04) — track BOTH sources of the
+                    // colliding MergeKey so the warning is actionable.
+                    // Pre-139.27 the warning only named the loser's
+                    // SourcePack; users couldn't tell which pack file to
+                    // edit because the winner is anonymous.
+                    if (result.TryGetValue(rule.MergeKey, out var existing))
+                    {
+                        string msg = $"PlacementRuleLoader: duplicate MergeKey '{rule.MergeKey}' — pack '{rule.SourcePack ?? "?"}' overrides earlier '{existing.SourcePack ?? "?"}'. Truncated RuleIds may collide silently — verify the long form differs.";
+                        warnings.Add(msg);
+                        StingLog.Warn(msg);
+                    }
                     result[rule.MergeKey] = rule.Clone();
                 }
             }
@@ -196,12 +214,16 @@ namespace StingTools.Core.Placement
                 {
                     if (rule == null) continue;
                     // Project override wins on same merge key — that's by design;
-                    // only log when the override is a strict duplicate of another override.
+                    // surface as Info-level so the user can confirm the override
+                    // landed without flooding the warnings list.
+                    if (result.ContainsKey(rule.MergeKey))
+                        StingLog.Info($"PlacementRuleLoader: project override '{rule.MergeKey}' replaces baseline rule.");
                     result[rule.MergeKey] = rule.Clone();
                 }
             }
 
-            ValidateRuleSet(result.Values);
+            ValidateRuleSet(result.Values, warnings);
+            LastValidationWarnings = warnings;
             return new List<PlacementRule>(result.Values);
         }
 
@@ -209,9 +231,11 @@ namespace StingTools.Core.Placement
         /// Phase 139.4 — log warnings for misconfigured rules so they
         /// surface at session start instead of failing silently inside
         /// the engine. Validation never throws — degraded-mode load
-        /// still returns the rules.
+        /// still returns the rules. Phase 139.27 (M-05) — also append
+        /// every validation warning into <paramref name="sink"/> so the
+        /// engine can surface them in <see cref="PlacementResult.Warnings"/>.
         /// </summary>
-        private static void ValidateRuleSet(IEnumerable<PlacementRule> rules)
+        private static void ValidateRuleSet(IEnumerable<PlacementRule> rules, List<string> sink)
         {
             if (rules == null) return;
             foreach (var r in rules)
@@ -224,7 +248,9 @@ namespace StingTools.Core.Placement
                     && r.PerBed <= 0 && r.PerWorkstation <= 0
                     && r.PerPupil <= 0 && r.PerToiletCubicle <= 0)
                 {
-                    StingLog.Warn($"PlacementRuleLoader: rule '{r.MergeKey}' is RuleKind=Density but declares no PerAreaM2/PerOccupant/PerBed/PerWorkstation/PerPupil/PerToiletCubicle rate. Will place at most one fixture per room.");
+                    string msg = $"PlacementRuleLoader: rule '{r.MergeKey}' is RuleKind=Density but declares no PerAreaM2/PerOccupant/PerBed/PerWorkstation/PerPupil/PerToiletCubicle rate. Will place at most one fixture per room.";
+                    sink?.Add(msg);
+                    StingLog.Warn(msg);
                 }
 
                 // Routing rule must declare a segment category.
@@ -232,7 +258,9 @@ namespace StingTools.Core.Placement
                     && !string.Equals(r.RoutingMode, "NONE", StringComparison.OrdinalIgnoreCase)
                     && string.IsNullOrEmpty(r.RouteSegmentCategory))
                 {
-                    StingLog.Warn($"PlacementRuleLoader: rule '{r.MergeKey}' has RoutingMode={r.RoutingMode} but no RouteSegmentCategory — defaulting to PIPE.");
+                    string msg = $"PlacementRuleLoader: rule '{r.MergeKey}' has RoutingMode={r.RoutingMode} but no RouteSegmentCategory — defaulting to PIPE.";
+                    sink?.Add(msg);
+                    StingLog.Warn(msg);
                 }
 
                 // Two-phase + cluster contradiction (#43): cluster placement
@@ -240,7 +268,9 @@ namespace StingTools.Core.Placement
                 // per-rule first-fix boxes — they don't compose.
                 if (r.TwoPhaseEnabled && r.IsClusterMember)
                 {
-                    StingLog.Warn($"PlacementRuleLoader: rule '{r.MergeKey}' has both TwoPhaseEnabled and IsClusterMember — undefined behaviour. Disabling cluster membership for this rule.");
+                    string msg = $"PlacementRuleLoader: rule '{r.MergeKey}' has both TwoPhaseEnabled and IsClusterMember — undefined behaviour. Disabling cluster membership for this rule.";
+                    sink?.Add(msg);
+                    StingLog.Warn(msg);
                     r.IsClusterMember = false;
                 }
 
@@ -248,6 +278,21 @@ namespace StingTools.Core.Placement
                 if (r.RuleKind == PlacementRuleKind.Density && r.MaxPerRoom == 0)
                 {
                     StingLog.Info($"PlacementRuleLoader: rule '{r.MergeKey}' is Density with MaxPerRoom=0 — placement count is bounded only by PerAreaM2/PerOccupant.");
+                }
+
+                // Phase 139.27 (M-05) — flag truncated RuleIds so users
+                // know their rule may collide with another rule whose
+                // long form starts the same. The MergeKey is whatever
+                // PlacementRule.MergeKey returns; if the underlying
+                // RuleId looks truncated (≥ 50 chars and not ending in
+                // a delimiter), warn. This is a heuristic, not a hard
+                // gate.
+                if (!string.IsNullOrEmpty(r.RuleId) && r.RuleId.Length >= 50
+                    && !r.RuleId.EndsWith("-") && !r.RuleId.EndsWith("_"))
+                {
+                    string msg = $"PlacementRuleLoader: rule '{r.MergeKey}' RuleId is {r.RuleId.Length} chars — may have been truncated. Two rules whose long form starts the same will silently collide on MergeKey.";
+                    sink?.Add(msg);
+                    StingLog.Warn(msg);
                 }
             }
         }

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -299,6 +299,17 @@ namespace StingTools.Core.Placement
         private readonly Dictionary<(ElementId, string), LightingGridResult> _gridCache
             = new Dictionary<(ElementId, string), LightingGridResult>();
 
+        /// <summary>
+        /// Phase 139.27 (M-02 partial) — snapshot of every LightingGridResult
+        /// the scorer cached during this run, keyed by (room, rule). The
+        /// engine walks this dictionary after placement to stamp
+        /// STING_NOGGIN_REQUIRED on placed instances whose XY matches a
+        /// NogginRequiredPoint, so NogginRequirementExportCommand can pick
+        /// them up. Without this surface, every noggin point computed by
+        /// LightingGridCalculator.CheckStructuralFixing was discarded.
+        /// </summary>
+        public IReadOnlyDictionary<(ElementId, string), LightingGridResult> GridResults => _gridCache;
+
         private void EmitLightingGridPoints(Room room, PlacementRule rule, XYZ roomPt,
             double offsetXFt, double offsetYFt, double anchorZ, List<XYZ> points)
         {

--- a/StingTools/Core/Placement/PostPlacementHooks.cs
+++ b/StingTools/Core/Placement/PostPlacementHooks.cs
@@ -30,6 +30,31 @@ namespace StingTools.Core.Placement
         /// <summary>Probe MEP connectors and warn when any are unconnected.</summary>
         public static bool AssignMepSystem { get; set; } = false;
 
+        // Phase 139.27 (C-03) — reflection target resolution result, cached
+        // and surfaced once per session. Without this, a renamed / moved
+        // TagPipelineHelper silently skipped tagging on every placed
+        // instance — provenance + ISO-19650 tags were promised by the
+        // Centre's checkbox but never delivered. The first call probes
+        // and remembers; later calls skip the probe and either tag or
+        // skip cheaply.
+        private static System.Reflection.MethodInfo _tagPipelineMethod;
+        private static bool _tagPipelineProbed;
+        private static bool _tagPipelineMissingWarned;
+
+        /// <summary>True once <see cref="RunDataTagPipeline"/> has been
+        /// requested at least once and the reflection target was missing.
+        /// PlaceFixturesCommand surfaces this in the result panel so the
+        /// user knows tagging was silently degraded.</summary>
+        public static bool TagPipelineMissing => _tagPipelineProbed && _tagPipelineMethod == null;
+
+        /// <summary>Reset the cached probe — used by tests / a future hot-reload path.</summary>
+        public static void ResetReflectionCache()
+        {
+            _tagPipelineMethod = null;
+            _tagPipelineProbed = false;
+            _tagPipelineMissingWarned = false;
+        }
+
         /// <summary>
         /// Entry point invoked by the engine. Each toggle is independent.
         /// Failures are swallowed at the call site so a hook can never
@@ -50,12 +75,28 @@ namespace StingTools.Core.Placement
                 // Reflection guard: the tagging pipeline lives in another
                 // assembly module and we don't want a hard dependency
                 // edge between Placement and Core. If TagPipelineHelper
-                // moves or is renamed we just skip silently.
-                var t = Type.GetType("StingTools.Core.TagPipelineHelper, StingTools");
-                if (t == null) return;
-                var m = t.GetMethod("RunFullPipeline", new[] { typeof(Document), typeof(Element) });
-                if (m == null) return;
-                m.Invoke(null, new object[] { fi.Document, fi });
+                // moves or is renamed we surface a one-shot warning so
+                // users notice that "Tag every placement" was silently
+                // a no-op (the historic behaviour swallowed the miss).
+                if (!_tagPipelineProbed)
+                {
+                    _tagPipelineProbed = true;
+                    var t = Type.GetType("StingTools.Core.TagPipelineHelper, StingTools");
+                    _tagPipelineMethod = t?.GetMethod(
+                        "RunFullPipeline", new[] { typeof(Document), typeof(Element) });
+                    if (_tagPipelineMethod == null && !_tagPipelineMissingWarned)
+                    {
+                        _tagPipelineMissingWarned = true;
+                        StingLog.Warn(
+                            "PostPlacementHooks.RunDataTagPipeline is enabled but " +
+                            "StingTools.Core.TagPipelineHelper.RunFullPipeline(Document,Element) " +
+                            "could not be found by reflection — tagging will be skipped on every " +
+                            "placed instance for this session. The class may have been renamed or " +
+                            "moved. Disable the option in the Placement Centre or repair the lookup.");
+                    }
+                }
+                if (_tagPipelineMethod == null) return;
+                _tagPipelineMethod.Invoke(null, new object[] { fi.Document, fi });
             }
             catch (Exception ex) { StingLog.Warn($"PostPlacementHooks.RunTagPipeline {fi.Id}: {ex.Message}"); }
         }

--- a/StingTools/Core/Placement/WallFollowerRouter.cs
+++ b/StingTools/Core/Placement/WallFollowerRouter.cs
@@ -115,6 +115,47 @@ namespace StingTools.Core.Placement
                         TryStampRouteRuleId(newId, rule.RuleId);
                     }
                 }
+
+                // Phase 139.28 — auto-emit physical clip / hanger family
+                // instances at the BS 5572 / BS EN 12056-2 / MSS SP-58
+                // spacing. Only fires for SURFACE / SUSPENDED contexts;
+                // CHASED routes are cast-in and don't need surface clips.
+                string ctx = (rule.MountingContext ?? "").ToUpperInvariant();
+                bool wantsSupports = (ctx == "SURFACE" || ctx == "SUSPENDED")
+                    && rule.EmitSupports
+                    && result.CreatedSegments.Count > 0;
+                if (wantsSupports)
+                {
+                    try
+                    {
+                        var supportRes = StingTools.Core.Calc.RoutingSupportPlacer.PlaceForRoute(
+                            _doc, rule, result.CreatedSegments);
+                        if (supportRes.SupportsPlaced > 0)
+                            result.Warnings.Add(
+                                $"WallFollowerRouter: emitted {supportRes.SupportsPlaced} support(s) " +
+                                $"({ctx}) per BS 5572 / MSS SP-58 spacing.");
+                        if (supportRes.FamilyMissCount > 0)
+                            result.Warnings.Add(
+                                $"WallFollowerRouter: {supportRes.FamilyMissCount} support(s) planned but no " +
+                                $"hanger / clip family loaded — load STING_HANGER_GENERIC.rfa or run Place_Hangers manually.");
+                        foreach (var w in supportRes.Warnings)
+                            if (!result.Warnings.Contains(w)) result.Warnings.Add(w);
+                    }
+                    catch (Exception sex) { result.Warnings.Add($"WallFollowerRouter support emit: {sex.Message}"); }
+                }
+
+                // Phase 139.28 — slope validation for gravity-drainage runs.
+                if (rule.MinSlopePercent > 0 && result.CreatedSegments.Count > 0)
+                {
+                    try
+                    {
+                        var slope = StingTools.Core.Calc.SlopeValidator.CheckSegments(
+                            _doc, result.CreatedSegments, rule.MinSlopePercent, rule.RuleId);
+                        foreach (var w in slope.Warnings)
+                            if (!result.Warnings.Contains(w)) result.Warnings.Add(w);
+                    }
+                    catch (Exception slx) { result.Warnings.Add($"WallFollowerRouter slope check: {slx.Message}"); }
+                }
             }
             catch (Exception ex)
             {
@@ -161,7 +202,27 @@ namespace StingTools.Core.Placement
         private List<XYZ> ApplyFaceOffset(List<XYZ> ordered, PlacementRule rule, Room room, string mode)
         {
             var offset = new List<XYZ>();
+            // Phase 139.28 — diameter-aware standoff when MountingContext=SURFACE.
+            // BS 5572 / BS EN 12056-2 standoff scales with pipe DN:
+            //   ≤ 25 mm  → 35 mm clip standoff
+            //   ≤ 50 mm  → 50 mm
+            //   ≤ 100 mm → 65 mm
+            //   ≤ 150 mm → 85 mm
+            //   > 150 mm → 100 mm
+            // Plus insulation thickness on top.
             double offsetMm = rule.RouteOffsetMm;
+            string ctx = (rule.MountingContext ?? "").ToUpperInvariant();
+            if (ctx == "SURFACE" && rule.NominalDiameterMm > 0)
+            {
+                double dn = rule.NominalDiameterMm;
+                double standoffMm =
+                      dn <=  25.0 ? 35.0
+                    : dn <=  50.0 ? 50.0
+                    : dn <= 100.0 ? 65.0
+                    : dn <= 150.0 ? 85.0
+                    : 100.0;
+                offsetMm = standoffMm + rule.InsulationThicknessMm;
+            }
             string face = (rule.RouteFace ?? "INTERIOR").ToUpperInvariant();
             double sign = (face == "INTERIOR" || face == "BOTTOM") ? -1.0 : 1.0;
             double offFt = offsetMm * MmToFt * sign;

--- a/StingTools/Core/Placement/WetZoneExclusionChecker.cs
+++ b/StingTools/Core/Placement/WetZoneExclusionChecker.cs
@@ -69,10 +69,28 @@ namespace StingTools.Core.Placement
                     new XYZ(bb.Max.X + pad, bb.Max.Y + pad, bb.Max.Z + pad));
                 var bbf = new BoundingBoxIntersectsFilter(outline);
 
+                // Phase 139.27 (N-02) — restrict to the room's phase so a
+                // demolished water fixture in a renovation project doesn't
+                // exclude an electrical socket in the new layout. When the
+                // room has no phase (older docs, schematic stage), the
+                // collector falls through to all phases.
                 var col = new FilteredElementCollector(_doc)
                     .OfCategory(BuiltInCategory.OST_PlumbingFixtures)
                     .WhereElementIsNotElementType()
                     .WherePasses(bbf);
+                ElementId roomPhaseId = ElementId.InvalidElementId;
+                try { roomPhaseId = room.CreatedPhaseId; }
+                catch { roomPhaseId = ElementId.InvalidElementId; }
+                if (roomPhaseId != null && roomPhaseId != ElementId.InvalidElementId)
+                {
+                    try
+                    {
+                        var phaseFilter = new ElementPhaseStatusFilter(roomPhaseId,
+                            new List<ElementOnPhaseStatus> { ElementOnPhaseStatus.Existing, ElementOnPhaseStatus.New });
+                        col = col.WherePasses(phaseFilter);
+                    }
+                    catch (Exception pex) { StingLog.Warn($"WetZone phase filter: {pex.Message}"); }
+                }
 
                 foreach (var el in col)
                 {

--- a/StingTools/Core/Placement/WetZoneExclusionChecker.cs
+++ b/StingTools/Core/Placement/WetZoneExclusionChecker.cs
@@ -78,18 +78,39 @@ namespace StingTools.Core.Placement
                 {
                     var fi = el as FamilyInstance;
                     if (fi == null) continue;
+                    // Phase 139.27 (M-03 partial) — combine Family name +
+                    // Type name + an explicit STING_WET_FIXTURE_KIND override.
+                    // The override lets users tag mis-named fixtures (e.g.
+                    // "Shower Head Bracket" in a corridor) explicitly so
+                    // they're not mistaken for water sources. Acceptable
+                    // override values: BATH / SHOWER / BASIN / SINK / NONE.
                     string famName = (fi.Symbol?.FamilyName ?? "").ToLowerInvariant();
                     string typName = (fi.Symbol?.Name ?? "").ToLowerInvariant();
                     string key     = famName + " " + typName;
                     XYZ origin = (fi.Location as LocationPoint)?.Point;
                     if (origin == null) continue;
 
-                    if (key.Contains("bath"))
-                        AddBathZones(zones, fi, origin);
-                    else if (key.Contains("shower"))
-                        AddShowerZones(zones, fi, origin);
-                    else if (key.Contains("basin") || key.Contains("sink"))
-                        AddBasinZones(zones, fi, origin);
+                    string kindOverride = "";
+                    try
+                    {
+                        kindOverride = (fi.LookupParameter("STING_WET_FIXTURE_KIND")?.AsString()
+                                     ?? fi.Symbol?.LookupParameter("STING_WET_FIXTURE_KIND")?.AsString()
+                                     ?? "").Trim().ToUpperInvariant();
+                    }
+                    catch { }
+
+                    if (kindOverride == "NONE") continue;
+
+                    bool isBath = kindOverride == "BATH"
+                        || (string.IsNullOrEmpty(kindOverride) && (key.Contains(" bath") || key.StartsWith("bath") || key.Contains("bathtub")));
+                    bool isShower = kindOverride == "SHOWER"
+                        || (string.IsNullOrEmpty(kindOverride) && (key.Contains(" shower") || key.StartsWith("shower") || key.Contains("shower head") || key.Contains("shower-head")) && !key.Contains("bracket"));
+                    bool isBasin = kindOverride == "BASIN" || kindOverride == "SINK"
+                        || (string.IsNullOrEmpty(kindOverride) && (key.Contains("basin") || key.Contains("lavatory") || (key.Contains("sink") && !key.Contains("sinkhole"))));
+
+                    if (isBath)        AddBathZones(zones, fi, origin);
+                    else if (isShower) AddShowerZones(zones, fi, origin);
+                    else if (isBasin)  AddBasinZones(zones, fi, origin);
                 }
             }
             catch (Exception ex) { StingLog.Warn($"WetZoneExclusionChecker.BuildForRoom {room.Id}: {ex.Message}"); }

--- a/StingTools/Core/Routing/DropEngineBase.cs
+++ b/StingTools/Core/Routing/DropEngineBase.cs
@@ -81,6 +81,18 @@ namespace StingTools.Core.Routing
         /// </summary>
         public bool EnforceSeparation { get; set; } = true;
 
+        /// <summary>
+        /// Phase 139.29 — when true, every drop's segment is checked
+        /// against StructuralAwareness for beam-junction / column
+        /// proximity (100 mm clearance). Default true; set false to skip
+        /// when the structural model isn't loaded into the host project.
+        /// </summary>
+        public bool CheckSoffitClash { get; set; } = true;
+
+        // Lazy-built StructuralAwareness for soffit clash. Per-engine
+        // instance — DropEngineBase isn't shared across runs.
+        private StingTools.Core.Placement.StructuralAwareness _soffitAwareness;
+
         protected DropEngineBase(Document doc)
         {
             Doc = doc;
@@ -366,6 +378,29 @@ namespace StingTools.Core.Routing
                 }
                 catch (Exception ex)
                 { result.Warnings.Add($"SeparationChecker failed: {ex.Message}"); }
+            }
+
+            // Phase 139.29 — soffit beam / joist clash check.
+            // Suspended drops sit under structural soffits; if a beam
+            // sits between origin and to, the drop must dodge it.
+            // StructuralAwareness was wired for chase routing; here we
+            // hand it the drop segment and warn when it passes within
+            // 100 mm of a beam-junction or column.
+            if (CheckSoffitClash)
+            {
+                try
+                {
+                    if (_soffitAwareness == null) _soffitAwareness = new StingTools.Core.Placement.StructuralAwareness(Doc);
+                    const double clearFt = 100.0 / 304.8;
+                    if (!_soffitAwareness.SegmentIsRoutable(null, origin, to, clearFt))
+                    {
+                        result.Warnings.Add(
+                            $"Drop {fixtureEl.Id} → host {host?.Id?.Value}: passes within 100 mm of " +
+                            "structural beam/junction. Dropped anyway — verify offset or tighten the " +
+                            "drop path before issue (BIM coordinator review).");
+                    }
+                }
+                catch (Exception sex) { result.Warnings.Add($"Soffit clash check: {sex.Message}"); }
             }
 
             // Stage 3: subclass creates the run geometry.

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -912,6 +912,24 @@ namespace StingTools.UI.PlacementCenter
                         panel.Metric(kv.Key, kv.Value.ToString());
                 }
 
+                // Phase 139.27 (I-03) — per-rule diagnostics in the Centre.
+                // Bubbles rules that generated candidates but placed zero
+                // to the top, with a one-line skip-reason summary.
+                if (result?.Diagnostics != null && result.Diagnostics.Count > 0)
+                {
+                    panel.AddSection("PER-RULE DIAGNOSTICS");
+                    var ordered = result.Diagnostics.Values
+                        .OrderByDescending(d => d.CandidatesGenerated > 0 && d.CandidatesPlaced == 0)
+                        .ThenByDescending(d => d.CandidatesGenerated)
+                        .Take(40)
+                        .ToList();
+                    foreach (var d in ordered) panel.Text(d.OneLineSummary());
+
+                    int zeroPlaced = result.Diagnostics.Values.Count(d => d.CandidatesGenerated > 0 && d.CandidatesPlaced == 0);
+                    if (zeroPlaced > 0)
+                        panel.Text($"⚠ {zeroPlaced} rule(s) generated candidates but placed nothing — see skip reasons above.");
+                }
+
                 if (placed == 0)
                 {
                     panel.AddSection("ZERO PLACED — common causes")


### PR DESCRIPTION
## Summary

This PR introduces comprehensive per-rule placement diagnostics, standards-based validation (BS 7671 electrical circuits, BS EN 12464-1 lighting uniformity, BS EN 12056-2 drainage slopes), structural awareness enhancements, and auto-emission of routing supports (clips/hangers). The changes span fixture placement, routing engines, and the UI result panel.

## Key Changes

**Placement Diagnostics & Reporting (Phase 139.27)**
- Added `RuleDiagnostic` class to track per-rule metrics: rooms considered/filtered/blocked, candidates generated/placed/rejected, skip reasons
- Integrated diagnostics collection throughout `FixturePlacementEngine.ProcessRoomRule` to capture filtering decisions and placement outcomes
- Surface validation warnings from `PlacementRuleLoader.LastValidationWarnings` in the result panel (previously log-only)
- Added one-shot warning when post-placement tagging is enabled but reflection target is missing

**Standards Validation**
- `HeightStandardsTable.ValidateRulesAgainstStandards()`: Validates mounting heights against accessibility/safety standards (Phase 139.27 N-05)
- `LightingGridCalculator`: Added `DefaultMinimumUniformity` property and uniformity-ratio gating per rule (`MinUniformityRatio`)
- `CircuitTopologyEngine` (new): Groups placed electrical fixtures into BS 7671-compliant ring/radial circuits, stamps circuit ID + RCD group per instance
- `SlopeValidator` (new): Validates gravity-drainage runs against BS EN 12056-2 minimum gradients (1.25%–2.5%)
- `ConcreteCoverTable` (new): Eurocode 2 / UK NA concrete-cover lookup for chased pipework

**Routing & Support Emission (Phase 139.28)**
- `RoutingSupportPlacer` (new): Bridges placement-side routers to `HangerPlacementEngine`, auto-emits clips/hangers per BS 5572 / MSS SP-58 spacing
- `AutoDropCommand`: Added `EmitSupports` flag (default true) to auto-emit hangers on dropped runs
- `WallFollowerRouter` & `DropEngineBase`: Integrated support emission for SURFACE/SUSPENDED mounting contexts
- `InWallChaseRouter`: Added rebar centreline cache and clash detection (Phase 139.29)

**Structural & Accessibility Audits (Phase 139.27–139.30)**
- `StampNogginRequirementsFromGrid()`: Stamps `STING_NOGGIN_REQUIRED` on placed instances matching lighting-grid cache points
- `AuditStructuralClearance()`: Warns when placements sit inside beam-junction/column clearance zones
- `AuditDoorSwingClearance()`: Checks switches against door swept envelopes (Phase 139.30 X-05)
- `AuditCableBundleDerating()`: Advisory warnings for cable bundles exceeding BS 7671 Table 4 derating thresholds

**CoPlaceWith Enhancement (Phase 139.27 M-06)**
- Fixed: Co-rules now fire at **every** placement point of the primary rule, not just the last
- Pre-139.27 behavior: 5-fixture primary only triggered co-rule at point #5; other 4 silently missed dependent devices
- Now: Smoke detector under every luminaire, isolator next to every fan, etc.

**Coverage & Placement Improvements**
- `CoverageGridGenerator`: Added iterative densification (Phase 139.30 M-08) when `GuaranteeCoverage=true` and coverage < 99%
- Clusters uncovered samples and places extra points at cluster centroids
- `WetZoneExclusionChecker`: Phase-aware filtering (Phase 139.27 N-02) so demolished fixtures don't exclude new sockets

**Rule Validation & Learning**
- `PlacementRuleLoader`: Added `LastValidationWarnings` property, surfaced to engine and result panel
- `LearnPlac

https://claude.ai/code/session_01Ui2N8RnsmQqg2n9FbTYms1