### PR TITLE
Integrate region-aware Standards API & compliance engine

### DIFF
--- a/StingTools.Standards/Compliance/StandardsComplianceEngine.cs
+++ b/StingTools.Standards/Compliance/StandardsComplianceEngine.cs
@@ -10,17 +10,30 @@ using System.IO;
 using System.Linq;
 using CsvHelper;
 using CsvHelper.Configuration;
-using NLog;
 
 namespace StingTools.Standards.Compliance
 {
+    // Pluggable log sink; default no-op so the library has no third-party
+    // logging dependency. Hosts (e.g. StingTools plugin) install StingLog
+    // by setting StandardsLog.Sink at startup.
+    public enum StandardsLogLevel { Info, Warn, Error }
+
+    public static class StandardsLog
+    {
+        public static Action<StandardsLogLevel, string, Exception> Sink { get; set; } =
+            (_, __, ___) => { };
+        internal static void Info(string m)               => Sink(StandardsLogLevel.Info, m, null);
+        internal static void Warn(string m)               => Sink(StandardsLogLevel.Warn, m, null);
+        internal static void Warn(Exception ex, string m) => Sink(StandardsLogLevel.Warn, m, ex);
+        internal static void Error(Exception ex, string m)=> Sink(StandardsLogLevel.Error, m, ex);
+    }
+
     /// <summary>
     /// Compliance engine for checking designs against building standards.
     /// Supports IBC, ASHRAE, ADA, ISO 19650, and regional codes.
     /// </summary>
     public class StandardsComplianceEngine
     {
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
         private readonly Dictionary<string, BuildingStandard> _standards;
         private readonly Dictionary<string, List<ComplianceRule>> _rulesByStandard;
         private readonly List<string> _enabledStandards;
@@ -41,7 +54,7 @@ namespace StingTools.Standards.Compliance
         {
             if (!File.Exists(filePath))
             {
-                Logger.Warn($"Standards file not found: {filePath}");
+                StandardsLog.Warn($"Standards file not found: {filePath}");
                 return;
             }
 
@@ -64,11 +77,11 @@ namespace StingTools.Standards.Compliance
                     AddRule(rule);
                 }
 
-                Logger.Info($"Loaded standards from {filePath}");
+                StandardsLog.Info($"Loaded standards from {filePath}");
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, $"Failed to load standards from {filePath}");
+                StandardsLog.Error(ex, $"Failed to load standards from {filePath}");
             }
         }
 
@@ -80,7 +93,7 @@ namespace StingTools.Standards.Compliance
             if (!_enabledStandards.Contains(standardCode, StringComparer.OrdinalIgnoreCase))
             {
                 _enabledStandards.Add(standardCode);
-                Logger.Info($"Enabled standard: {standardCode}");
+                StandardsLog.Info($"Enabled standard: {standardCode}");
             }
         }
 
@@ -90,7 +103,7 @@ namespace StingTools.Standards.Compliance
         public void DisableStandard(string standardCode)
         {
             _enabledStandards.RemoveAll(s => s.Equals(standardCode, StringComparison.OrdinalIgnoreCase));
-            Logger.Info($"Disabled standard: {standardCode}");
+            StandardsLog.Info($"Disabled standard: {standardCode}");
         }
 
         /// <summary>
@@ -405,7 +418,7 @@ namespace StingTools.Standards.Compliance
             {
                 result.IsCompliant = false;
                 result.Message = $"Error evaluating rule: {ex.Message}";
-                Logger.Warn(ex, $"Failed to evaluate rule {rule.Id}");
+                StandardsLog.Warn(ex, $"Failed to evaluate rule {rule.Id}");
             }
 
             return result;

--- a/StingTools.Standards/StingTools.Standards.csproj
+++ b/StingTools.Standards/StingTools.Standards.csproj
@@ -37,9 +37,8 @@
     <!-- Standards CSV loading + structured config. Matches StingTools.csproj. -->
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <!-- Re-added Phase 118: StandardsComplianceEngine.cs uses NLog for
-         6 Logger.{Info,Warn,Error} calls. Dropped in S110.03 on the
-         assumption it was unused; Windows build proved otherwise. -->
-    <PackageReference Include="NLog" Version="5.2.8" />
+    <!-- NLog dropped: StandardsComplianceEngine now logs through the
+         pluggable StandardsLog.Sink hook (default no-op). Hosts wire
+         their own logger (StingLog) on startup. -->
   </ItemGroup>
 </Project>

--- a/StingTools/Commands/MepDesign/MepDesignCommands.cs
+++ b/StingTools/Commands/MepDesign/MepDesignCommands.cs
@@ -54,10 +54,12 @@ namespace StingTools.Commands.MepDesign
                             double currentA = ReadNamed(el, new[] { "Apparent Current", "Current", "Total Installed Current" });
                             if (voltageV <= 0 || currentA <= 0) { skipped++; continue; }
 
+                            // Region-aware: BS 7671 / IEC 60364 / NEC 310 driven by the active project region.
+                            string elecStd = ProjectStandardsManager.Instance.GetStandardForDiscipline(StandardsDiscipline.Electrical);
                             var res = StingTools.Standards.StandardsAPI.CalculateCableSize(
                                 voltageV: voltageV, currentA: currentA, lengthM: v[0],
                                 conductorType: "Copper", insulationType: "THHN",
-                                conduitFill: (int)v[2], ambientTempC: v[1], standard: "IEC60364");
+                                conduitFill: (int)v[2], ambientTempC: v[1], standard: elecStd);
                             if (!res.Success || string.IsNullOrEmpty(res.SizeAWG)) { skipped++; continue; }
 
                             var p = el.LookupParameter("CABLE_SIZE") ??

--- a/StingTools/Commands/Standards/StandardsCommands.cs
+++ b/StingTools/Commands/Standards/StandardsCommands.cs
@@ -116,10 +116,13 @@ namespace StingTools.Commands.Standards
             CableSizeResult res;
             try
             {
+                // Region-aware: pull the active electrical standard from the project
+                // (BS 7671 for UK, NEC 310 for US, IEC 60364 for International, etc.).
+                string elecStd = ProjectStandardsManager.Instance.GetStandardForDiscipline(StandardsDiscipline.Electrical);
                 res = StandardsAPI.CalculateCableSize(
                     voltageV: v[0], currentA: v[1], lengthM: v[2],
                     conductorType: "Copper", insulationType: "THHN",
-                    conduitFill: (int)v[3], ambientTempC: v[4], standard: "IEC60364");
+                    conduitFill: (int)v[3], ambientTempC: v[4], standard: elecStd);
             }
             catch (Exception ex) { StingLog.Error("CalcCableSize failed", ex); message = ex.Message; return Result.Failed; }
 
@@ -362,9 +365,10 @@ namespace StingTools.Commands.Standards
                 // Library signature: (floorAreaM2, occupancyType, hazardClassification, standard)
                 string hazard = v[1] <= 1.5 ? "Light" : v[1] <= 2.5 ? "OrdinaryGroup1" :
                                 v[1] <= 3.5 ? "OrdinaryGroup2" : "ExtraHazard";
+                string fireStd = ProjectStandardsManager.Instance.GetStandardForDiscipline(StandardsDiscipline.FireProtection);
                 var res = StandardsAPI.DesignSprinklerSystem(
                     floorAreaM2: v[0], occupancyType: "Office",
-                    hazardClassification: hazard);
+                    hazardClassification: hazard, standard: fireStd);
 
                 var panel = StingResultPanel.Create("Sprinkler design — NFPA 13 / BS EN 12845");
                 panel.SetSubtitle(res.NFPAReference ?? "NFPA 13 / BS EN 12845");

--- a/StingTools/Commands/Standards/StandardsCommands.cs
+++ b/StingTools/Commands/Standards/StandardsCommands.cs
@@ -126,8 +126,9 @@ namespace StingTools.Commands.Standards
             }
             catch (Exception ex) { StingLog.Error("CalcCableSize failed", ex); message = ex.Message; return Result.Failed; }
 
+            string region = ProjectStandardsManager.Instance.Region ?? "International";
             var panel = StingResultPanel.Create("Cable sizing — BS 7671 / IEC 60364");
-            panel.SetSubtitle(res.Success ? (res.IsNECCompliant ? "COMPLIANT" : "REVIEW") : "FAILED");
+            panel.SetSubtitle($"{region} · {(res.Success ? (res.IsNECCompliant ? "COMPLIANT" : "REVIEW") : "FAILED")}");
             panel.AddSection("RESULT")
                  .Metric("Size", res.SizeAWG ?? "-")
                  .Metric("Required ampacity", $"{res.Ampacity:F1} A")
@@ -175,8 +176,9 @@ namespace StingTools.Commands.Standards
                     basicWindSpeedMPH: mph, exposureCategory: exp,
                     buildingHeightFt: ft, riskCategory: "II");
 
+                string region = ProjectStandardsManager.Instance.Region ?? "International";
                 var panel = StingResultPanel.Create("Wind load — ASCE 7 / Eurocode EN 1991-1-4");
-                panel.SetSubtitle(res.StandardReference ?? "");
+                panel.SetSubtitle($"{region} · {res.StandardReference ?? ""}");
                 panel.AddSection("DESIGN WIND PRESSURE")
                      .Metric("Basic wind speed",     $"{res.BasicWindSpeed:F0} mph ({v[0]:F0} m/s)")
                      .Metric("Velocity pressure qz", $"{res.VelocityPressureKPa * 1000:F0} Pa ({res.VelocityPressurePSF:F1} psf)")
@@ -218,8 +220,9 @@ namespace StingTools.Commands.Standards
                 var res = StandardsAPI.CalculateLighting(
                     floorAreaM2: v[0], spaceType: space, ceilingHeightM: v[1]);
 
+                string region = ProjectStandardsManager.Instance.Region ?? "International";
                 var panel = StingResultPanel.Create("Lighting — CIBSE / EN 12464-1");
-                panel.SetSubtitle(res.CIBSEReference ?? "BS EN 12464-1:2021");
+                panel.SetSubtitle($"{region} · {res.CIBSEReference ?? "BS EN 12464-1:2021"}");
                 panel.AddSection("RESULT")
                      .Metric("Space type",           res.SpaceType ?? space)
                      .Metric("Illuminance target",   $"{res.IlluminanceLux:F0} lx ({res.IlluminanceFootcandles:F0} fc)")
@@ -265,8 +268,9 @@ namespace StingTools.Commands.Standards
                     equipmentLoadW: equipW, lightingLoadW: lightW,
                     orientationN_E_S_W: "N", ceilingHeightM: v[4]);
 
+                string region = ProjectStandardsManager.Instance.Region ?? "International";
                 var panel = StingResultPanel.Create("HVAC cooling load — ASHRAE / CIBSE Guide A");
-                panel.SetSubtitle(res.CIBSEReference ?? "ASHRAE 62.1 + CIBSE Guide A");
+                panel.SetSubtitle($"{region} · {res.CIBSEReference ?? "ASHRAE 62.1 + CIBSE Guide A"}");
                 panel.AddSection("LOADS")
                      .Metric("Sensible",      $"{res.SensibleLoadKW:F1} kW")
                      .Metric("Latent",        $"{res.LatentLoadKW:F1} kW")
@@ -316,8 +320,9 @@ namespace StingTools.Commands.Standards
                 var td = AECCalculations.CalculateTravelDistance(
                     occupancyGroup: "B", sprinklered: v[3] >= 0.5);
 
+                string region = ProjectStandardsManager.Instance.Region ?? "International";
                 var panel = StingResultPanel.Create("Egress + travel distance — IBC / NFPA 101");
-                panel.SetSubtitle($"Occupancy {occ.OccupantLoad}, sprinklered: {(v[3] >= 0.5 ? "yes" : "no")}");
+                panel.SetSubtitle($"{region} · Occupancy {occ.OccupantLoad}, sprinklered: {(v[3] >= 0.5 ? "yes" : "no")}");
 
                 panel.AddSection("OCCUPANT LOAD")
                      .Metric("Occupant load", occ.OccupantLoad.ToString())
@@ -370,8 +375,9 @@ namespace StingTools.Commands.Standards
                     floorAreaM2: v[0], occupancyType: "Office",
                     hazardClassification: hazard, standard: fireStd);
 
+                string region = ProjectStandardsManager.Instance.Region ?? "International";
                 var panel = StingResultPanel.Create("Sprinkler design — NFPA 13 / BS EN 12845");
-                panel.SetSubtitle(res.NFPAReference ?? "NFPA 13 / BS EN 12845");
+                panel.SetSubtitle($"{region} · {res.NFPAReference ?? "NFPA 13 / BS EN 12845"}");
                 panel.AddSection("HYDRAULIC DEMAND")
                      .Metric("Hazard class",       res.HazardClass ?? hazard)
                      .Metric("Occupancy",           res.OccupancyType ?? "Office")

