### PR TITLE
Add sync watermark and conflict log REST endpoints (S01)

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -557,7 +557,8 @@ public class DocumentsController : ControllerBase
                 v.FileSizeBytes,
                 v.ContentHash,
                 v.UploadedBy,
-                v.UploadedAt
+                v.UploadedAt,
+                v.ChangeDescription
             })
             .ToListAsync();
 

--- a/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
@@ -380,6 +380,155 @@ public class TagSyncController : ControllerBase
         entity.SyncedAt = DateTime.UtcNow; entity.SyncedBy = userName;
     }
 
+    // ── S01 — explicit sync watermark + conflict log REST endpoints ──────
+    // The bulk-sync POST /sync path already upserts watermarks and logs
+    // conflicts inline as a side-effect of the delta pull. These endpoints
+    // expose the same surfaces directly so a thin client (or a dashboard)
+    // can read/write them without a full element batch.
+
+    [HttpGet("~/api/projects/{projectId:guid}/sync/watermark")]
+    public async Task<ActionResult<SyncWatermarkDto>> GetWatermark(Guid projectId, [FromQuery] string deviceId)
+    {
+        if (RequireTenantClaim(out var tenantId) is { } badClaim) return badClaim;
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return BadRequest(new { message = "deviceId query parameter is required" });
+
+        var projectExists = await _db.Projects
+            .AnyAsync(p => p.Id == projectId && p.TenantId == tenantId);
+        if (!projectExists) return NotFound();
+
+        var wm = await _db.SyncWatermarks
+            .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.DeviceId == deviceId);
+        if (wm == null) return NotFound();
+
+        return Ok(new SyncWatermarkDto
+        {
+            Id = wm.Id,
+            ProjectId = wm.ProjectId,
+            DeviceId = wm.DeviceId,
+            LastSyncUtc = wm.LastSyncUtc,
+            ElementCount = wm.ElementCount
+        });
+    }
+
+    [HttpPut("~/api/projects/{projectId:guid}/sync/watermark")]
+    public async Task<ActionResult<SyncWatermarkDto>> UpsertWatermark(Guid projectId, [FromBody] UpsertWatermarkRequest req)
+    {
+        if (RequireTenantClaim(out var tenantId) is { } badClaim) return badClaim;
+        if (string.IsNullOrWhiteSpace(req.DeviceId))
+            return BadRequest(new { message = "DeviceId is required" });
+
+        var projectExists = await _db.Projects
+            .AnyAsync(p => p.Id == projectId && p.TenantId == tenantId);
+        if (!projectExists) return NotFound();
+
+        var wm = await _db.SyncWatermarks
+            .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.DeviceId == req.DeviceId);
+        if (wm == null)
+        {
+            wm = new SyncWatermark
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                ProjectId = projectId,
+                DeviceId = req.DeviceId,
+                CreatedAt = DateTime.UtcNow
+            };
+            _db.SyncWatermarks.Add(wm);
+        }
+        // Monotonic — never rewind a device's cursor on an explicit upsert
+        // either. Matches the inline behaviour at the bulk-sync delta pull.
+        if (req.LastSyncUtc > wm.LastSyncUtc) wm.LastSyncUtc = req.LastSyncUtc;
+        wm.ElementCount = req.ElementCount;
+        wm.UpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync();
+
+        return Ok(new SyncWatermarkDto
+        {
+            Id = wm.Id,
+            ProjectId = wm.ProjectId,
+            DeviceId = wm.DeviceId,
+            LastSyncUtc = wm.LastSyncUtc,
+            ElementCount = wm.ElementCount
+        });
+    }
+
+    [HttpPost("~/api/projects/{projectId:guid}/sync/conflicts")]
+    public async Task<ActionResult<SyncConflictDto>> LogConflict(Guid projectId, [FromBody] LogConflictRequest req)
+    {
+        if (RequireTenantClaim(out var tenantId) is { } badClaim) return badClaim;
+        if (string.IsNullOrWhiteSpace(req.ElementId))
+            return BadRequest(new { message = "ElementId is required" });
+
+        var projectExists = await _db.Projects
+            .AnyAsync(p => p.Id == projectId && p.TenantId == tenantId);
+        if (!projectExists) return NotFound();
+
+        var conflict = new SyncConflict
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            ProjectId = projectId,
+            ElementId = req.ElementId,
+            ConflictType = string.IsNullOrWhiteSpace(req.ConflictType) ? "STALE_UPDATE" : req.ConflictType,
+            Resolution = string.IsNullOrWhiteSpace(req.Resolution) ? "SERVER_WINS" : req.Resolution,
+            ClientUserName = req.ResolvedBy,
+            DetectedAt = DateTime.UtcNow
+        };
+        // ServerValue / ClientValue from the request are intentionally not
+        // persisted yet — the existing schema captures Server/ClientTimestamp
+        // instead. Adding a ConflictPayload JSON column is queued behind a
+        // concrete need for value-level diffing.
+
+        _db.SyncConflicts.Add(conflict);
+        await _db.SaveChangesAsync();
+
+        var dto = new SyncConflictDto
+        {
+            Id = conflict.Id,
+            ElementId = conflict.ElementId,
+            ConflictType = conflict.ConflictType,
+            Resolution = conflict.Resolution,
+            ResolvedAt = conflict.DetectedAt,
+            ResolvedBy = conflict.ClientUserName
+        };
+        return Created($"/api/projects/{projectId}/sync/conflicts/{conflict.Id}", dto);
+    }
+
+    [HttpGet("~/api/projects/{projectId:guid}/sync/conflicts")]
+    public async Task<ActionResult<List<SyncConflictDto>>> GetConflicts(Guid projectId,
+        [FromQuery] int page = 1, [FromQuery] int pageSize = 50)
+    {
+        if (RequireTenantClaim(out var tenantId) is { } badClaim) return badClaim;
+        page = Math.Max(page, 1);
+        pageSize = Math.Clamp(pageSize, 1, 200);
+
+        var projectExists = await _db.Projects
+            .AnyAsync(p => p.Id == projectId && p.TenantId == tenantId);
+        if (!projectExists) return NotFound();
+
+        var rows = await _db.SyncConflicts
+            .Where(c => c.ProjectId == projectId)
+            .OrderByDescending(c => c.DetectedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(c => new SyncConflictDto
+            {
+                Id = c.Id,
+                ElementId = c.ElementId,
+                ConflictType = c.ConflictType,
+                ServerTimestamp = c.ServerTimestamp,
+                ClientTimestamp = c.ClientTimestamp,
+                Resolution = c.Resolution,
+                ResolvedAt = c.DetectedAt,
+                ResolvedBy = c.ClientUserName
+            })
+            .ToListAsync();
+
+        return Ok(rows);
+    }
+
     private Guid GetTenantId()
     {
         var claim = User.FindFirst("tenant_id")?.Value;

--- a/Planscape.Server/src/Planscape.Core/DTOs/SyncDtos.cs
+++ b/Planscape.Server/src/Planscape.Core/DTOs/SyncDtos.cs
@@ -63,6 +63,57 @@ public record SyncConflictDto
     public DateTime? ServerTimestamp { get; init; }
     public DateTime? ClientTimestamp { get; init; }
     public string Resolution { get; init; } = "";
+    // S01 — additional fields populated by the GET /sync/conflicts list
+    // endpoint. Optional on the inline bulk-sync path, which still only
+    // sets ElementId/Server|ClientTimestamp/Resolution.
+    public Guid? Id { get; init; }
+    public string? ConflictType { get; init; }
+    public DateTime? ResolvedAt { get; init; }
+    public string? ResolvedBy { get; init; }
+}
+
+// ── S01 — sync watermark + conflict log REST DTOs ────────────────────
+public record SyncWatermarkDto
+{
+    public Guid Id { get; init; }
+    public Guid ProjectId { get; init; }
+    public string DeviceId { get; init; } = "";
+    public DateTime LastSyncUtc { get; init; }
+    public int ElementCount { get; init; }
+}
+
+public record UpsertWatermarkRequest
+{
+    public string DeviceId { get; init; } = "";
+    public DateTime LastSyncUtc { get; init; }
+    public int ElementCount { get; init; }
+}
+
+public record LogConflictRequest
+{
+    public string ElementId { get; init; } = "";
+    public string ConflictType { get; init; } = "";
+    /// <summary>
+    /// Optional value-level diff fields. Currently ignored server-side —
+    /// kept on the wire for forward compatibility so a future
+    /// ConflictPayload column can be populated without a client change.
+    /// </summary>
+    public string? ServerValue { get; init; }
+    public string? ClientValue { get; init; }
+    public string Resolution { get; init; } = "";
+    public string? ResolvedBy { get; init; }
+}
+
+public record DocumentVersionDto
+{
+    public Guid Id { get; init; }
+    public int VersionNumber { get; init; }
+    public string FilePath { get; init; } = "";
+    public string? FileHash { get; init; }
+    public long? FileSize { get; init; }
+    public string? UploadedBy { get; init; }
+    public DateTime UploadedAt { get; init; }
+    public string? ChangeDescription { get; init; }
 }
 
 public record ComplianceSummaryDto

--- a/Planscape.Server/src/Planscape.Core/Entities/DocumentVersion.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/DocumentVersion.cs
@@ -17,6 +17,13 @@ public class DocumentVersion : ITenantScoped
     public string UploadedBy { get; set; } = "";
     public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Optional human-readable note describing what changed in this revision
+    /// (e.g. "Updated section 4 floor plans", "Tagged S4 for client review").
+    /// Nullable — additive, safe for legacy rows.
+    /// </summary>
+    public string? ChangeDescription { get; set; }
+
     // Navigation
     public DocumentRecord? Document { get; set; }
 }

