### PR TITLE
Add title-block readiness diagnostics and routing policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ When you finish a piece of work, log it in `docs/CHANGELOG.md` rather than exten
 | `StingTools/Data/Placement/` | STING_PLACEMENT_RULES.json (43 rules) |
 | `StingTools/Data/Fabrication/` | STING_FAB_RULES.json (6 disciplines), STING_ISO_SYMBOLS_INDEX.csv (180+ symbols) |
 | `StingTools/Data/Parameters/` | STING_PARAMS_V4.txt shared-parameter fragment |
-| `Families/AssemblyTitleBlocks/` | 8 title block parameter spec stubs + README |
+| `Families/AssemblyTitleBlocks/` | 7 title block parameter spec stubs + README |
 
 ### New namespaces
 
@@ -106,7 +106,7 @@ When you finish a piece of work, log it in `docs/CHANGELOG.md` rather than exten
 ### Caveats
 
 1. Built without `dotnet build` verification — every Revit API call uses the documented signature but has not been compile-checked. `// TODO-VERIFY-API` comments mark the most uncertain spots (`AssemblyInstance.Create` category arg, `Conduit.Create` / `Pipe.Create` / `Duct.Create` overloads, ISO 6412 axonometric section transform).
-2. The 8 title block `.rfa` families are NOT shipped — only their parameter specs. `ShopDrawingComposer.ResolveTitleBlock` falls back to the first available title block in the project.
+2. The 7 title block `.rfa` families are NOT shipped — only their parameter specs. `ShopDrawingComposer.ResolveTitleBlock` falls back to the first available title block in the project (now warns loudly via `FabricationResult.Warnings` and `StingLog`).
 3. ISO 6412 detail families (180 entries) are referenced by name in `STING_ISO_SYMBOLS_INDEX.csv`; `IsoSymbolPlacer` lazy-loads from `Families/ISO6412/` and warns once per missing family.
 
 ## Drawing Template Manager (Phase 113)
@@ -491,7 +491,7 @@ a default `manifest.json` seeded from `ProjectInformation` and
 | `StingTools/Data/Placement/` | STING_PLACEMENT_RULES.json (43 rules) |
 | `StingTools/Data/Fabrication/` | STING_FAB_RULES.json (6 disciplines), STING_ISO_SYMBOLS_INDEX.csv (180+ symbols) |
 | `StingTools/Data/Parameters/` | STING_PARAMS_V4.txt shared-parameter fragment |
-| `Families/AssemblyTitleBlocks/` | 8 title block parameter spec stubs + README |
+| `Families/AssemblyTitleBlocks/` | 7 title block parameter spec stubs + README |
 
 ### New namespaces
 
@@ -527,7 +527,7 @@ a default `manifest.json` seeded from `ProjectInformation` and
 ### Caveats
 
 1. Built without `dotnet build` verification — every Revit API call uses the documented signature but has not been compile-checked. `// TODO-VERIFY-API` comments mark the most uncertain spots (`AssemblyInstance.Create` category arg, `Conduit.Create` / `Pipe.Create` / `Duct.Create` overloads, ISO 6412 axonometric section transform).
-2. The 8 title block `.rfa` families are NOT shipped — only their parameter specs. `ShopDrawingComposer.ResolveTitleBlock` falls back to the first available title block in the project.
+2. The 7 title block `.rfa` families are NOT shipped — only their parameter specs. `ShopDrawingComposer.ResolveTitleBlock` falls back to the first available title block in the project (now warns loudly via `FabricationResult.Warnings` and `StingLog`).
 3. ISO 6412 detail families (180 entries) are referenced by name in `STING_ISO_SYMBOLS_INDEX.csv`; `IsoSymbolPlacer` lazy-loads from `Families/ISO6412/` and warns once per missing family.
 
 ## Technology Stack

--- a/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
@@ -60,6 +60,13 @@ namespace StingTools.Commands.Drawing
                 }
                 sb.AppendLine();
 
+                // Title-block readiness — fast pre-flight summary of which
+                // title-block families profiles reference vs. what's loaded
+                // in the project, plus whether the TitleBlockRouter has a
+                // discipline default configured. Surfaces the silent
+                // "first available" fallback risk in one place.
+                AppendTitleBlockReadiness(doc, lib, sb);
+
                 // Validation summary
                 int errors   = reports.Sum(r => r.Issues.Count(i => i.Severity == ValidationSeverity.Error));
                 int warnings = reports.Sum(r => r.Issues.Count(i => i.Severity == ValidationSeverity.Warning));
