### PR TITLE
Implement ISO 6412 detail symbol placement with collision avoidance

### DIFF
--- a/Families/ISO6412/README.md
+++ b/Families/ISO6412/README.md
@@ -1,0 +1,125 @@
+# ISO 6412 Detail Symbol Library — Family Contract
+
+This directory holds the `.rfa` detail-component families that
+`StingTools.Core.Fabrication.IsoSymbolPlacer` drops onto fabrication
+shop drawings (the ISO 6412 axonometric created by
+`AssemblyViewBuilder` for every spool / assembly).
+
+The placer is invoked two ways:
+
+1. **Auto** — `Generate Fabrication Package` runs the placer for every
+   generated assembly when `FabricationOptions.PlaceISO6412Symbols` is
+   on (Fabrication tab → "Place ISO 6412 symbols" checkbox).
+2. **Manual** — the standalone `Place ISO 6412 Symbols` command
+   (`Fabrication_PlaceISOSymbols`) re-runs the placer against the
+   active assembly view or a selection of `AssemblyInstance`s, useful
+   when this folder is updated after the package was generated.
+
+## Catalogue
+
+The catalogue lives in `StingTools/Data/Fabrication/STING_ISO_SYMBOLS_INDEX.csv`
+(188 rows). Each row maps:
+
+| Column           | Purpose                                                   |
+|------------------|-----------------------------------------------------------|
+| `symbol_code`    | Uppercase keyword matched against assembly member names   |
+| `family_filename`| `.rfa` to load — must live in **this** directory          |
+| `category`       | `Pipe` / `Duct` / `Conduit` / etc. (used as fallback)     |
+| `description`    | Human-readable description (not used at runtime)          |
+
+Lookup order in `IsoSymbolPlacer.ResolveSymbol`:
+
+1. Substring match: member name (uppercase) **contains** `symbol_code`.
+2. Category fallback: `member.Category.Name == row.Category` (first row wins).
+
+## Family contract
+
+Every family in this folder MUST satisfy the following so the placer
+can use it without per-family special cases:
+
+### File naming
+
+* Filename matches `family_filename` in the CSV exactly, **including**
+  case on case-sensitive filesystems.
+* Extension is `.rfa`.
+* Convention: `STING_FAM_<DISCIPLINE>_<KIND>.rfa`, e.g.
+  `STING_FAM_PIPE_ELBOW_90_BW.rfa`.
+
+### Family template
+
+* **Detail Item** family (`Metric Detail Item.rft` or your local
+  equivalent) — NOT a 3D model component. The placer calls
+  `doc.Create.NewFamilyInstance(point, fs, view)` with a 2D detail
+  view, so the family must accept that overload (Detail Item families
+  do; Generic Model 3D families do not).
+* Drawn **at the family origin**. The placer puts the symbol at the
+  member's `LocationPoint` (or first `LocationCurve` endpoint) — there
+  is no per-symbol offset, so author the linework so the visual
+  centre is at (0,0).
+* Symbols are 2D linework only (Symbolic Lines, Filled Regions,
+  Detail Lines). No 3D extrusions, no host requirements.
+
+### Required parameters
+
+The placer sets up to three optional instance parameters when present.
+None are mandatory — the placer's `LookupParameter` calls are guarded
+by null-checks — but adding them lets the symbol size match the host
+view's plotted scale.
+
+| Parameter name              | Storage  | Purpose                                                  |
+|-----------------------------|----------|----------------------------------------------------------|
+| `Symbol Scale`              | Integer  | View scale (e.g. 50 for a 1:50 detail view).            |
+| `Symbol Scale`              | Double   | Same — placer accepts either storage type.              |
+| `STING_ISO_SYMBOL_SCALE_IN` | Double   | STING-namespaced parallel param for shared-param users. |
+
+If you parameterise linework size by `Symbol Scale`, a 1:25 detail and
+a 1:50 spool render the same plotted millimetres.
+
+### Authoring checklist
+
+- [ ] Detail Item family template
+- [ ] Linework centred at origin
+- [ ] 8 × 8 mm bounding box at 1:50 (scale via `Symbol Scale`)
+- [ ] No 3D, no host
+- [ ] No reference planes named `Center (Front/Back)` etc. that
+      collide with annotation symbol-host expectations
+- [ ] `Symbol Scale` instance parameter (Integer, default 50)
+- [ ] Family filename matches CSV exactly
+- [ ] Test: load into a project, place on a Section view → renders
+      cleanly at 1:50 and 1:25
+
+## Missing families
+
+If a family listed in the CSV is not present in this directory:
+
+* `IsoSymbolPlacer.ResolveFamilySymbol` logs a single warning per
+  family per session (`StingLog.Warn` → `StingTools.log`).
+* The missing filename is added to `FabricationResult.MissingFamilies`
+  and surfaced in the `FabricationResultDialog`'s "ISO 6412 symbols"
+  card so the user sees exactly what to author next.
+* The element is silently skipped — placement continues for other
+  members.
+
+## Recommended authoring order
+
+The 188-row catalogue is long; ship a placeholder pack of the highest-
+frequency symbols first to validate the wiring, then fill in the long
+tail. The top-20 quick-win set:
+
+| Discipline | Symbol codes |
+|---|---|
+| Pipe | `ELBOW_90_BW`, `ELBOW_45_BW`, `TEE_EQ`, `TEE_RED`, `RED_CONC`, `RED_ECC`, `COUPLING`, `UNION`, `CAP`, `FLANGE_WN`, `FLANGE_SO`, `VALVE_GATE`, `VALVE_BALL`, `VALVE_CHECK` |
+| Duct  | `DUCT_ELBOW_90`, `DUCT_TEE`, `DUCT_RED`, `DAMPER_VOLUME` |
+| Conduit | `CDT_ELBOW_90`, `CDT_BOX_4SQ` |
+
+Author those 20 first, regenerate a fabrication package against a test
+project, and verify symbols render on the ISO views before committing
+to the long tail.
+
+## Project overrides
+
+The CSV itself can be overridden per project. `IsoSymbolPlacer` reads
+the bundled file via `StingToolsApp.FindDataFile(...)`, which prefers
+project-local copies — drop a customised `STING_ISO_SYMBOLS_INDEX.csv`
+into the project's data folder to add or remap symbols without
+shipping a new plugin build.

--- a/Families/ISO6412/README.md
+++ b/Families/ISO6412/README.md
@@ -61,19 +61,40 @@ can use it without per-family special cases:
 
 ### Required parameters
 
-The placer sets up to three optional instance parameters when present.
-None are mandatory — the placer's `LookupParameter` calls are guarded
-by null-checks — but adding them lets the symbol size match the host
-view's plotted scale.
+All listed parameters are **optional** — the placer's `LookupParameter`
+calls are guarded by null-checks — but adding them unlocks features:
 
-| Parameter name              | Storage  | Purpose                                                  |
-|-----------------------------|----------|----------------------------------------------------------|
-| `Symbol Scale`              | Integer  | View scale (e.g. 50 for a 1:50 detail view).            |
-| `Symbol Scale`              | Double   | Same — placer accepts either storage type.              |
-| `STING_ISO_SYMBOL_SCALE_IN` | Double   | STING-namespaced parallel param for shared-param users. |
+| Parameter name                          | Storage  | Purpose                                                  |
+|-----------------------------------------|----------|----------------------------------------------------------|
+| `Symbol Scale`                          | Integer  | View scale (50 for a 1:50 view). Placer only writes when current value is at the convention default of 50, so families authored at non-default scales aren't overwritten. |
+| `Symbol Scale`                          | Double   | Same — placer accepts either storage type.              |
+| `STING_ISO_SYMBOL_SCALE_IN`             | Double   | STING-namespaced parallel param.                        |
+| `STING_PLACED_BY_SYMBOL_PLACER_BOOL`    | Integer  | **Required for idempotency.** Set to 1 by the placer; used to detect "already placed" instances in NewOnly mode and to find purge targets in Replace mode. |
+| `STING_PLACER_ASSY_ID_TXT`              | String   | Owning assembly's ElementId.                            |
+| `STING_PLACER_MEMBER_ID_TXT`            | String   | Source member's ElementId — keyed for idempotency.      |
+| `STING_PLACER_SYMBOL_CODE_TXT`          | String   | Resolved CSV `symbol_code`.                             |
+
+**Without** the stamp parameters above, re-running the placer will
+create duplicates because the placer can't tell that a member was
+already symbolised. Add them as instance shared parameters in every
+family in this folder.
 
 If you parameterise linework size by `Symbol Scale`, a 1:25 detail and
 a 1:50 spool render the same plotted millimetres.
+
+### Placement modes
+
+`FabricationOptions.SymbolPlacementMode` is a tri-state read by both
+auto and manual paths:
+
+| Mode      | Behaviour                                                           |
+|-----------|--------------------------------------------------------------------|
+| `Off`     | Skip the placer entirely.                                          |
+| `NewOnly` | (default) Skip members whose `STING_PLACER_MEMBER_ID_TXT` already matches a placed instance on the view — idempotent re-runs. |
+| `Replace` | Purge every placer-stamped instance on the view first, then re-place all members from scratch. |
+
+Per-discipline gates (`FabricationOptions.PlaceISOPipe / PlaceISODuct
+/ PlaceISOElectrical`) further restrict which fabricators emit symbols.
 
 ### Authoring checklist
 
@@ -123,3 +144,38 @@ the bundled file via `StingToolsApp.FindDataFile(...)`, which prefers
 project-local copies — drop a customised `STING_ISO_SYMBOLS_INDEX.csv`
 into the project's data folder to add or remap symbols without
 shipping a new plugin build.
+
+## View identification
+
+Every ISO 6412 view created by `AssemblyViewBuilder.CreateIso6412Section`
+is renamed to:
+
+```
+STING ISO 6412 - {assemblyTypeName} ::{assemblyElementId}
+```
+
+The trailing `::id` is parsed back by `PlaceIsoSymbolsCommand` so the
+standalone command can find the right view from a selected
+`AssemblyInstance` (and vice-versa). Don't rename these views —
+renaming breaks the link and the standalone command falls back to a
+slow `GetAssociatedAssemblyViews()` scan that won't return the
+hand-rolled section.
+
+## Audit trail
+
+Every placement run appends to `STING_v4_iso_symbols.csv` in the
+project's output directory:
+
+```
+assembly_id, assembly_name, view_id, view_name, member_id,
+member_category, member_name, family_name, symbol_code,
+family_file, resolved
+```
+
+`resolved = 1` rows show what got matched; `resolved = 0` rows show
+which members fell through the resolution chain — useful for extending
+the catalogue.
+
+Placed `FamilyInstance` ids are added to `FabricationResult.SymbolIds`
+and persisted by `FabricationUndoManager`, so the standard
+`Undo Fabrication Package` command rolls back symbols too.

--- a/Families/ISO6412/README.md
+++ b/Families/ISO6412/README.md
@@ -52,6 +52,12 @@ can use it without per-family special cases:
   `doc.Create.NewFamilyInstance(point, fs, view)` with a 2D detail
   view, so the family must accept that overload (Detail Item families
   do; Generic Model 3D families do not).
+* The placer validates `Family.FamilyCategory` at load time and warns
+  (once per session per family) when the category is not Detail Item
+  or Generic Annotation. Hosted families, 3D Generic Models, and MEP
+  families will trigger the warning — placement may still proceed but
+  the symbol can render at the wrong scale or fail to position
+  correctly. Re-author from the Detail Item template.
 * Drawn **at the family origin**. The placer puts the symbol at the
   member's `LocationPoint` (or first `LocationCurve` endpoint) — there
   is no per-symbol offset, so author the linework so the visual
@@ -81,6 +87,21 @@ family in this folder.
 
 If you parameterise linework size by `Symbol Scale`, a 1:25 detail and
 a 1:50 spool render the same plotted millimetres.
+
+### Leaders
+
+When the 8-quadrant collision-avoidance pass displaces a symbol from
+its true anchor (because another symbol is already there), the placer
+draws a straight `DetailCurve` leader from the displaced symbol back
+toward the member anchor. The leader stops a half-step short of the
+symbol so it doesn't pass through the symbol body. Co-located symbols
+(no displacement) skip the leader since the symbol overlay is its own
+visual cue per ISO 6412.
+
+Leader detail curves carry the same placer stamps as the symbols, so:
+
+* Replace mode purges them with the symbols.
+* `FabricationUndoManager` rolls them back as part of the package.
 
 ### Placement modes
 

--- a/StingTools/Commands/Fabrication/FabricationUndoManager.cs
+++ b/StingTools/Commands/Fabrication/FabricationUndoManager.cs
@@ -37,6 +37,7 @@ namespace StingTools.Commands.Fabrication
         public List<long> AssemblyIds { get; set; } = new List<long>();
         public List<long> SheetIds    { get; set; } = new List<long>();
         public List<long> ViewIds     { get; set; } = new List<long>();
+        public List<long> SymbolIds   { get; set; } = new List<long>();
         public string Summary { get; set; } = "";
     }
 
