### PR TITLE
Phase 176: Tagging-workflow review fixes (token/leader/scale/depth)

### DIFF
--- a/StingTools/Core/ParamRegistry.cs
+++ b/StingTools/Core/ParamRegistry.cs
@@ -173,6 +173,12 @@ namespace StingTools.Core
         public const string VIEW_TAG_STYLE_GUID = "E2F3A4B5-C6D7-4E8F-9A0B-1C2D3E4F5A6C";
         public const string TAG_SEG_MASK = "TAG_SEG_MASK_TXT";
         public const string TAG_SEG_MASK_GUID = "F3A4B5C6-D7E8-4F9A-0B1C-2D3E4F5A6B7D";
+        // Per-view 8-char "1"/"0" mask gating which segments render in
+        // BuildDisplayTag without mutating the canonical ASS_TAG_1_TXT.
+        // Bound to OST_Views so users can hide ZONE in a presentation view
+        // without breaking exports — review fix for TAG-token-toggling #1.
+        public const string VIEW_TOKEN_MASK = "STING_VIEW_TOKEN_MASK_TXT";
+        public const string VIEW_TOKEN_MASK_GUID = "F4A5B6C7-D8E9-4F0A-1B2C-3D4E5F6A7B8E";
 
         // ── Phase 175 — Symbol system parameters ─────────────────────────
         public const string SYMBOL_ID                 = "STING_SYMBOL_ID";

--- a/StingTools/Core/StingDocumentChangedHandler.cs
+++ b/StingTools/Core/StingDocumentChangedHandler.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Events;
 using Autodesk.Revit.UI;
@@ -97,12 +98,6 @@ namespace StingTools.Core
         {
             if (id == null || id == ElementId.InvalidElementId) return;
             long key = id.Value;
-            lock (_recentlyProcessed)
-            {
-                if (_recentlyProcessed.Contains(key)) return;
-                if (_recentlyProcessed.Count > RecentCacheLimit)
-                    _recentlyProcessed.Clear();
-            }
 
             Element el;
             try { el = doc.GetElement(id); } catch { return; }
@@ -110,6 +105,20 @@ namespace StingTools.Core
 
             CascadeKind kind = ClassifyCascade(el);
             if (kind == CascadeKind.None) return;
+
+            // Views can be re-scaled multiple times; the dedup set is a
+            // one-shot guard, so skip it for ViewScaleChanged. All other
+            // cascades stay deduped to avoid re-running rebuilds on every
+            // micro-edit during a single transaction batch.
+            if (kind != CascadeKind.ViewScaleChanged)
+            {
+                lock (_recentlyProcessed)
+                {
+                    if (_recentlyProcessed.Contains(key)) return;
+                    if (_recentlyProcessed.Count > RecentCacheLimit)
+                        _recentlyProcessed.Clear();
+                }
+            }
 
             _queue.Enqueue(new CascadeItem { Kind = kind, ElementId = id, DocHash = doc.PathName ?? "" });
         }
@@ -122,12 +131,37 @@ namespace StingTools.Core
                 int catId = (int)(el.Category.Id.Value);
                 if (catId == (int)BuiltInCategory.OST_Rooms) return CascadeKind.RoomRenamed;
                 if (catId == (int)BuiltInCategory.OST_Sheets) return CascadeKind.SheetRenumbered;
+                // Review fix for tag-scale issue: a View with TAG_SCALE_TIER_AUTO
+                // active needs to re-apply scale-aware tag styling whenever its
+                // Scale property is mutated. View elements come through
+                // GetModifiedElementIds with no category match above; pick them
+                // up here so OnIdling can dispatch Tags.SetScaleAwareTagSize.
+                if (el is Autodesk.Revit.DB.View view && !view.IsTemplate
+                    && IsScalable(view))
+                    return CascadeKind.ViewScaleChanged;
                 // Any taggable category whose level may have changed.
                 if (el.LevelId != null && el.LevelId != ElementId.InvalidElementId)
                     return CascadeKind.ElementLevelChanged;
             }
             catch { }
             return CascadeKind.None;
+        }
+
+        private static bool IsScalable(Autodesk.Revit.DB.View v)
+        {
+            switch (v.ViewType)
+            {
+                case ViewType.FloorPlan:
+                case ViewType.CeilingPlan:
+                case ViewType.Elevation:
+                case ViewType.Section:
+                case ViewType.Detail:
+                case ViewType.AreaPlan:
+                case ViewType.EngineeringPlan:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         private static void OnIdling(object sender, IdlingEventArgs e)
@@ -159,7 +193,11 @@ namespace StingTools.Core
                                 ApplyCascade(doc, el, item.Kind);
                                 t.Commit();
                             }
-                            lock (_recentlyProcessed) _recentlyProcessed.Add(item.ElementId.Value);
+                            // ViewScaleChanged stays out of the dedup set so a
+                            // user adjusting view scale repeatedly keeps getting
+                            // the auto-style apply each time.
+                            if (item.Kind != CascadeKind.ViewScaleChanged)
+                                lock (_recentlyProcessed) _recentlyProcessed.Add(item.ElementId.Value);
                             drained++;
                         }
                         catch (Exception ex)
@@ -221,6 +259,31 @@ namespace StingTools.Core
                     }
                     catch { /* non-fatal */ }
                     break;