@@ -144,6 +151,56 @@ namespace StingTools.Commands.Drawing
         {
             if (string.IsNullOrEmpty(s)) return "";
             return s.Length <= len ? s : s.Substring(0, len - 1) + "…";
+        }
+
+        private static void AppendTitleBlockReadiness(Document doc, DrawingTypeLibrary lib, StringBuilder sb)
+        {
+            if (doc == null || lib == null) return;
+            try
+            {
+                var loadedFamilies = new System.Collections.Generic.HashSet<string>(
+                    new FilteredElementCollector(doc)
+                        .OfCategory(BuiltInCategory.OST_TitleBlocks)
+                        .OfClass(typeof(FamilySymbol))
+                        .Cast<FamilySymbol>()
+                        .Select(fs => fs.FamilyName ?? ""),
+                    StringComparer.OrdinalIgnoreCase);
+
+                var referenced = lib.DrawingTypes
+                    .Where(t => !string.IsNullOrWhiteSpace(t.TitleBlockFamily))
+                    .GroupBy(t => t.TitleBlockFamily, StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(g => g.Key)
+                    .ToList();
+
+                sb.AppendLine("Title-block readiness:");
+                if (referenced.Count == 0)
+                {
+                    sb.AppendLine("  (no profiles declare a titleBlockFamily)");
+                }
+                else
+                {
+                    int missing = 0;
+                    foreach (var grp in referenced)
+                    {
+                        bool loaded = loadedFamilies.Contains(grp.Key);
+                        if (!loaded) missing++;
+                        sb.AppendLine($"  {(loaded ? "✓" : "✗")} {grp.Key}  ({grp.Count()} profile{(grp.Count() == 1 ? "" : "s")})");
+                    }
+                    if (missing > 0)
+                        sb.AppendLine($"  ⚠ {missing} family(ies) not loaded — sheets created from those profiles will fall back to the first available title block, and populated cells may silently drop.");
+                }
+
+                // TitleBlockRouter status
+                var router = StingTools.Core.TitleBlockRouter.ByDiscipline ?? new System.Collections.Generic.Dictionary<string, ElementId>();
+                int routed = router.Values.Count(id => id != ElementId.InvalidElementId);
+                bool hasDefault = StingTools.Core.TitleBlockRouter.DefaultId != ElementId.InvalidElementId;
+                sb.AppendLine($"  Router: {routed} discipline override(s); default {(hasDefault ? "set" : "UNSET")} (run Project Setup Wizard to configure).");
+                sb.AppendLine();
+            }
+            catch (Exception ex)
+            {
+                sb.AppendLine($"Title-block readiness check failed: {ex.Message}");
+            }
         }
     }
 

--- a/StingTools/Core/Fabrication/ShopDrawingComposer.cs
+++ b/StingTools/Core/Fabrication/ShopDrawingComposer.cs
@@ -114,9 +114,22 @@ namespace StingTools.Core.Fabrication
             }
             else
             {
+                // 1) DrawingType profile (corporate spool A1 etc.)
                 tbId = ResolveTitleBlockFromDrawingType(doc, drawingType);
+                // 2) Project Setup Wizard router — single source of truth
+                //    populated by ProjectSetupCommand. Honoured here so the
+                //    fabrication path obeys the same per-discipline policy
+                //    as DocAutomation / SheetManager / BatchCreateSheets.
                 if (tbId == ElementId.InvalidElementId)
-                    tbId = ResolveTitleBlock(doc, discipline);
+                {
+                    string discCode = DisciplineCode.TryGetValue(discipline ?? "", out var dc)
+                        ? dc : "G";
+                    var routed = StingTools.Core.TitleBlockRouter.Resolve(doc, discCode);
+                    if (routed != null) tbId = routed.Id;
+                }
+                // 3) Per-discipline STING_TB_ASSEMBLY_* hard-code as last resort
+                if (tbId == ElementId.InvalidElementId)
+                    tbId = ResolveTitleBlock(doc, discipline, result);
             }
 
             ViewSheet sheet = null;
@@ -190,7 +203,7 @@ namespace StingTools.Core.Fabrication
             catch (Exception ex) { result.Warnings.Add($"PlaceView {viewId.Value}: {ex.Message}"); }
         }
 
-        private static ElementId ResolveTitleBlock(Document doc, string discipline)
+        private static ElementId ResolveTitleBlock(Document doc, string discipline, FabricationResult result)
         {
             string familyName = TitleBlockByDiscipline.TryGetValue(discipline ?? "", out var n)
                 ? n : TitleBlockByDiscipline["Generic"];
@@ -204,9 +217,19 @@ namespace StingTools.Core.Fabrication
                     if (el is FamilySymbol fs && string.Equals(fs.FamilyName, familyName, StringComparison.OrdinalIgnoreCase))
                         return fs.Id;
                 }
-                // Fallback: first available title block
+                // Last-resort fallback: first available title block. Warn
+                // loudly — populated cells (spool / weight / FAB_LOC / BOM
+                // rev) may land on parameters this family doesn't carry.
                 foreach (var el in col)