@@ -73,6 +74,7 @@ namespace StingTools.Commands.Fabrication
             {
                 AssemblyIds = res.AssemblyIds?.Select(i => i.Value).ToList() ?? new List<long>(),
                 SheetIds    = res.SheetIds?.Select(i => i.Value).ToList()    ?? new List<long>(),
+                SymbolIds   = res.SymbolIds?.Select(i => i.Value).ToList()   ?? new List<long>(),
                 Summary     = res.FormatSummary(),
             };
             try { File.WriteAllText(path, JsonConvert.SerializeObject(rec, Formatting.Indented)); }
@@ -99,6 +101,27 @@ namespace StingTools.Commands.Fabrication
                 tg.Start();
                 try
                 {
+                    // Delete placed ISO symbols first — they're detail
+                    // components owned by views that we're about to delete,
+                    // but we delete explicitly so the count is reportable.
+                    if (rec.SymbolIds != null && rec.SymbolIds.Count > 0)
+                    {
+                        using (var t = new Transaction(doc, "Undo fab symbols"))
+                        {
+                            t.Start();
+                            foreach (var id in rec.SymbolIds)
+                            {
+                                try
+                                {
+                                    var el = doc.GetElement(new ElementId(id));
+                                    if (el != null) { doc.Delete(el.Id); removed++; }
+                                }
+                                catch (Exception ex) { StingLog.Warn($"UndoLast symbol {id}: {ex.Message}"); }
+                            }
+                            t.Commit();
+                        }
+                    }
+
                     // Delete sheets first so viewports release their views
                     using (var t = new Transaction(doc, "Undo fab sheets"))
                     {

--- a/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
+++ b/StingTools/Commands/Fabrication/GenerateFabPackageCommand.cs
@@ -39,6 +39,20 @@ namespace StingTools.Commands.Fabrication
         public static bool PlaceISO6412Symbols { get; set; } = true;
         public static bool EmitPerDisciplineCsv{ get; set; } = true;
 
+        // Per-discipline ISO 6412 symbol toggles (only honoured when the
+        // master PlaceISO6412Symbols flag above is on). Lets a user
+        // generate symbol-stamped pipe drawings while leaving duct /
+        // electrical assemblies bare.
+        public static bool PlaceISOPipe       { get; set; } = true;
+        public static bool PlaceISODuct       { get; set; } = true;
+        public static bool PlaceISOElectrical { get; set; } = true;
+
+        /// <summary>Symbol placement run-mode. Off = skip; NewOnly =
+        /// idempotent (skip members already symbolised); Replace = purge
+        /// previously placed symbols on the view first, then re-place.</summary>
+        public enum PlacementMode { Off, NewOnly, Replace }
+        public static PlacementMode SymbolPlacementMode { get; set; } = PlacementMode.NewOnly;
+
         // Content mode — ISO 6412 (workshop) vs Generic (geometry only)
         public static bool ContentModeIso6412  { get; set; } = true;
 

--- a/StingTools/Commands/Fabrication/PlaceIsoSymbolsCommand.cs
+++ b/StingTools/Commands/Fabrication/PlaceIsoSymbolsCommand.cs
@@ -1,0 +1,215 @@
+// StingTools v4 MVP — PlaceIsoSymbolsCommand.
+//
+// Standalone re-run of the ISO 6412 detail-symbol placer for an
+// existing AssemblyInstance. Generate Fabrication Package wires the
+// placer in automatically (gated on FabricationOptions.PlaceISO6412Symbols);
+// this command is the manual entry point for the same pipeline so
+// users can iterate symbol placement without regenerating the whole
+// fabrication package — useful when the family library has just been
+// updated, when symbols need to land on a different detail view than
+// the auto-generated ISO 6412 one, or when the placement option was
+// off at package time.
+//
+// Resolution order for (assembly, view):
+//   1. Active view is a ViewSection and is associated with an
+//      AssemblyInstance — place on the active view (1 assembly).
+//   2. Selection contains AssemblyInstance(s) — for each, find the
+//      first associated ViewSection (the ISO 6412 axonometric created
+//      by AssemblyViewBuilder is a Section view).
+//   3. Otherwise — clear TaskDialog explaining what to select / open.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Fabrication;
+
+namespace StingTools.Commands.Fabrication
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class PlaceIsoSymbolsCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(commandData);
+            if (ctx == null) { message = "No active document."; return Result.Failed; }
+            var doc = ctx.Doc;
+            var uidoc = ctx.UIDoc;
+
+            var targets = ResolveTargets(doc, uidoc);
+            if (targets.Count == 0)
+            {
+                TaskDialog.Show("STING v4 — ISO 6412 Symbols",
+                    "Nothing to place against.\n\n" +
+                    "Open a fabrication assembly's ISO 6412 detail view, OR select " +
+                    "one or more AssemblyInstance elements, then re-run this command.\n\n" +
+                    "If you haven't generated a package yet, run Generate Fabrication " +
+                    "Package first — it creates the assembly + detail views automatically.");
+                return Result.Cancelled;
+            }
+
+            var result = new FabricationResult();
+            foreach (var pair in targets)
+            {
+                try
+                {
+                    var view = doc.GetElement(pair.IsoViewId) as View;
+                    if (view == null) continue;
+                    int placed = IsoSymbolPlacer.PlaceSymbolsForAssembly(
+                        doc, pair.AssyId, view, result);
+                    result.SymbolsPlaced += placed;
+                }
+                catch (Exception ex)
+                {
+                    result.Warnings.Add($"PlaceIsoSymbols {pair.AssyId}: {ex.Message}");
+                    StingLog.Warn($"PlaceIsoSymbolsCommand: {ex.Message}");
+                }
+            }
+
+            ShowResult(result, targets.Count);
+            return Result.Succeeded;
+        }
+
+        // ─── Target resolution ──────────────────────────────────────────
+
+        private static List<(ElementId AssyId, ElementId IsoViewId)> ResolveTargets(
+            Document doc, UIDocument uidoc)
+        {
+            var targets = new List<(ElementId, ElementId)>();
+
+            // 1) Active view is a section/detail tied to an assembly.
+            try
+            {
+                var av = doc.ActiveView;
+                if (av is ViewSection || av is ViewPlan || av is ViewDrafting)
+                {
+                    var assyId = FindAssemblyForView(doc, av.Id);
+                    if (assyId != null && assyId != ElementId.InvalidElementId)
+                    {
+                        targets.Add((assyId, av.Id));
+                        return targets;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"PlaceIsoSymbols.ActiveView: {ex.Message}"); }
+
+            // 2) Selection contains AssemblyInstance(s).
+            try
+            {
+                var selIds = uidoc?.Selection?.GetElementIds();
+                if (selIds != null)
+                {
+                    foreach (var id in selIds)
+                    {
+                        var ai = doc.GetElement(id) as AssemblyInstance;
+                        if (ai == null) continue;
+                        var viewId = FindFirstSectionViewForAssembly(doc, ai);
+                        if (viewId == null || viewId == ElementId.InvalidElementId) continue;
+                        targets.Add((ai.Id, viewId));
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"PlaceIsoSymbols.Selection: {ex.Message}"); }
+
+            return targets;
+        }
+
+        /// <summary>
+        /// Walks every AssemblyInstance in the document and returns the
+        /// id of the one whose associated views contain <paramref name="viewId"/>.
+        /// Returns InvalidElementId when no assembly owns the view.
+        /// </summary>
+        private static ElementId FindAssemblyForView(Document doc, ElementId viewId)
+        {
+            try
+            {
+                var col = new FilteredElementCollector(doc)
+                    .OfClass(typeof(AssemblyInstance));
+                foreach (var el in col)
+                {
+                    if (!(el is AssemblyInstance ai)) continue;
+                    var views = ai.GetAssociatedAssemblyViews();
+                    if (views != null && views.Contains(viewId)) return ai.Id;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"FindAssemblyForView: {ex.Message}"); }
+            return ElementId.InvalidElementId;
+        }
+
+        /// <summary>
+        /// Picks the first ViewSection associated with the assembly — that
+        /// is the ISO 6412 axonometric created by AssemblyViewBuilder,
+        /// since the builder only emits one Section view per assembly
+        /// (elevations are CreateDetailSection but live as ViewSection too,
+        /// which is fine — symbol placement works on any 2D detail view).
+        /// </summary>
+        private static ElementId FindFirstSectionViewForAssembly(Document doc, AssemblyInstance ai)
+        {
+            try
+            {
+                var views = ai.GetAssociatedAssemblyViews();
+                if (views == null) return ElementId.InvalidElementId;
+                foreach (var vid in views)
+                {
+                    if (doc.GetElement(vid) is ViewSection) return vid;
+                }
+                // Fallback: any non-3D, non-schedule view.
+                foreach (var vid in views)
+                {
+                    var v = doc.GetElement(vid) as View;
+                    if (v == null) continue;
+                    if (v is View3D) continue;
+                    if (v is ViewSchedule) continue;
+                    return vid;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"FindFirstSectionViewForAssembly: {ex.Message}"); }
+            return ElementId.InvalidElementId;
+        }
+
+        // ─── Result reporting ──────────────────────────────────────────
+
+        private static void ShowResult(FabricationResult res, int assemblyCount)
+        {
+            foreach (var w in res.Warnings) StingLog.Warn($"PlaceIsoSymbols: {w}");
+
+            var dlg = new TaskDialog("STING v4 — ISO 6412 Symbols")
+            {
+                MainInstruction = res.SymbolsPlaced > 0
+                    ? $"{res.SymbolsPlaced} symbol(s) placed across {assemblyCount} assembly(ies)."
+                    : "No symbols placed.",
+                MainContent = BuildResultBody(res, assemblyCount),
+                CommonButtons = TaskDialogCommonButtons.Close,
+            };
+            dlg.Show();
+        }
+
+        private static string BuildResultBody(FabricationResult res, int assemblyCount)
+        {
+            var lines = new List<string>();
+            lines.Add($"Assemblies processed: {assemblyCount}");
+            lines.Add($"Symbols placed: {res.SymbolsPlaced}");
+            if (res.MissingFamilies.Count > 0)
+            {
+                lines.Add("");
+                lines.Add($"Missing families ({res.MissingFamilies.Count}):");
+                foreach (var fam in res.MissingFamilies.OrderBy(f => f).Take(10))
+                    lines.Add("  • " + fam);
+                if (res.MissingFamilies.Count > 10)
+                    lines.Add($"  (+{res.MissingFamilies.Count - 10} more — see StingTools.log)");
+                lines.Add("");
+                lines.Add("Drop the .rfa files into Families/ISO6412/ alongside the plugin and re-run.");
+            }
+            if (res.Warnings.Count > 0)
+            {
+                lines.Add("");
+                lines.Add($"{res.Warnings.Count} warning(s) — full detail in StingTools.log.");
+            }
+            return string.Join(Environment.NewLine, lines);
+        }
+    }
+}

--- a/StingTools/Commands/Fabrication/PlaceIsoSymbolsCommand.cs
+++ b/StingTools/Commands/Fabrication/PlaceIsoSymbolsCommand.cs
@@ -11,12 +11,14 @@
 // off at package time.
 //
 // Resolution order for (assembly, view):
-//   1. Active view is a ViewSection and is associated with an
-//      AssemblyInstance — place on the active view (1 assembly).
-//   2. Selection contains AssemblyInstance(s) — for each, find the
-//      first associated ViewSection (the ISO 6412 axonometric created
-//      by AssemblyViewBuilder is a Section view).
-//   3. Otherwise — clear TaskDialog explaining what to select / open.
+//   1. Active view is the ISO 6412 view itself — its name was stamped
+//      with the assembly id by AssemblyViewBuilder, so we parse the
+//      assembly id back out of view.Name (`STING ISO 6412 - <name> ::<id>`).
+//   2. Active view is some other section/plan/drafting view associated
+//      with an assembly via AssemblyInstance.GetAssociatedAssemblyViews().
+//   3. Selection contains AssemblyInstance(s) — for each, find its
+//      stamped ISO 6412 section view by name suffix scan.
+//   4. Otherwise — clear TaskDialog explaining what to select / open.
 
 using System;
 using System.Collections.Generic;
@@ -81,7 +83,25 @@ namespace StingTools.Commands.Fabrication
         {
             var targets = new List<(ElementId, ElementId)>();
 
-            // 1) Active view is a section/detail tied to an assembly.
+            // 1) Active view IS a STING ISO 6412 view (stamped by name).
+            try
+            {
+                var av = doc.ActiveView;
+                if (av != null && IsStingIsoView(av))
+                {
+                    var aid = ParseAssemblyIdFromIsoViewName(av.Name);
+                    if (aid != null && aid != ElementId.InvalidElementId
+                        && doc.GetElement(aid) is AssemblyInstance)
+                    {
+                        targets.Add((aid, av.Id));
+                        return targets;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"PlaceIsoSymbols.IsoView: {ex.Message}"); }
+
+            // 2) Active view associated with an assembly (older path —
+            //    AssemblyViewUtils-created views like elevations).
             try
             {
                 var av = doc.ActiveView;
@@ -97,25 +117,81 @@ namespace StingTools.Commands.Fabrication
             }
             catch (Exception ex) { StingLog.Warn($"PlaceIsoSymbols.ActiveView: {ex.Message}"); }
 
-            // 2) Selection contains AssemblyInstance(s).
+            // 3) Selection contains AssemblyInstance(s) — find each one's
+            //    STING ISO 6412 view by name suffix `:: <id>`.
             try
             {
                 var selIds = uidoc?.Selection?.GetElementIds();
                 if (selIds != null)
                 {
+                    var nameIndex = BuildIsoViewNameIndex(doc);
                     foreach (var id in selIds)
                     {
                         var ai = doc.GetElement(id) as AssemblyInstance;
                         if (ai == null) continue;
-                        var viewId = FindFirstSectionViewForAssembly(doc, ai);
-                        if (viewId == null || viewId == ElementId.InvalidElementId) continue;
-                        targets.Add((ai.Id, viewId));
+                        if (nameIndex.TryGetValue(ai.Id.Value, out ElementId viewId))
+                        {
+                            targets.Add((ai.Id, viewId));
+                            continue;
+                        }
+                        // Final fallback: AssemblyViewUtils-associated section.
+                        var fallback = FindFirstSectionViewForAssembly(doc, ai);
+                        if (fallback != null && fallback != ElementId.InvalidElementId)
+                            targets.Add((ai.Id, fallback));
                     }
                 }
             }
             catch (Exception ex) { StingLog.Warn($"PlaceIsoSymbols.Selection: {ex.Message}"); }
 
             return targets;
+        }
+
+        private static bool IsStingIsoView(View v)
+        {
+            try { return (v?.Name ?? "").StartsWith("STING ISO 6412", StringComparison.OrdinalIgnoreCase); }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// Parses the assembly element-id out of a STING ISO 6412 view
+        /// name. Format: `STING ISO 6412 - {assyName} ::{id}`.
+        /// </summary>
+        private static ElementId ParseAssemblyIdFromIsoViewName(string name)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(name)) return ElementId.InvalidElementId;
+                int idx = name.LastIndexOf("::", StringComparison.Ordinal);
+                if (idx < 0) return ElementId.InvalidElementId;
+                string tail = name.Substring(idx + 2).Trim();
+                if (long.TryParse(tail, out long val)) return new ElementId(val);
+            }
+            catch { }
+            return ElementId.InvalidElementId;
+        }
+
+        /// <summary>
+        /// One-pass scan of every ViewSection in the document whose name
+        /// matches the STING ISO 6412 pattern. Returns map of
+        /// assemblyId.Value → viewId.
+        /// </summary>
+        private static Dictionary<long, ElementId> BuildIsoViewNameIndex(Document doc)
+        {
+            var map = new Dictionary<long, ElementId>();
+            try
+            {
+                var col = new FilteredElementCollector(doc).OfClass(typeof(View));
+                foreach (var el in col)
+                {
+                    if (!(el is View v) || v.IsTemplate) continue;
+                    if (!IsStingIsoView(v)) continue;
+                    var aid = ParseAssemblyIdFromIsoViewName(v.Name);
+                    if (aid == null || aid == ElementId.InvalidElementId) continue;
+                    map[aid.Value] = v.Id;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"BuildIsoViewNameIndex: {ex.Message}"); }
+            return map;
         }
 
         /// <summary>