+
+                case CascadeKind.ViewScaleChanged:
+                    try
+                    {
+                        if (!(el is Autodesk.Revit.DB.View view) || view.IsTemplate) break;
+                        // Honour the project-level opt-in: TAG_SCALE_TIER_AUTO_BOOL on
+                        // ProjectInformation. When unset / false, leave the user's
+                        // manual style alone.
+                        Element projInfo = doc.ProjectInformation;
+                        Parameter flag = projInfo?.LookupParameter(ParamRegistry.TAG_SCALE_TIER_AUTO);
+                        if (flag == null || flag.StorageType != StorageType.Integer || flag.AsInteger() == 0)
+                            break;
+
+                        ScaleTiers.Tier tier = ScaleTiers.ForView(view);
+                        if (!ParamRegistry.TagStyleSizes.Contains(tier.TextSizeMm)) break;
+                        var result = Tags.SetScaleAwareTagSizeCommand.ApplyToView(
+                            doc, view, tier.TextSizeMm, "AutoOnScaleChange");
+                        int total = result.InstanceSwitches + result.TypeMatrixFlips;
+                        if (total > 0)
+                            StingLog.Info($"AutoScaleTagSize on view-scale change: view='{view.Name}' " +
+                                          $"changed={total} (instances={result.InstanceSwitches}, " +
+                                          $"typeFlips={result.TypeMatrixFlips})");
+                    }
+                    catch (Exception ex) { StingLog.Warn($"ViewScaleChanged cascade: {ex.Message}"); }
+                    break;
             }
         }
 
@@ -238,6 +301,7 @@ namespace StingTools.Core
             RoomRenamed,
             ElementLevelChanged,
             SheetRenumbered,