--- a/Planscape.Server/src/Planscape.Core/Entities/SyncWatermark.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/SyncWatermark.cs
@@ -26,6 +26,14 @@ public class SyncWatermark : ITenantScoped
     /// </summary>
     public DateTime LastSyncUtc { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Optional client-reported element count captured at the moment of the
+    /// watermark upsert. Lets a device cheaply sanity-check that the server
+    /// agrees on its expected row count without a follow-up read. Defaults
+    /// to 0 — additive column, safe for legacy rows.
+    /// </summary>
+    public int ElementCount { get; set; } = 0;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -406,6 +406,9 @@ public class PlanscapeDbContext : DbContext
             e.HasIndex(t => t.Tag1);
             e.HasIndex(t => t.Disc);
             e.HasIndex(t => t.IsStale);
+            // Delta-sync cutoff queries (`(LastModifiedUtc ?? SyncedAt) > cutoff`)
+            // benefit from an index on the modification timestamp.
+            e.HasIndex(t => t.LastModifiedUtc);
         });
 
         // ── BimIssue ──
@@ -581,7 +584,28 @@ public class PlanscapeDbContext : DbContext
             e.Property(w => w.DeviceId).HasMaxLength(128).IsRequired();
             // One watermark per (project, device) — upserts key on this pair.
             e.HasIndex(w => new { w.ProjectId, w.DeviceId }).IsUnique();