@@ -192,7 +268,17 @@ namespace StingTools.Commands.Fabrication
         {
             var lines = new List<string>();
             lines.Add($"Assemblies processed: {assemblyCount}");
+            lines.Add($"Mode: {StingTools.Commands.Fabrication.FabricationOptions.SymbolPlacementMode}");
             lines.Add($"Symbols placed: {res.SymbolsPlaced}");
+            if (res.SymbolsReplaced > 0) lines.Add($"Symbols replaced: {res.SymbolsReplaced}");
+            if (res.UnmatchedMembers > 0)
+            {
+                lines.Add($"Members with no symbol mapping: {res.UnmatchedMembers}");
+                foreach (var s in res.UnmatchedSamples.Take(5))
+                    lines.Add("  • " + s);
+                if (res.UnmatchedSamples.Count > 5)
+                    lines.Add($"  (+{res.UnmatchedMembers - res.UnmatchedSamples.Count} more)");
+            }
             if (res.MissingFamilies.Count > 0)
             {
                 lines.Add("");

--- a/StingTools/Commands/Fabrication/PlaceIsoSymbolsCommand.cs
+++ b/StingTools/Commands/Fabrication/PlaceIsoSymbolsCommand.cs
@@ -15,7 +15,7 @@
 //      with the assembly id by AssemblyViewBuilder, so we parse the
 //      assembly id back out of view.Name (`STING ISO 6412 - <name> ::<id>`).
 //   2. Active view is some other section/plan/drafting view associated
-//      with an assembly via AssemblyInstance.GetAssociatedAssemblyViews().
+//      with an assembly via View.AssociatedAssemblyInstanceId.
 //   3. Selection contains AssemblyInstance(s) — for each, find its
 //      stamped ISO 6412 section view by name suffix scan.
 //   4. Otherwise — clear TaskDialog explaining what to select / open.
@@ -203,13 +203,10 @@ namespace StingTools.Commands.Fabrication
         {
             try
             {
-                var col = new FilteredElementCollector(doc)
-                    .OfClass(typeof(AssemblyInstance));
-                foreach (var el in col)
+                if (doc.GetElement(viewId) is View v
+                    && v.AssociatedAssemblyInstanceId != ElementId.InvalidElementId)
                 {
-                    if (!(el is AssemblyInstance ai)) continue;
-                    var views = ai.GetAssociatedAssemblyViews();
-                    if (views != null && views.Contains(viewId)) return ai.Id;
+                    return v.AssociatedAssemblyInstanceId;
                 }
             }
             catch (Exception ex) { StingLog.Warn($"FindAssemblyForView: {ex.Message}"); }
@@ -225,22 +222,30 @@ namespace StingTools.Commands.Fabrication
         /// </summary>
         private static ElementId FindFirstSectionViewForAssembly(Document doc, AssemblyInstance ai)
         {
+            if (ai == null) return ElementId.InvalidElementId;
             try
             {
-                var views = ai.GetAssociatedAssemblyViews();
-                if (views == null) return ElementId.InvalidElementId;
-                foreach (var vid in views)
+                // Revit has no AssemblyInstance.GetAssociatedAssemblyViews
+                // helper; views own their owning-assembly via
+                // View.AssociatedAssemblyInstanceId. Filter the view set by
+                // that id and pick the first ViewSection — that's the
+                // ISO 6412 axonometric AssemblyViewBuilder mints.
+                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(ViewSection)))
                 {
-                    if (doc.GetElement(vid) is ViewSection) return vid;
+                    if (el is ViewSection vs && vs.AssociatedAssemblyInstanceId == ai.Id)
+                        return vs.Id;
                 }
-                // Fallback: any non-3D, non-schedule view.
-                foreach (var vid in views)
+                // Fallback: any non-3D, non-schedule view bound to the
+                // assembly. Catches projects where the user duplicated the
+                // ISO into a Detail / DraftingView before triggering the
+                // command.
+                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(View)))
                 {
-                    var v = doc.GetElement(vid) as View;
-                    if (v == null) continue;
+                    if (!(el is View v) || v.IsTemplate) continue;
+                    if (v.AssociatedAssemblyInstanceId != ai.Id) continue;
                     if (v is View3D) continue;
                     if (v is ViewSchedule) continue;
-                    return vid;
+                    return v.Id;
                 }
             }
             catch (Exception ex) { StingLog.Warn($"FindFirstSectionViewForAssembly: {ex.Message}"); }

--- a/StingTools/Core/Fabrication/AssemblyViewBuilder.cs
+++ b/StingTools/Core/Fabrication/AssemblyViewBuilder.cs
@@ -103,6 +103,28 @@ namespace StingTools.Core.Fabrication
             try
             {
                 set.ViewIso6412 = CreateIso6412Section(doc, ai);
+                // Stamp the view name with the assembly id so
+                // PlaceIsoSymbolsCommand and any future drift-checker
+                // can resolve view ↔ assembly without depending on
+                // GetAssociatedAssemblyViews() (which only returns views
+                // created via AssemblyViewUtils, not raw ViewSection).
+                if (set.ViewIso6412 != null && set.ViewIso6412 != ElementId.InvalidElementId
+                    && doc.GetElement(set.ViewIso6412) is View v)
+                {
+                    try
+                    {
+                        string assyName = "";
+                        try { assyName = (doc.GetElement(ai.GetTypeId()) as AssemblyType)?.Name ?? ""; } catch { }
+                        string suffix = $"::{assemblyId.Value}";
+                        string baseName = $"STING ISO 6412 - {assyName}";
+                        if (string.IsNullOrEmpty(assyName)) baseName = "STING ISO 6412";
+                        // Revit view names must be unique — append assy id
+                        // to avoid collisions when two assemblies share a
+                        // type name in the same document.
+                        v.Name = baseName + " " + suffix;
+                    }
+                    catch (Exception nx) { set.Warnings.Add($"ISO 6412 rename: {nx.Message}"); }
+                }
             }
             catch (Exception ex) { set.Warnings.Add($"ISO 6412: {ex.Message}"); }
 

--- a/StingTools/Core/Fabrication/Duct/DuctFabricator.cs
+++ b/StingTools/Core/Fabrication/Duct/DuctFabricator.cs
@@ -56,7 +56,7 @@ namespace StingTools.Core.Fabrication.Duct
             }
             result.AssembliesByDiscipline["Duct"] = seq - 1;
 
-            FabricationEngine.PlaceSymbolsIfRequested(doc, symbolTargets, result);
+            FabricationEngine.PlaceSymbolsIfRequested(doc, "Duct", symbolTargets, result);
 
             try { EmitSeamTallyCsv(doc, elementIds, result); }
             catch (Exception ex) { result.Warnings.Add($"Seam tally csv: {ex.Message}"); }

--- a/StingTools/Core/Fabrication/Duct/DuctFabricator.cs
+++ b/StingTools/Core/Fabrication/Duct/DuctFabricator.cs
@@ -22,6 +22,7 @@ namespace StingTools.Core.Fabrication.Duct
             var groups = grouper.GroupForDiscipline(doc, elementIds, "Duct",
                 out List<AssemblyGrouper.SpoolMetrics> metrics);
             int seq = 1;
+            var symbolTargets = new List<(ElementId AssyId, ElementId IsoViewId)>();
 
             using (var tx = new Transaction(doc, "STING v4 Duct fabrication"))
             {
@@ -42,6 +43,8 @@ namespace StingTools.Core.Fabrication.Duct
                         var sheetId = ShopDrawingComposer.ComposeSheet(doc, "Duct", assyId, views, result);
                         if (sheetId != null && sheetId != ElementId.InvalidElementId)
                             result.SheetIds.Add(sheetId);
+                        if (views.ViewIso6412 != null && views.ViewIso6412 != ElementId.InvalidElementId)
+                            symbolTargets.Add((assyId, views.ViewIso6412));
                     }
                     tx.Commit();
                 }
@@ -52,6 +55,8 @@ namespace StingTools.Core.Fabrication.Duct
                 }
             }
             result.AssembliesByDiscipline["Duct"] = seq - 1;
+
+            FabricationEngine.PlaceSymbolsIfRequested(doc, symbolTargets, result);
 
             try { EmitSeamTallyCsv(doc, elementIds, result); }
             catch (Exception ex) { result.Warnings.Add($"Seam tally csv: {ex.Message}"); }

--- a/StingTools/Core/Fabrication/Electrical/ElectricalFabricator.cs
+++ b/StingTools/Core/Fabrication/Electrical/ElectricalFabricator.cs
@@ -57,7 +57,7 @@ namespace StingTools.Core.Fabrication.Electrical
 
             result.AssembliesByDiscipline["Electrical"] = seq - 1;
 
-            FabricationEngine.PlaceSymbolsIfRequested(doc, symbolTargets, result);
+            FabricationEngine.PlaceSymbolsIfRequested(doc, "Electrical", symbolTargets, result);
 
             // Bend + tray schedules as CSV sidecars
             try { EmitBendScheduleCsv(doc, elementIds, result); }

--- a/StingTools/Core/Fabrication/Electrical/ElectricalFabricator.cs
+++ b/StingTools/Core/Fabrication/Electrical/ElectricalFabricator.cs
@@ -22,6 +22,7 @@ namespace StingTools.Core.Fabrication.Electrical
             var groups = grouper.GroupForDiscipline(doc, elementIds, "Electrical",
                 out List<AssemblyGrouper.SpoolMetrics> metrics);
             int seq = 1;