+            ViewScaleChanged,
         }
 
         private class CascadeItem

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -86,6 +86,14 @@ namespace StingTools.Core
         /// <summary>Tokens that must be non-empty for compliant tags (e.g., ["DISC","SYS","FUNC","PROD","SEQ"]).</summary>
         public HashSet<string> RequiredTokens { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Default paragraph depth (1-10) for this discipline's TAG7 tier
+        /// visibility. Null = use the global ParaDepth value. Used by
+        /// SetParagraphDepthCommand's "By discipline" scope and read by
+        /// WriteTag7All when no per-element override is set.
+        /// </summary>
+        public int? DefaultParagraphDepth { get; set; }
+
         /// <summary>Parse a DisciplineProfile from a JSON dictionary.</summary>
         public static DisciplineProfile FromDict(Dictionary<string, object> dict)
         {
@@ -125,6 +133,12 @@ namespace StingTools.Core
             {
                 if (vs is bool vsb) p.ValidationStrictness = vsb;
                 else if (vs is string vss) p.ValidationStrictness = vss.Equals("true", StringComparison.OrdinalIgnoreCase);
+            }
+            if (dict.TryGetValue("default_paragraph_depth", out object dpd))
+            {
+                if (dpd is long dpdl && dpdl >= 1 && dpdl <= 10) p.DefaultParagraphDepth = (int)dpdl;
+                else if (int.TryParse(dpd?.ToString(), out int dpdi) && dpdi >= 1 && dpdi <= 10)
+                    p.DefaultParagraphDepth = dpdi;
             }
             return p;
         }
@@ -3181,15 +3195,62 @@ namespace StingTools.Core
                 // we keep the historic behaviour of only seeding PARA_STATE_1 to
                 // avoid stomping manual tier selections.
                 int paraDepth = 0;
+                bool preserveParaState = false;
                 try
                 {
                     string pd = StingTools.UI.StingCommandHandler.GetExtraParam("ParaDepth");
                     if (!string.IsNullOrEmpty(pd) && int.TryParse(pd, out int v) && v >= 1 && v <= 10)
                         paraDepth = v;
+
+                    // Review fix for token-depth issue #2: when the user has
+                    // explicitly run SetParagraphDepthCommand the resulting
+                    // type-level state must not be clobbered by every Auto-Tag
+                    // pass. The ExtraParam below is set by that command and
+                    // makes WriteTag7All only seed PARA_STATE_1 when depth has
+                    // never been written.
+                    string ps = StingTools.UI.StingCommandHandler.GetExtraParam("PreserveParaState");
+                    if (!string.IsNullOrEmpty(ps) &&
+                        (ps.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                         ps.Equals("true", StringComparison.OrdinalIgnoreCase)))
+                        preserveParaState = true;
                 }
                 catch { /* ignore — use default */ }
 
-                if (paraDepth >= 1)
+                // Discipline-default fallback (review fix for token-depth #3):
+                // when no slider value is set, prefer the active discipline's
+                // configured DefaultParagraphDepth before defaulting to depth=1.
+                if (paraDepth == 0 && doc != null)
+                {
+                    try
+                    {
+                        string disc = ParameterHelpers.GetString(el, ParamRegistry.DISC);
+                        if (!string.IsNullOrEmpty(disc))
+                        {
+                            var profile = GetDisciplineProfile(disc);
+                            if (profile?.DefaultParagraphDepth.HasValue == true)
+                                paraDepth = profile.DefaultParagraphDepth.Value;
+                        }
+                    }
+                    catch { /* discipline-default resolution is best-effort */ }
+                }
+
+                if (preserveParaState)
+                {
+                    // Honour any existing PARA_STATE_1 setting; only seed if the
+                    // element has never been touched (all states empty).
+                    bool anySet = false;
+                    foreach (var pn in ParamRegistry.AllParaStates)
+                    {
+                        Parameter pp = el.LookupParameter(pn);
+                        if (pp == null) continue;
+                        if (pp.StorageType == StorageType.Integer && pp.AsInteger() != 0) { anySet = true; break; }
+                        if (pp.StorageType == StorageType.String &&
+                            !string.IsNullOrEmpty(pp.AsString())) { anySet = true; break; }
+                    }
+                    if (!anySet)
+                        ParameterHelpers.SetYesNo(el, ParamRegistry.PARA_STATE_1, true);
+                }
+                else if (paraDepth >= 1)
                 {
                     string[] paraStates = ParamRegistry.AllParaStates;
                     for (int i = 0; i < paraStates.Length; i++)
@@ -3248,6 +3309,10 @@ namespace StingTools.Core
                 string narrative = ParameterHelpers.GetString(el, ParamRegistry.TAG7);
                 if (!string.IsNullOrEmpty(narrative)) return narrative;
                 // Fallback: best plain-language hint we can build right now.
+                // Throttled log so a partially-tagged model surfaces the
+                // missing-narrative state instead of pretending mode-4 is by
+                // design — see review TAG-token-toggling issue #2.
+                StingLog.Warn($"BuildDisplayTag: mode 6 requested on element {el.Id} but ASS_TAG_7_TXT is empty; falling back to mode 4. Run Auto Tag / WriteTag7All to populate the narrative.");
                 mode = 4; // DISC-PROD-SEQ — most readable compact form
             }
 
@@ -3293,19 +3358,37 @@ namespace StingTools.Core
             if (mode == 0) mode = ParamRegistry.DisplayModeDefault;
             string display = BuildDisplayTag(el, mode);
 
-            // FG-04: honour TAG_SEG_MASK_TXT (per-element / view-stamped by
-            // TokenProfileApplier step 7.5) BEFORE the global TokenMask UX
-            // hint. Profile-driven mask wins over UI hint, both apply only
-            // in full 8-segment mode (mode 5 / 0).
+            // Token-mask precedence (highest first):
+            //   1. STING_VIEW_TOKEN_MASK_TXT on the active view — user-set
+            //      "hide ZONE in this view" without mutating ASS_TAG_1_TXT
+            //      (review fix for TAG-token-toggling #1).
+            //   2. TAG_SEG_MASK_TXT on the element — written by
+            //      TokenProfileApplier step 7.5.
+            //   3. UI ExtraParam "TokenMask" — ad-hoc preview override.
+            // Mask now applies in modes 1-5/0 (was 5/0 only). Modes that
+            // already drop segments by design just no-op when the mask
+            // matches, so layered masks stay safe.
             try
             {
-                if (mode == 5 || mode == 0)
+                string mask = null;
+                try
                 {
-                    string elMask = ParameterHelpers.GetString(el, ParamRegistry.TAG_SEG_MASK);
-                    if (string.IsNullOrEmpty(elMask))
-                        elMask = StingTools.UI.StingCommandHandler.GetExtraParam("TokenMask");
-                    if (!string.IsNullOrEmpty(elMask) && elMask.Length >= 8 && elMask != "11111111")
-                        display = ApplySegmentMask(display, elMask);
+                    var doc = el.Document;
+                    var view = doc?.ActiveView;
+                    if (view != null)
+                        mask = ParameterHelpers.GetString(view, ParamRegistry.VIEW_TOKEN_MASK);
+                }
+                catch { /* view lookup is best-effort */ }
+
+                if (string.IsNullOrEmpty(mask))
+                    mask = ParameterHelpers.GetString(el, ParamRegistry.TAG_SEG_MASK);
+                if (string.IsNullOrEmpty(mask))
+                    mask = StingTools.UI.StingCommandHandler.GetExtraParam("TokenMask");
+
+                if (!string.IsNullOrEmpty(mask) && mask.Length >= 8 && mask != "11111111"
+                    && (mode == 0 || mode == 5))
+                {
+                    display = ApplySegmentMask(display, mask);
                 }
             }
             catch { /* mask is an optional UX hint — ignore failures */ }

--- a/StingTools/Organise/TagOperationCommands.cs
+++ b/StingTools/Organise/TagOperationCommands.cs
@@ -3957,21 +3957,29 @@ namespace StingTools.Organise
         /// away from the leader line with proper clearance.
         /// Falls back to host center when elbow data is unavailable.
         /// </summary>
+        // Diagnostic counters from the most recent AutoAlignTagsToLeaders call.
+        // Surfaced by the caller's TaskDialog so users see WHY a leader op
+        // appeared to do nothing (review fix for leader-and-style #3).
+        public static int LastAutoAlignOrphanCount;
+        public static int LastAutoAlignNoLeaderCount;
+
         public static int AutoAlignTagsToLeaders(Document doc, List<IndependentTag> tags, View view)
         {
             int aligned = 0;
+            int orphans = 0;
+            int noLeader = 0;
             double scaleFactor = view.Scale / 100.0; // Normalize scale for offset calculations
 
             foreach (IndependentTag tag in tags)
             {
                 try
                 {
-                    if (!tag.HasLeader) continue;
+                    if (!tag.HasLeader) { noLeader++; continue; }
 
                     var hostIds = tag.GetTaggedLocalElementIds();
-                    if (hostIds.Count == 0) continue;
+                    if (hostIds.Count == 0) { orphans++; continue; }
                     Element host = doc.GetElement(hostIds.First());
-                    if (host == null) continue;
+                    if (host == null) { orphans++; continue; }
 
                     XYZ hostCenter = GetElementCenter(host);
                     if (hostCenter == null) continue;
@@ -4041,6 +4049,11 @@ namespace StingTools.Organise
                     StingLog.Warn($"AutoAlignTag {tag.Id}: {ex.Message}");
                 }
             }
+            LastAutoAlignOrphanCount = orphans;
+            LastAutoAlignNoLeaderCount = noLeader;
+            if (orphans > 0 || noLeader > 0)
+                StingLog.Info($"AutoAlignTagsToLeaders: aligned={aligned}, " +
+                    $"orphans (no host)={orphans}, no-leader={noLeader}");
             return aligned;
         }
     }