-                    if (el is FamilySymbol fs) return fs.Id;
+                {
+                    if (el is FamilySymbol fs)
+                    {
+                        string msg = $"Title block '{familyName}' not loaded; falling back to '{fs.FamilyName}'. Populated fab cells may be silently dropped.";
+                        StingLog.Warn("ShopDrawingComposer: " + msg);
+                        result?.Warnings.Add(msg);
+                        return fs.Id;
+                    }
+                }
             }
             catch (Exception ex) { StingLog.Warn($"ShopDrawingComposer: title block resolve: {ex.Message}"); }
             return ElementId.InvalidElementId;
@@ -514,13 +537,24 @@ namespace StingTools.Core.Fabrication
                 return ElementId.InvalidElementId;
             try
             {
-                var col = new FilteredElementCollector(doc)
+                // Mirror DrawingTypeSheetAdapter.ResolveTitleBlock so the
+                // optional TitleBlockSymbolType variant (Tender / Construction
+                // / As-Built etc.) is honoured on the fabrication path too.
+                var matches = new FilteredElementCollector(doc)
                     .OfCategory(BuiltInCategory.OST_TitleBlocks)
-                    .OfClass(typeof(FamilySymbol));
-                foreach (var el in col)
-                    if (el is FamilySymbol fs && string.Equals(
-                            fs.FamilyName, dt.TitleBlockFamily, StringComparison.OrdinalIgnoreCase))
-                        return fs.Id;
+                    .OfClass(typeof(FamilySymbol))
+                    .Cast<FamilySymbol>()
+                    .Where(fs => string.Equals(
+                        fs.FamilyName, dt.TitleBlockFamily, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (!string.IsNullOrWhiteSpace(dt.TitleBlockSymbolType))
+                {
+                    var picked = matches.FirstOrDefault(fs => string.Equals(
+                        fs.Name, dt.TitleBlockSymbolType, StringComparison.OrdinalIgnoreCase));
+                    if (picked != null) return picked.Id;
+                }
+                var fallback = matches.FirstOrDefault();
+                if (fallback != null) return fallback.Id;
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/TitleBlockRouter.cs
+++ b/StingTools/Core/TitleBlockRouter.cs
@@ -59,8 +59,16 @@ namespace StingTools.Core
                 if (match != null) return EnsureActive(doc, match);
             }
 
-            // 4) First available
-            return all.Count > 0 ? EnsureActive(doc, all[0]) : null;
+            // 4) First available — warn so the caller can surface that the
+            //    project's title-block routing policy is unconfigured for
+            //    this discipline.
+            if (all.Count > 0)
+            {
+                StingLog.Warn(
+                    $"TitleBlockRouter: no per-discipline / default / preferred match for '{disciplineCode}'; falling back to first available '{all[0].FamilyName}'.");
+                return EnsureActive(doc, all[0]);
+            }
+            return null;
         }
 
         /// <summary>Activate a FamilySymbol inside its own transaction if not already active.</summary>


### PR DESCRIPTION
## Summary
Implements comprehensive title-block readiness diagnostics and establishes a unified routing policy for title-block resolution across fabrication and drawing automation paths. This surfaces silent fallback risks and ensures consistent discipline-based title-block selection.

## Key Changes

- **DrawingTypesInspectCommand**: Added `AppendTitleBlockReadiness()` method that provides a pre-flight summary showing:
  - Which title-block families are referenced by DrawingType profiles vs. what's loaded in the project
  - TitleBlockRouter configuration status (discipline overrides and default)
  - Clear warnings when families are missing (with ✓/✗ indicators)

- **ShopDrawingComposer**: Refactored title-block resolution to follow a 3-tier fallback strategy:
  1. DrawingType profile's `TitleBlockFamily` (with optional `TitleBlockSymbolType` variant support)
  2. TitleBlockRouter per-discipline policy (via ProjectSetupCommand configuration)
  3. Hard-coded discipline defaults as last resort
  - Now passes `FabricationResult` to `ResolveTitleBlock()` to surface warnings when falling back to first-available
  - Enhanced `ResolveTitleBlockFromDrawingType()` to honor the optional `TitleBlockSymbolType` variant (Tender/Construction/As-Built)

- **TitleBlockRouter**: Added warning log when falling back to first-available title block, helping users identify unconfigured discipline routing

- **Documentation**: Updated CLAUDE.md to reflect that title-block fallback now warns loudly via `FabricationResult.Warnings` and `StingLog`

## Notable Implementation Details

- Title-block readiness check is wrapped in try-catch to prevent inspection failures
- Uses case-insensitive string comparison for family name matching (consistent with existing patterns)
- Warnings clearly explain the risk: "populated cells may silently drop" when families don't carry expected parameters
- Maintains backward compatibility while establishing ProjectSetupCommand as the single source of truth for discipline routing policy

https://claude.ai/code/session_01JnggRSSaEU9xsWZwFa44ud