--- a/StingTools/Commands/StandardsExt/StandardsBulkWrappers.cs
+++ b/StingTools/Commands/StandardsExt/StandardsBulkWrappers.cs
@@ -91,9 +91,12 @@ namespace StingTools.Commands.StandardsExt
                 new[] { 500.0, 1.0 }, out var v)) return Result.Cancelled;
             try
             {
-                // Library expects CFM + in.WG/100ft; convert from L/s + Pa/m
+                // Library expects CFM + in.WG/100ft. Convert from L/s + Pa/m:
+                //   1 L/s ≈ 2.1189 CFM
+                //   100 ft = 30.48 m, 1 in.WG ≈ 248.84 Pa
+                //   in.WG/100ft = (Pa/m × 30.48 m) / 248.84 Pa/in.WG
                 double cfm = v[0] * 2.1189;
-                double frictionInWG = (v[1] * 100 / 0.3048) / 248.84; // Pa/m → in.WG/100ft
+                double frictionInWG = v[1] * 30.48 / 248.84;
                 var res = AECCalculations.CalculateDuctSize(cfm, frictionInWG);
                 Bk.B("Equal friction duct", $"{Bk.Region} · {res.StandardReference ?? "CIBSE Guide B3"}")
                     .AddSection("RESULT")

--- a/StingTools/Commands/StandardsExt/StandardsBulkWrappers.cs
+++ b/StingTools/Commands/StandardsExt/StandardsBulkWrappers.cs
@@ -1,79 +1,545 @@
-// STING Tools — Phase 116: 20 additional StandardsAPI + AECCalculations wrappers.
-// Minimal body per wrapper — prompt + result panel + cited standard.
+// STING Tools — Standards bulk wrappers (region-aware library calls).
+//
+// Each command collects inputs through NumericPrompt, dispatches to
+// StandardsAPI / AECCalculations using the active region from
+// ProjectStandardsManager, and renders the typed result through
+// StingResultPanel. Replaces the original Phase-116 reference-card
+// stubs that hard-coded calculation values inline.
+
 using System;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using StingTools.Commands.Standards;
 using StingTools.Core;
+using StingTools.Standards;
 using StingTools.UI;
 
 namespace StingTools.Commands.StandardsExt
 {
-    internal static class Bk { public static StingResultPanel.Builder B(string t, string s) => StingResultPanel.Create(t).SetSubtitle(s); }
+    internal static class Bk
+    {
+        public static StingResultPanel.Builder B(string t, string s) =>
+            StingResultPanel.Create(t).SetSubtitle(s);
 
-    // 1. Ventilation (ASHRAE 62.1)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class VentilationCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Ventilation","ASHRAE 62.1 + CIBSE TM60").AddSection("RATES").Metric("Office","10 L/s/person").Metric("Classroom","10 L/s/person").Metric("Corridor","0.5 L/s/m²").Metric("Toilet extract","50 L/s/wc").Show(); return Result.Succeeded; } }
-    // 2. Plumbing pipe size (Hunter / BS 6700)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class PlumbingPipeSizeCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Plumbing pipe (BS 6700)", new[] {"Fixture units"}, new[] {20.0}, out var v)) return Result.Cancelled; double dn = v[0] < 5 ? 20 : v[0] < 15 ? 25 : v[0] < 40 ? 32 : v[0] < 100 ? 50 : 80; Bk.B("Plumbing pipe size","BS 6700 + Hunter curves").AddSection("").Metric("FU", $"{v[0]:F0}").Metric("DN",$"{dn:F0}").Show(); return Result.Succeeded; } }
-    // 3. Duct size equal friction (CIBSE Guide B3)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class DuctEqualFrictionCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Equal friction duct", new[] {"Flow L/s","Friction Pa/m"}, new[] {500.0, 1.0}, out var v)) return Result.Cancelled; double d = Math.Pow((v[0] * 1e-3 * 4 * 0.02) / (Math.PI * Math.Sqrt(2 * v[1] / 1.2)), 0.4) * 1000; Bk.B("Equal friction duct","CIBSE Guide B3").AddSection("").Metric("Flow",$"{v[0]:F0} L/s").Metric("Dia mm",$"{d:F0}").Show(); return Result.Succeeded; } }
-    // 4. Psychrometric
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class PsychrometricCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Moist air (ASHRAE)", new[] {"DBT °C","RH %","P kPa"}, new[] {25.0,60.0,101.3}, out var v)) return Result.Cancelled; double pws = 0.611 * Math.Exp(17.27 * v[0] / (v[0] + 237.3)); double pw = v[1] / 100 * pws; double w = 0.622 * pw / (v[2] - pw); Bk.B("Psychrometric","ASHRAE Handbook Chapter 1").AddSection("").Metric("DBT",$"{v[0]:F1} °C").Metric("RH",$"{v[1]:F0}%").Metric("W",$"{w*1000:F2} g/kg").Show(); return Result.Succeeded; } }
-    // 5. Fault current + arc flash (IEEE 1584)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class ArcFlashCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Arc flash","IEEE 1584 + NFPA 70E").AddSection("PPE CATEGORY").Metric("Cat 0","1.2 cal/cm²").Metric("Cat 1","4 cal/cm²").Metric("Cat 2","8 cal/cm²").Metric("Cat 3","25 cal/cm²").Metric("Cat 4","40 cal/cm²").Show(); return Result.Succeeded; } }
-    // 6. Conduit fill (NEC Ch 9)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class ConduitFillCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Conduit fill","NEC Chapter 9 Table 1").AddSection("").Metric("1 wire","53%").Metric("2 wires","31%").Metric("3+ wires","40%").Show(); return Result.Succeeded; } }
-    // 7. Steel beam (AISC 360 / EC3)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class SteelBeamCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Steel beam", new[] {"Span m","UDL kN/m"}, new[] {8.0,20.0}, out var v)) return Result.Cancelled; double mMax = v[1] * v[0] * v[0] / 8; Bk.B("Steel beam","AISC 360 LRFD / EC3").AddSection("").Metric("Mmax",$"{mMax:F0} kNm").Metric("Section (est)", mMax < 100 ? "UB 356x171x45" : mMax < 300 ? "UB 457x191x67" : "UB 533x210x82").Show(); return Result.Succeeded; } }
-    // 8. Concrete beam (ACI 318 / EC2)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class ConcreteBeamCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Concrete beam","ACI 318 + EC2").AddSection("DEFAULT RATIOS").Metric("L/d simple span","20").Metric("L/d continuous","26").Metric("min steel ρmin","1.4/fy (ACI 10.5)").Show(); return Result.Succeeded; } }
-    // 9. Foundation (ACI 318-14 / EC7)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class FoundationCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Pad foundation", new[] {"Column load kN","Bearing capacity kN/m²"}, new[] {1000.0,200.0}, out var v)) return Result.Cancelled; double a = v[0] * 1.35 / v[1]; double b = Math.Sqrt(a); Bk.B("Pad foundation","ACI 318-14 + EC7").AddSection("").Metric("Area required",$"{a:F2} m²").Metric("Square pad",$"{b*1000:F0} mm × {b*1000:F0} mm").Show(); return Result.Succeeded; } }
-    // 10. Seismic (ASCE 7 Ch 12)
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class SeismicCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Seismic","ASCE 7 Chapter 12").AddSection("SDS SITE CLASS").Metric("A hard rock","Fa=0.8, Fv=0.8").Metric("B rock","Fa=1.0").Metric("C dense soil","Fa=1.2").Metric("D stiff soil","Fa=1.6").Metric("E soft soil","Fa=2.5").Show(); return Result.Succeeded; } }
-}
+        public static string Region => ProjectStandardsManager.Instance.Region ?? "International";
 
-namespace StingTools.Commands.StandardsExt
-{
-    // 11. Occupant load (IBC / NFPA 101)
+        public static string GetStd(StandardsDiscipline d) =>
+            ProjectStandardsManager.Instance.GetStandardForDiscipline(d);
+    }
+
+    // 1. Ventilation (ASHRAE 62.1 / CIBSE TM60)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class OccupantLoadCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Occupant load", new[] {"Area m²","Load factor m²/occ"}, new[] {500.0,9.3}, out var v)) return Result.Cancelled; Bk.B("Occupant load","IBC 1004 + NFPA 101").AddSection("").Metric("Occupants", $"{(int)Math.Ceiling(v[0]/v[1])}").Show(); return Result.Succeeded; } }
-    // 12. Travel distance
+    public class VentilationCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Ventilation (ASHRAE 62.1 / CIBSE TM60)",
+                new[] { "Floor area (m²)", "Occupants", "Space type (1=Office, 2=Class, 3=Retail)" },
+                new[] { 100.0, 10.0, 1.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string space = v[2] <= 1.5 ? "Office" : v[2] <= 2.5 ? "Classroom" : "Retail";
+                var res = StandardsAPI.CalculateVentilation(v[0], v[1], space);
+                Bk.B("Ventilation", $"{Bk.Region} · {res.CIBSEReference ?? "ASHRAE 62.1"}")
+                    .AddSection("RESULT")
+                    .Metric("Space type",         res.SpaceType ?? space)
+                    .Metric("Fresh air",          $"{res.FreshAirLPS:F0} L/s ({res.FreshAirM3H:F0} m³/h)")
+                    .Metric("Air changes / hour", $"{res.AirChangesPerHour:F1}")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("Ventilation", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 2. Plumbing pipe size (IPC / BS EN 806)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class TravelDistanceCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Travel distance","IBC 1017 + BS 9999").AddSection("B-Office").Metric("Sprinklered","91 m").Metric("Not sprinklered","61 m").Metric("Common path","30 m").Metric("Dead-end","15 m").Show(); return Result.Succeeded; } }
-    // 13. Egress width
+    public class PlumbingPipeSizeCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Plumbing pipe (IPC / BS EN 806)",
+                new[] { "Flow (gpm)", "Length (ft)", "Fixtures" },
+                new[] { 20.0, 50.0, 8.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string std = Bk.GetStd(StandardsDiscipline.Plumbing);
+                var res = StandardsAPI.CalculatePlumbingPipeSize(v[0], v[1], "Copper", std, (int)v[2]);
+                Bk.B("Plumbing pipe size", $"{Bk.Region} · {res.IPCReference ?? std}")
+                    .AddSection("RESULT")
+                    .Metric("Nominal size", res.NominalSize ?? "-")
+                    .Metric("Pipe Ø",       $"{res.PipeDiameterMM:F0} mm ({res.PipeDiameterInch:F2}\")")
+                    .Metric("Velocity",     $"{res.VelocityMPS:F2} m/s ({res.VelocityFPS:F2} fps)")
+                    .Metric("Flow",         $"{res.FlowRateGPM:F0} gpm · WSFU {res.WSFU:F0}")
+                    .Metric("Compliant",    res.IsIPCCompliant ? "yes" : "review")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("PlumbingPipe", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 3. Duct size — equal friction (CIBSE Guide B3 / ASHRAE Handbook)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class EgressWidthCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Egress width", new[] {"Occupant load"}, new[] {300.0}, out var v)) return Result.Cancelled; Bk.B("Egress width","IBC 1005 + NFPA 101").AddSection("").Metric("Required width",$"{v[0] * 5.1:F0} mm at 5.1 mm/occupant").Metric("Min door","915 mm (32 in)").Metric("Min corridor","1120 mm (44 in)").Show(); return Result.Succeeded; } }
-    // 14. Space utilization (IFMA)
+    public class DuctEqualFrictionCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Equal friction duct (CIBSE B3 / ASHRAE)",
+                new[] { "Flow (L/s)", "Friction (Pa/m)" },
+                new[] { 500.0, 1.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                // Library expects CFM + in.WG/100ft; convert from L/s + Pa/m
+                double cfm = v[0] * 2.1189;
+                double frictionInWG = (v[1] * 100 / 0.3048) / 248.84; // Pa/m → in.WG/100ft
+                var res = AECCalculations.CalculateDuctSize(cfm, frictionInWG);
+                Bk.B("Equal friction duct", $"{Bk.Region} · {res.StandardReference ?? "CIBSE Guide B3"}")
+                    .AddSection("RESULT")
+                    .Metric("Round Ø",  $"{res.RoundDiameterMM:F0} mm ({res.RoundDiameterInches:F1}\")")
+                    .Metric("Velocity", $"{res.VelocityMPS:F1} m/s ({res.VelocityFPM:F0} fpm)")
+                    .Metric("Friction", $"{res.FrictionRate:F3} in.WG/100ft")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("DuctEqFr", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 4. Psychrometric (ASHRAE Handbook ch. 1) — closed-form, no library overload
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class SpaceUtilizationCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Space utilisation","IFMA + BOMA").AddSection("TARGETS").Metric("Usable / Gross","≥ 0.85").Metric("Rentable / Gross","0.80-0.88").Metric("Density (office)","10-15 m²/person").Show(); return Result.Succeeded; } }
-    // 15. Hydrant (NFPA 24)
+    public class PsychrometricCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Moist air (ASHRAE)",
+                new[] { "DBT °C", "RH %", "P kPa" },
+                new[] { 25.0, 60.0, 101.3 }, out var v)) return Result.Cancelled;
+            double pws = 0.611 * Math.Exp(17.27 * v[0] / (v[0] + 237.3));
+            double pw = v[1] / 100 * pws;
+            double w = 0.622 * pw / (v[2] - pw);
+            double h = 1.006 * v[0] + w * (2501 + 1.86 * v[0]);
+            Bk.B("Psychrometric", $"{Bk.Region} · ASHRAE Handbook ch. 1")
+                .AddSection("STATE")
+                .Metric("DBT",            $"{v[0]:F1} °C")
+                .Metric("RH",             $"{v[1]:F0}%")
+                .Metric("Vapor pressure", $"{pw:F3} kPa")
+                .Metric("Humidity ratio", $"{w * 1000:F2} g/kg")
+                .Metric("Enthalpy",       $"{h:F1} kJ/kg")
+                .Show();
+            return Result.Succeeded;
+        }
+    }
+
+    // 5. Arc flash PPE (IEEE 1584 / NFPA 70E) — reference card
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class HydrantCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Hydrant","NFPA 24 + BS EN 14384").AddSection("PLACEMENT").Metric("Max spacing","100 m (NFPA 1)").Metric("From building","≥ 12 m").Metric("Flow test","946 L/min @ 137 kPa min").Show(); return Result.Succeeded; } }
-    // 16. Maintenance cost (BSRIA)
+    public class ArcFlashCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            Bk.B("Arc flash", $"{Bk.Region} · IEEE 1584 + NFPA 70E")
+                .AddSection("PPE CATEGORY (cal/cm²)")
+                .Metric("Cat 0", "1.2 (≤ 1.2 cal/cm²)")
+                .Metric("Cat 1", "4")
+                .Metric("Cat 2", "8")
+                .Metric("Cat 3", "25")
+                .Metric("Cat 4", "40")
+                .Show();
+            return Result.Succeeded;
+        }
+    }
+
+    // 6. Conduit fill — uses StandardsAPI.CalculateBoundingSize
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class MaintenanceCostCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { if (!NumericPrompt.TryAsk("Maintenance cost", new[] {"GFA m²","Building type (1=Off, 2=Hosp, 3=School)"}, new[] {2000.0,1.0}, out var v)) return Result.Cancelled; double rate = v[1] <= 1.5 ? 55 : v[1] <= 2.5 ? 90 : 45; Bk.B("Maintenance cost","BSRIA BG 21 + CIBSE TM56").AddSection("").Metric("Rate",$"£{rate:F0}/m²/yr").Metric("Annual",$"£{v[0]*rate:F0}").Show(); return Result.Succeeded; } }
-    // 17. Accessible toilet
+    public class ConduitFillCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Conduit fill (NEC ch.9 / BS 7671)",
+                new[] { "Number of cables", "Cable Ø (mm)" },
+                new[] { 6.0, 12.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                var res = StandardsAPI.CalculateBoundingSize((int)v[0], v[1]);
+                Bk.B("Conduit fill", $"{Bk.Region} · NEC ch.9 + BS 7671 App.4")
+                    .AddSection("RESULT")
+                    .Metric("Recommended size", res.RecommendedSize ?? "-")
+                    .Metric("Cables",           res.NumberOfCables.ToString())
+                    .Metric("Fill",             $"{res.FillPercentage:F1}%")
+                    .Metric("Conduit type",     res.ConduitType ?? "EMT")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("ConduitFill", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 7. Steel beam — StandardsAPI.DesignSteelBeam (AISC 360 / EC3)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class AccessibleToiletCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Accessible toilet","BS 8300 + Part M + ADA").AddSection("MIN DIMS").Metric("Cubicle","2200 × 1500 mm").Metric("Door clear","850 mm outward").Metric("WC centreline","450 mm from sidewall").Metric("Grab rails","H = 200 mm above seat").Show(); return Result.Succeeded; } }
-    // 18. Accessible fixtures
+    public class SteelBeamCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Steel beam (AISC 360 / EC3)",
+                new[] { "Span (m)", "UDL (kN/m)" },
+                new[] { 8.0, 20.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                double total = v[0] * v[1]; // kN
+                string std = Bk.GetStd(StandardsDiscipline.Structural);
+                string method = std.IndexOf("Eurocode", StringComparison.OrdinalIgnoreCase) >= 0
+                    ? "ULS" : "LRFD";
+                string grade = std.IndexOf("Eurocode", StringComparison.OrdinalIgnoreCase) >= 0
+                    ? "S355" : "A992";
+                var res = StandardsAPI.DesignSteelBeam(v[0], total, "Uniform", grade, method);
+                Bk.B("Steel beam", $"{Bk.Region} · {res.EurocodeReference ?? std}")
+                    .AddSection("DESIGN")
+                    .Metric("Section",       res.SectionSize ?? "-")
+                    .Metric("Applied moment",$"{res.AppliedMoment:F1} kNm")
+                    .Metric("Required Zx",    $"{res.RequiredZx:F0} mm³")
+                    .Metric("Steel grade",   res.SteelGrade ?? grade)
+                    .Metric("Adequate",      res.IsAdequate ? "yes" : "review")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("SteelBeam", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 8. Concrete beam — reference card (no library overload yet)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class AccessibleFixturesCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Accessible fixtures","ADA 309 + BS 8300").AddSection("REACH").Metric("Forward reach","≤ 1200 mm").Metric("Side reach","≤ 1400 mm").Metric("Low reach","≥ 400 mm").Metric("Switch height","1000 mm (standard 1100 mm)").Show(); return Result.Succeeded; } }
-    // 19. Energy analysis
+    public class ConcreteBeamCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            Bk.B("Concrete beam", $"{Bk.Region} · ACI 318 + EC2")
+                .AddSection("DEFAULT RATIOS")
+                .Metric("L/d simple span", "20")
+                .Metric("L/d continuous",  "26")
+                .Metric("min steel ρmin",  "1.4 / fy (ACI 10.5)")
+                .Show();
+            return Result.Succeeded;
+        }
+    }
+
+    // 9. Pad foundation — reference card with quick sizing
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class EnergyAnalysisCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Energy analysis","Part L + ASHRAE 90.1 + CIBSE TM54").AddSection("FABRIC").Metric("External wall U","≤ 0.18 W/m²K").Metric("Roof U","≤ 0.11").Metric("Floor U","≤ 0.13").Metric("Glazing U","≤ 1.4").Metric("Airtightness","≤ 5 m³/hr/m² @ 50 Pa").Show(); return Result.Succeeded; } }
-    // 20. Sprinkler design criteria
+    public class FoundationCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Pad foundation (ACI 318-14 / EC7)",
+                new[] { "Column load (kN)", "Bearing capacity (kN/m²)" },
+                new[] { 1000.0, 200.0 }, out var v)) return Result.Cancelled;
+            double a = v[0] * 1.35 / v[1];
+            double b = Math.Sqrt(a);
+            Bk.B("Pad foundation", $"{Bk.Region} · ACI 318-14 + EC7")
+                .AddSection("SIZING")
+                .Metric("Required area", $"{a:F2} m²")
+                .Metric("Square pad",    $"{b * 1000:F0} × {b * 1000:F0} mm")
+                .Show();
+            return Result.Succeeded;
+        }
+    }
+
+    // 10. Seismic — AECCalculations.CalculateSeismicLoad
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class SprinklerCriteriaCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string m, ElementSet e) { Bk.B("Sprinkler criteria","NFPA 13 + BS EN 12845").AddSection("DENSITY mm/min × AREA m²").Metric("LH","2.25 × 84").Metric("OH1","5 × 72").Metric("OH2","5 × 144").Metric("OH3","5 × 216").Metric("HHP1","7.5 × 260").Metric("HHS1","7.5 × 260").Show(); return Result.Succeeded; } }
+    public class SeismicCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Seismic (ASCE 7)",
+                new[] { "Building weight (kips)", "Ss", "S1", "Site (1=A,2=B,3=C,4=D,5=E)" },
+                new[] { 5000.0, 1.0, 0.4, 4.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string site = v[3] <= 1.5 ? "A" : v[3] <= 2.5 ? "B" : v[3] <= 3.5 ? "C"
+                              : v[3] <= 4.5 ? "D" : "E";
+                var res = AECCalculations.CalculateSeismicLoad(v[0], v[1], v[2], site);
+                Bk.B("Seismic", $"{Bk.Region} · {res.StandardReference ?? "ASCE 7-22"}")
+                    .AddSection("DESIGN")
+                    .Metric("Base shear", $"{res.BaseShearKips:F0} kips ({res.BaseShearKN:F0} kN)")
+                    .Metric("Cs",         $"{res.Cs:F3}")
+                    .Metric("SDs",        $"{res.SDs:F3}")
+                    .Metric("SD1",        $"{res.SD1:F3}")
+                    .Metric("Fa / Fv",    $"{res.Fa:F2} / {res.Fv:F2}")
+                    .Metric("SDC",        res.SeismicDesignCategory ?? "-")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("Seismic", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 11. Occupant load — AECCalculations.CalculateOccupantLoad
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class OccupantLoadCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Occupant load (IBC 1004 / NFPA 101)",
+                new[] { "Area (m²)", "Type (1=Office, 2=Classroom, 3=Retail-Ground, 4=Assembly-Unconcentrated)" },
+                new[] { 500.0, 1.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string occ = v[1] <= 1.5 ? "Office" : v[1] <= 2.5 ? "Classroom"
+                            : v[1] <= 3.5 ? "Retail-Ground" : "Assembly-Unconcentrated";
+                double sqft = v[0] * 10.7639;
+                var res = AECCalculations.CalculateOccupantLoad(sqft, occ);
+                Bk.B("Occupant load", $"{Bk.Region} · {res.StandardReference ?? "IBC 1004"}")
+                    .AddSection("RESULT")
+                    .Metric("Occupants",   res.OccupantLoad.ToString())
+                    .Metric("Load factor", $"{res.LoadFactor:F0} sqft/occupant")
+                    .Metric("Type",        res.OccupancyType ?? occ)
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("OccLoad", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 12. Travel distance — AECCalculations.CalculateTravelDistance
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class TravelDistanceCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Travel distance (IBC 1017 / BS 9999)",
+                new[] { "Group (1=A,2=B,3=E,4=F,5=H,6=R)", "Sprinklered? (0/1)" },
+                new[] { 2.0, 1.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string grp = v[0] <= 1.5 ? "A" : v[0] <= 2.5 ? "B" : v[0] <= 3.5 ? "E"
+                            : v[0] <= 4.5 ? "F" : v[0] <= 5.5 ? "H" : "R";
+                bool sp = v[1] >= 0.5;
+                var res = AECCalculations.CalculateTravelDistance(grp, sp);
+                Bk.B("Travel distance", $"{Bk.Region} · {res.StandardReference ?? "IBC 1017"}")
+                    .AddSection("LIMIT")
+                    .Metric("Max travel",  $"{res.MaxTravelDistanceM:F0} m ({res.MaxTravelDistanceFt:F0} ft)")
+                    .Metric("Group",       res.OccupancyGroup ?? grp)
+                    .Metric("Sprinklered", res.IsSprinklered ? "yes" : "no")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("Travel", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 13. Egress width — AECCalculations.CalculateEgressWidth
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class EgressWidthCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Egress width (IBC 1005 / NFPA 101)",
+                new[] { "Occupant load", "Sprinklered? (0/1)" },
+                new[] { 300.0, 1.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                var res = AECCalculations.CalculateEgressWidth(
+                    occupantLoad: (int)v[0], egressComponent: "Corridor", sprinklered: v[1] >= 0.5);
+                Bk.B("Egress width", $"{Bk.Region} · {res.StandardReference ?? "IBC 1005"}")
+                    .AddSection("RESULT")
+                    .Metric("Required width", $"{res.RequiredWidthMM:F0} mm ({res.RequiredWidthInches:F1}\")")
+                    .Metric("Min width",       $"{res.MinimumWidthInches:F1}\"")
+                    .Metric("Exits required",  res.ExitsRequired.ToString())
+                    .Metric("Sprinklered",     res.IsSprinklered ? "yes" : "no")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("Egress", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 14. Space utilisation — AECCalculations.CalculateSpaceEfficiency
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class SpaceUtilizationCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Space utilisation (BOMA / IFMA)",
+                new[] { "Gross (m²)", "Usable (m²)", "Rentable (m²)", "Occupants", "Workstations" },
+                new[] { 2000.0, 1700.0, 1850.0, 150.0, 130.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                var res = AECCalculations.CalculateSpaceEfficiency(
+                    grossFloorAreaSqFt: v[0] * 10.7639,
+                    usableAreaSqFt:    v[1] * 10.7639,
+                    rentableAreaSqFt:  v[2] * 10.7639,
+                    totalOccupants:    (int)v[3],
+                    workstations:      (int)v[4]);
+                Bk.B("Space utilisation", $"{Bk.Region} · {res.StandardReference ?? "BOMA / IFMA"}")
+                    .AddSection("EFFICIENCY")
+                    .Metric("Usable / gross",  $"{res.EfficiencyRatio:F1}%")
+                    .Metric("Load factor",     $"{res.LoadFactor:F2}")
+                    .Metric("ft² / person",    $"{res.SqFtPerPerson:F0}")
+                    .Metric("ft² / workstation",$"{res.SqFtPerWorkstation:F0}")
+                    .Metric("Rating",          res.EfficiencyRating ?? "-")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("SpaceUtil", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 15. Fire hydrant — reference card
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class HydrantCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            Bk.B("Hydrant", $"{Bk.Region} · NFPA 24 + BS EN 14384")
+                .AddSection("PLACEMENT")
+                .Metric("Max spacing",  "100 m (NFPA 1)")
+                .Metric("From building", "≥ 12 m")
+                .Metric("Flow test",    "946 L/min @ 137 kPa min")
+                .Show();
+            return Result.Succeeded;
+        }
+    }
+
+    // 16. Maintenance cost — AECCalculations.CalculateMaintenanceCosts
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class MaintenanceCostCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Maintenance cost (BSRIA BG21 / IFMA)",
+                new[] { "GFA (m²)", "Type (1=Office,2=Hospital,3=School,4=Warehouse)", "Building age (years)" },
+                new[] { 2000.0, 1.0, 5.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string type = v[1] <= 1.5 ? "Office" : v[1] <= 2.5 ? "Hospital"
+                            : v[1] <= 3.5 ? "School" : "Warehouse";
+                var res = AECCalculations.CalculateMaintenanceCosts(v[0] * 10.7639, type, (int)v[2]);
+                Bk.B("Maintenance cost", $"{Bk.Region} · {res.StandardReference ?? "IFMA + BSRIA BG21"}")
+                    .AddSection("ANNUAL")
+                    .Metric("Building type", res.BuildingType ?? type)
+                    .Metric("Cost / ft²",    $"${res.CostPerSqFt:F2}")
+                    .Metric("Annual cost",    $"${res.AnnualMaintenanceCost:F0}")
+                    .Metric("Age factor",    $"{res.AgeFactor:F2}")
+                    .Metric("Condition factor",$"{res.ConditionFactor:F2}")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("MaintCost", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 17. Accessible toilet — AECCalculations.CalculateAccessibleToilet
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class AccessibleToiletCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Accessible toilet (ADA / BS 8300 / Part M)",
+                new[] { "Width (mm)", "Depth (mm)", "Layout (1=Side, 2=Front)" },
+                new[] { 1500.0, 2200.0, 1.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string layout = v[2] <= 1.5 ? "Side" : "Front";
+                var res = AECCalculations.CalculateAccessibleToilet(v[0] / 25.4, v[1] / 25.4, layout);
+                var sec = Bk.B("Accessible toilet", $"{Bk.Region} · {res.StandardReference ?? "ADA + BS 8300"}")
+                    .AddSection("RESULT")
+                    .Metric("Compliant", res.IsCompliant ? "yes" : "REVIEW")
+                    .Metric("Required",  $"{res.RequiredWidth:F0}\" × {res.RequiredDepth:F0}\"")
+                    .Metric("Actual",    $"{res.ActualWidth:F0}\" × {res.ActualDepth:F0}\"")
+                    .Metric("WC ⌀ wall", $"{res.ToiletCenterlineFromWall:F0}\"");
+                if (res.Issues != null && res.Issues.Count > 0)
+                {
+                    sec.AddSection("ISSUES");
+                    foreach (var i in res.Issues) sec.Text(i);
+                }
+                sec.Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("AccToilet", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 18. Accessible fixtures — AECCalculations.CalculateAccessibleFixtures
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class AccessibleFixturesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Accessible fixtures (ADA 309 / BS 8300)",
+                new[] { "Toilets", "Urinals", "Lavatories", "Drinking fountains" },
+                new[] { 8.0, 4.0, 8.0, 2.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                var res = AECCalculations.CalculateAccessibleFixtures(
+                    (int)v[0], (int)v[1], (int)v[2], (int)v[3]);
+                Bk.B("Accessible fixtures", $"{Bk.Region} · {res.StandardReference ?? "ADA 309"}")
+                    .AddSection("REQUIRED")
+                    .Metric("Toilets",            $"{res.AccessibleToilets} of {res.TotalToilets}")
+                    .Metric("Urinals",            $"{res.AccessibleUrinals} of {res.TotalUrinals}")
+                    .Metric("Lavatories",         $"{res.AccessibleLavatories} of {res.TotalLavatories}")
+                    .Metric("Drinking fountains", $"{res.HiLoDrinkingFountains} of {res.TotalDrinkingFountains}")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("AccFix", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 19. EUI energy analysis — AECCalculations.CalculateEUI
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class EnergyAnalysisCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("EUI (Part L / ASHRAE 90.1 / CIBSE TM46)",
+                new[] { "Annual kWh", "GFA (m²)", "Type (1=Office,2=Retail,3=Hotel,4=Hospital,5=School)" },
+                new[] { 200000.0, 2000.0, 1.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string type = v[2] <= 1.5 ? "Office" : v[2] <= 2.5 ? "Retail"
+                            : v[2] <= 3.5 ? "Hotel"  : v[2] <= 4.5 ? "Hospital" : "School K-12";
+                var res = AECCalculations.CalculateEUI(v[0], v[1] * 10.7639, type);
+                Bk.B("EUI", $"{Bk.Region} · {res.StandardReference ?? "ENERGY STAR + CIBSE TM46"}")
+                    .AddSection("BENCHMARK")
+                    .Metric("EUI",          $"{res.EUIKWhPerM2:F0} kWh/m²/yr ({res.EUIKBtuPerSqFt:F1} kBtu/ft²)")
+                    .Metric("Baseline",     $"{res.BaselineEUI:F0} kBtu/ft²")
+                    .Metric("vs baseline",  $"{res.PercentBetterThanBaseline:F1}% better")
+                    .Metric("LEED EAp2",    $"{res.EstimatedLEEDPoints} points (est.)")
+                    .Metric("Type",         res.BuildingType ?? type)
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("EUI", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // 20. Sprinkler design criteria — StandardsAPI.DesignSprinklerSystem
+    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
+    public class SprinklerCriteriaCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string m, ElementSet e)
+        {
+            if (!NumericPrompt.TryAsk("Sprinkler criteria (NFPA 13 / BS EN 12845)",
+                new[] { "Floor area (m²)", "Hazard (1=LH, 2=OH1, 3=OH2, 4=HHS)" },
+                new[] { 1000.0, 2.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string hz = v[1] <= 1.5 ? "Light" : v[1] <= 2.5 ? "OrdinaryGroup1"
+                          : v[1] <= 3.5 ? "OrdinaryGroup2" : "ExtraHazard";
+                string std = Bk.GetStd(StandardsDiscipline.FireProtection);
+                var res = StandardsAPI.DesignSprinklerSystem(v[0], "Office", hz, std);
+                Bk.B("Sprinkler criteria", $"{Bk.Region} · {res.NFPAReference ?? std}")
+                    .AddSection("HYDRAULIC")
+                    .Metric("Hazard",          res.HazardClass ?? hz)
+                    .Metric("Density",         $"{res.DesignDensity:F3} gpm/ft²")
+                    .Metric("Design area",     $"{res.DesignAreaFt2:F0} ft² ({res.DesignAreaFt2 * 0.0929:F0} m²)")
+                    .Metric("Heads in design",  res.DesignHeads.ToString())
+                    .Metric("Total heads",      res.NumberOfHeads.ToString())
+                    .Metric("Flow",             $"{res.FlowRateGPM:F0} gpm ({res.FlowRateGPM * 3.785:F0} L/min)")
+                    .Metric("Hose stream",      $"{res.HoseStreamGPM:F0} gpm")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("SprinklerCrit", ex); m = ex.Message; return Result.Failed; }
+        }
+    }
 }

--- a/StingTools/Commands/StandardsExt/StandardsComplianceCommand.cs
+++ b/StingTools/Commands/StandardsExt/StandardsComplianceCommand.cs
@@ -1,0 +1,209 @@
+// STING Tools — Standards compliance command.
+//
+// Bridges Revit elements to the StandardsComplianceEngine. Rooms +
+// doors + corridors are converted to DesignElement records and run
+// through the engine's CheckBatchCompliance against the rules loaded
+// from data\AEC_COMPLIANCE_RULES.csv (optional). Results are
+// rendered through StingResultPanel grouped by violation severity.
+//
+// The engine is region-aware via ProjectStandardsManager — only rules
+// whose Region matches the active project region (or are global) run.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Standards;
+using StingTools.Standards.Compliance;
+using StingTools.UI;
+
+namespace StingTools.Commands.StandardsExt
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class RunStandardsComplianceCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(cd);
+            if (ctx == null) { message = "No active document."; return Result.Failed; }
+
+            var engine = new StandardsComplianceEngine();
+
+            // Optional CSV — projects can drop their rule pack alongside the DLL
+            // (data\AEC_COMPLIANCE_RULES.csv). When absent, we bootstrap a small
+            // demo pack so the command produces a meaningful result on first install.
+            try
+            {
+                var csv = StingToolsApp.FindDataFile("AEC_COMPLIANCE_RULES.csv");
+                if (!string.IsNullOrEmpty(csv) && File.Exists(csv))
+                    engine.LoadFromCsv(csv);
+                else
+                    SeedDefaultRules(engine);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Compliance rule load failed, seeding defaults: {ex.Message}");
+                SeedDefaultRules(engine);
+            }
+
+            string region = ProjectStandardsManager.Instance.Region ?? "International";
+            List<DesignElement> bag;
+            try { bag = CollectElements(ctx.Doc); }
+            catch (Exception ex) { StingLog.Error("Compliance collect", ex); message = ex.Message; return Result.Failed; }
+
+            if (bag.Count == 0)
+            {
+                TaskDialog.Show("STING Standards Compliance",
+                    "No rooms or doors found in the active document — nothing to validate.");
+                return Result.Cancelled;
+            }
+
+            BatchComplianceResult batch;
+            try { batch = engine.CheckBatchCompliance(bag, region); }
+            catch (Exception ex) { StingLog.Error("Compliance run", ex); message = ex.Message; return Result.Failed; }
+
+            // Render — overall RAG bar + violations + warnings
+            int violations = batch.ElementResults.Sum(r => r.Violations.Count);
+            int warnings   = batch.ElementResults.Sum(r => r.Warnings.Count);
+            double scorePct = batch.OverallComplianceScore * 100.0;
+
+            var panel = StingResultPanel.Create("Standards compliance audit")
+                .SetSubtitle($"{region} · {batch.TotalElements} elements · {engine.GetEnabledStandards().Count()} standards");
+            panel.SetOverallPct(scorePct);
+
+            panel.AddSection("SUMMARY")
+                 .Metric("Compliant elements", $"{batch.CompliantElements} / {batch.TotalElements}")
+                 .Metric("Overall score",      $"{scorePct:F1}%")
+                 .Metric("Critical violations", violations.ToString())
+                 .Metric("Warnings",            warnings.ToString())
+                 .Metric("Region",              region);
+
+            if (violations > 0)
+            {
+                panel.AddSection("VIOLATIONS");
+                foreach (var er in batch.ElementResults.Where(r => r.Violations.Any()).Take(40))
+                {
+                    foreach (var v in er.Violations)
+                        panel.MetricError(
+                            $"{er.ElementType} {er.ElementId}",
+                            v.RuleName,
+                            $"{v.StandardCode}: {v.Message}");
+                }
+            }
+
+            if (warnings > 0)
+            {
+                panel.AddSection("WARNINGS");
+                foreach (var er in batch.ElementResults.Where(r => r.Warnings.Any()).Take(40))
+                {
+                    foreach (var w in er.Warnings)
+                        panel.MetricWarn(
+                            $"{er.ElementType} {er.ElementId}",
+                            w.RuleName,
+                            $"{w.StandardCode}: {w.Message}");
+                }
+            }
+
+            panel.Show();
+            return Result.Succeeded;
+        }
+
+        // Builds DesignElement records for rooms (area, occupancy) and doors
+        // (clear width, fire rating). Extend by category as more rule packs land.
+        private static List<DesignElement> CollectElements(Document doc)
+        {
+            var bag = new List<DesignElement>();
+
+            var rooms = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_Rooms)
+                .WhereElementIsNotElementType()
+                .OfType<Autodesk.Revit.DB.Architecture.Room>()
+                .Where(r => r.Area > 0);
+
+            foreach (var r in rooms)
+            {
+                var de = new DesignElement
+                {
+                    Id = r.Id.ToString(),
+                    Type = "Room",
+                    Category = "Spatial",
+                    Properties = new Dictionary<string, object>
+                    {
+                        ["Name"]      = r.Name ?? string.Empty,
+                        ["AreaM2"]    = r.Area * 0.092903,         // ft² → m²
+                        ["AreaSqFt"]  = r.Area,
+                        ["Number"]    = r.Number ?? string.Empty,
+                        ["Department"]= ParameterHelpers.GetString(r, "Department") ?? string.Empty,
+                    }
+                };
+                bag.Add(de);
+            }
+
+            var doors = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_Doors)
+                .WhereElementIsNotElementType()
+                .OfType<FamilyInstance>();
+
+            foreach (var d in doors)
+            {
+                double widthFt = d.LookupParameter("Width")?.AsDouble() ?? 0;
+                double heightFt = d.LookupParameter("Height")?.AsDouble() ?? 0;
+                string fire = ParameterHelpers.GetString(d, "Fire Rating");
+                bag.Add(new DesignElement
+                {
+                    Id = d.Id.ToString(),
+                    Type = "Door",
+                    Category = "Egress",
+                    Properties = new Dictionary<string, object>
+                    {
+                        ["WidthMM"]    = widthFt * 304.8,
+                        ["HeightMM"]   = heightFt * 304.8,
+                        ["FireRating"] = fire ?? string.Empty
+                    }
+                });
+            }
+
+            return bag;
+        }
+
+        // Default rule pack — fires when no CSV is shipped. Mirrors a minimal
+        // BS 8300 + Approved Doc M + ISO 19650 baseline. Replace by dropping
+        // a real AEC_COMPLIANCE_RULES.csv next to the DLL.
+        private static void SeedDefaultRules(StandardsComplianceEngine engine)
+        {
+            void AddRule(string id, string code, string name, RuleSeverity sev,
+                         string applicableType, string condition, string required, string unit)
+            {
+                var rule = new ComplianceRule
+                {
+                    Id = id,
+                    StandardCode = code,
+                    Category = applicableType,
+                    Name = name,
+                    Description = name,
+                    Condition = condition,
+                    RequiredValue = required,
+                    Unit = unit,
+                    Severity = sev,
+                    Region = "International"
+                };
+                rule.ApplicableTypes.Add(applicableType);
+                engine.AddRule(rule);
+            }
+
+            AddRule("BS8300-DOOR-WIDTH",   "BS8300",      "Door clear width ≥ 800 mm",     RuleSeverity.Critical, "Door", "WidthMM>=800",  "800",  "mm");
+            AddRule("ADM-DOOR-WIDTH",      "ApprovedDocM","Door clear width ≥ 850 mm (ADA)", RuleSeverity.Major,    "Door", "WidthMM>=850",  "850",  "mm");
+            AddRule("BS8300-DOOR-HEIGHT",  "BS8300",      "Door clear height ≥ 2000 mm",   RuleSeverity.Major,    "Door", "HeightMM>=2000", "2000", "mm");
+            AddRule("ROOM-AREA-MIN",       "BS6465",      "Room area > 0",                  RuleSeverity.Critical, "Room", "AreaM2>0",       ">0",   "m²");
+
+            engine.EnableStandard("BS8300");
+            engine.EnableStandard("ApprovedDocM");
+            engine.EnableStandard("BS6465");
+        }
+    }
+}

--- a/StingTools/Commands/StandardsExt/StandardsComplianceCommand.cs
+++ b/StingTools/Commands/StandardsExt/StandardsComplianceCommand.cs
@@ -151,9 +151,17 @@ namespace StingTools.Commands.StandardsExt
 
             foreach (var d in doors)
             {
-                double widthFt = d.LookupParameter("Width")?.AsDouble() ?? 0;
-                double heightFt = d.LookupParameter("Height")?.AsDouble() ?? 0;
+                // Door Width / Height are normally TYPE parameters. LookupParameter
+                // on an instance does NOT walk through to the family symbol, so
+                // we fall back to the symbol when the instance returns null/0.
+                double widthFt = ReadDoubleWithTypeFallback(doc, d, "Width");
+                double heightFt = ReadDoubleWithTypeFallback(doc, d, "Height");
                 string fire = ParameterHelpers.GetString(d, "Fire Rating");
+                if (string.IsNullOrEmpty(fire))
+                {
+                    var symbol = doc.GetElement(d.GetTypeId()) as ElementType;
+                    if (symbol != null) fire = ParameterHelpers.GetString(symbol, "Fire Rating");
+                }
                 bag.Add(new DesignElement
                 {
                     Id = d.Id.ToString(),
@@ -169,6 +177,17 @@ namespace StingTools.Commands.StandardsExt
             }
 
             return bag;
+        }
+
+        // Read a numeric parameter from an instance, falling back to the
+        // associated FamilySymbol when the instance value is null or zero.
+        // Door / window dimensions are nearly always type-bound.
+        private static double ReadDoubleWithTypeFallback(Document doc, FamilyInstance fi, string name)
+        {
+            double v = fi.LookupParameter(name)?.AsDouble() ?? 0.0;
+            if (v > 0) return v;
+            var symbol = doc.GetElement(fi.GetTypeId()) as ElementType;
+            return symbol?.LookupParameter(name)?.AsDouble() ?? 0.0;
         }
 
         // Default rule pack — fires when no CSV is shipped. Mirrors a minimal

--- a/StingTools/Commands/StandardsExt/StandardsExtCommands.cs
+++ b/StingTools/Commands/StandardsExt/StandardsExtCommands.cs
@@ -202,9 +202,11 @@ namespace StingTools.Commands.StandardsExt
             try { mgr.ApplyRegionalPreset(picked); }
             catch (Exception ex) { StingLog.Error("ApplyRegionalPreset failed", ex); message = ex.Message; return Result.Failed; }
 
-            // Persist on the Revit document so the choice travels with the .rvt
-            // and the dock-panel status bar can read it back without consulting
-            // %APPDATA%. PROJECT_REGION lives on ProjectInformation.
+            // Persist on the Revit document so the choice travels with the .rvt.
+            // Two channels: PROJECT_REGION on ProjectInformation (preferred —
+            // visible in schedules) and a sidecar JSON next to the .rvt
+            // (resilient fallback when the shared parameter isn't bound).
+            bool paramWritten = false;
             try
             {
                 var pi = ctx.Doc.ProjectInformation;
@@ -214,19 +216,29 @@ namespace StingTools.Commands.StandardsExt
                     {
                         t.Start();
                         var p = pi.LookupParameter("PROJECT_REGION");
-                        if (p != null && !p.IsReadOnly) p.Set(picked);
+                        if (p != null && !p.IsReadOnly)
+                        {
+                            p.Set(picked);
+                            paramWritten = true;
+                        }
                         t.Commit();
                     }
                 }
             }
             catch (Exception ex) { StingLog.Warn($"PROJECT_REGION write skipped: {ex.Message}"); }
+            bool sidecarWritten = ProjectRegionSidecar.Write(ctx.Doc, picked);
 
             var summary = mgr.GetConfigurationSummary();
             var panel = StingResultPanel.Create("Active region updated").SetSubtitle(picked);
             var sec = panel.AddSection("STANDARDS BINDING");
             foreach (var kv in summary.Standards) sec.Metric(kv.Key, kv.Value);
             sec.Metric("Unit system", summary.UnitSystem.ToString());
-            panel.Text($"Saved to {Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\StingTools\\config\\project-standards.json");
+            var persist = panel.AddSection("PERSISTENCE");
+            persist.Metric("PROJECT_REGION param", paramWritten ? "written" : "NOT BOUND — load shared params to enable");
+            persist.Metric("Project sidecar",      sidecarWritten ? "written" : "FAILED (unsaved doc?)");
+            persist.Metric("User store",            $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\StingTools\\config\\project-standards.json");
+            if (!paramWritten)
+                panel.Text("Tip: PROJECT_REGION isn't bound to Project Information on this project. The region is still saved to the per-project sidecar (sting_region.json) and the per-user appdata store, so document-open sync will recover it. Bind the shared parameter to surface the value in schedules and title blocks.");
             panel.Show();
             return Result.Succeeded;
         }

--- a/StingTools/Commands/StandardsExt/StandardsExtCommands.cs
+++ b/StingTools/Commands/StandardsExt/StandardsExtCommands.cs
@@ -1,10 +1,13 @@
 // STING Tools — Phase 116: Standards Extensions (STD-01..10 + REG-01).
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using StingTools.Commands.Standards;
 using StingTools.Core;
+using StingTools.Standards;
 using StingTools.UI;
 
 namespace StingTools.Commands.StandardsExt
@@ -60,119 +63,266 @@ namespace StingTools.Commands.StandardsExt
         }
     }
 
-    // STD-04 — Parking audit
+    // STD-04 — Parking audit (AECCalculations.CalculateParkingRequirements)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
     public class ParkingAuditCommand : IExternalCommand
     {
         public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
         {
-            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message="No doc"; return Result.Failed; }
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
             if (!NumericPrompt.TryAsk("STD-04 Parking requirement",
-                new[] { "GFA (m²)", "Occupancy (1=Office, 2=Retail, 3=Residential, 4=Industrial)" },
+                new[] { "GFA (m²)", "Type (1=Office,2=Retail,3=Restaurant,4=Hotel,5=Residential-Multi,6=Warehouse)" },
                 new[] { 2000.0, 1.0 }, out var v)) return Result.Cancelled;
-            double ratio = v[1] <= 1.5 ? 1/40.0 : v[1] <= 2.5 ? 1/25.0 : v[1] <= 3.5 ? 1.0 : 1/50.0;
-            int required = (int)Math.Ceiling(v[0] * ratio);
-            int accessible = (int)Math.Max(1, required * 0.05);
-            StdP.B("STD-04 Parking", "Approved Document M + local auth + BS 6100")
-                .AddSection("REQUIREMENT")
-                .Metric("Required spaces",    required.ToString())
-                .Metric("Accessible (5% min)", accessible.ToString())
-                .Metric("Ratio",              $"1 per {1/ratio:F0} m²")
-                .Show();
-            return Result.Succeeded;
+            try
+            {
+                string useType = v[1] <= 1.5 ? "Office" : v[1] <= 2.5 ? "Retail"
+                                : v[1] <= 3.5 ? "Restaurant" : v[1] <= 4.5 ? "Hotel"
+                                : v[1] <= 5.5 ? "Residential-Multi" : "Warehouse";
+                var res = AECCalculations.CalculateParkingRequirements(v[0] * 10.7639, useType);
+                StdP.B("STD-04 Parking", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "ITE / Approved Doc M"}")
+                    .AddSection("REQUIREMENT")
+                    .Metric("Total spaces",        res.TotalSpaces.ToString())
+                    .Metric("Standard spaces",     res.StandardSpaces.ToString())
+                    .Metric("Accessible spaces",   res.AccessibleSpaces.ToString())
+                    .Metric("Van accessible",      res.VanAccessibleSpaces.ToString())
+                    .Metric("Ratio",                $"{res.ParkingRatio:F2} {res.RatioBasis}")
+                    .Metric("Use type",             res.UseType ?? useType)
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("ParkingAudit", ex); message = ex.Message; return Result.Failed; }
         }
     }
 
-    // STD-05 — Live load audit
+    // STD-05 — Live load (AECCalculations.CalculateFloorLiveLoad)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
     public class LiveLoadAuditCommand : IExternalCommand
     {
         public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
         {
-            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message="No doc"; return Result.Failed; }
-            StdP.B("STD-05 Floor live load", "EC 1991-1-1 + BS 6399-1 + ASCE 7 Table 4-1")
-                .AddSection("CATEGORY QK kN/m²")
-                .Metric("A — Domestic/residential",  "1.5-2.0")
-                .Metric("B — Office",                 "2.0-3.0")
-                .Metric("C — Congregation / circ.",  "3.0-5.0")
-                .Metric("D — Shopping",               "4.0-5.0")
-                .Metric("E — Storage / industrial",   "7.5+ (E1) to 12.5+ (E2)")
-                .Metric("F — Vehicles ≤ 30 kN",       "2.5")
-                .Metric("G — Vehicles 30-160 kN",     "5.0")
-                .Metric("Roof H (access)",            "1.5")
-                .Metric("Roof I (no access)",         "0.6")
-                .Show();
-            return Result.Succeeded;
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
+            if (!NumericPrompt.TryAsk("STD-05 Live load",
+                new[] { "Type (1=Office,2=Residential,3=Hotel-Public,4=Assembly-Fixed,5=Assembly-Movable)", "Tributary area (m²)" },
+                new[] { 1.0, 50.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string occ = v[0] <= 1.5 ? "Office" : v[0] <= 2.5 ? "Residential"
+                            : v[0] <= 3.5 ? "Hotel-Public"
+                            : v[0] <= 4.5 ? "Assembly-Fixed Seats" : "Assembly-Movable Seats";
+                var res = AECCalculations.CalculateFloorLiveLoad(occ, true, v[1] * 10.7639);
+                StdP.B("STD-05 Floor live load", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "ASCE 7-22 Table 4.3-1"}")
+                    .AddSection("LIVE LOAD")
+                    .Metric("Uniform",            $"{res.UniformLoadKPa:F2} kN/m² ({res.UniformLoadPSF:F0} psf)")
+                    .Metric("Reduced",             $"{res.ReducedLoadKPa:F2} kN/m² ({res.ReducedLoadPSF:F0} psf)")
+                    .Metric("Concentrated",        $"{res.ConcentratedLoadKN:F1} kN ({res.ConcentratedLoadLbs:F0} lb)")
+                    .Metric("Reduction factor",   $"{res.ReductionFactor:F2}")
+                    .Metric("Tributary area",      $"{res.TributaryArea:F0} ft² ({v[1]:F0} m²)")
+                    .Metric("Occupancy",           res.OccupancyType ?? occ)
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("LiveLoad", ex); message = ex.Message; return Result.Failed; }
         }
     }
 
-    // STD-06 — Load combinations
+    // STD-06 — Load combinations (AECCalculations.CalculateLoadCombinations)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
     public class LoadCombinationsCommand : IExternalCommand
     {
         public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
         {
-            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message="No doc"; return Result.Failed; }
-            StdP.B("STD-06 Load combinations", "EC 0 + ASCE 7 + BS")
-                .AddSection("EC 0 STR + GEO (6.10)")
-                .Metric("Persistent + transient",  "1.35 Gk + 1.5 Qk + Σ(1.5 ψ0 Qk,i)")
-                .Metric("Accidental",               "Gk + Ad + ψ1 Qk + Σ(ψ2 Qk,i)")
-                .Metric("Seismic",                  "Gk + AEd + Σ(ψ2 Qk,i)")
-                .AddSection("ASCE 7 LRFD (2.3.2)")
-                .Metric("1",  "1.4 D")
-                .Metric("2",  "1.2 D + 1.6 L + 0.5 Lr/S/R")
-                .Metric("3",  "1.2 D + 1.6 Lr/S/R + 0.5 L/0.5 W")
-                .Metric("4",  "1.2 D + 1.0 W + L + 0.5 Lr/S/R")
-                .Metric("5",  "0.9 D + 1.0 W")
-                .Metric("6",  "1.2 D + 1.0 E + L + 0.2 S")
-                .Metric("7",  "0.9 D + 1.0 E")
-                .Show();
-            return Result.Succeeded;
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
+            if (!NumericPrompt.TryAsk("STD-06 Load combinations",
+                new[] { "Dead (kips)", "Live (kips)", "Roof live (kips)", "Snow (kips)", "Wind (kips)", "Seismic (kips)" },
+                new[] { 100.0, 60.0, 20.0, 15.0, 30.0, 25.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                var res = AECCalculations.CalculateLoadCombinations(v[0], v[1], v[2], v[3], v[4], v[5]);
+                var sec = StdP.B("STD-06 Load combinations", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "ASCE 7-22 §2.3"}")
+                    .AddSection($"{res.DesignMethod ?? "LRFD"} COMBINATIONS");
+                if (res.Combinations != null)
+                    foreach (var kv in res.Combinations) sec.Metric(kv.Key, $"{kv.Value:F1} kips");
+                sec.AddSection("GOVERNING")
+                   .Metric("Combination", res.GoverningCombination ?? "-")
+                   .Metric("Load",         $"{res.GoverningLoadKips:F1} kips ({res.GoverningLoadKN:F1} kN)")
+                   .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("LoadCombos", ex); message = ex.Message; return Result.Failed; }
         }
     }
 
-    // STD-07 — EUI benchmark
+    // STD-07 — EUI benchmark (AECCalculations.CalculateEUI)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
     public class EUIBenchmarkCommand : IExternalCommand
     {
         public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
         {
-            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message="No doc"; return Result.Failed; }
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
             if (!NumericPrompt.TryAsk("STD-07 Energy use intensity",
-                new[] { "Annual kWh", "GFA (m²)", "Type (1=Office, 2=Retail, 3=School, 4=Hospital)" },
+                new[] { "Annual kWh", "GFA (m²)", "Type (1=Office,2=Retail,3=School,4=Hospital,5=Hotel)" },
                 new[] { 200000.0, 2000.0, 1.0 }, out var v)) return Result.Cancelled;
-            double eui = v[0] / v[1];
-            double target = v[2] <= 1.5 ? 100 : v[2] <= 2.5 ? 150 : v[2] <= 3.5 ? 100 : 300;
-            StdP.B("STD-07 EUI benchmark", "Part L 2021 + ASHRAE 90.1 + CIBSE TM46")
-                .AddSection("BENCHMARK")
-                .Metric("EUI",            $"{eui:F0} kWh/m²/yr")
-                .Metric("CIBSE TM46 target",$"{target:F0} kWh/m²/yr")
-                .Metric("Verdict",         eui <= target ? "PASS" : "REVIEW")
-                .Show();
-            return Result.Succeeded;
+            try
+            {
+                string type = v[2] <= 1.5 ? "Office" : v[2] <= 2.5 ? "Retail"
+                            : v[2] <= 3.5 ? "School K-12" : v[2] <= 4.5 ? "Hospital" : "Hotel";
+                var res = AECCalculations.CalculateEUI(v[0], v[1] * 10.7639, type);
+                StdP.B("STD-07 EUI benchmark", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "ENERGY STAR"}")
+                    .AddSection("BENCHMARK")
+                    .Metric("EUI",            $"{res.EUIKWhPerM2:F0} kWh/m²/yr ({res.EUIKBtuPerSqFt:F1} kBtu/ft²)")
+                    .Metric("Baseline",       $"{res.BaselineEUI:F1} kBtu/ft²")
+                    .Metric("vs baseline",    $"{res.PercentBetterThanBaseline:F1}% better")
+                    .Metric("LEED EAp2 (est.)", res.EstimatedLEEDPoints.ToString())
+                    .Metric("Verdict",         res.PercentBetterThanBaseline > 0 ? "PASS" : "REVIEW")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("EUIBench", ex); message = ex.Message; return Result.Failed; }
         }
     }
 
-    // STD-02/08/09/10 — Water, space, lifecycle
-    [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class SetRegionCommand : IExternalCommand {
-        public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements) {
-            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message="No doc"; return Result.Failed; }
-            StdP.B("STD-02 / REG-01 Regional overlay", "Kenya / Uganda / Tanzania / Rwanda / SA / etc.")
-                .AddSection("REGIONS SUPPORTED")
-                .Metric("East Africa",    "KEBS, UNBS, TBS, RSB, SSBS, BBN, EAS")
-                .Metric("West Africa",    "ECOWAS")
-                .Metric("Southern Africa","SANS")
-                .Metric("Construction",   "CIDB")
-                .Text("Writes PROJECT_REGION to project info; every validator filters to the selected code set.")
-                .Show();
+    // STD-02 / REG-01 — Regional overlay (active driver of every Standards command)
+    [Transaction(TransactionMode.Manual)][Regeneration(RegenerationOption.Manual)]
+    public class SetRegionCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
+
+            var mgr = ProjectStandardsManager.Instance;
+            var regions = mgr.GetAvailableRegions().ToList();
+            string current = mgr.Region ?? "International";
+
+            string picked = StingListPicker.Show(
+                "STING Standards — Active region",
+                $"Current: {current}. Pick a region to switch electrical / HVAC / structural / fire / lighting / energy bindings.",
+                regions);
+            if (string.IsNullOrEmpty(picked)) return Result.Cancelled;
+
+            try { mgr.ApplyRegionalPreset(picked); }
+            catch (Exception ex) { StingLog.Error("ApplyRegionalPreset failed", ex); message = ex.Message; return Result.Failed; }
+
+            // Persist on the Revit document so the choice travels with the .rvt
+            // and the dock-panel status bar can read it back without consulting
+            // %APPDATA%. PROJECT_REGION lives on ProjectInformation.
+            try
+            {
+                var pi = ctx.Doc.ProjectInformation;
+                if (pi != null)
+                {
+                    using (var t = new Transaction(ctx.Doc, "STING Set Region"))
+                    {
+                        t.Start();
+                        var p = pi.LookupParameter("PROJECT_REGION");
+                        if (p != null && !p.IsReadOnly) p.Set(picked);
+                        t.Commit();
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"PROJECT_REGION write skipped: {ex.Message}"); }
+
+            var summary = mgr.GetConfigurationSummary();
+            var panel = StingResultPanel.Create("Active region updated").SetSubtitle(picked);
+            var sec = panel.AddSection("STANDARDS BINDING");
+            foreach (var kv in summary.Standards) sec.Metric(kv.Key, kv.Value);
+            sec.Metric("Unit system", summary.UnitSystem.ToString());
+            panel.Text($"Saved to {Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\StingTools\\config\\project-standards.json");
+            panel.Show();
             return Result.Succeeded;
         }
     }
+    // STD-08 — Water use reduction (AECCalculations.CalculateWaterUseReduction)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class WaterUseCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements) { StdP.B("STD-08 Water use reduction","LEED WE + BREEAM Wat 01").AddSection("FIXTURE TARGETS").Metric("WC dual flush","≤ 6/4 L").Metric("Urinal","≤ 0.5 L/flush").Metric("Basin tap","≤ 2 L/min @ 0.3 MPa").Metric("Shower","≤ 6 L/min").Show(); return Result.Succeeded; } }
+    public class WaterUseCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
+            if (!NumericPrompt.TryAsk("STD-08 Water use reduction (LEED WE / BREEAM Wat 01)",
+                new[] { "Occupants", "Workdays/yr", "WC GPF", "Urinal GPF", "Lavatory GPM", "Shower GPM" },
+                new[] { 100.0, 250.0, 1.28, 0.5, 0.5, 1.5 }, out var v)) return Result.Cancelled;
+            try
+            {
+                var res = AECCalculations.CalculateWaterUseReduction(
+                    occupants: (int)v[0], workdaysPerYear: (int)v[1],
+                    toiletGPF: v[2], urinalGPF: v[3],
+                    lavatoryGPM: v[4], showerGPM: v[5]);
+                StdP.B("STD-08 Water use reduction", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "LEED WE Prereq"}")
+                    .AddSection("REDUCTION")
+                    .Metric("Baseline",        $"{res.BaselineGallonsPerYear:F0} gal/yr")
+                    .Metric("Design",          $"{res.DesignGallonsPerYear:F0} gal/yr")
+                    .Metric("Reduction",       $"{res.ReductionPercent:F1}%")
+                    .Metric("Annual savings",  $"{res.AnnualSavingsGallons:F0} gal")
+                    .Metric("LEED points",      res.EstimatedLEEDPoints.ToString())
+                    .Metric("Prereq met",       res.MeetsPrerequisite ? "yes" : "REVIEW")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("WaterUse", ex); message = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // STD-09 — Space efficiency (AECCalculations.CalculateSpaceEfficiency)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class SpaceEffCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements) { StdP.B("STD-09 Space efficiency","BCO + IFMA").AddSection("RATIOS").Metric("Net:Gross target","≥ 0.80 (BCO grade A)").Metric("Workstation m²","8-10").Metric("Meeting/desk","1:8 BCO").Show(); return Result.Succeeded; } }
+    public class SpaceEffCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
+            if (!NumericPrompt.TryAsk("STD-09 Space efficiency (BOMA / IFMA)",
+                new[] { "Gross (m²)", "Usable (m²)", "Rentable (m²)", "Occupants", "Workstations" },
+                new[] { 2000.0, 1700.0, 1850.0, 150.0, 130.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                var res = AECCalculations.CalculateSpaceEfficiency(
+                    grossFloorAreaSqFt: v[0] * 10.7639,
+                    usableAreaSqFt:    v[1] * 10.7639,
+                    rentableAreaSqFt:  v[2] * 10.7639,
+                    totalOccupants:    (int)v[3],
+                    workstations:      (int)v[4]);
+                StdP.B("STD-09 Space efficiency", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "BOMA / IFMA"}")
+                    .AddSection("EFFICIENCY")
+                    .Metric("Usable / gross",   $"{res.EfficiencyRatio:F1}%")
+                    .Metric("Load factor",      $"{res.LoadFactor:F2}")
+                    .Metric("ft² / person",     $"{res.SqFtPerPerson:F0}")
+                    .Metric("ft² / workstation", $"{res.SqFtPerWorkstation:F0}")
+                    .Metric("Rating",           res.EfficiencyRating ?? "-")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("SpaceEff", ex); message = ex.Message; return Result.Failed; }
+        }
+    }
+
+    // STD-10 — Equipment lifecycle (AECCalculations.CalculateEquipmentLifecycle)
     [Transaction(TransactionMode.ReadOnly)][Regeneration(RegenerationOption.Manual)]
-    public class LifecycleCostCommand : IExternalCommand { public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements) { StdP.B("STD-10 Lifecycle cost","CIBSE TM56 + ISO 15686").AddSection("NPV ANALYSIS").Metric("Analysis period","30 years").Metric("Discount rate","3.5% (Green Book)").Metric("Service life HVAC","15-20").Metric("Service life luminaires","50 000 hours (LED)").Show(); return Result.Succeeded; } }
+    public class LifecycleCostCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
+            if (!NumericPrompt.TryAsk("STD-10 Equipment lifecycle (CIBSE TM56 / ISO 15686)",
+                new[] { "Type (1=AHU, 2=Chiller, 3=Boiler, 4=Pump, 5=Luminaire LED)", "Current age (years)", "Replacement cost ($)", "Annual maintenance ($)" },
+                new[] { 1.0, 8.0, 50000.0, 2000.0 }, out var v)) return Result.Cancelled;
+            try
+            {
+                string type = v[0] <= 1.5 ? "AHU" : v[0] <= 2.5 ? "Chiller"
+                           : v[0] <= 3.5 ? "Boiler" : v[0] <= 4.5 ? "Pump" : "LED Luminaire";
+                var res = AECCalculations.CalculateEquipmentLifecycle(type, (int)v[1], v[2], v[3]);
+                StdP.B("STD-10 Lifecycle cost", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "ISO 15686 + CIBSE TM56"}")
+                    .AddSection("LIFECYCLE")
+                    .Metric("Equipment type",     res.EquipmentType ?? type)
+                    .Metric("Expected life",      $"{res.ExpectedLifeYears} years")
+                    .Metric("Current age",        $"{res.CurrentAgeYears} years")
+                    .Metric("Remaining life",     $"{res.RemainingLifeYears} years")
+                    .Metric("% life used",        $"{res.PercentLifeUsed:F0}%")
+                    .Metric("Replacement priority", res.ReplacementPriority ?? "-")
+                    .Metric("Replacement cost",    $"${res.ReplacementCost:F0}")
+                    .Metric("Annualised cost",     $"${res.AnnualizedCost:F0}/yr")
+                    .Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex) { StingLog.Error("Lifecycle", ex); message = ex.Message; return Result.Failed; }
+        }
+    }
 }

--- a/StingTools/Commands/StandardsExt/StandardsExtCommands.cs
+++ b/StingTools/Commands/StandardsExt/StandardsExtCommands.cs
@@ -301,13 +301,21 @@ namespace StingTools.Commands.StandardsExt
         public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
         {
             var ctx = ParameterHelpers.GetContext(cd); if (ctx == null) { message = "No doc"; return Result.Failed; }
+            // Names below match the ASHRAE service-life lookup in
+            // AECCalculations.CalculateEquipmentLifecycle (Boiler-Cast Iron / -Steel,
+            // Chiller-Centrifugal / -Screw, Pump-Base Mounted / -Inline, etc.).
+            // Anything not in that lookup falls through to a 20 yr default.
             if (!NumericPrompt.TryAsk("STD-10 Equipment lifecycle (CIBSE TM56 / ISO 15686)",
-                new[] { "Type (1=AHU, 2=Chiller, 3=Boiler, 4=Pump, 5=Luminaire LED)", "Current age (years)", "Replacement cost ($)", "Annual maintenance ($)" },
+                new[] { "Type (1=AHU, 2=Chiller-Centrifugal, 3=Boiler-Cast Iron, 4=Pump-Base Mounted, 5=Cooling Tower, 6=Transformer-Dry)", "Current age (years)", "Replacement cost ($)", "Annual maintenance ($)" },
                 new[] { 1.0, 8.0, 50000.0, 2000.0 }, out var v)) return Result.Cancelled;
             try
             {
-                string type = v[0] <= 1.5 ? "AHU" : v[0] <= 2.5 ? "Chiller"
-                           : v[0] <= 3.5 ? "Boiler" : v[0] <= 4.5 ? "Pump" : "LED Luminaire";
+                string type = v[0] <= 1.5 ? "AHU"
+                           : v[0] <= 2.5 ? "Chiller-Centrifugal"
+                           : v[0] <= 3.5 ? "Boiler-Cast Iron"
+                           : v[0] <= 4.5 ? "Pump-Base Mounted"
+                           : v[0] <= 5.5 ? "Cooling Tower"
+                           : "Transformer-Dry";
                 var res = AECCalculations.CalculateEquipmentLifecycle(type, (int)v[1], v[2], v[3]);
                 StdP.B("STD-10 Lifecycle cost", $"{ProjectStandardsManager.Instance.Region} · {res.StandardReference ?? "ISO 15686 + CIBSE TM56"}")
                     .AddSection("LIFECYCLE")

--- a/StingTools/Core/ProjectRegionSidecar.cs
+++ b/StingTools/Core/ProjectRegionSidecar.cs
@@ -1,0 +1,72 @@
+// STING Tools — Standards region sidecar.
+//
+// Persists the active regional preset key into a per-project file
+// (<project>/_BIM_COORD/sting_region.json) so the region travels with
+// the .rvt even when the PROJECT_REGION shared parameter isn't bound
+// to ProjectInformation. The Revit param is the preferred channel
+// (visible in schedules, surveyable in the Properties palette); the
+// sidecar is the resilient fallback.
+//
+// Read order at OnDocumentOpened: PROJECT_REGION param → sidecar →
+// %APPDATA% manager state. Writes go to BOTH the param (if bound) and
+// the sidecar so either store can recover the choice.
+
+using System;
+using System.IO;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json;
+
+namespace StingTools.Core
+{
+    public static class ProjectRegionSidecar
+    {
+        public static string GetSidecarPath(Document doc)
+        {
+            string rvt = doc?.PathName;
+            if (string.IsNullOrEmpty(rvt)) return null;
+            string dir = Path.GetDirectoryName(rvt);
+            if (string.IsNullOrEmpty(dir)) return null;
+            return Path.Combine(dir, "_BIM_COORD", "sting_region.json");
+        }
+
+        public static string Read(Document doc)
+        {
+            try
+            {
+                string path = GetSidecarPath(doc);
+                if (string.IsNullOrEmpty(path) || !File.Exists(path)) return null;
+                var json = File.ReadAllText(path);
+                var obj = JsonConvert.DeserializeAnonymousType(json, new { region = "" });
+                return string.IsNullOrWhiteSpace(obj?.region) ? null : obj.region;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ProjectRegionSidecar.Read: {ex.Message}");
+                return null;
+            }
+        }
+
+        // Returns true on success.
+        public static bool Write(Document doc, string region)
+        {
+            try
+            {
+                string path = GetSidecarPath(doc);
+                if (string.IsNullOrEmpty(path)) return false;
+                string dir = Path.GetDirectoryName(path);
+                if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                File.WriteAllText(path, JsonConvert.SerializeObject(new
+                {
+                    region,
+                    written = DateTime.UtcNow.ToString("o")
+                }, Formatting.Indented));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ProjectRegionSidecar.Write: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -418,6 +418,28 @@ namespace StingTools.Core
                 // Prevents stale project-wide scope from carrying over between projects
                 Select.SelectionScopeHelper.SetScope(false);
 
+                // Standards: sync ProjectStandardsManager from this document's
+                // PROJECT_REGION instance parameter. The manager persists to
+                // %APPDATA%, which is per-user not per-project — without this
+                // sync, opening a different .rvt keeps the previous region's
+                // electrical / fire / structural bindings active.
+                try
+                {
+                    var pi = e.Document?.ProjectInformation;
+                    var pRegion = pi?.LookupParameter("PROJECT_REGION");
+                    string projectRegion = pRegion?.AsString();
+                    if (!string.IsNullOrWhiteSpace(projectRegion))
+                    {
+                        var mgr = StingTools.Standards.ProjectStandardsManager.Instance;
+                        if (!string.Equals(mgr.Region, projectRegion, StringComparison.OrdinalIgnoreCase))
+                        {
+                            mgr.ApplyRegionalPreset(projectRegion);
+                            StingLog.Info($"Standards: synced active region → {projectRegion} from PROJECT_REGION");
+                        }
+                    }
+                }
+                catch (Exception regEx) { StingLog.Warn($"Standards region sync skipped: {regEx.Message}"); }
+
                 // C4 / G1.3: Reload TagConfig on document open — prefer project-adjacent config
                 // to prevent config bleed between projects
                 try

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -54,6 +54,16 @@ namespace StingTools.Core
                 // loads later in OnDocumentOpened and can flip the flag off.
                 StingOfflineConfig.ApplyDefaults();
 
+                // Wire the Standards library's pluggable log sink to StingLog so
+                // StandardsComplianceEngine messages land in the same log file as
+                // the rest of the plugin (replaces the old NLog dependency).
+                StingTools.Standards.Compliance.StandardsLog.Sink = (lvl, msg, ex) =>
+                {
+                    if (lvl == StingTools.Standards.Compliance.StandardsLogLevel.Info) StingLog.Info(msg);
+                    else if (lvl == StingTools.Standards.Compliance.StandardsLogLevel.Warn) StingLog.Warn(msg);
+                    else StingLog.Error(msg, ex);
+                };
+
                 // Pack 7 — wire the DocumentChanged cascade handler (room
                 // renumbers, level changes, sheet ISO violations). Gated by
                 // StingOfflineConfig.RealtimeCascadesEnabled at callback time.

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -418,23 +418,29 @@ namespace StingTools.Core
                 // Prevents stale project-wide scope from carrying over between projects
                 Select.SelectionScopeHelper.SetScope(false);
 
-                // Standards: sync ProjectStandardsManager from this document's
-                // PROJECT_REGION instance parameter. The manager persists to
-                // %APPDATA%, which is per-user not per-project — without this
-                // sync, opening a different .rvt keeps the previous region's
-                // electrical / fire / structural bindings active.
+                // Standards: sync ProjectStandardsManager from this document.
+                // The manager persists to %APPDATA% (per-user, not per-project)
+                // so without a per-project hint, opening a different .rvt keeps
+                // the previous region's electrical / fire / structural bindings
+                // active. Read order: PROJECT_REGION param → sidecar JSON next
+                // to the .rvt → leave singleton unchanged.
                 try
                 {
                     var pi = e.Document?.ProjectInformation;
-                    var pRegion = pi?.LookupParameter("PROJECT_REGION");
-                    string projectRegion = pRegion?.AsString();
+                    string projectRegion = pi?.LookupParameter("PROJECT_REGION")?.AsString();
+                    string source = "PROJECT_REGION";
+                    if (string.IsNullOrWhiteSpace(projectRegion))
+                    {
+                        projectRegion = ProjectRegionSidecar.Read(e.Document);
+                        source = "sting_region.json";
+                    }
                     if (!string.IsNullOrWhiteSpace(projectRegion))
                     {
                         var mgr = StingTools.Standards.ProjectStandardsManager.Instance;
                         if (!string.Equals(mgr.Region, projectRegion, StringComparison.OrdinalIgnoreCase))
                         {
                             mgr.ApplyRegionalPreset(projectRegion);
-                            StingLog.Info($"Standards: synced active region → {projectRegion} from PROJECT_REGION");
+                            StingLog.Info($"Standards: synced active region → {projectRegion} (from {source})");
                         }
                     }
                 }

--- a/StingTools/StingTools.csproj
+++ b/StingTools/StingTools.csproj
@@ -93,25 +93,6 @@
     <Compile Remove="BIMManager\BcfEngine.cs" />
   </ItemGroup>
 
-  <!-- S03: bring in the Planscape plugin-sync client (SyncScheduler / SyncClient /
-       OfflineQueue) and the shared sync payload contracts. Both are plain net8.0
-       libraries, consumable from this net8.0-windows plugin. -->
-  <ItemGroup>
-    <ProjectReference Include="..\Planscape.Server\src\Planscape.Shared\Planscape.Shared.csproj" />
-    <ProjectReference Include="..\Planscape.Server\src\Planscape.PluginSync\Planscape.PluginSync.csproj" />
-    <!-- Phase 110: Standards & compliance calc library. Pure C#, no
-         Revit dependency; StingTools commands wrap the APIs. -->
-    <ProjectReference Include="..\StingTools.Standards\StingTools.Standards.csproj" />
-  </ItemGroup>
-
-  <!-- Phase 95: BcfEngine physically lives here but is compiled into
-       Planscape.Shared.dll (via <Compile Include="..\..\..\StingTools\..."/>
-       in Planscape.Shared.csproj). Exclude it from the StingTools assembly to
-       avoid a duplicate-type collision with the Planscape.Shared reference. -->
-  <ItemGroup>
-    <Compile Remove="BIMManager\BcfEngine.cs" />
-  </ItemGroup>
-
   <!--
     Prevent .NET runtime/framework assemblies from being copied to the output directory.
     ClosedXML's dependency chain (ClosedXML -> DocumentFormat.OpenXml -> System.IO.Packaging

--- a/StingTools/Temp/ProjectSetupCommand.cs
+++ b/StingTools/Temp/ProjectSetupCommand.cs
@@ -842,7 +842,41 @@ namespace StingTools.Temp
                     // Write discipline-specific design data to Project Information params
                     WriteDisciplineDesignParams(pi, data);
 
+                    // Standards regional preset — write PROJECT_REGION so the
+                    // choice persists on the .rvt; the in-process singleton
+                    // is updated below (after the transaction commits).
+                    if (!string.IsNullOrWhiteSpace(data.Region))
+                    {
+                        try
+                        {
+                            Parameter regionParam = pi.LookupParameter("PROJECT_REGION");
+                            if (regionParam != null && !regionParam.IsReadOnly)
+                                regionParam.Set(data.Region);
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"Could not set PROJECT_REGION on ProjectInfo: {ex.Message}");
+                        }
+                    }
+
                     tx.Commit();
+                }
+
+                // Apply the regional preset on the in-process singleton so
+                // every Standards-aware command that runs immediately after
+                // the wizard already sees the new electrical / HVAC / fire
+                // bindings (avoids the next-doc-open race).
+                if (!string.IsNullOrWhiteSpace(data.Region))
+                {
+                    try
+                    {
+                        StingTools.Standards.ProjectStandardsManager.Instance
+                            .ApplyRegionalPreset(data.Region);
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"ApplyRegionalPreset({data.Region}) skipped: {ex.Message}");
+                    }
                 }
 
                 StingLog.Info($"Project Info set: '{data.ProjectName}' #{data.ProjectNumber}");

--- a/StingTools/Temp/ProjectSetupCommand.cs
+++ b/StingTools/Temp/ProjectSetupCommand.cs
@@ -844,7 +844,8 @@ namespace StingTools.Temp
 
                     // Standards regional preset — write PROJECT_REGION so the
                     // choice persists on the .rvt; the in-process singleton
-                    // is updated below (after the transaction commits).
+                    // and per-project sidecar are updated below (after the
+                    // transaction commits).
                     if (!string.IsNullOrWhiteSpace(data.Region))
                     {
                         try
@@ -865,7 +866,9 @@ namespace StingTools.Temp
                 // Apply the regional preset on the in-process singleton so
                 // every Standards-aware command that runs immediately after
                 // the wizard already sees the new electrical / HVAC / fire
-                // bindings (avoids the next-doc-open race).
+                // bindings (avoids the next-doc-open race). Also write the
+                // sidecar so the choice survives even on projects where
+                // PROJECT_REGION isn't bound to ProjectInformation.
                 if (!string.IsNullOrWhiteSpace(data.Region))
                 {
                     try
@@ -877,6 +880,7 @@ namespace StingTools.Temp
                     {
                         StingLog.Warn($"ApplyRegionalPreset({data.Region}) skipped: {ex.Message}");
                     }
+                    ProjectRegionSidecar.Write(doc, data.Region);
                 }
 
                 StingLog.Info($"Project Info set: '{data.ProjectName}' #{data.ProjectNumber}");

--- a/StingTools/UI/ProjectSetupWizard.xaml
+++ b/StingTools/UI/ProjectSetupWizard.xaml
@@ -1139,7 +1139,7 @@
                 <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16,8">
                     <StackPanel>
                         <TextBlock Style="{StaticResource WizSectionHeader}"
-                                   Text="7. Review &amp; Execute"/>
+                                   Text="8. Review &amp; Execute"/>
                         <TextBlock Text="Review your selections, then click Run to automate the entire project setup."
                                    FontSize="10" Foreground="#777" Margin="0,0,0,8"/>
 

--- a/StingTools/UI/ProjectSetupWizard.xaml
+++ b/StingTools/UI/ProjectSetupWizard.xaml
@@ -1066,7 +1066,75 @@
                 </ScrollViewer>
             </TabItem>
 
-            <!-- ═══ PAGE 7: REVIEW + RUN ═══ -->
+            <!-- ═══ PAGE 7: STANDARDS REGION ═══ -->
+            <TabItem Header="Region">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16,8">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource WizSectionHeader}"
+                                   Text="7. Standards &amp; Region"/>
+                        <TextBlock Text="Pick the regional preset that drives every Standards-aware command (cable size, sprinkler design, EUI benchmark, …). The Run step writes PROJECT_REGION onto Project Information so the choice travels with the .rvt."
+                                   FontSize="10" Foreground="#777" Margin="0,0,0,8" TextWrapping="Wrap"/>
+
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="220"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Preset list -->
+                            <Border Grid.Column="0" Style="{StaticResource WizGroupBox}" Padding="0">
+                                <ListBox x:Name="lstRegionPresets"
+                                         SelectionChanged="LstRegionPresets_SelectionChanged"
+                                         BorderThickness="0" Height="320"/>
+                            </Border>
+
+                            <!-- Resolved bindings preview -->
+                            <Border Grid.Column="1" Style="{StaticResource WizGroupBox}" Margin="8,0,0,0">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource WizSubHeader}" Text="Resolved standards"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="120"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Electrical"/>
+                                        <TextBlock Grid.Row="0" Grid.Column="1" x:Name="txtRegElec"   FontSize="11" Margin="0,4"/>
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Style="{StaticResource WizLabel}" Text="HVAC"/>
+                                        <TextBlock Grid.Row="1" Grid.Column="1" x:Name="txtRegHvac"   FontSize="11" Margin="0,4"/>
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Plumbing"/>
+                                        <TextBlock Grid.Row="2" Grid.Column="1" x:Name="txtRegPlumb"  FontSize="11" Margin="0,4"/>
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Structural"/>
+                                        <TextBlock Grid.Row="3" Grid.Column="1" x:Name="txtRegStruct" FontSize="11" Margin="0,4"/>
+                                        <TextBlock Grid.Row="4" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Fire"/>
+                                        <TextBlock Grid.Row="4" Grid.Column="1" x:Name="txtRegFire"   FontSize="11" Margin="0,4"/>
+                                        <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Lighting"/>
+                                        <TextBlock Grid.Row="5" Grid.Column="1" x:Name="txtRegLight"  FontSize="11" Margin="0,4"/>
+                                        <TextBlock Grid.Row="6" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Energy"/>
+                                        <TextBlock Grid.Row="6" Grid.Column="1" x:Name="txtRegEnergy" FontSize="11" Margin="0,4"/>
+                                        <TextBlock Grid.Row="7" Grid.Column="0" Style="{StaticResource WizLabel}" Text="Units"/>
+                                        <TextBlock Grid.Row="7" Grid.Column="1" x:Name="txtRegUnits"  FontSize="11" Margin="0,4"/>
+                                    </Grid>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+
+                        <TextBlock Text="Tip: regions cover UK / USA / Europe / East Africa (KEBS, UNBS, TBS, RSB, SSBS, BBN, EAS) / South Africa (SANS) / Australia / International. The Run step persists PROJECT_REGION; subsequent document opens auto-sync."
+                                   FontSize="10" Foreground="#777" Margin="0,8,0,0" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- ═══ PAGE 8: REVIEW + RUN ═══ -->
             <TabItem Header="Review">
                 <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16,8">
                     <StackPanel>
@@ -1101,7 +1169,7 @@
 
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
                     <TextBlock x:Name="txtPageInfo" FontSize="11" Foreground="#777"
-                               VerticalAlignment="Center" Text="Step 1 of 7"/>
+                               VerticalAlignment="Center" Text="Step 1 of 8"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal">

--- a/StingTools/UI/ProjectSetupWizard.xaml.cs
+++ b/StingTools/UI/ProjectSetupWizard.xaml.cs
@@ -29,7 +29,9 @@ namespace StingTools.UI
     /// </summary>
     public partial class ProjectSetupWizard : Window
     {
-        private const int TotalPages = 7;
+        // 8 pages: Project Info → Levels → Grids → Disciplines → Disc. Config
+        //          → Automation → Region → Review.
+        private const int TotalPages = 8;
         private int _currentPage = 0;
 
         /// <summary>Result data — populated when user clicks Run.</summary>
@@ -64,6 +66,52 @@ namespace StingTools.UI
 
             BuildStepIndicators();
             UpdateNavigation();
+            PopulateRegionPresets();
+        }
+
+        // Standards & Region — populate the listbox from
+        // ProjectStandardsManager.RegionalPresets and pre-select the
+        // active region so the wizard reflects whatever was already set.
+        private void PopulateRegionPresets()
+        {
+            try
+            {
+                var mgr = StingTools.Standards.ProjectStandardsManager.Instance;
+                var regions = mgr.GetAvailableRegions().ToList();
+                lstRegionPresets.ItemsSource = regions;
+                string current = mgr.Region;
+                int idx = !string.IsNullOrEmpty(current)
+                    ? regions.FindIndex(r => string.Equals(r, current, StringComparison.OrdinalIgnoreCase))
+                    : -1;
+                lstRegionPresets.SelectedIndex = idx >= 0 ? idx : regions.IndexOf("International");
+            }
+            catch (System.Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"PopulateRegionPresets: {ex.Message}");
+            }
+        }
+
+        private void LstRegionPresets_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            try
+            {
+                if (lstRegionPresets.SelectedItem is string key &&
+                    StingTools.Standards.ProjectStandardsManager.RegionalPresets.TryGetValue(key, out var p))
+                {
+                    txtRegElec.Text   = p.ElectricalStandard;
+                    txtRegHvac.Text   = p.HVACStandard;
+                    txtRegPlumb.Text  = p.PlumbingStandard;
+                    txtRegStruct.Text = p.StructuralStandard;
+                    txtRegFire.Text   = p.FireProtectionStandard;
+                    txtRegLight.Text  = p.LightingStandard;
+                    txtRegEnergy.Text = p.EnergyStandard;
+                    txtRegUnits.Text  = p.UnitSystem.ToString();
+                }
+            }
+            catch (System.Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"LstRegionPresets_SelectionChanged: {ex.Message}");
+            }
         }
 
         private void RenumberLevelRows()
@@ -100,6 +148,30 @@ namespace StingTools.UI
                         txtBuildingName.Text = pi.BuildingName;
                     if (!string.IsNullOrEmpty(pi.Address))
                         txtAddress.Text = pi.Address;
+
+                    // Pre-select the regional preset from PROJECT_REGION when
+                    // it's already been set on this document (e.g. by a prior
+                    // wizard run or the SetRegionCommand). Falls back to the
+                    // singleton's current region otherwise.
+                    try
+                    {
+                        string projRegion = pi.LookupParameter("PROJECT_REGION")?.AsString();
+                        if (string.IsNullOrWhiteSpace(projRegion))
+                            projRegion = StingTools.Standards.ProjectStandardsManager.Instance.Region;
+                        if (!string.IsNullOrWhiteSpace(projRegion) && lstRegionPresets.Items.Count > 0)
+                        {
+                            for (int i = 0; i < lstRegionPresets.Items.Count; i++)
+                            {
+                                if (string.Equals(lstRegionPresets.Items[i] as string, projRegion,
+                                    StringComparison.OrdinalIgnoreCase))
+                                {
+                                    lstRegionPresets.SelectedIndex = i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception rex) { StingLog.Warn($"PrePopulate region: {rex.Message}"); }
                 }
             }
             catch (Exception ex)
@@ -367,11 +439,11 @@ namespace StingTools.UI
         // ── Step indicators ──────────────────────────────────────────
 
         private readonly List<Border> _stepBorders = new List<Border>();
-        private readonly string[] _stepLabels = { "1", "2", "3", "4", "5", "6", "7" };
+        private readonly string[] _stepLabels = { "1", "2", "3", "4", "5", "6", "7", "8" };
         private readonly string[] _stepTitles =
         {
             "Project Info", "Levels", "Grids",
-            "Disciplines", "Disc. Config", "Automation", "Review"
+            "Disciplines", "Disc. Config", "Automation", "Region", "Review"
         };
 
         private void BuildStepIndicators()
@@ -1037,6 +1109,9 @@ namespace StingTools.UI
             data.CreateSections = chkCreateSections.IsChecked == true;
             data.CreateElevations = chkCreateElevations.IsChecked == true;
 
+            // Page 7: Standards & Region
+            data.Region = lstRegionPresets.SelectedItem as string;
+
             return data;
         }
 
@@ -1169,6 +1244,28 @@ namespace StingTools.UI
             sb.AppendLine($"  Status:        {data.Status}");
             sb.AppendLine($"  LOC codes:     {string.Join(", ", data.LocCodes)}");
             sb.AppendLine($"  ZONE codes:    {string.Join(", ", data.ZoneCodes)}");
+
+            // Standards & Region
+            sb.AppendLine();
+            sb.AppendLine("STANDARDS & REGION");
+            sb.AppendLine(new string('─', 55));
+            if (!string.IsNullOrEmpty(data.Region) &&
+                StingTools.Standards.ProjectStandardsManager.RegionalPresets.TryGetValue(data.Region, out var preset))
+            {
+                sb.AppendLine($"  Region:        {preset.Name} ({data.Region})");
+                sb.AppendLine($"  Electrical:    {preset.ElectricalStandard}");
+                sb.AppendLine($"  HVAC:          {preset.HVACStandard}");
+                sb.AppendLine($"  Plumbing:      {preset.PlumbingStandard}");
+                sb.AppendLine($"  Structural:    {preset.StructuralStandard}");
+                sb.AppendLine($"  Fire:          {preset.FireProtectionStandard}");
+                sb.AppendLine($"  Lighting:      {preset.LightingStandard}");
+                sb.AppendLine($"  Energy:        {preset.EnergyStandard}");
+                sb.AppendLine($"  Units:         {preset.UnitSystem}");
+            }
+            else
+            {
+                sb.AppendLine("  Region:        (not set — defaults to International)");
+            }
 
             // Levels
             sb.AppendLine();
@@ -1500,6 +1597,13 @@ namespace StingTools.UI
     /// </summary>
     public class ProjectSetupData
     {
+        // Page 7: Standards regional preset (UK / USA / EastAfrica / Uganda /
+        // Kenya / SouthAfrica / Australia / Europe / International). Run step
+        // calls ProjectStandardsManager.ApplyRegionalPreset and writes
+        // PROJECT_REGION onto Project Information so the choice travels with
+        // the .rvt and OnDocumentOpened can re-sync the singleton.
+        public string Region { get; set; }
+
         // Page 1: Project info
         public string ProjectName { get; set; }
         public string ProjectNumber { get; set; }

--- a/StingTools/UI/ProjectSetupWizard.xaml.cs
+++ b/StingTools/UI/ProjectSetupWizard.xaml.cs
@@ -151,11 +151,13 @@ namespace StingTools.UI
 
                     // Pre-select the regional preset from PROJECT_REGION when
                     // it's already been set on this document (e.g. by a prior
-                    // wizard run or the SetRegionCommand). Falls back to the
-                    // singleton's current region otherwise.
+                    // wizard run or SetRegionCommand). Read order: param →
+                    // sidecar (sting_region.json) → singleton's current region.
                     try
                     {
                         string projRegion = pi.LookupParameter("PROJECT_REGION")?.AsString();
+                        if (string.IsNullOrWhiteSpace(projRegion))
+                            projRegion = ProjectRegionSidecar.Read(doc);
                         if (string.IsNullOrWhiteSpace(projRegion))
                             projRegion = StingTools.Standards.ProjectStandardsManager.Instance.Region;
                         if (!string.IsNullOrWhiteSpace(projRegion) && lstRegionPresets.Items.Count > 0)

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -241,6 +241,7 @@ namespace StingTools.UI
                     case "StdBulk_AccessibleFix":     RunCommand<Commands.StandardsExt.AccessibleFixturesCommand>(app); break;
                     case "StdBulk_EnergyAnalysis":    RunCommand<Commands.StandardsExt.EnergyAnalysisCommand>(app); break;
                     case "StdBulk_SprinklerCriteria": RunCommand<Commands.StandardsExt.SprinklerCriteriaCommand>(app); break;
+                    case "StdExt_RunCompliance":      RunCommand<Commands.StandardsExt.RunStandardsComplianceCommand>(app); break;
 
                     // ── Phase 115: Fabrication Extensions ──
                     case "FabExt_ACCPublish":    RunCommand<Commands.FabricationExt.ACCPublishShopCommand>(app); break;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -111,6 +111,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel>
                     <TextBlock Text="STINGTOOLS V2.1" FontWeight="Bold" FontSize="13" Foreground="{DynamicResource HeaderFg}"/>
@@ -132,10 +133,18 @@
                         MouseLeftButtonUp="SyncIndicator_Click" Cursor="Hand">
                     <TextBlock x:Name="txtSync" Text="Sync: off" FontSize="9" Foreground="{DynamicResource HeaderFg}" Opacity="0.85"/>
                 </Border>
-                <Button x:Name="btnPin" Grid.Column="4" Content="Pin" Width="30" Height="20"
+                <!-- Standards regional preset indicator. Click opens the region picker (StdExt_SetRegion). -->
+                <Border Grid.Column="4" x:Name="bdrRegion" Background="#33000000" CornerRadius="3" Padding="4,1"
+                        VerticalAlignment="Center" Margin="0,0,6,0"
+                        Cursor="Hand"
+                        MouseLeftButtonUp="RegionIndicator_Click"
+                        ToolTip="Active Standards region — click to switch (BS 7671 / NEC / IEC 60364, ASHRAE / CIBSE, NFPA / BS 9999, Eurocode / AISC, KEBS / UNBS / SANS, …). Persisted to PROJECT_REGION on the document.">
+                    <TextBlock x:Name="txtRegion" Text="Region: —" FontSize="9" Foreground="{DynamicResource HeaderFg}" Opacity="0.85"/>
+                </Border>
+                <Button x:Name="btnPin" Grid.Column="5" Content="Pin" Width="30" Height="20"
                         FontSize="9" Background="{DynamicResource AccentBrush}" Foreground="White" BorderThickness="0"
                         ToolTip="Pin panel" Click="BtnPin_Click" Margin="0,0,2,0"/>
-                <Button Grid.Column="5" Content="&#x2600;" Width="26" Height="20"
+                <Button Grid.Column="6" Content="&#x2600;" Width="26" Height="20"
                         FontSize="13" Background="{DynamicResource AccentBrush}" Foreground="White" BorderThickness="0"
                         ToolTip="Cycle theme: Light / Warm / Cool / Corporate" Tag="CycleTheme" Click="Cmd_Click"/>
             </Grid>

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -4455,6 +4455,7 @@
                                         <Button Style="{StaticResource GreenBtn}"  Content="Cover audit"     Tag="Arch_CoverAudit"       Click="Cmd_Click" Width="90"  Height="30" ToolTip="ARCH-06 Fire / moisture / thermal cover audit"/>
                                         <Button Style="{StaticResource ActionBtn}" Content="Wind apply"      Tag="StrExt_WindAutoApply"  Click="Cmd_Click" Width="90"  Height="30" ToolTip="STR-03 ASCE 7 / EC 1 wind pressure"/>
                                         <Button Style="{StaticResource OrangeBtn}" Content="Stage audit"     Tag="StdExt_StageCompliance" Click="Cmd_Click" Width="90"  Height="30" ToolTip="STD-01 RIBA 0-7 compliance gate"/>
+                                        <Button Style="{StaticResource GreenBtn}"  Content="Compliance"     Tag="StdExt_RunCompliance"  Click="Cmd_Click" Width="90"  Height="30" ToolTip="Run StandardsComplianceEngine over rooms + doors using the active region's rule pack"/>
                                     </WrapPanel>
                                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                                         <StackPanel Margin="4">

--- a/StingTools/UI/StingDockPanel.xaml.cs
+++ b/StingTools/UI/StingDockPanel.xaml.cs
@@ -88,6 +88,18 @@ namespace StingTools.UI
             // Pack 0 — reflect current offline state the moment the panel is realised.
             try { UpdateOfflineStatus(StingTools.Core.StingOfflineConfig.IsOffline, StingTools.Core.StingOfflineConfig.Source); }
             catch { /* non-fatal */ }
+
+            // Standards — paint the active region into the header chip and
+            // subscribe to ProjectStandardsManager.StandardsChanged so the
+            // chip updates live whenever a region is applied (SetRegionCommand,
+            // OnDocumentOpened sync, ProjectSetupWizard finish).
+            try
+            {
+                RefreshRegionIndicator();
+                StingTools.Standards.ProjectStandardsManager.Instance.StandardsChanged
+                    += (_, __) => RefreshRegionIndicator();
+            }
+            catch { /* non-fatal */ }
         }
 
         /// <summary>
@@ -945,6 +957,56 @@ namespace StingTools.UI
             {
                 Core.StingLog.Warn($"SyncIndicator_Click failed: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Repaint the active Standards region chip in the header. Reads
+        /// ProjectStandardsManager.Instance and is safe to call from any thread.
+        /// </summary>
+        public void RefreshRegionIndicator()
+        {
+            void Apply()
+            {
+                try
+                {
+                    if (txtRegion == null) return;
+                    var mgr = StingTools.Standards.ProjectStandardsManager.Instance;
+                    string region = mgr?.Region;
+                    txtRegion.Text = string.IsNullOrEmpty(region)
+                        ? "Region: —"
+                        : $"Region: {region}";
+                    if (bdrRegion != null && mgr != null)
+                    {
+                        bdrRegion.ToolTip =
+                            $"Active Standards region: {region ?? "(unset)"}.\n" +
+                            $"Electrical: {mgr.ElectricalStandard}\n" +
+                            $"HVAC: {mgr.HVACStandard}\n" +
+                            $"Plumbing: {mgr.PlumbingStandard}\n" +
+                            $"Structural: {mgr.StructuralStandard}\n" +
+                            $"Fire: {mgr.FireProtectionStandard}\n" +
+                            $"Lighting: {mgr.LightingStandard}\n" +
+                            $"Energy: {mgr.EnergyStandard}\n" +
+                            $"Units: {mgr.UnitSystem}\n\n" +
+                            "Click to switch (writes PROJECT_REGION onto ProjectInformation).";
+                    }
+                }
+                catch (System.Exception ex) { Core.StingLog.Warn($"RefreshRegionIndicator: {ex.Message}"); }
+            }
+            if (Dispatcher.CheckAccess()) Apply();
+            else Dispatcher.BeginInvoke(new System.Action(Apply));
+        }
+
+        // Region chip click — fires StdExt_SetRegion via the existing handler.
+        // The command's ApplyRegionalPreset triggers StandardsChanged which
+        // refreshes the chip automatically.
+        private void RegionIndicator_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            try
+            {
+                _handler?.SetCommand("StdExt_SetRegion");
+                _externalEvent?.Raise();
+            }
+            catch (System.Exception ex) { Core.StingLog.Warn($"RegionIndicator_Click: {ex.Message}"); }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
This PR refactors the Standards extension commands to use the region-aware StandardsAPI and AECCalculations libraries, replacing hard-coded reference-card stubs with live calculations. It also introduces a new Standards Compliance Engine that validates Revit elements against region-specific rules, and adds regional preset management to the Project Setup Wizard.

## Key Changes

### Standards Bulk Wrappers (StandardsBulkWrappers.cs)
- **Expanded from reference cards to live calculations**: All 10 commands (Ventilation, Plumbing, Duct, Psychrometric, Arc Flash, Conduit, Steel Beam, Concrete, Foundation, Seismic) now dispatch to StandardsAPI/AECCalculations instead of displaying static values
- **Region-aware dispatch**: Added `Bk.Region` and `Bk.GetStd()` helpers to pull the active region and discipline-specific standards from `ProjectStandardsManager`
- **Proper unit conversion**: Implemented conversions (L/s ↔ CFM, Pa/m ↔ in.WG/100ft, m² ↔ ft²) to bridge metric/imperial library expectations
- **Structured result rendering**: Each command now displays typed result objects through `StingResultPanel` with sections for inputs, calculations, and compliance status

### Standards Compliance Engine (StandardsComplianceCommand.cs - new)
- **New command**: `RunStandardsComplianceCommand` bridges Revit elements (rooms, doors, corridors) to the `StandardsComplianceEngine`
- **CSV rule loading**: Loads compliance rules from optional `data\AEC_COMPLIANCE_RULES.csv`; seeds demo rules if absent
- **Region filtering**: Only rules matching the active project region (or global rules) execute
- **Batch validation**: Collects rooms (area, occupancy) and doors (width, fire rating) as `DesignElement` records and runs `CheckBatchCompliance`
- **RAG reporting**: Renders violations and warnings grouped by severity through `StingResultPanel`

### Project Setup Wizard (ProjectSetupWizard.xaml/cs)
- **New page 7: Standards & Region**: Added regional preset selection UI with live preview of resolved standards (Electrical, HVAC, Plumbing, Structural, Fire, Lighting, Energy)
- **Preset population**: `PopulateRegionPresets()` loads available regions from `ProjectStandardsManager.RegionalPresets` and pre-selects the active region
- **Persistence**: Region choice is written to `PROJECT_REGION` shared parameter and per-project sidecar (`_BIM_COORD/sting_region.json`)

### Project Region Sidecar (ProjectRegionSidecar.cs - new)
- **Resilient region storage**: Persists regional preset key to `<project>/_BIM_COORD/sting_region.json` so the choice travels with the .rvt
- **Read order**: PROJECT_REGION param → sidecar → manager state
- **Dual-write**: Updates both the Revit param (if bound) and sidecar on save

### Standards Library Integration
- **Pluggable logging**: Replaced NLog dependency in `StandardsComplianceEngine` with a pluggable `StandardsLog.Sink` callback; wired to `StingLog` at startup in `StingToolsApp.OnStartup`
- **Region-aware commands**: Updated `StandardsCommands.cs` (cable size) and `StandardsExtCommands.cs` (parking, live load, load combos, EUI, etc.) to read active standards from `ProjectStandardsManager`

### UI Updates
- **Dock panel region indicator**: Added live region chip in `StingDockPanel` header; subscribes to `ProjectStandardsManager.StandardsChanged` for real-time updates
- **Command routing**: Wired new compliance command to `StingCommandHandler`

## Notable Implementation Details
- **Closed-form calculations**: Psychrometric command uses Magnus formula (no library overload); Arc Flash is a reference card
- **Type fallback**: Door width/height parameters fall back to family symbol when instance parameter is null
- **Error handling**:

https://claude.ai/code/session_011V48GLc1aQEy9bTUH1CVbQ