@@ -4303,9 +4316,15 @@ namespace StingTools.Organise
                 tx.Commit();
             }
 
+            // Surface orphan / missing-host counts so users see why
+            // some tags appeared to be skipped (review fix #3).
+            string orphanNote = "";
+            if (LeaderHelper.LastAutoAlignOrphanCount > 0)
+                orphanNote = $"\n⚠ {LeaderHelper.LastAutoAlignOrphanCount} tags skipped: " +
+                    "host element missing or unbound (orphaned tags).";
             TaskDialog.Show("Auto-Align Leader Text",
                 $"Auto-aligned {aligned} of {tags.Count} tagged leaders.\n" +
-                "Tags repositioned so text reads away from leader direction.");
+                "Tags repositioned so text reads away from leader direction." + orphanNote);
             return Result.Succeeded;
         }
     }

--- a/StingTools/Tags/ParagraphDepthCommand.cs
+++ b/StingTools/Tags/ParagraphDepthCommand.cs
@@ -127,6 +127,8 @@ namespace StingTools.Tags
                     "Selected elements", "Set depth on types of selected elements");
                 scopeTd.AddCommandLink(TaskDialogCommandLinkId.CommandLink2,
                     "All element types in project", "Set depth on all element types");
+                scopeTd.AddCommandLink(TaskDialogCommandLinkId.CommandLink3,
+                    "By discipline...", "Pick a discipline (M/E/P/A/S/...) and apply depth only to its types");
                 scopeTd.CommonButtons = TaskDialogCommonButtons.Cancel;
 
                 TaskDialogResult scopeResult = scopeTd.Show();
@@ -142,6 +144,20 @@ namespace StingTools.Tags
                 else if (scopeResult == TaskDialogResult.CommandLink2)
                 {
                     targetTypeIds = CollectAllElementTypeIds(doc);
+                }
+                else if (scopeResult == TaskDialogResult.CommandLink3)
+                {
+                    string disc = PickDiscipline();
+                    if (string.IsNullOrEmpty(disc)) return Result.Cancelled;
+                    targetTypeIds = CollectTypeIdsForDiscipline(doc, disc);
+                    if (targetTypeIds.Count == 0)
+                    {
+                        TaskDialog.Show("Set Paragraph Depth",
+                            $"No element types found for discipline '{disc}'.\n" +
+                            "Tag elements first (Auto Tag) so DISC tokens propagate to types.");
+                        return Result.Cancelled;
+                    }
+                    depthName = $"{depthName} (discipline: {disc})";
                 }
                 else
                 {
@@ -346,6 +362,56 @@ namespace StingTools.Tags
             return new FilteredElementCollector(doc)
                 .WhereElementIsElementType()
                 .ToElementIds();
+        }
+
+        /// <summary>
+        /// Discipline-scoped depth: collect every element TYPE that has at
+        /// least one tagged INSTANCE whose ASS_DISCIPLINE_COD_TXT matches.
+        /// This stops cross-talk between disciplines that share generic tag
+        /// families (review fix for token-depth issue #1).
+        /// </summary>
+        private static ICollection<ElementId> CollectTypeIdsForDiscipline(Document doc, string disc)
+        {
+            var typeIds = new HashSet<ElementId>();
+            foreach (Element inst in new FilteredElementCollector(doc)
+                .WhereElementIsNotElementType())
+            {
+                string d = ParameterHelpers.GetString(inst, ParamRegistry.DISC);
+                if (!string.Equals(d, disc, StringComparison.OrdinalIgnoreCase)) continue;
+                ElementId tid = inst.GetTypeId();
+                if (tid != ElementId.InvalidElementId) typeIds.Add(tid);
+            }
+            return typeIds;
+        }
+
+        /// <summary>
+        /// Discipline picker — pulls choices from configured DisciplineProfiles
+        /// or the static DISC list when no profiles are configured.
+        /// Returns null on cancel.
+        /// </summary>
+        private static string PickDiscipline()
+        {
+            var choices = new List<string>();
+            if (TagConfig.DisciplineProfiles != null && TagConfig.DisciplineProfiles.Count > 0)
+                choices.AddRange(TagConfig.DisciplineProfiles.Keys);
+            if (choices.Count == 0)
+                choices.AddRange(new[] { "M", "E", "P", "A", "S", "FP", "LV", "G" });
+            choices.Sort(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                string picked = StingTools.Select.StingListPicker.Show(
+                    "Set Paragraph Depth — by discipline",
+                    "Choose discipline. Depth will apply only to types whose tagged " +
+                    "instances carry that DISC token.",
+                    choices);
+                return picked;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"PickDiscipline list picker failed: {ex.Message}");
+                return null;
+            }
         }
 
         private static bool SetYesNo(Element el, string paramName, bool value)