+            var symbolTargets = new List<(ElementId AssyId, ElementId IsoViewId)>();
 
             using (var tx = new Transaction(doc, "STING v4 Electrical fabrication"))
             {
@@ -42,6 +43,8 @@ namespace StingTools.Core.Fabrication.Electrical
                         var sheetId = ShopDrawingComposer.ComposeSheet(doc, "Electrical", assyId, views, result);
                         if (sheetId != null && sheetId != ElementId.InvalidElementId)
                             result.SheetIds.Add(sheetId);
+                        if (views.ViewIso6412 != null && views.ViewIso6412 != ElementId.InvalidElementId)
+                            symbolTargets.Add((assyId, views.ViewIso6412));
                     }
                     tx.Commit();
                 }
@@ -53,6 +56,8 @@ namespace StingTools.Core.Fabrication.Electrical
             }
 
             result.AssembliesByDiscipline["Electrical"] = seq - 1;
+
+            FabricationEngine.PlaceSymbolsIfRequested(doc, symbolTargets, result);
 
             // Bend + tray schedules as CSV sidecars
             try { EmitBendScheduleCsv(doc, elementIds, result); }

--- a/StingTools/Core/Fabrication/FabricationEngine.cs
+++ b/StingTools/Core/Fabrication/FabricationEngine.cs
@@ -113,9 +113,10 @@ namespace StingTools.Core.Fabrication
         {
             if (doc == null || result == null) return;
             if (targets == null || targets.Count == 0) return;
-            var opts = StingTools.Commands.Fabrication.FabricationOptions;
-            if (!opts.PlaceISO6412Symbols) return;
-            if (opts.SymbolPlacementMode ==
+            // FabricationOptions is a static class, so it can't be assigned
+            // to a local. Reference its static members directly.
+            if (!StingTools.Commands.Fabrication.FabricationOptions.PlaceISO6412Symbols) return;
+            if (StingTools.Commands.Fabrication.FabricationOptions.SymbolPlacementMode ==
                 StingTools.Commands.Fabrication.FabricationOptions.PlacementMode.Off) return;
             if (!IsDisciplineOn(discipline)) return;
 
@@ -146,12 +147,13 @@ namespace StingTools.Core.Fabrication
 
         private static bool IsDisciplineOn(string discipline)
         {
-            var o = StingTools.Commands.Fabrication.FabricationOptions;
+            // FabricationOptions is static — read the per-discipline flag
+            // directly rather than aliasing the type to a local.
             switch ((discipline ?? "").ToUpperInvariant())
             {
-                case "PIPE":       return o.PlaceISOPipe;
-                case "DUCT":       return o.PlaceISODuct;
-                case "ELECTRICAL": return o.PlaceISOElectrical;
+                case "PIPE":       return StingTools.Commands.Fabrication.FabricationOptions.PlaceISOPipe;
+                case "DUCT":       return StingTools.Commands.Fabrication.FabricationOptions.PlaceISODuct;
+                case "ELECTRICAL": return StingTools.Commands.Fabrication.FabricationOptions.PlaceISOElectrical;
                 default:           return true;
             }
         }

--- a/StingTools/Core/Fabrication/FabricationEngine.cs
+++ b/StingTools/Core/Fabrication/FabricationEngine.cs
@@ -29,10 +29,17 @@ namespace StingTools.Core.Fabrication
         public List<string> Warnings { get; } = new List<string>();
         public int FailedCount { get; set; }
 
+        // ISO 6412 symbol placement results — populated by IsoSymbolPlacer
+        // after each discipline's transaction commits. Surfaced in the
+        // FabricationResultDialog so users see whether the option had effect.
+        public int SymbolsPlaced { get; set; }
+        public HashSet<string> MissingFamilies { get; }
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         public string FormatSummary()
         {
             int total = AssembliesByDiscipline.Values.Sum();
-            return $"Assemblies: {total}, Sheets: {SheetIds.Count}, Failed: {FailedCount}";
+            return $"Assemblies: {total}, Sheets: {SheetIds.Count}, Failed: {FailedCount}, Symbols: {SymbolsPlaced}";
         }
     }
 
@@ -83,6 +90,39 @@ namespace StingTools.Core.Fabrication
                 result.Warnings.Add($"FabricationEngine fatal: {ex.Message}");
             }
             return result;
+        }
+
+        /// <summary>
+        /// Run IsoSymbolPlacer for each (assembly, ISO view) pair when the
+        /// user has ticked PlaceISO6412Symbols on the Fabrication tab. Must
+        /// be called AFTER the discipline's transaction commits — the placer
+        /// opens its own Transaction and may need to LoadFamily, which is
+        /// not legal inside an active outer Transaction.
+        /// </summary>
+        public static void PlaceSymbolsIfRequested(
+            Document doc,
+            IList<(ElementId AssyId, ElementId IsoViewId)> targets,
+            FabricationResult result)
+        {
+            if (doc == null || result == null) return;
+            if (targets == null || targets.Count == 0) return;
+            if (!StingTools.Commands.Fabrication.FabricationOptions.PlaceISO6412Symbols) return;
+
+            foreach (var pair in targets)
+            {
+                try
+                {
+                    var view = doc.GetElement(pair.IsoViewId) as View;
+                    if (view == null) continue;
+                    int placed = IsoSymbolPlacer.PlaceSymbolsForAssembly(
+                        doc, pair.AssyId, view, result);
+                    result.SymbolsPlaced += placed;
+                }
+                catch (Exception ex)
+                {
+                    result.Warnings.Add($"PlaceSymbolsIfRequested {pair.AssyId}: {ex.Message}");
+                }
+            }
         }
 
         public static string DisciplineFor(Element el)

--- a/StingTools/Core/Fabrication/FabricationEngine.cs
+++ b/StingTools/Core/Fabrication/FabricationEngine.cs
@@ -33,8 +33,14 @@ namespace StingTools.Core.Fabrication
         // after each discipline's transaction commits. Surfaced in the
         // FabricationResultDialog so users see whether the option had effect.
         public int SymbolsPlaced { get; set; }
+        public int SymbolsReplaced { get; set; }
+        public int UnmatchedMembers { get; set; }
+        public List<ElementId> SymbolIds { get; } = new List<ElementId>();
+        public List<string> UnmatchedSamples { get; } = new List<string>();
         public HashSet<string> MissingFamilies { get; }
             = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, int> SymbolsByDiscipline { get; }
+            = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
         public string FormatSummary()
         {
@@ -94,20 +100,26 @@ namespace StingTools.Core.Fabrication
 
         /// <summary>
         /// Run IsoSymbolPlacer for each (assembly, ISO view) pair when the
-        /// user has ticked PlaceISO6412Symbols on the Fabrication tab. Must
-        /// be called AFTER the discipline's transaction commits — the placer
-        /// opens its own Transaction and may need to LoadFamily, which is
-        /// not legal inside an active outer Transaction.
+        /// user has ticked PlaceISO6412Symbols on the Fabrication tab and
+        /// the per-discipline toggle for <paramref name="discipline"/> is
+        /// also on. Must be called AFTER the discipline's transaction
+        /// commits — the placer opens its own Transaction.
         /// </summary>
         public static void PlaceSymbolsIfRequested(
             Document doc,
+            string discipline,
             IList<(ElementId AssyId, ElementId IsoViewId)> targets,
             FabricationResult result)
         {
             if (doc == null || result == null) return;
             if (targets == null || targets.Count == 0) return;
-            if (!StingTools.Commands.Fabrication.FabricationOptions.PlaceISO6412Symbols) return;
+            var opts = StingTools.Commands.Fabrication.FabricationOptions;
+            if (!opts.PlaceISO6412Symbols) return;
+            if (opts.SymbolPlacementMode ==
+                StingTools.Commands.Fabrication.FabricationOptions.PlacementMode.Off) return;
+            if (!IsDisciplineOn(discipline)) return;
 
+            int totalForDisc = 0;
             foreach (var pair in targets)
             {
                 try
@@ -117,11 +129,30 @@ namespace StingTools.Core.Fabrication
                     int placed = IsoSymbolPlacer.PlaceSymbolsForAssembly(
                         doc, pair.AssyId, view, result);
                     result.SymbolsPlaced += placed;
+                    totalForDisc += placed;
                 }
                 catch (Exception ex)
                 {
                     result.Warnings.Add($"PlaceSymbolsIfRequested {pair.AssyId}: {ex.Message}");
                 }
+            }
+            if (totalForDisc > 0)
+            {
+                if (!result.SymbolsByDiscipline.ContainsKey(discipline))
+                    result.SymbolsByDiscipline[discipline] = 0;
+                result.SymbolsByDiscipline[discipline] += totalForDisc;
+            }
+        }
+
+        private static bool IsDisciplineOn(string discipline)
+        {
+            var o = StingTools.Commands.Fabrication.FabricationOptions;
+            switch ((discipline ?? "").ToUpperInvariant())
+            {
+                case "PIPE":       return o.PlaceISOPipe;
+                case "DUCT":       return o.PlaceISODuct;
+                case "ELECTRICAL": return o.PlaceISOElectrical;
+                default:           return true;
             }
         }
 

--- a/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
+++ b/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
@@ -145,6 +145,7 @@ namespace StingTools.Core.Fabrication
 
             if (_missingFamiliesLogged.Add(famName))
                 StingLog.Warn($"IsoSymbolPlacer: family not found -> {famName}");
+            try { result?.MissingFamilies?.Add(famName); } catch { }
             return null;
         }
 

--- a/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
+++ b/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
@@ -4,17 +4,43 @@
 // from STING_ISO_SYMBOLS_INDEX.csv via name/category heuristics,
 // resolves the corresponding FamilySymbol (lazy-loads the .rfa from
 // the families folder when not yet in the project), and calls
-// DetailComponent.Create to drop the symbol on a host detail view.
+// NewFamilyInstance to drop the symbol on a host detail/section view.
 //
-// First-pass heuristic mapping uses three rules:
-//   1. Category match (Pipe / Duct / Conduit / etc.)
-//   2. Name keyword match against the symbol_code uppercase
-//   3. Element type metadata (e.g. valve type, fitting angle)
-// Symbols whose family file cannot be located are silently skipped
-// with a single StingLog.Warn per missing family.
+// Placement algorithm (Phase 178):
+//   1. Sort _index by SymbolCode length descending so longer keywords
+//      win against shorter substrings (TEE_RED before TEE).
+//   2. Resolve symbol: search Family.Name + FamilySymbol.Name +
+//      member.Name with token-split logic — every "_"-separated token
+//      of SymbolCode must appear in the haystack. Fall back to
+//      Category match (mapped from CSV strings to Revit category names).
+//   3. Pre-resolve all required FamilySymbols and LoadFamily missing
+//      ones BEFORE the placement transaction (faster, also keeps load
+//      separate from placement so a single bad family doesn't kill the
+//      whole pass).
+//   4. Honour FabricationOptions.SymbolPlacementMode:
+//        Off       — bail.
+//        NewOnly   — skip members whose symbol is already placed at
+//                    approximately the same XYZ on the view.
+//        Replace   — purge previously-stamped placer instances on the
+//                    view first, then re-place every member.
+//   5. Project member XYZ onto the view's RightDirection × UpDirection
+//      plane so the symbol lands on the section, not at its 3D world
+//      position (which often clips the view).
+//   6. For LocationCurve members, use the curve mid-point instead of
+//      the start endpoint so symbols centre on long runs.
+//   7. Rotate the symbol to match the member's primary axis (curve
+//      direction for pipes/ducts, host axis for fittings).
+//   8. 8-quadrant collision avoidance — if a placed symbol overlaps a
+//      previous one, try N/NE/E/SE/S/SW/W/NW offsets at scale-aware
+//      step size before giving up.
+//   9. Stamp placed instance with STING_PLACED_BY_SYMBOL_PLACER_BOOL +
+//      STING_PLACER_ASSY_ID_TXT for idempotency + undo traceability.
+//  10. Emit STING_v4_iso_symbols.csv audit sidecar with per-member
+//      decision (resolved code, family, success, reason).
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Autodesk.Revit.DB;
@@ -27,12 +53,29 @@ namespace StingTools.Core.Fabrication
         public string FamilyFile { get; set; } = "";
         public string Category   { get; set; } = "";
         public string Description{ get; set; } = "";