+            // Tenant scope filtering on admin/list endpoints.
+            e.HasIndex(w => w.TenantId);
+            // "Most recent activity" queries / monitoring sort by LastSyncUtc.
+            e.HasIndex(w => w.LastSyncUtc);
             e.HasOne(w => w.Project).WithMany().HasForeignKey(w => w.ProjectId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // ── SyncConflict (S01 — log of last-write-wins sync rejections) ──
+        modelBuilder.Entity<SyncConflict>(e =>
+        {
+            e.HasKey(c => c.Id);
+            e.Property(c => c.ElementId).HasMaxLength(128).IsRequired();
+            e.Property(c => c.ConflictType).HasMaxLength(40).IsRequired();
+            e.Property(c => c.Resolution).HasMaxLength(20).IsRequired();
+            // Drill-down: list every conflict that happened on a given element.
+            e.HasIndex(c => new { c.ProjectId, c.ElementId });
+            // Time-windowed queries ("conflicts in the last 24h") + dashboard sort.
+            e.HasIndex(c => c.DetectedAt);
+            // Tenant scope filtering for cross-project admin views.
+            e.HasIndex(c => c.TenantId);
+            e.HasOne(c => c.Project).WithMany().HasForeignKey(c => c.ProjectId).OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(c => c.TaggedElement).WithMany().HasForeignKey(c => c.TaggedElementId).OnDelete(DeleteBehavior.SetNull);
         });
 
         // ── Planscape MIM Entities ──


### PR DESCRIPTION
## Summary
Expose sync watermark and conflict log management as dedicated REST endpoints, allowing thin clients and dashboards to read/write synchronization state without performing full element batch operations.

## Key Changes

- **New REST Endpoints** in `TagSyncController`:
  - `GET /api/projects/{projectId}/sync/watermark` — retrieve sync watermark for a device
  - `PUT /api/projects/{projectId}/sync/watermark` — upsert watermark with monotonic timestamp enforcement
  - `POST /api/projects/{projectId}/sync/conflicts` — log a sync conflict
  - `GET /api/projects/{projectId}/sync/conflicts` — list conflicts with pagination

- **Entity & DTO Updates**:
  - Added `ElementCount` field to `SyncWatermark` entity to capture client-reported row counts
  - Extended `SyncConflictDto` with `Id`, `ConflictType`, `ResolvedAt`, and `ResolvedBy` fields for dashboard consumption
  - Added `UpsertWatermarkRequest`, `LogConflictRequest`, and `DocumentVersionDto` request/response DTOs
  - Added `ChangeDescription` field to `DocumentVersion` entity for revision notes

- **Database Indexing**:
  - Added index on `TaggedElement.LastModifiedUtc` for delta-sync cutoff queries
  - Added indexes on `SyncWatermark` for tenant filtering and activity queries (`TenantId`, `LastSyncUtc`)
  - Added composite and single-column indexes on `SyncConflict` for drill-down, time-windowed, and tenant-scoped queries
  - Configured cascade delete behavior for `SyncConflict` → `Project` and soft-delete for `SyncConflict` → `TaggedElement`

## Implementation Details

- Watermark upserts enforce monotonic timestamps (never rewind a device's sync cursor), matching inline bulk-sync behavior
- Conflict logging accepts optional `ServerValue`/`ClientValue` fields for forward compatibility with future value-level diffing, but does not persist them yet
- All endpoints include tenant-scoped authorization checks and project existence validation
- Conflict list endpoint supports pagination (default 50 items, max 200) sorted by detection time descending

https://claude.ai/code/session_01LWWA8cPk8VFVJA3q7Y33yB