--- a/StingTools/Tags/PresentationModeCommand.cs
+++ b/StingTools/Tags/PresentationModeCommand.cs
@@ -95,6 +95,7 @@ namespace StingTools.Tags
                 .ToList();
 
             int updated = 0;
+            ResetBoolDiagnostics();
             using (Transaction tx = new Transaction(doc, $"STING Set Mode: {modeName}"))
             {
                 tx.Start();
@@ -112,16 +113,48 @@ namespace StingTools.Tags
                 tx.Commit();
             }
 
+            // Mixed paragraph BOOL storage types (some families YESNO, others
+            // TEXT) are a known silent-failure source — surface the counts so
+            // users see why a depth toggle didn't propagate everywhere.
+            string diag = "";
+            if (LastBoolStringPath > 0 && LastBoolIntegerPath > 0)
+                diag = $"\n\n⚠ Mixed paragraph BOOL storage detected: " +
+                       $"{LastBoolStringPath} TEXT writes, {LastBoolIntegerPath} YESNO writes. " +
+                       "Run 'Audit Tag Families' to migrate.";
+            else if (LastBoolBadStorageCount > 0)
+                diag = $"\n\n⚠ {LastBoolBadStorageCount} parameters had unsupported storage types.";
+
             TaskDialog.Show("Presentation Mode",
                 $"Mode: {modeName}\n" +
                 $"State 1: {(s1 ? "ON" : "OFF")} | State 2: {(s2 ? "ON" : "OFF")} | " +
                 $"State 3: {(s3 ? "ON" : "OFF")} | Warnings: {(warn ? "ON" : "OFF")}\n\n" +
                 $"Element types updated: {updated}\n\n" +
                 "Tag families with calculated values gated by these parameters\n" +
-                "will now show/hide their tier content accordingly.");
+                "will now show/hide their tier content accordingly." + diag);
 
-            StingLog.Info($"Presentation mode set to {modeName}, {updated} types updated");
+            StingLog.Info($"Presentation mode set to {modeName}, {updated} types updated " +
+                $"(stringPath={LastBoolStringPath}, intPath={LastBoolIntegerPath}, " +
+                $"missing={LastBoolMissingCount}, readonly={LastBoolReadOnlyCount}, " +
+                $"badStorage={LastBoolBadStorageCount})");
             return Result.Succeeded;
+        }
+
+        // Diagnostic counters surfaced in the result dialog so users see
+        // when families ship paragraph BOOLs as the wrong storage type
+        // (review fix for leader-and-style issue #4).
+        internal static int LastBoolMissingCount;
+        internal static int LastBoolReadOnlyCount;
+        internal static int LastBoolBadStorageCount;
+        internal static int LastBoolStringPath;
+        internal static int LastBoolIntegerPath;
+
+        internal static void ResetBoolDiagnostics()
+        {
+            LastBoolMissingCount = 0;
+            LastBoolReadOnlyCount = 0;
+            LastBoolBadStorageCount = 0;
+            LastBoolStringPath = 0;
+            LastBoolIntegerPath = 0;
         }
 
         private static bool SetBool(Element el, string paramName, bool value)
@@ -130,9 +163,11 @@ namespace StingTools.Tags
             // Calculated Values can reference them inside if(...); legacy YESNO
             // families still resolve via the Integer branch.
             Parameter p = el.LookupParameter(paramName);
-            if (p == null || p.IsReadOnly) return false;
+            if (p == null) { LastBoolMissingCount++; return false; }
+            if (p.IsReadOnly) { LastBoolReadOnlyCount++; return false; }
             if (p.StorageType == StorageType.String)
             {
+                LastBoolStringPath++;
                 string target = value ? "Yes" : "No";
                 string cur = p.AsString() ?? "";
                 if (string.Equals(cur, target, StringComparison.OrdinalIgnoreCase)) return false;
@@ -141,11 +176,13 @@ namespace StingTools.Tags
             }
             if (p.StorageType == StorageType.Integer)
             {
+                LastBoolIntegerPath++;
                 int target = value ? 1 : 0;
                 if (p.AsInteger() == target) return false;
                 p.Set(target);
                 return true;
             }
+            LastBoolBadStorageCount++;
             return false;
         }
     }

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -2726,6 +2726,94 @@ namespace StingTools.Tags
                     report.AppendLine($"  {pname}: {stype}");
             }
 