+
+        // Pre-computed when EnsureIndexLoaded sorts the index.
+        public string[] Tokens   { get; set; } = Array.Empty<string>();
     }
 
     public static class IsoSymbolPlacer
     {
         private static List<SymbolEntry> _index;
-        private static readonly HashSet<string> _missingFamiliesLogged = new HashSet<string>();
+
+        // Process-static dedup of "missing family" log lines so a project
+        // with hundreds of members doesn't spam the log. The set is reset
+        // per call via FabricationResult.MissingFamilies — that one is
+        // always populated for UI surfacing.
+        private static readonly HashSet<string> _missingFamiliesLogged
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Stamps written onto every placed FamilyInstance so re-runs can
+        // detect them (NewOnly mode) or purge them (Replace mode), and
+        // FabricationUndoManager can roll them back.
+        public const string STAMP_BOOL = "STING_PLACED_BY_SYMBOL_PLACER_BOOL";
+        public const string STAMP_ASSY = "STING_PLACER_ASSY_ID_TXT";
+        public const string STAMP_MEMBER = "STING_PLACER_MEMBER_ID_TXT";
+        public const string STAMP_CODE = "STING_PLACER_SYMBOL_CODE_TXT";
 
         public static int PlaceSymbolsForAssembly(
             Document doc,
@@ -42,11 +85,51 @@ namespace StingTools.Core.Fabrication
         {
             int placed = 0;
             if (doc == null || assemblyId == null || detailView == null) return placed;
+            if (result == null) return placed;
             EnsureIndexLoaded();
             if (_index == null || _index.Count == 0) return placed;
 
             var ai = doc.GetElement(assemblyId) as AssemblyInstance;
             if (ai == null) return placed;
+
+            var memberIds = ai.GetMemberIds();
+            if (memberIds == null || memberIds.Count == 0) return placed;
+
+            var mode = StingTools.Commands.Fabrication.FabricationOptions.SymbolPlacementMode;
+
+            // ── Pass 1: per-member symbol resolution + record audit row.
+            //    We do this OUTSIDE the placement transaction so it's
+            //    cheap to abandon when the user cancels.
+            var resolutions = new List<MemberResolution>();
+            foreach (var mid in memberIds)
+            {
+                var member = doc.GetElement(mid);
+                if (member == null) continue;
+                var entry = ResolveSymbol(member);
+                resolutions.Add(new MemberResolution
+                {
+                    MemberId = mid,
+                    Member   = member,
+                    Entry    = entry,
+                });
+            }
+
+            // ── Pass 2: pre-load every unique family file before we start
+            //    the placement transaction. LoadFamily inside a transaction
+            //    is legal but doubles the rollback surface area, and
+            //    pre-resolving lets us batch the missing-family warnings.
+            var familyCache = new Dictionary<string, FamilySymbol>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in resolutions)
+            {
+                if (r.Entry == null) continue;
+                if (familyCache.ContainsKey(r.Entry.FamilyFile)) continue;
+                var fs = ResolveFamilySymbol(doc, r.Entry, result);
+                if (fs != null) familyCache[r.Entry.FamilyFile] = fs;
+            }
+
+            // Existing-symbol index for NewOnly / Replace modes. Built
+            // BEFORE the transaction so we don't re-read the view mid-loop.
+            var existingByMember = CollectExistingPlaced(doc, detailView);
 
             using (var tx = new Transaction(doc, "STING v4 ISO 6412 symbols"))
             {
@@ -55,15 +138,52 @@ namespace StingTools.Core.Fabrication
 
                 try
                 {
-                    foreach (ElementId memberId in ai.GetMemberIds())
+                    // Replace mode: purge first.
+                    if (mode == StingTools.Commands.Fabrication.FabricationOptions.PlacementMode.Replace
+                        && existingByMember.Count > 0)
                     {
-                        var member = doc.GetElement(memberId);
-                        if (member == null) continue;
-                        SymbolEntry entry = ResolveSymbol(member);
-                        if (entry == null) continue;
-                        FamilySymbol fs = ResolveFamilySymbol(doc, entry, result);
-                        if (fs == null) continue;
-                        if (TryPlace(doc, detailView, member, fs, result))
+                        int purged = 0;
+                        foreach (var kv in existingByMember)
+                        {
+                            try { doc.Delete(kv.Value); purged++; } catch { }
+                        }
+                        result.SymbolsReplaced += purged;
+                        existingByMember.Clear();
+                    }
+
+                    // 2D AABB collision tracker (view-space coords). Each
+                    // placed symbol contributes a small rect; subsequent
+                    // placements try the 8-quadrant fallback when the
+                    // primary anchor overlaps.
+                    var occupied = new List<UV>(); // approximate centre points
+                    double scale = (double)(detailView?.Scale ?? 50);
+                    double stepFt = MmToFt(8.0 * scale * 0.5); // half symbol-width step
+
+                    foreach (var r in resolutions)
+                    {
+                        if (r.Entry == null)
+                        {
+                            result.UnmatchedMembers++;
+                            if (result.UnmatchedSamples.Count < 10)
+                            {
+                                string sample = $"{r.Member?.Category?.Name}: {r.Member?.Name}";
+                                if (!result.UnmatchedSamples.Contains(sample))
+                                    result.UnmatchedSamples.Add(sample);
+                            }
+                            continue;
+                        }
+
+                        // NewOnly mode: skip if a placer-stamped instance
+                        // already exists for this member.
+                        long memberKey = r.MemberId.Value;
+                        if (mode == StingTools.Commands.Fabrication.FabricationOptions.PlacementMode.NewOnly
+                            && existingByMember.ContainsKey(memberKey))
+                            continue;
+
+                        if (!familyCache.TryGetValue(r.Entry.FamilyFile, out var fs) || fs == null)
+                            continue;
+
+                        if (TryPlace(doc, detailView, assemblyId, r, fs, occupied, stepFt, result))
                             placed++;
                     }
                     tx.Commit();
@@ -74,46 +194,389 @@ namespace StingTools.Core.Fabrication
                     result.Warnings.Add($"IsoSymbolPlacer fatal: {ex.Message}");
                 }
             }
+
+            // Audit CSV — one row per member with the decision trail.
+            try { EmitAuditCsv(doc, ai, detailView, resolutions, result); }
+            catch (Exception ex) { StingLog.Warn($"IsoSymbolPlacer audit csv: {ex.Message}"); }
+
             return placed;
         }
 
-        private static bool TryPlace(Document doc, View view, Element member, FamilySymbol fs, FabricationResult result)
+        // ─── Placement primitives ───────────────────────────────────────
+
+        private sealed class MemberResolution
+        {
+            public ElementId MemberId;
+            public Element Member;
+            public SymbolEntry Entry;
+        }
+
+        private static bool TryPlace(
+            Document doc, View view, ElementId assemblyId, MemberResolution r,
+            FamilySymbol fs, List<UV> occupied, double stepFt,
+            FabricationResult result)
         {
             try
             {
                 if (!fs.IsActive) { fs.Activate(); doc.Regenerate(); }
-                XYZ point = (member.Location as LocationPoint)?.Point
-                         ?? (member.Location as LocationCurve)?.Curve?.GetEndPoint(0)
-                         ?? XYZ.Zero;
-                var inst = doc.Create.NewFamilyInstance(point, fs, view);
 
-                // Phase 4 #15 — scale-aware sizing. Detail symbols are
-                // drawn at paper-space size; if the family exposes a
-                // "Symbol Scale" instance parameter we set it to match
-                // the host view's current scale so a 1:50 spool and a
-                // 1:25 detail both show symbols at the same plotted mm.
-                try
+                XYZ worldPoint = ResolveWorldAnchor(r.Member);
+                if (worldPoint == null) return false;
+                UV anchorUv = ProjectToViewPlane(view, worldPoint);
+
+                // 8-quadrant collision avoidance.
+                UV pickedUv = anchorUv;
+                if (Overlaps(occupied, anchorUv, stepFt))
                 {
-                    int vs = (view?.Scale ?? 50);
-                    var p = inst?.LookupParameter("Symbol Scale");
-                    if (p != null && !p.IsReadOnly)
-                    {
-                        if (p.StorageType == StorageType.Double)      p.Set((double)vs);
-                        else if (p.StorageType == StorageType.Integer) p.Set(vs);
-                    }
-                    var pAss = inst?.LookupParameter("STING_ISO_SYMBOL_SCALE_IN");
-                    if (pAss != null && !pAss.IsReadOnly && pAss.StorageType == StorageType.Double)
-                        pAss.Set((double)vs);
+                    pickedUv = TryFallbackPositions(anchorUv, occupied, stepFt) ?? anchorUv;
                 }
-                catch (Exception sx) { StingLog.Warn($"IsoSymbolPlacer scale: {sx.Message}"); }
+                XYZ placePoint = UvToXyz(view, pickedUv);
+
+                var inst = doc.Create.NewFamilyInstance(placePoint, fs, view);
+                if (inst == null) return false;
+                occupied.Add(pickedUv);
+
+                // Rotation — align to member's primary axis projected onto view.
+                ApplyRotation(doc, view, inst, r.Member, placePoint);
+
+                // Scale param — preserve baked-in family default; only override
+                // when the family is at the template default of 1.0 / 0 / unset.
+                ApplySymbolScale(inst, view);
+
+                // Stamps — for idempotency + undo + audit.
+                StampInstance(inst, assemblyId, r);
+
+                // Track for undo.
+                if (result?.SymbolIds != null) result.SymbolIds.Add(inst.Id);
                 return true;
             }
             catch (Exception ex)
             {
-                result.Warnings.Add($"IsoSymbolPlacer.TryPlace {member.Id} -> {fs.FamilyName}: {ex.Message}");
+                result.Warnings.Add($"IsoSymbolPlacer.TryPlace {r.Member.Id} -> {fs.FamilyName}: {ex.Message}");
                 return false;
             }
         }
+
+        /// <summary>
+        /// Picks the anchor point in WORLD coords. For curve hosts use
+        /// the mid-point (visual centre); for point hosts use the point
+        /// itself. Returns null when both are unavailable.
+        /// </summary>
+        private static XYZ ResolveWorldAnchor(Element member)
+        {
+            try
+            {
+                var lp = member.Location as LocationPoint;
+                if (lp != null) return lp.Point;
+
+                var lc = member.Location as LocationCurve;
+                if (lc?.Curve != null)
+                {
+                    try { return lc.Curve.Evaluate(0.5, true); }
+                    catch { return lc.Curve.GetEndPoint(0); }
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        /// <summary>
+        /// Projects a 3D world point onto the view's 2D plane in view
+        /// (right × up) coordinates. Origin is the view's Origin.
+        /// </summary>
+        private static UV ProjectToViewPlane(View view, XYZ world)
+        {
+            try
+            {
+                XYZ origin = view.Origin ?? XYZ.Zero;
+                XYZ right  = view.RightDirection ?? XYZ.BasisX;
+                XYZ up     = view.UpDirection    ?? XYZ.BasisY;
+                XYZ delta  = world - origin;
+                return new UV(delta.DotProduct(right), delta.DotProduct(up));
+            }
+            catch { return new UV(0, 0); }
+        }
+
+        private static XYZ UvToXyz(View view, UV uv)
+        {
+            XYZ origin = view.Origin ?? XYZ.Zero;
+            XYZ right  = view.RightDirection ?? XYZ.BasisX;
+            XYZ up     = view.UpDirection    ?? XYZ.BasisY;
+            return origin + right.Multiply(uv.U) + up.Multiply(uv.V);
+        }
+
+        private static bool Overlaps(List<UV> occupied, UV candidate, double stepFt)
+        {
+            double r2 = stepFt * stepFt;
+            foreach (var p in occupied)
+            {
+                double du = p.U - candidate.U;
+                double dv = p.V - candidate.V;
+                if (du * du + dv * dv < r2) return true;
+            }
+            return false;
+        }
+
+        private static UV TryFallbackPositions(UV anchor, List<UV> occupied, double stepFt)
+        {
+            // 8 candidates: N, NE, E, SE, S, SW, W, NW at one step.
+            for (int radius = 1; radius <= 2; radius++)
+            {
+                double r = stepFt * radius;
+                var candidates = new[]
+                {
+                    new UV(anchor.U,         anchor.V + r),
+                    new UV(anchor.U + r,     anchor.V + r),
+                    new UV(anchor.U + r,     anchor.V),
+                    new UV(anchor.U + r,     anchor.V - r),
+                    new UV(anchor.U,         anchor.V - r),
+                    new UV(anchor.U - r,     anchor.V - r),
+                    new UV(anchor.U - r,     anchor.V),
+                    new UV(anchor.U - r,     anchor.V + r),
+                };
+                foreach (var c in candidates)
+                {
+                    if (!Overlaps(occupied, c, stepFt)) return c;
+                }
+            }
+            return null;
+        }
+
+        private static void ApplyRotation(Document doc, View view, FamilyInstance inst, Element member, XYZ pivot)
+        {
+            try
+            {
+                XYZ axisDir = ResolvePrimaryAxis(member);
+                if (axisDir == null) return;
+
+                // Project axis onto view plane and compute angle relative
+                // to view's RightDirection.
+                XYZ right = view.RightDirection ?? XYZ.BasisX;
+                XYZ up    = view.UpDirection    ?? XYZ.BasisY;
+                double dx = axisDir.DotProduct(right);
+                double dy = axisDir.DotProduct(up);
+                if (Math.Abs(dx) < 1e-9 && Math.Abs(dy) < 1e-9) return;
+
+                double angle = Math.Atan2(dy, dx);
+                if (Math.Abs(angle) < 1e-6) return;
+
+                // Rotate around view's normal at the placement pivot.
+                XYZ normal = view.ViewDirection ?? right.CrossProduct(up).Normalize();
+                var line = Line.CreateBound(pivot, pivot + normal);
+                ElementTransformUtils.RotateElement(doc, inst.Id, line, angle);
+            }
+            catch (Exception ex) { StingLog.Warn($"IsoSymbolPlacer rotate: {ex.Message}"); }
+        }
+
+        private static XYZ ResolvePrimaryAxis(Element member)
+        {
+            try
+            {
+                var lc = member.Location as LocationCurve;
+                if (lc?.Curve != null)
+                {
+                    var dir = (lc.Curve.GetEndPoint(1) - lc.Curve.GetEndPoint(0));
+                    if (dir.GetLength() > 1e-9) return dir.Normalize();
+                }
+                // For fittings, infer from connectors: first to last.
+                var fi = member as FamilyInstance;
+                if (fi?.MEPModel?.ConnectorManager != null)
+                {
+                    var iter = fi.MEPModel.ConnectorManager.Connectors.ForwardIterator();
+                    XYZ first = null, last = null;
+                    while (iter.MoveNext())
+                    {
+                        if (iter.Current is Connector c)
+                        {
+                            if (first == null) first = c.Origin;
+                            else                last  = c.Origin;
+                        }
+                    }
+                    if (first != null && last != null && (last - first).GetLength() > 1e-9)
+                        return (last - first).Normalize();
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        private static void ApplySymbolScale(FamilyInstance inst, View view)
+        {
+            try
+            {
+                int vs = (view?.Scale ?? 50);
+
+                var p = inst?.LookupParameter("Symbol Scale");
+                if (p != null && !p.IsReadOnly)
+                {
+                    // Only set when the family is at the convention default
+                    // of 50. Families authored at non-default scales are
+                    // assumed to know what they want.
+                    bool atDefault =
+                        (p.StorageType == StorageType.Integer && p.AsInteger() == 50) ||
+                        (p.StorageType == StorageType.Double  && Math.Abs(p.AsDouble() - 50.0) < 1e-6);
+                    if (atDefault)
+                    {
+                        if (p.StorageType == StorageType.Double)      p.Set((double)vs);
+                        else if (p.StorageType == StorageType.Integer) p.Set(vs);
+                    }
+                }
+                var pAss = inst?.LookupParameter("STING_ISO_SYMBOL_SCALE_IN");
+                if (pAss != null && !pAss.IsReadOnly && pAss.StorageType == StorageType.Double)
+                    pAss.Set((double)vs);
+            }
+            catch (Exception sx) { StingLog.Warn($"IsoSymbolPlacer scale: {sx.Message}"); }
+        }
+
+        private static void StampInstance(FamilyInstance inst, ElementId assemblyId, MemberResolution r)
+        {
+            try
+            {
+                var pBool = inst.LookupParameter(STAMP_BOOL);
+                if (pBool != null && !pBool.IsReadOnly && pBool.StorageType == StorageType.Integer)
+                    pBool.Set(1);
+
+                var pAssy = inst.LookupParameter(STAMP_ASSY);
+                if (pAssy != null && !pAssy.IsReadOnly && pAssy.StorageType == StorageType.String)
+                    pAssy.Set(assemblyId?.Value.ToString() ?? "");
+
+                var pMember = inst.LookupParameter(STAMP_MEMBER);
+                if (pMember != null && !pMember.IsReadOnly && pMember.StorageType == StorageType.String)
+                    pMember.Set(r.MemberId.Value.ToString());
+
+                var pCode = inst.LookupParameter(STAMP_CODE);
+                if (pCode != null && !pCode.IsReadOnly && pCode.StorageType == StorageType.String)
+                    pCode.Set(r.Entry?.SymbolCode ?? "");
+            }
+            catch (Exception ex) { StingLog.Warn($"IsoSymbolPlacer stamp: {ex.Message}"); }
+        }
+
+        // ─── Existing-symbol detection (idempotency) ───────────────────
+
+        /// <summary>
+        /// Returns map of memberId.Value → existing FamilyInstance id for
+        /// every placer-stamped detail component on the view. Honours the
+        /// STAMP_BOOL + STAMP_MEMBER stamps. Falls back to "any detail
+        /// component on this view" detection when stamps aren't present
+        /// (legacy placements pre-Phase 178).
+        /// </summary>
+        private static Dictionary<long, ElementId> CollectExistingPlaced(Document doc, View view)
+        {
+            var map = new Dictionary<long, ElementId>();
+            try
+            {
+                var col = new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(FamilyInstance));
+                foreach (var el in col)
+                {
+                    if (!(el is FamilyInstance fi)) continue;
+                    var pBool = fi.LookupParameter(STAMP_BOOL);
+                    if (pBool == null || pBool.StorageType != StorageType.Integer) continue;
+                    if (pBool.AsInteger() != 1) continue;
+
+                    var pMember = fi.LookupParameter(STAMP_MEMBER);
+                    if (pMember == null || pMember.StorageType != StorageType.String) continue;
+                    string raw = pMember.AsString();
+                    if (long.TryParse(raw, out long memberKey))
+                        map[memberKey] = fi.Id;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"IsoSymbolPlacer.CollectExistingPlaced: {ex.Message}"); }
+            return map;
+        }
+
+        // ─── Symbol resolution ─────────────────────────────────────────
+
+        private static SymbolEntry ResolveSymbol(Element member)
+        {
+            string memberName = (member?.Name ?? "").ToUpperInvariant();
+            string famName = "";
+            string symName = "";
+            try
+            {
+                var fi = member as FamilyInstance;
+                famName = (fi?.Symbol?.FamilyName ?? "").ToUpperInvariant();
+                symName = (fi?.Symbol?.Name ?? "").ToUpperInvariant();
+            }
+            catch { }
+
+            string haystack = $"{memberName} {famName} {symName}";
+            // Normalise non-alphanumeric to underscore so token matching
+            // works regardless of "Tee 50mm" vs "TEE_50MM" etc.
+            string normalised = Normalise(haystack);
+
+            // 1. Token-based match — every "_" token of SymbolCode must
+            //    appear in normalised haystack. Index is sorted by length
+            //    descending in EnsureIndexLoaded so longer codes win.
+            foreach (var entry in _index)
+            {
+                if (string.IsNullOrEmpty(entry.SymbolCode)) continue;
+                if (entry.Tokens.Length == 0) continue;
+                bool allMatch = true;
+                foreach (var tok in entry.Tokens)
+                {
+                    // Match whole token surrounded by non-alphanumeric
+                    // boundaries to prevent BW matching e.g. "BWALL".
+                    if (!HasTokenBoundary(normalised, tok)) { allMatch = false; break; }
+                }
+                if (allMatch) return entry;
+            }
+
+            // 2. Category fallback — map CSV labels to Revit category
+            //    display strings. CSV says "Pipe" but Revit returns
+            //    "Pipes" / "Pipe Fittings".
+            string catNm = (member?.Category?.Name ?? "").ToUpperInvariant();
+            foreach (var entry in _index)
+            {
+                if (string.IsNullOrEmpty(entry.Category)) continue;
+                if (CategoryMatches(entry.Category, catNm)) return entry;
+            }
+            return null;
+        }
+
+        private static bool CategoryMatches(string csvCat, string revitCatUpper)
+        {
+            string up = (csvCat ?? "").ToUpperInvariant();
+            switch (up)
+            {
+                case "PIPE":     return revitCatUpper.Contains("PIPE");
+                case "DUCT":     return revitCatUpper.Contains("DUCT");
+                case "CONDUIT":  return revitCatUpper.Contains("CONDUIT");
+                case "VALVE":    return revitCatUpper.Contains("PIPE ACCESS")
+                                   || revitCatUpper.Contains("VALVE");
+                case "FITTING":  return revitCatUpper.Contains("FITTING");
+                default:         return string.Equals(up, revitCatUpper, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private static string Normalise(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return "";
+            var sb = new System.Text.StringBuilder(s.Length);
+            foreach (var ch in s)
+            {
+                if (char.IsLetterOrDigit(ch)) sb.Append(ch);
+                else                          sb.Append(' ');
+            }
+            return sb.ToString();
+        }
+
+        private static bool HasTokenBoundary(string normalised, string token)
+        {
+            if (string.IsNullOrEmpty(token)) return false;
+            int idx = 0;
+            while ((idx = normalised.IndexOf(token, idx, StringComparison.Ordinal)) >= 0)
+            {
+                bool leftOk  = idx == 0 || !char.IsLetterOrDigit(normalised[idx - 1]);
+                bool rightOk = idx + token.Length >= normalised.Length
+                              || !char.IsLetterOrDigit(normalised[idx + token.Length]);
+                if (leftOk && rightOk) return true;
+                idx += token.Length;
+            }
+            return false;
+        }
+
+        // ─── Family resolution ─────────────────────────────────────────
 
         private static FamilySymbol ResolveFamilySymbol(Document doc, SymbolEntry entry, FabricationResult result)
         {
@@ -149,33 +612,17 @@ namespace StingTools.Core.Fabrication
             return null;
         }
 
-        private static SymbolEntry ResolveSymbol(Element member)
-        {
-            string nameUp = (member.Name ?? "").ToUpperInvariant();
-            string catNm  = member.Category?.Name ?? "";
-            // Quick keyword-based match
-            foreach (var entry in _index)
-            {
-                if (string.IsNullOrEmpty(entry.SymbolCode)) continue;
-                if (nameUp.Contains(entry.SymbolCode)) return entry;
-            }
-            // Category fallback
-            foreach (var entry in _index)
-            {
-                if (string.Equals(entry.Category, catNm, StringComparison.OrdinalIgnoreCase))
-                    return entry;
-            }
-            return null;
-        }
+        // ─── Index loading ─────────────────────────────────────────────
 
         private static void EnsureIndexLoaded()
         {
             if (_index != null) return;
-            _index = new List<SymbolEntry>();
+            var list = new List<SymbolEntry>();
             string path = StingToolsApp.FindDataFile("STING_ISO_SYMBOLS_INDEX.csv");
             if (string.IsNullOrEmpty(path) || !File.Exists(path))
             {
                 StingLog.Warn("IsoSymbolPlacer: STING_ISO_SYMBOLS_INDEX.csv not found");
+                _index = list;
                 return;
             }
             try
@@ -187,19 +634,79 @@ namespace StingTools.Core.Fabrication
                     if (first) { first = false; continue; }
                     var cols = StingToolsApp.ParseCsvLine(line);
                     if (cols == null || cols.Length < 4) continue;
-                    _index.Add(new SymbolEntry
+                    var entry = new SymbolEntry
                     {
                         SymbolCode  = cols[0],
                         FamilyFile  = cols[1],
                         Category    = cols[2],
-                        Description = cols[3]
-                    });
+                        Description = cols[3],
+                    };
+                    entry.Tokens = (entry.SymbolCode ?? "")
+                        .ToUpperInvariant()
+                        .Split(new[] { '_' }, StringSplitOptions.RemoveEmptyEntries);
+                    list.Add(entry);
                 }
             }
             catch (Exception ex)
             {
                 StingLog.Warn($"IsoSymbolPlacer: index load failed: {ex.Message}");
             }
+            // Longest SymbolCode first so TEE_RED beats TEE.
+            _index = list
+                .OrderByDescending(e => (e.SymbolCode ?? "").Length)
+                .ThenByDescending(e => e.Tokens?.Length ?? 0)
+                .ToList();
         }
+
+        // ─── Audit CSV ─────────────────────────────────────────────────
+
+        private static void EmitAuditCsv(
+            Document doc, AssemblyInstance ai, View view,
+            List<MemberResolution> resolutions, FabricationResult result)
+        {
+            string outDir = OutputLocationHelper.GetOutputDirectory(doc);
+            if (string.IsNullOrEmpty(outDir)) return;
+            Directory.CreateDirectory(outDir);
+            string path = Path.Combine(outDir, "STING_v4_iso_symbols.csv");
+            bool firstWrite = !File.Exists(path);
+            using (var w = new StreamWriter(path, append: !firstWrite))
+            {
+                if (firstWrite)
+                {
+                    try { Core.Branding.BrandTokens.StampCsvHeader(w, doc, "iso_symbols_audit"); } catch { }
+                    w.WriteLine("assembly_id,assembly_name,view_id,view_name,member_id,member_category,member_name,family_name,symbol_code,family_file,resolved");
+                }
+                string assyName = "";
+                try { assyName = (doc.GetElement(ai.GetTypeId()) as AssemblyType)?.Name ?? ""; } catch { }
+                string viewName = "";
+                try { viewName = view?.Name ?? ""; } catch { }
+                foreach (var r in resolutions)
+                {
+                    string memCat = (r.Member?.Category?.Name ?? "").Replace(',', ';');
+                    string memNm  = (r.Member?.Name ?? "").Replace(',', ';');
+                    string famNm  = "";
+                    try { famNm = ((r.Member as FamilyInstance)?.Symbol?.FamilyName ?? "").Replace(',', ';'); } catch { }
+                    string code   = (r.Entry?.SymbolCode  ?? "").Replace(',', ';');
+                    string ff     = (r.Entry?.FamilyFile  ?? "").Replace(',', ';');
+                    string resolved = r.Entry == null ? "0" : "1";
+                    w.WriteLine(string.Join(",", new[]
+                    {
+                        ai.Id.Value.ToString(CultureInfo.InvariantCulture),
+                        assyName.Replace(',', ';'),
+                        view.Id.Value.ToString(CultureInfo.InvariantCulture),
+                        viewName.Replace(',', ';'),
+                        r.MemberId.Value.ToString(CultureInfo.InvariantCulture),
+                        memCat,
+                        memNm,
+                        famNm,
+                        code,
+                        ff,
+                        resolved,
+                    }));
+                }
+            }
+        }
+
+        private static double MmToFt(double mm) => mm / 304.8;
     }
 }

--- a/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
+++ b/StingTools/Core/Fabrication/IsoSymbolPlacer.cs
@@ -138,14 +138,16 @@ namespace StingTools.Core.Fabrication
 
                 try
                 {
-                    // Replace mode: purge first.
-                    if (mode == StingTools.Commands.Fabrication.FabricationOptions.PlacementMode.Replace
-                        && existingByMember.Count > 0)
+                    // Replace mode: purge ALL stamped elements (symbols +
+                    // leader curves) on the view first. Symbol-only purge
+                    // would orphan leaders.
+                    if (mode == StingTools.Commands.Fabrication.FabricationOptions.PlacementMode.Replace)
                     {
+                        var stampedIds = CollectAllStamped(doc, detailView);
                         int purged = 0;
-                        foreach (var kv in existingByMember)
+                        foreach (var sid in stampedIds)
                         {
-                            try { doc.Delete(kv.Value); purged++; } catch { }
+                            try { doc.Delete(sid); purged++; } catch { }
                         }
                         result.SymbolsReplaced += purged;
                         existingByMember.Clear();
@@ -226,9 +228,15 @@ namespace StingTools.Core.Fabrication
 
                 // 8-quadrant collision avoidance.
                 UV pickedUv = anchorUv;
+                bool displaced = false;
                 if (Overlaps(occupied, anchorUv, stepFt))
                 {
-                    pickedUv = TryFallbackPositions(anchorUv, occupied, stepFt) ?? anchorUv;
+                    var fallback = TryFallbackPositions(anchorUv, occupied, stepFt);
+                    if (fallback != null)
+                    {
+                        pickedUv = fallback;
+                        displaced = true;
+                    }
                 }
                 XYZ placePoint = UvToXyz(view, pickedUv);
 
@@ -248,6 +256,14 @@ namespace StingTools.Core.Fabrication
 
                 // Track for undo.
                 if (result?.SymbolIds != null) result.SymbolIds.Add(inst.Id);
+
+                // P5: leader from displaced symbol to anchor. Skip when the
+                // symbol sits over the member (no displacement) — the
+                // overlay is its own visual cue per ISO 6412.
+                if (displaced)
+                {
+                    TryPlaceLeader(doc, view, anchorUv, pickedUv, stepFt, assemblyId, r, result);
+                }
                 return true;
             }
             catch (Exception ex)
@@ -340,6 +356,63 @@ namespace StingTools.Core.Fabrication
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// P5: draws a straight leader from the displaced symbol's
+        /// placement point back toward the member's true anchor. The
+        /// leader stops one half-step short of the symbol so it doesn't
+        /// pass through the symbol body. Stamps the curve so the undo
+        /// manager can roll it back with the symbol.
+        /// </summary>
+        private static void TryPlaceLeader(
+            Document doc, View view,
+            UV anchorUv, UV pickedUv, double stepFt,
+            ElementId assemblyId, MemberResolution r,
+            FabricationResult result)
+        {
+            try
+            {
+                // Pull the leader endpoint half a step toward the anchor
+                // so it doesn't cross under the symbol family graphics.
+                double dx = anchorUv.U - pickedUv.U;
+                double dy = anchorUv.V - pickedUv.V;
+                double len = Math.Sqrt(dx * dx + dy * dy);
+                if (len < 1e-9) return;
+                double pullback = Math.Min(stepFt * 0.5, len * 0.25);
+                double t = (len - pullback) / len;
+                UV leaderTipUv = new UV(
+                    pickedUv.U + dx * (pullback / len),
+                    pickedUv.V + dy * (pullback / len));
+                UV leaderEndUv = new UV(
+                    pickedUv.U + dx * t,
+                    pickedUv.V + dy * t);
+
+                XYZ p0 = UvToXyz(view, leaderTipUv);
+                XYZ p1 = UvToXyz(view, leaderEndUv);
+                if (p0.IsAlmostEqualTo(p1, 1e-9)) return;
+
+                Line line = Line.CreateBound(p0, p1);
+                DetailCurve curve = doc.Create.NewDetailCurve(view, line);
+                if (curve == null) return;
+
+                // Track + stamp so undo + replace mode pick it up.
+                if (result?.SymbolIds != null) result.SymbolIds.Add(curve.Id);
+                try
+                {
+                    var pBool = curve.LookupParameter(STAMP_BOOL);
+                    if (pBool != null && !pBool.IsReadOnly && pBool.StorageType == StorageType.Integer)
+                        pBool.Set(1);
+                    var pAssy = curve.LookupParameter(STAMP_ASSY);
+                    if (pAssy != null && !pAssy.IsReadOnly && pAssy.StorageType == StorageType.String)
+                        pAssy.Set(assemblyId?.Value.ToString() ?? "");
+                    var pMember = curve.LookupParameter(STAMP_MEMBER);
+                    if (pMember != null && !pMember.IsReadOnly && pMember.StorageType == StorageType.String)
+                        pMember.Set(r.MemberId.Value.ToString());
+                }
+                catch { /* curves rarely accept these stamps; that's OK */ }
+            }
+            catch (Exception ex) { StingLog.Warn($"IsoSymbolPlacer leader: {ex.Message}"); }
         }
 
         private static void ApplyRotation(Document doc, View view, FamilyInstance inst, Element member, XYZ pivot)
@@ -452,6 +525,30 @@ namespace StingTools.Core.Fabrication
         }
 
         // ─── Existing-symbol detection (idempotency) ───────────────────
+
+        /// <summary>
+        /// Replace-mode purge target: every element on the view stamped
+        /// with STAMP_BOOL = 1 — symbols (FamilyInstance) AND leader
+        /// curves (DetailCurve / CurveElement). Leaders without stamps
+        /// survive (legacy placements pre-Phase 178).
+        /// </summary>
+        private static List<ElementId> CollectAllStamped(Document doc, View view)
+        {
+            var ids = new List<ElementId>();
+            try
+            {
+                var col = new FilteredElementCollector(doc, view.Id);
+                foreach (var el in col)
+                {
+                    if (el == null) continue;
+                    var pBool = el.LookupParameter(STAMP_BOOL);
+                    if (pBool == null || pBool.StorageType != StorageType.Integer) continue;
+                    if (pBool.AsInteger() == 1) ids.Add(el.Id);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"IsoSymbolPlacer.CollectAllStamped: {ex.Message}"); }
+            return ids;
+        }
 
         /// <summary>
         /// Returns map of memberId.Value → existing FamilyInstance id for
@@ -587,7 +684,10 @@ namespace StingTools.Core.Fabrication
                 {
                     if (el is FamilySymbol fs &&
                         string.Equals(fs.FamilyName, famName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        ValidateFamilyTemplate(fs, result);
                         return fs;
+                    }
                 }
                 // Try lazy load from families folder
                 string familyPath = Path.Combine(StingToolsApp.DataPath ?? "", "..", "Families", "ISO6412", entry.FamilyFile);
@@ -597,7 +697,13 @@ namespace StingTools.Core.Fabrication
                     if (doc.LoadFamily(familyPath, out f) && f != null)
                     {
                         foreach (ElementId sid in f.GetFamilySymbolIds())
-                            if (doc.GetElement(sid) is FamilySymbol fs) return fs;
+                        {
+                            if (doc.GetElement(sid) is FamilySymbol fs)
+                            {
+                                ValidateFamilyTemplate(fs, result);
+                                return fs;
+                            }
+                        }
                     }
                 }
             }
@@ -610,6 +716,56 @@ namespace StingTools.Core.Fabrication
                 StingLog.Warn($"IsoSymbolPlacer: family not found -> {famName}");
             try { result?.MissingFamilies?.Add(famName); } catch { }
             return null;
+        }
+
+        // Process-static dedup so the per-family warning only fires once
+        // per session even when the same wrong-template family is used by
+        // hundreds of members.
+        private static readonly HashSet<string> _badTemplateLogged
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// P6: warns when a family loaded for symbol placement is NOT
+        /// a Detail Item or Generic Annotation. Hosted families
+        /// (walls, ceilings, level-based) and 3D Generic Models will
+        /// either fail to place on a section view or render at the
+        /// wrong scale. We don't reject the family — we only warn —
+        /// because Revit's family-category landscape is fragmented and
+        /// users may have valid reasons (e.g. an annotation symbol
+        /// authored as a Generic Annotation Tag with a custom subcategory).
+        /// </summary>
+        private static void ValidateFamilyTemplate(FamilySymbol fs, FabricationResult result)
+        {
+            try
+            {
+                if (fs?.Family == null) return;
+                var fam = fs.Family;
+                var catId = fam.FamilyCategory?.Id ?? ElementId.InvalidElementId;
+                if (catId == ElementId.InvalidElementId) return;
+
+                // Acceptable templates: Detail Items, Generic Annotations,
+                // Title Blocks (rare), Filled Region — anything that the
+                // Revit API accepts on a 2D detail/section view.
+                var ok = new HashSet<long>
+                {
+                    (long)BuiltInCategory.OST_DetailComponents,
+                    (long)BuiltInCategory.OST_GenericAnnotation,
+                    (long)BuiltInCategory.OST_TitleBlocks,
+                };
+                if (ok.Contains(catId.Value)) return;
+
+                // Hosted / 3D families: warn (once per family per session).
+                if (_badTemplateLogged.Add(fam.Name))
+                {
+                    string warn = $"ISO 6412 family '{fam.Name}' has unexpected category " +
+                                  $"({fam.FamilyCategory?.Name ?? "unknown"}). Expected " +
+                                  $"Detail Item or Generic Annotation — placement may render " +
+                                  $"incorrectly. Re-author from the Detail Item template.";
+                    result?.Warnings?.Add(warn);
+                    StingLog.Warn($"IsoSymbolPlacer: {warn}");
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"IsoSymbolPlacer.ValidateFamilyTemplate: {ex.Message}"); }
         }
 
         // ─── Index loading ─────────────────────────────────────────────

--- a/StingTools/Core/Fabrication/Pipe/PipeFabricator.cs
+++ b/StingTools/Core/Fabrication/Pipe/PipeFabricator.cs
@@ -22,6 +22,7 @@ namespace StingTools.Core.Fabrication.Pipe
             var groups = grouper.GroupForDiscipline(doc, elementIds, "Pipe",
                 out List<AssemblyGrouper.SpoolMetrics> metrics);
             int seq = 1;
+            var symbolTargets = new List<(ElementId AssyId, ElementId IsoViewId)>();
 
             using (var tx = new Transaction(doc, "STING v4 Pipe fabrication"))
             {
@@ -42,6 +43,8 @@ namespace StingTools.Core.Fabrication.Pipe
                         var sheetId = ShopDrawingComposer.ComposeSheet(doc, "Pipe", assyId, views, result);
                         if (sheetId != null && sheetId != ElementId.InvalidElementId)
                             result.SheetIds.Add(sheetId);
+                        if (views.ViewIso6412 != null && views.ViewIso6412 != ElementId.InvalidElementId)
+                            symbolTargets.Add((assyId, views.ViewIso6412));
                     }
                     tx.Commit();
                 }
@@ -52,6 +55,8 @@ namespace StingTools.Core.Fabrication.Pipe
                 }
             }
             result.AssembliesByDiscipline["Pipe"] = seq - 1;