+            // ── Style-pack coverage (review fix for leader-and-style #2) ──
+            // Tag families should expose all 128 TAG_{SIZE}{STYLE}_{COLOR}_BOOL
+            // params. If injection partly failed, ApplyTagStyle silently
+            // updates 0 types and the user sees no error — this audit makes
+            // the partial state visible. Counted on type-elements that have
+            // at least ONE style param (i.e. STING tag types).
+            var stylePack = ParamRegistry.AllTagStyleParams;
+            int stingTypesScanned = 0;
+            int stingTypesFullPack = 0;
+            int stingTypesPartialPack = 0;
+            int stingTypesNoPack = 0;
+            int worstMissing = 0;
+            string worstTypeName = "";
+            foreach (Element typeEl in new FilteredElementCollector(doc).WhereElementIsElementType())
+            {
+                if (typeEl?.Category == null) continue;
+                if (typeEl.Category.CategoryType != CategoryType.Annotation) continue;
+                int present = 0;
+                foreach (var name in stylePack)
+                    if (typeEl.LookupParameter(name) != null) present++;
+                if (present == 0) continue;
+                stingTypesScanned++;
+                int missing = stylePack.Length - present;
+                if (missing == 0) stingTypesFullPack++;
+                else
+                {
+                    stingTypesPartialPack++;
+                    if (missing > worstMissing)
+                    {
+                        worstMissing = missing;
+                        worstTypeName = $"{typeEl.Name} ({((typeEl as ElementType)?.FamilyName) ?? "?"})";
+                    }
+                }
+                if (present < 8) stingTypesNoPack++;
+            }
+            if (stingTypesScanned > 0)
+            {
+                report.AppendLine();
+                report.AppendLine("── Style-pack coverage (128 TAG_*_BOOL params) ──");
+                report.AppendLine($"  Annotation types with style params: {stingTypesScanned}");
+                report.AppendLine($"  Full pack (all 128):                {stingTypesFullPack}");
+                report.AppendLine($"  Partial pack (silent style failure): {stingTypesPartialPack}");
+                if (stingTypesPartialPack > 0)
+                {
+                    report.AppendLine($"  Worst: {worstTypeName} — missing {worstMissing} of {stylePack.Length} params");
+                    report.AppendLine("  → ApplyTagStyle will silently no-op for missing slots.");
+                    report.AppendLine("  → Re-run 'Create Tag Families' or 'Family Parameter Processor'.");
+                }
+            }
+
+            // ── Paragraph BOOL storage mix (review fix for leader-and-style #5) ──
+            // Mixed YESNO + TEXT bindings cause SetParagraphDepth to update
+            // half the project; surface the count so a migration can be run.
+            var paraStates = ParamRegistry.AllParaStates;
+            int paraStringTypes = 0, paraIntegerTypes = 0, paraMixed = 0;
+            foreach (Element typeEl in new FilteredElementCollector(doc).WhereElementIsElementType())
+            {
+                bool sawString = false, sawInt = false;
+                foreach (var pn in paraStates)
+                {
+                    Parameter p = typeEl.LookupParameter(pn);
+                    if (p == null) continue;
+                    if (p.StorageType == StorageType.String) sawString = true;
+                    else if (p.StorageType == StorageType.Integer) sawInt = true;
+                }
+                if (sawString && sawInt) paraMixed++;
+                else if (sawString) paraStringTypes++;
+                else if (sawInt) paraIntegerTypes++;
+            }
+            if (paraStringTypes + paraIntegerTypes + paraMixed > 0)
+            {
+                report.AppendLine();
+                report.AppendLine("── Paragraph BOOL storage (TAG_PARA_STATE_*_BOOL) ──");
+                report.AppendLine($"  TEXT-storage (v5.3+):  {paraStringTypes}");
+                report.AppendLine($"  YESNO-storage (legacy): {paraIntegerTypes}");
+                report.AppendLine($"  Mixed within one type:  {paraMixed}");
+                if (paraIntegerTypes > 0 || paraMixed > 0)
+                {
+                    report.AppendLine("  ⚠ Mixed bindings make SetParagraphDepth half-silent.");
+                    report.AppendLine("    Calculated-Value `if(BOOL, …)` only resolves on TEXT params.");
+                    report.AppendLine("    Re-load MR_PARAMETERS.txt v5.3+ then re-bind from project.");
+                }
+            }
+
+            StingLog.Info($"TagFamilyAudit stylePack: scanned={stingTypesScanned}, " +
+                $"full={stingTypesFullPack}, partial={stingTypesPartialPack}; " +
+                $"paraBOOL: text={paraStringTypes}, yesno={paraIntegerTypes}, mixed={paraMixed}");
+
             TaskDialog td = new TaskDialog("Tag Family Audit");
             td.MainInstruction = $"Tag coverage: {stingLoaded + otherTag}/{TagFamilyConfig.CategoryTemplateMap.Count} categories";
             td.MainContent = report.ToString();

--- a/StingTools/Tags/TagStyleCommands.cs
+++ b/StingTools/Tags/TagStyleCommands.cs
@@ -250,6 +250,17 @@ namespace StingTools.Tags
                         body.AppendLine("All style parameters already match the requested style — nothing to change.");
                     }
                 }
+                else if (updated > 0 && diag != null && diag.MissingActiveParam > 0)
+                {
+                    // Review fix for leader-and-style #2: surface partial style
+                    // failure even when updated > 0, so partial 128-pack injection
+                    // doesn't keep silently no-opping on some types.
+                    body.AppendLine();
+                    body.AppendLine($"⚠ Partial style coverage: {diag.MissingActiveParam} of " +
+                                     $"{diag.HadAnyStyleParam} style-aware types lack '{diag.ActiveParam}'.");
+                    body.AppendLine("Run 'Audit Tag Families' for the full coverage report,");
+                    body.AppendLine("then 'Family Parameter Creator' to inject missing slots.");
+                }
                 TaskDialog.Show("Tag Style Applied", body.ToString());
             }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10489,3 +10489,144 @@ Modified:
 - `StingTools/UI/StingDockPanel.xaml` — Migrate Labels button in
   SLD GENERATOR section
 - `docs/CHANGELOG.md` — this entry