+
+            FabricationEngine.PlaceSymbolsIfRequested(doc, symbolTargets, result);
 
             try { EmitWeldMapCsv(doc, elementIds, result); }
             catch (Exception ex) { result.Warnings.Add($"Weld map csv: {ex.Message}"); }

--- a/StingTools/Core/Fabrication/Pipe/PipeFabricator.cs
+++ b/StingTools/Core/Fabrication/Pipe/PipeFabricator.cs
@@ -56,7 +56,7 @@ namespace StingTools.Core.Fabrication.Pipe
             }
             result.AssembliesByDiscipline["Pipe"] = seq - 1;
 
-            FabricationEngine.PlaceSymbolsIfRequested(doc, symbolTargets, result);
+            FabricationEngine.PlaceSymbolsIfRequested(doc, "Pipe", symbolTargets, result);
 
             try { EmitWeldMapCsv(doc, elementIds, result); }
             catch (Exception ex) { result.Warnings.Add($"Weld map csv: {ex.Message}"); }

--- a/StingTools/UI/FabricationResultDialog.cs
+++ b/StingTools/UI/FabricationResultDialog.cs
@@ -188,11 +188,13 @@ namespace StingTools.UI
         private UIElement BuildSymbolsCard()
         {
             var body = new StackPanel();
-            var opts = StingTools.Commands.Fabrication.FabricationOptions;
-            bool optionOn = opts.PlaceISO6412Symbols;
+            // FabricationOptions is static — read directly rather than
+            // aliasing the type to a local (CS0723 / CS0176).
+            bool optionOn = StingTools.Commands.Fabrication.FabricationOptions.PlaceISO6412Symbols;
             body.Children.Add(MetricRow("Placement option", optionOn ? "ON" : "OFF",
                 accent: optionOn ? GreenColor : (Color?)SubtleColor));
-            body.Children.Add(MetricRow("Mode", opts.SymbolPlacementMode.ToString()));
+            body.Children.Add(MetricRow("Mode",
+                StingTools.Commands.Fabrication.FabricationOptions.SymbolPlacementMode.ToString()));
             body.Children.Add(MetricRow("Symbols placed", _res.SymbolsPlaced.ToString(),
                 accent: _res.SymbolsPlaced > 0 ? GreenColor : (Color?)null,
                 bold: _res.SymbolsPlaced > 0));

--- a/StingTools/UI/FabricationResultDialog.cs
+++ b/StingTools/UI/FabricationResultDialog.cs
@@ -188,14 +188,36 @@ namespace StingTools.UI
         private UIElement BuildSymbolsCard()
         {
             var body = new StackPanel();
-            bool optionOn = StingTools.Commands.Fabrication.FabricationOptions.PlaceISO6412Symbols;
+            var opts = StingTools.Commands.Fabrication.FabricationOptions;
+            bool optionOn = opts.PlaceISO6412Symbols;
             body.Children.Add(MetricRow("Placement option", optionOn ? "ON" : "OFF",
                 accent: optionOn ? GreenColor : (Color?)SubtleColor));
+            body.Children.Add(MetricRow("Mode", opts.SymbolPlacementMode.ToString()));
             body.Children.Add(MetricRow("Symbols placed", _res.SymbolsPlaced.ToString(),
                 accent: _res.SymbolsPlaced > 0 ? GreenColor : (Color?)null,
                 bold: _res.SymbolsPlaced > 0));
+            if (_res.SymbolsReplaced > 0)
+                body.Children.Add(MetricRow("Symbols replaced", _res.SymbolsReplaced.ToString(),
+                    accent: AmberColor));
+            if (_res.UnmatchedMembers > 0)
+                body.Children.Add(MetricRow("Unmatched members", _res.UnmatchedMembers.ToString(),
+                    accent: AmberColor));
             body.Children.Add(MetricRow("Missing families", _res.MissingFamilies.Count.ToString(),
                 accent: _res.MissingFamilies.Count > 0 ? AmberColor : (Color?)null));
+
+            // Per-discipline breakdown when there's more than one.
+            if (_res.SymbolsByDiscipline.Count > 1)
+            {
+                body.Children.Add(new TextBlock
+                {
+                    Text = "By discipline:",
+                    FontSize = 11,
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    Margin = new Thickness(0, 6, 0, 4),
+                });
+                foreach (var kv in _res.SymbolsByDiscipline.OrderByDescending(kv => kv.Value))
+                    body.Children.Add(MetricRow("  " + kv.Key, kv.Value.ToString()));
+            }
 
             if (_res.MissingFamilies.Count > 0)
             {
@@ -230,16 +252,44 @@ namespace StingTools.UI
             }
             else if (optionOn && _res.AssemblyIds.Count > 0 && _res.SymbolsPlaced == 0)
             {
+                string hint = _res.UnmatchedMembers > 0
+                    ? "Option was ON but every member was unmatched — extend STING_ISO_SYMBOLS_INDEX.csv " +
+                      "with codes that match your fitting names, or check the family keyword tokens."
+                    : "Option was ON but nothing placed — check that STING_ISO_SYMBOLS_INDEX.csv " +
+                      "is in the data folder and the symbol_code keywords match member names.";
                 body.Children.Add(new TextBlock
                 {
-                    Text = "Option was ON but nothing placed — check that STING_ISO_SYMBOLS_INDEX.csv " +
-                           "is in the data folder and the symbol_code keywords match member names.",
+                    Text = hint,
                     Foreground = new SolidColorBrush(SubtleColor),
                     FontSize = 11,
                     FontStyle = FontStyles.Italic,
                     TextWrapping = TextWrapping.Wrap,
                     Margin = new Thickness(0, 6, 0, 0),
                 });
+            }
+
+            // Sample of unmatched member names so users can see WHY
+            // symbols weren't found and update the catalogue.
+            if (_res.UnmatchedSamples.Count > 0)
+            {
+                body.Children.Add(new TextBlock
+                {
+                    Text = $"Unmatched member samples (first {Math.Min(5, _res.UnmatchedSamples.Count)}):",
+                    FontSize = 11,
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    Margin = new Thickness(0, 6, 0, 4),
+                });
+                foreach (var s in _res.UnmatchedSamples.Take(5))
+                {
+                    body.Children.Add(new TextBlock
+                    {
+                        Text = "• " + s,
+                        Foreground = new SolidColorBrush(FgColor),
+                        FontSize = 11,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 1, 0, 1),
+                    });
+                }
             }
             return Card("ISO 6412 symbols", body);
         }