+
+#### Completed (Phase 176 — Tagging-workflow review fixes: token toggling / leader & style / scale / depth)
+
+Six concrete fixes from the deep audit of the four pillars of the
+tagging workflow: token toggling, leader & style functions, scale
+tiers, and per-discipline paragraph depth. Each fix targets a
+specific silent-failure mode where the user clicks something and
+nothing visibly happens because the underlying parameter is missing,
+the wrong storage type, or scoped too widely.
+
+##### Per-view token mask (TAG-token-toggling)
+
+`STING_VIEW_TOKEN_MASK_TXT` (new `ParamRegistry.VIEW_TOKEN_MASK`)
+is an 8-character "1"/"0" mask bound to OST_Views that gates which
+ISO 19650 segments render in `BuildDisplayTag` for the active view.
+Lookup precedence is view-mask → element `TAG_SEG_MASK_TXT` → UI
+`ExtraParam("TokenMask")`. The canonical `ASS_TAG_1_TXT` is never
+mutated, so the same model can show DISC-PROD-SEQ in a presentation
+view and the full 8-segment string in an export — this is the first
+time the segment-mask path runs for non-mode-5 callers.
+
+##### Mode-6 narrative-fallback logging
+
+`BuildDisplayTag` mode 6 (TAG7 narrative) used to silently downgrade
+to mode 4 (DISC-PROD-SEQ) whenever `ASS_TAG_7_TXT` was empty —
+common right after a fresh `RunFullPipeline` if `WriteTag7All`
+partially failed. Now warns to `StingLog` so partial-tagging state
+surfaces instead of looking like a 3-segment design choice.
+
+##### SetBool storage diagnostics
+
+`PresentationModeCommand.SetBool` now tracks string-path,
+integer-path, missing, read-only, and bad-storage counters per call.
+Mixed YESNO + TEXT bindings (a known silent-failure source when
+families pre-date MR_PARAMETERS v5.3+) are surfaced inline in the
+result dialog with a "Run Audit Tag Families to migrate" hint.
+
+##### Tag-family auditor: 128-pack + paragraph BOOL storage
+
+`AuditTagFamiliesCommand` gains two new sections:
+
+1. **Style-pack coverage** — counts annotation types that carry the
+   full 128-entry `TAG_{SIZE}{STYLE}_{COLOR}_BOOL` pack vs partial
+   (silent style failure source) vs missing. Names the worst
+   offender so users can see which family to re-process. Without
+   this audit, `ApplyTagStyle` could update zero types on a partial
+   family and the user would have no signal beyond the dead-end "0
+   types updated" line.
+2. **Paragraph BOOL storage mix** — counts types whose 10
+   `TAG_PARA_STATE_*_BOOL` parameters resolve as TEXT (v5.3+),
+   YESNO (legacy), or mixed within one type. Mixed bindings make
+   `SetParagraphDepth` half-silent because Calculated-Value
+   `if(BOOL, …)` only resolves on TEXT params.
+
+`ApplyTagStyleCommand` result panel additionally surfaces partial
+style coverage even when `updated > 0`, so a partial 128-pack
+injection no longer keeps silently no-opping on some types.
+
+##### Scale-tier auto-apply on view-scale change
+
+`StingDocumentChangedHandler` classifies modified Views as a new
+`CascadeKind.ViewScaleChanged` and dispatches
+`Tags.SetScaleAwareTagSizeCommand.ApplyToView` from the next Idling
+tick, gated by the existing `TAG_SCALE_TIER_AUTO_BOOL` opt-in on
+ProjectInformation. Until this phase, scale-aware sizing only ran on
+view _activation_ (`OnViewActivated` → `MaybeAutoApplyScaleSize`),
+so changing the scale of the currently-active view did nothing.
+
+Views are exempted from the `_recentlyProcessed` dedup set so
+repeated scale edits keep firing — without that guard, the second
+scale change in a session would be silently dropped.
+
+##### Discipline-scoped paragraph depth
+
+Three changes that together stop cross-talk between disciplines that
+share generic tag families:
+
+1. **`DisciplineProfile.DefaultParagraphDepth`** (1-10) — new
+   nullable int field plus `default_paragraph_depth` JSON parser.
+   `WriteTag7All` consults the active discipline's value when no
+   `ParaDepth` slider override is set, before falling back to the
+   historic depth-1 default.
+2. **"By discipline…" scope on `SetParagraphDepthCommand`** — third
+   command-link added to the legacy scope dialog. Picks a discipline
+   via `StingListPicker`, then collects every type that has a
+   tagged instance carrying that DISC token. Setting depth on M now
+   leaves E and A untouched even when they share a common generic
+   tag family.
+3. **`PreserveParaState` ExtraParam** — read by `WriteTag7All`. When
+   set, the writer only seeds `PARA_STATE_1` if the element has
+   never been touched (all states empty) instead of unconditionally
+   re-deriving the full state vector from the slider value. This
+   stops Auto-Tag passes from clobbering manual
+   `SetParagraphDepth` selections.
+
+##### Diagnostic surface
+
+`LeaderHelper.AutoAlignTagsToLeaders` now records per-call
+orphan-tag and no-leader counters; `AutoAlignLeaderTextCommand`
+dialog surfaces the orphan count so leader operations on linked /
+deleted-host tags don't appear to silently succeed.
+
+##### Files
+
+Modified:
+- `StingTools/Core/ParamRegistry.cs` — `VIEW_TOKEN_MASK` constant +
+  GUID
+- `StingTools/Core/TagConfig.cs` — `BuildDisplayTag` view-first mask
+  precedence; mode-6 fallback Warn; `WriteTag7All` discipline-default
+  depth + `PreserveParaState` honouring;
+  `DisciplineProfile.DefaultParagraphDepth` + JSON parser
+- `StingTools/Core/StingDocumentChangedHandler.cs` —
+  `CascadeKind.ViewScaleChanged` + `IsScalable` view-type filter;
+  view-exempt dedup; `ApplyCascade` dispatch to
+  `SetScaleAwareTagSizeCommand.ApplyToView`
+- `StingTools/Tags/PresentationModeCommand.cs` — SetBool
+  diagnostic counters; mixed-storage warning surface
+- `StingTools/Tags/ParagraphDepthCommand.cs` — third "By discipline…"
+  scope; `PickDiscipline` + `CollectTypeIdsForDiscipline` helpers
+- `StingTools/Tags/TagFamilyCreatorCommand.cs` — style-pack coverage
+  + paragraph BOOL storage report sections
+- `StingTools/Tags/TagStyleCommands.cs` — partial-coverage warning
+  on `updated > 0` path
+- `StingTools/Organise/TagOperationCommands.cs` —
+  `LeaderHelper.LastAutoAlignOrphanCount` + dialog surface
+- `docs/CHANGELOG.md` — this entry
+
+##### Caveats
+
+- Built without `dotnet build` verification (Linux sandbox).
+- `STING_VIEW_TOKEN_MASK_TXT` needs binding to `OST_Views` in
+  `MR_PARAMETERS.txt` before the per-view mask path activates;
+  unbound projects fall through to the historic element / UI
+  precedence with no behaviour change.
+- The view-scale cascade depends on Revit reporting View elements
+  through `DocumentChangedEventArgs.GetModifiedElementIds()` when
+  `View.Scale` changes — verified against the Revit 2025 docs but
+  not yet exercised in-product.
+- `DisciplineProfile.DefaultParagraphDepth` only takes effect when
+  the element's `DISC` token has been written; untagged elements
+  still get depth-1 from the historic fallback.