--- a/StingTools/UI/FabricationResultDialog.cs
+++ b/StingTools/UI/FabricationResultDialog.cs
@@ -144,6 +144,7 @@ namespace StingTools.UI
 
             stack.Children.Add(BuildAssembliesCard());
             stack.Children.Add(BuildSheetsCard());
+            stack.Children.Add(BuildSymbolsCard());
             if (_res.Warnings.Count > 0) stack.Children.Add(BuildWarningsCard());
 
             scroll.Content = stack;
@@ -182,6 +183,65 @@ namespace StingTools.UI
             body.Children.Add(MetricRow("Failed", _res.FailedCount.ToString(),
                 accent: _res.FailedCount > 0 ? RedColor : (Color?)null));
             return Card("Sheets", body);
+        }
+
+        private UIElement BuildSymbolsCard()
+        {
+            var body = new StackPanel();
+            bool optionOn = StingTools.Commands.Fabrication.FabricationOptions.PlaceISO6412Symbols;
+            body.Children.Add(MetricRow("Placement option", optionOn ? "ON" : "OFF",
+                accent: optionOn ? GreenColor : (Color?)SubtleColor));
+            body.Children.Add(MetricRow("Symbols placed", _res.SymbolsPlaced.ToString(),
+                accent: _res.SymbolsPlaced > 0 ? GreenColor : (Color?)null,
+                bold: _res.SymbolsPlaced > 0));
+            body.Children.Add(MetricRow("Missing families", _res.MissingFamilies.Count.ToString(),
+                accent: _res.MissingFamilies.Count > 0 ? AmberColor : (Color?)null));
+
+            if (_res.MissingFamilies.Count > 0)
+            {
+                body.Children.Add(new TextBlock
+                {
+                    Text = $"Missing .rfa files (first {Math.Min(6, _res.MissingFamilies.Count)} of {_res.MissingFamilies.Count}):",
+                    FontSize = 11,
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    Margin = new Thickness(0, 6, 0, 4),
+                });
+                foreach (var fam in _res.MissingFamilies.OrderBy(f => f).Take(6))
+                {
+                    body.Children.Add(new TextBlock
+                    {
+                        Text = "• " + fam,
+                        Foreground = new SolidColorBrush(FgColor),
+                        FontSize = 11,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 1, 0, 1),
+                    });
+                }
+                body.Children.Add(new TextBlock
+                {
+                    Text = "Drop the .rfa files into Families/ISO6412/ next to the plugin and re-run, " +
+                           "or use the standalone Place ISO 6412 Symbols command.",
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    FontSize = 11,
+                    FontStyle = FontStyles.Italic,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 6, 0, 0),
+                });
+            }
+            else if (optionOn && _res.AssemblyIds.Count > 0 && _res.SymbolsPlaced == 0)
+            {
+                body.Children.Add(new TextBlock
+                {
+                    Text = "Option was ON but nothing placed — check that STING_ISO_SYMBOLS_INDEX.csv " +
+                           "is in the data folder and the symbol_code keywords match member names.",
+                    Foreground = new SolidColorBrush(SubtleColor),
+                    FontSize = 11,
+                    FontStyle = FontStyles.Italic,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 6, 0, 0),
+                });
+            }
+            return Card("ISO 6412 symbols", body);
         }
 
         private UIElement BuildWarningsCard()

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -421,7 +421,8 @@ namespace StingTools.UI
 
                     // ── v4 Phase D: hanger placement ──
                     case "Routing_PlaceHangers": RunCommand<Commands.Routing.PlaceHangersCommand>(app); break;