### PR DESCRIPTION
## Summary

Six concrete fixes addressing silent-failure modes in the tagging workflow's four pillars: token toggling, leader & style functions, scale tiers, and per-discipline paragraph depth. Each fix targets a specific scenario where user actions produce no visible feedback because underlying parameters are missing, incorrectly typed, or scoped too broadly.

## Key Changes

- **Per-view token mask (TAG-token-toggling #1)**: Added `STING_VIEW_TOKEN_MASK_TXT` parameter bound to views, enabling segment visibility control per-view without mutating the canonical `ASS_TAG_1_TXT`. Implements three-tier lookup precedence: view mask → element mask → UI hint.

- **Mode-6 narrative-fallback logging (TAG-token-toggling #2)**: `BuildDisplayTag` mode 6 now warns to `StingLog` when falling back to mode 4 due to empty `ASS_TAG_7_TXT`, surfacing partial-tagging state instead of silently appearing as a design choice.

- **SetBool storage diagnostics (leader-and-style #4)**: `PresentationModeCommand.SetBool` tracks string-path, integer-path, missing, read-only, and bad-storage counters. Mixed YESNO + TEXT bindings are surfaced inline in the result dialog with migration hints.

- **Tag-family auditor enhancements (leader-and-style #2, #5)**: 
  - Added style-pack coverage section counting annotation types with full 128-entry `TAG_{SIZE}{STYLE}_{COLOR}_BOOL` pack vs partial/missing, naming the worst offender.
  - Added paragraph BOOL storage mix section detecting TEXT (v5.3+) vs YESNO (legacy) vs mixed bindings within types.

- **Scale-tier auto-apply on view-scale change (tag-scale)**: `StingDocumentChangedHandler` now classifies modified Views as `CascadeKind.ViewScaleChanged` and dispatches `SetScaleAwareTagSizeCommand.ApplyToView` from the next Idling tick, gated by `TAG_SCALE_TIER_AUTO_BOOL`. Views are exempted from dedup so repeated scale edits keep firing.

- **Discipline-scoped paragraph depth (token-depth #1, #2, #3)**:
  - Added `DisciplineProfile.DefaultParagraphDepth` (1-10) nullable int field with JSON parser.
  - `WriteTag7All` consults active discipline's default when no slider override is set.
  - Added "By discipline…" scope to `SetParagraphDepthCommand` via `StingListPicker`, collecting types by DISC token match.
  - Added `PreserveParaState` ExtraParam: when set, `WriteTag7All` only seeds `PARA_STATE_1` if element has never been touched, preventing Auto-Tag passes from clobbering manual selections.

- **Leader diagnostic surface (leader-and-style #3)**: `LeaderHelper.AutoAlignTagsToLeaders` now records orphan-tag and no-leader counters; `AutoAlignLeaderTextCommand` dialog surfaces orphan count so silent failures on linked/deleted-host tags become visible.

## Files Modified

- `StingTools/Core/ParamRegistry.cs` — `VIEW_TOKEN_MASK` constant + GUID
- `StingTools/Core/TagConfig.cs` — view-first mask precedence, mode-6 fallback warn, discipline-default depth, `PreserveParaState` honouring, `DisciplineProfile.DefaultParagraphDepth` + JSON parser
- `StingTools/Core/StingDocumentChangedHandler.cs` — `CascadeKind.ViewScaleChanged`, `IsScalable` view-type filter, view-exempt dedup, cascade dispatch to `SetScaleAwareTagSizeCommand.ApplyToView`
- `StingTools/Tags/PresentationModeCommand.cs` — SetBool diagnostic counters, mixed-storage warning surface
- `StingTools/Tags/ParagraphDepthCommand.cs` — "By discipline…" scope

https://claude.ai/code/session_01ABUxb4ADu1uK3tHMaGpRVo