-                    case "Fabrication_PlaceISOSymbols": TaskDialog.Show("STING v4 — ISO 6412 Symbols", "Place is wired through GenerateFabPackageCommand;\nrun Generate Fabrication Package against your selection."); break;
+                    case "Fabrication_PlaceISOSymbols":
+                        RunCommand<Commands.Fabrication.PlaceIsoSymbolsCommand>(app); break;
                     case "Fabrication_ConfigureShopDrawing":
                     {
                         var doc = app?.ActiveUIDocument?.Document;


### PR DESCRIPTION
## Summary

This PR implements a complete ISO 6412 detail symbol placement system for fabrication assemblies. The placer automatically drops 2D detail symbols onto shop drawing views, with intelligent symbol resolution, family loading, collision avoidance, and audit logging.

## Key Changes

### Core Symbol Placement (`IsoSymbolPlacer.cs`)
- **Symbol resolution algorithm**: Three-tier matching (token-split name search → category fallback) with index pre-sorting by symbol code length to prioritize longer keywords
- **Pre-transaction family loading**: Resolves all required families before placement transaction starts, improving performance and error isolation
- **8-quadrant collision avoidance**: When a symbol overlaps an existing one, tries N/NE/E/SE/S/SW/W/NW offsets at scale-aware step sizes before giving up
- **View-plane projection**: Projects 3D member anchors onto the detail view's 2D plane (RightDirection × UpDirection) so symbols land on the section, not at world coordinates
- **Rotation alignment**: Rotates symbols to match member primary axis (curve direction for pipes/ducts, connector axis for fittings)
- **Leader curves**: Draws straight detail curve leaders from displaced symbols back to true anchor points (P5 feature)
- **Placement modes**: Supports Off/NewOnly (idempotent re-runs)/Replace (purge-then-replace) via `FabricationOptions.SymbolPlacementMode`
- **Instance stamping**: Marks placed symbols with `STING_PLACED_BY_SYMBOL_PLACER_BOOL`, `STING_PLACER_ASSY_ID_TXT`, `STING_PLACER_MEMBER_ID_TXT`, and `STING_PLACER_SYMBOL_CODE_TXT` for idempotency and undo traceability
- **Audit CSV export**: Emits `STING_v4_iso_symbols.csv` sidecar with per-member resolution decisions

### Manual Placement Command (`PlaceIsoSymbolsCommand.cs`)
- New standalone command for re-running symbol placement without regenerating the entire fabrication package
- Smart target resolution: detects active ISO 6412 view by name pattern, falls back to active view's associated assembly, or uses selection
- Useful when family library is updated post-package-generation or symbols need to land on different views

### Integration Points
- **FabricationEngine**: Added `PlaceSymbolsIfRequested()` to invoke placer after each discipline's transaction commits
- **FabricationResult**: Extended with symbol placement metrics (placed count, replaced count, unmatched members, missing families, per-discipline breakdown)
- **FabricationResultDialog**: New "Symbols" card displaying placement results and missing family warnings
- **AssemblyViewBuilder**: Stamps ISO 6412 view names with assembly ID (`::id` suffix) for view↔assembly resolution
- **FabricationUndoManager**: Tracks symbol IDs for rollback capability
- **Fabrication options**: Added per-discipline toggles (`PlaceISOPipe`, `PlaceISODuct`, `PlaceISOElectrical`) to gate symbol placement by discipline

### Family Contract Documentation (`Families/ISO6412/README.md`)
- Comprehensive guide for family authoring: Detail Item template requirement, origin-centered linework, required/optional parameters
- Explains symbol scale parameterization, leader behavior, and placement mode semantics
- Authoring checklist for contributors

## Implementation Details

- **Token-split matching**: Every underscore-separated token of `symbol_code` must appear in the haystack (Family.Name + FamilySymbol.Name + member.Name) for a match
- **Scale-aware collision step**: Computed as `8.0 * view.Scale * 0.5 mm` converted to feet, ensuring symbols space proportionally at different view scales
- **Mid-point anchoring**: For LocationCurve members, uses curve mid-point instead of start endpoint so symbols center on long runs
- **Leader pullback**: Leader endpoint stops one half-step short of symbol to avoid passing through symbol body
- **Process-static dedup**: Missing family warnings logged

https://claude.ai/code/session_01LPfTrbvFjsXxHt7RLMXJ5N