### PR TITLE
Phase 177: Document manager review with per-folder ACLs and approvals

### DIFF
--- a/Planscape.Server/src/Planscape.API/Authorization/ProjectMemberAcl.cs
+++ b/Planscape.Server/src/Planscape.API/Authorization/ProjectMemberAcl.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.API.Authorization;
+
+/// <summary>
+/// Phase 177 — per-folder/per-discipline/per-suitability ACL lookup for the
+/// authenticated user against a project. Sits beside <see cref="ProjectAccessAttribute"/>:
+/// that gate decides "can this user see the project at all"; this helper
+/// then narrows what slice they see *inside* the project.
+///
+/// Nulls preserve old behaviour: a member without any populated allow-list
+/// gets the whole project (matching the pre-Phase 177 semantics).
+/// Tenant Admins / Owners / SecurityOfficers bypass member-row narrowing
+/// entirely so they retain their cross-project audit reach.
+/// </summary>
+public static class ProjectMemberAcl
+{
+    public sealed record AclSlice(
+        string[]? Cde,
+        string[]? Disciplines,
+        string[]? Suitabilities,
+        bool BypassesAcl)
+    {
+        public bool AllowsCde(string? state) =>
+            BypassesAcl || ProjectMember.IsAllowed(JoinOrNull(Cde), state);
+
+        public bool AllowsDiscipline(string? disc) =>
+            BypassesAcl || ProjectMember.IsAllowed(JoinOrNull(Disciplines), disc);
+
+        public bool AllowsSuitability(string? suit) =>
+            BypassesAcl || ProjectMember.IsAllowed(JoinOrNull(Suitabilities), suit);
+
+        public bool AllowsDocument(DocumentRecord d) =>
+            AllowsCde(d.CdeStatus) && AllowsDiscipline(d.Discipline) && AllowsSuitability(d.SuitabilityCode);
+
+        private static string? JoinOrNull(string[]? arr) =>
+            arr == null || arr.Length == 0 ? null : string.Join(',', arr);
+    }
+
+    /// <summary>
+    /// Read the ACL slice for the calling user. Returns a "bypass" slice
+    /// when the user is a tenant Admin/Owner/SecurityOfficer or when no
+    /// ProjectMember row exists (e.g. project author falls through
+    /// ProjectVisibility but isn't yet on the member table).
+    /// </summary>
+    public static async Task<AclSlice> ResolveAsync(
+        PlanscapeDbContext db,
+        Guid projectId,
+        System.Security.Claims.ClaimsPrincipal user,
+        CancellationToken ct = default)
+    {
+        var role = user.FindFirst("role")?.Value ?? "";
+        if (role is "Admin" or "Owner" or "SecurityOfficer")
+            return new AclSlice(null, null, null, BypassesAcl: true);
+
+        var subClaim = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? user.FindFirst("sub")?.Value;
+        if (!Guid.TryParse(subClaim, out var userId))
+            return new AclSlice(null, null, null, BypassesAcl: true); // can't narrow what we can't identify
+
+        var member = await db.ProjectMembers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.ProjectId == projectId && m.UserId == userId && m.IsActive, ct);
+
+        // No member row = inherit (project author / tenant manager fallthrough).
+        // Don't 403 here — ProjectAccessAttribute already cleared visibility.
+        if (member == null)
+            return new AclSlice(null, null, null, BypassesAcl: true);
+
+        return new AclSlice(
+            Cde:           ProjectMember.ParseAllowList(member.AllowedCdeStates),
+            Disciplines:   ProjectMember.ParseAllowList(member.AllowedDisciplines),
+            Suitabilities: ProjectMember.ParseAllowList(member.AllowedSuitabilities),
+            BypassesAcl:   false);
+    }
+
+    /// <summary>
+    /// Apply the ACL to a document IQueryable. No-op when the slice bypasses
+    /// or every axis is null. Filtering happens in SQL via three IN clauses.
+    /// </summary>
+    public static IQueryable<DocumentRecord> ApplyTo(IQueryable<DocumentRecord> query, AclSlice acl)
+    {
+        if (acl.BypassesAcl) return query;
+        if (acl.Cde is { Length: > 0 } cde)
+            query = query.Where(d => cde.Contains(d.CdeStatus));
+        if (acl.Disciplines is { Length: > 0 } disc)
+            query = query.Where(d => d.Discipline != null && disc.Contains(d.Discipline));
+        if (acl.Suitabilities is { Length: > 0 } suit)
+            query = query.Where(d => suit.Contains(d.SuitabilityCode));
+        return query;
+    }
+}

--- a/Planscape.Server/src/Planscape.API/Controllers/AccessProfilesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AccessProfilesController.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// Phase 177-D — tenant-scoped CRUD for named ACL presets used when
+/// inviting / updating <see cref="ProjectMember"/> rows. Reads are
+/// available to any signed-in user (the picker needs to render);
+/// writes require Manager+ at the tenant level.
+/// </summary>
+[ApiController]
+[Route("api/access-profiles")]
+[Authorize]
+[EnableRateLimiting("mobile")]
+public class AccessProfilesController : ControllerBase
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly ILogger<AccessProfilesController> _log;
+
+    public AccessProfilesController(PlanscapeDbContext db, ILogger<AccessProfilesController> log)
+    {
+        _db = db;
+        _log = log;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult> List()
+    {
+        var tenantId = GetTenantId();
+        if (tenantId == Guid.Empty) return Unauthorized();
+
+        var rows = await _db.AccessProfiles
+            .AsNoTracking()
+            .Where(p => p.TenantId == tenantId && p.IsActive)
+            .OrderBy(p => p.Name)
+            .Select(p => Project(p))
+            .ToListAsync();
+        return Ok(rows);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult> Get(Guid id)
+    {
+        var tenantId = GetTenantId();
+        var p = await _db.AccessProfiles.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id && x.TenantId == tenantId);
+        return p == null ? NotFound() : Ok(Project(p));
+    }
+
+    [HttpPost]
+    public async Task<ActionResult> Create([FromBody] AccessProfileBody req)
+    {
+        if (!IsManagerOrAbove()) return Forbid();
+        if (string.IsNullOrWhiteSpace(req.Name))
+            return BadRequest(new { message = "name is required" });
+
+        var tenantId = GetTenantId();
+        if (await _db.AccessProfiles.AnyAsync(p => p.TenantId == tenantId && p.Name == req.Name && p.IsActive))
+            return Conflict(new { message = "An access profile with that name already exists." });
+
+        var entity = new AccessProfile
+        {
+            TenantId             = tenantId,
+            Name                 = req.Name.Trim(),
+            Description          = req.Description?.Trim(),
+            AllowedCdeStates     = ToCsv(req.AllowedCdeStates),
+            AllowedDisciplines   = ToCsv(req.AllowedDisciplines),
+            AllowedSuitabilities = ToCsv(req.AllowedSuitabilities),
+            DefaultProjectRole   = string.IsNullOrWhiteSpace(req.DefaultProjectRole)  ? "Contributor" : req.DefaultProjectRole.Trim(),
+            DefaultIso19650Role  = string.IsNullOrWhiteSpace(req.DefaultIso19650Role) ? "M"           : req.DefaultIso19650Role.Trim(),
+            CreatedBy            = User.FindFirst("display_name")?.Value,
+        };
+        _db.AccessProfiles.Add(entity);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(Get), new { id = entity.Id }, Project(entity));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult> Update(Guid id, [FromBody] AccessProfileBody req)
+    {
+        if (!IsManagerOrAbove()) return Forbid();
+
+        var tenantId = GetTenantId();
+        var entity = await _db.AccessProfiles
+            .FirstOrDefaultAsync(p => p.Id == id && p.TenantId == tenantId);
+        if (entity == null) return NotFound();
+
+        if (!string.IsNullOrWhiteSpace(req.Name))         entity.Name        = req.Name.Trim();
+        if (req.Description != null)                       entity.Description = req.Description.Trim();
+        if (req.AllowedCdeStates     != null) entity.AllowedCdeStates     = ToCsv(req.AllowedCdeStates);
+        if (req.AllowedDisciplines   != null) entity.AllowedDisciplines   = ToCsv(req.AllowedDisciplines);
+        if (req.AllowedSuitabilities != null) entity.AllowedSuitabilities = ToCsv(req.AllowedSuitabilities);
+        if (!string.IsNullOrWhiteSpace(req.DefaultProjectRole))  entity.DefaultProjectRole  = req.DefaultProjectRole.Trim();
+        if (!string.IsNullOrWhiteSpace(req.DefaultIso19650Role)) entity.DefaultIso19650Role = req.DefaultIso19650Role.Trim();
+
+        await _db.SaveChangesAsync();
+        return Ok(Project(entity));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<ActionResult> Delete(Guid id)
+    {
+        if (!IsManagerOrAbove()) return Forbid();
+        var tenantId = GetTenantId();
+        var entity = await _db.AccessProfiles
+            .FirstOrDefaultAsync(p => p.Id == id && p.TenantId == tenantId);
+        if (entity == null) return NotFound();
+        // Soft-delete to preserve invite history references.
+        entity.IsActive = false;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private Guid GetTenantId() =>
+        Guid.TryParse(User.FindFirst("tenant_id")?.Value, out var id) ? id : Guid.Empty;
+
+    private bool IsManagerOrAbove()
+    {
+        var role = User.FindFirst("role")?.Value ?? "";
+        return role is "Manager" or "Admin" or "Owner";
+    }
+
+    private static string? ToCsv(string[]? arr)
+    {
+        if (arr == null) return null;
+        var cleaned = arr.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToArray();
+        return cleaned.Length == 0 ? null : string.Join(',', cleaned);
+    }
+
+    private static object Project(AccessProfile p) => new
+    {
+        p.Id,
+        p.Name,
+        p.Description,
+        allowedCdeStates     = ProjectMember.ParseAllowList(p.AllowedCdeStates)     ?? Array.Empty<string>(),
+        allowedDisciplines   = ProjectMember.ParseAllowList(p.AllowedDisciplines)   ?? Array.Empty<string>(),
+        allowedSuitabilities = ProjectMember.ParseAllowList(p.AllowedSuitabilities) ?? Array.Empty<string>(),
+        p.DefaultProjectRole,
+        p.DefaultIso19650Role,
+        p.CreatedAt,
+        p.CreatedBy,
+    };
+}
+
+public record AccessProfileBody(
+    string?  Name,
+    string?  Description,
+    string[]? AllowedCdeStates,
+    string[]? AllowedDisciplines,
+    string[]? AllowedSuitabilities,
+    string?  DefaultProjectRole,
+    string?  DefaultIso19650Role);

--- a/Planscape.Server/src/Planscape.API/Controllers/AuditEventsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuditEventsController.cs
@@ -1,0 +1,108 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Planscape.API.Authorization;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// Phase 177 — accepts a batch of audit events from the plugin so the
+/// SHA-256-chained tamper-evidence log written under
+/// <c>&lt;project&gt;/_BIM_COORD/audit_log_*.jsonl</c> reaches the server
+/// where it can be queried, retained, and verified centrally.
+///
+/// The plugin keeps its local chain (verified by <c>AuditLog.VerifyChain</c>);
+/// this endpoint mirrors selected events into the server's
+/// <see cref="Planscape.Core.Entities.AuditLog"/> table so cross-workstation
+/// queries and SOC2 reports see the union, not just what the server itself
+/// generated.
+///
+/// Trust model: the plugin runs as the JWT user; we attribute every event
+/// to that user and ignore any conflicting <c>userId</c> claim in the body.
+/// The server is authoritative for tenant + user; the plugin is
+/// authoritative for action/entity/details/timestamp.
+/// </summary>
+[ApiController]
+[Route("api/projects/{projectId}/audit-events")]
+[Authorize]
+[ProjectAccess]
+[EnableRateLimiting("mobile")]
+public class AuditEventsController : ControllerBase
+{
+    private const int MaxBatch = 200;
+
+    private readonly PlanscapeDbContext _db;
+    private readonly ILogger<AuditEventsController> _log;
+
+    public AuditEventsController(PlanscapeDbContext db, ILogger<AuditEventsController> log)
+    {
+        _db = db;
+        _log = log;
+    }
+
+    [HttpPost("batch")]
+    public async Task<ActionResult> PostBatch(Guid projectId, [FromBody] AuditEventBatch req)
+    {
+        if (req?.Events == null || req.Events.Count == 0)
+            return BadRequest(new { message = "events array is required" });
+        if (req.Events.Count > MaxBatch)
+            return BadRequest(new { message = $"batch exceeds {MaxBatch} events" });
+
+        var tenantId = Guid.TryParse(User.FindFirst("tenant_id")?.Value, out var t) ? t : Guid.Empty;
+        if (tenantId == Guid.Empty) return Unauthorized();
+
+        var subClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        var userId = Guid.TryParse(subClaim, out var u) ? (Guid?)u : null;
+
+        var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
+
+        var rows = new List<AuditLog>(req.Events.Count);
+        foreach (var ev in req.Events)
+        {
+            if (string.IsNullOrWhiteSpace(ev.Action) || string.IsNullOrWhiteSpace(ev.EntityType))
+                continue;
+
+            rows.Add(new AuditLog
+            {
+                TenantId    = tenantId,
+                ProjectId   = projectId,
+                UserId      = userId,
+                Action      = Truncate(ev.Action, 100),
+                EntityType  = Truncate(ev.EntityType, 80),
+                EntityId    = Truncate(ev.EntityId, 200),
+                DetailsJson = Truncate(ev.DetailsJson, 8000),
+                IpAddress   = ipAddress,
+                Timestamp   = ev.Timestamp ?? DateTime.UtcNow,
+                Source      = "plugin",
+                DeviceId    = Truncate(ev.DeviceId, 100),
+            });
+        }
+
+        if (rows.Count == 0)
+            return BadRequest(new { message = "no valid events in batch" });
+
+        _db.AuditLogs.AddRange(rows);
+        await _db.SaveChangesAsync();
+
+        return Ok(new { accepted = rows.Count, rejected = req.Events.Count - rows.Count });
+    }
+
+    private static string? Truncate(string? s, int max)
+    {
+        if (s == null) return null;
+        return s.Length <= max ? s : s.Substring(0, max);
+    }
+}
+
+public record AuditEventBatch(List<AuditEventDto> Events);
+
+public record AuditEventDto(
+    string    Action,
+    string    EntityType,
+    string?   EntityId,
+    string?   DetailsJson,
+    DateTime? Timestamp,
+    string?   DeviceId);

--- a/Planscape.Server/src/Planscape.API/Controllers/AuditEventsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuditEventsController.cs
@@ -23,6 +23,13 @@ namespace Planscape.API.Controllers;
 /// to that user and ignore any conflicting <c>userId</c> claim in the body.
 /// The server is authoritative for tenant + user; the plugin is
 /// authoritative for action/entity/details/timestamp.
+///
+/// Hardening:
+///   • Every persisted Action is normalised to a <c>plugin.</c> prefix so a
+///     malicious plugin can't smuggle a row that looks like a server-side
+///     event (<c>admin_login</c>, <c>token_revoked</c>, …).
+///   • EntityType is whitelisted to a known set; unknown types are rejected
+///     so an attacker can't pollute the audit table with arbitrary "types".
 /// </summary>
 [ApiController]
 [Route("api/projects/{projectId}/audit-events")]
@@ -32,6 +39,17 @@ namespace Planscape.API.Controllers;
 public class AuditEventsController : ControllerBase
 {
     private const int MaxBatch = 200;
+
+    // Phase 177 — only these EntityTypes are accepted from the plugin. Anything
+    // else (e.g. "AppUser", "AuditLog") is dropped silently and counted as
+    // rejected so the metric reveals abuse attempts.
+    private static readonly HashSet<string> AllowedEntityTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Deliverable", "Document", "Transmittal", "Workflow", "Meeting",
+    };
+
+    // Action namespace forced on every plugin-sourced row.
+    private const string PluginActionPrefix = "plugin.";
 
     private readonly PlanscapeDbContext _db;
     private readonly ILogger<AuditEventsController> _log;
@@ -60,34 +78,57 @@ public class AuditEventsController : ControllerBase
         var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
 
         var rows = new List<AuditLog>(req.Events.Count);
+        var rejected = 0;
+        var now = DateTime.UtcNow;
+        var floor = now.AddDays(-30);   // backdating older than 30 days is dropped
+        var ceil  = now.AddMinutes(5);  // small clock-skew window forward
+
         foreach (var ev in req.Events)
         {
             if (string.IsNullOrWhiteSpace(ev.Action) || string.IsNullOrWhiteSpace(ev.EntityType))
-                continue;
+            { rejected++; continue; }
+            if (!AllowedEntityTypes.Contains(ev.EntityType))
+            { rejected++; continue; }
+
+            // Force the plugin. namespace — strip any pre-existing prefix so
+            // an attacker can't smuggle "admin_login" or "token_revoked".
+            var rawAction = ev.Action.Trim();
+            if (rawAction.StartsWith(PluginActionPrefix, StringComparison.OrdinalIgnoreCase))
+                rawAction = rawAction.Substring(PluginActionPrefix.Length);
+            var normalisedAction = PluginActionPrefix + rawAction;
+
+            // Clamp the timestamp to a sane window so a backdated event can't
+            // poison the audit chain ordering.
+            var ts = ev.Timestamp ?? now;
+            if (ts < floor || ts > ceil) ts = now;
 
             rows.Add(new AuditLog
             {
                 TenantId    = tenantId,
                 ProjectId   = projectId,
                 UserId      = userId,
-                Action      = Truncate(ev.Action, 100),
-                EntityType  = Truncate(ev.EntityType, 80),
+                Action      = Truncate(normalisedAction, 100)!,
+                EntityType  = Truncate(ev.EntityType, 80)!,
                 EntityId    = Truncate(ev.EntityId, 200),
                 DetailsJson = Truncate(ev.DetailsJson, 8000),
                 IpAddress   = ipAddress,
-                Timestamp   = ev.Timestamp ?? DateTime.UtcNow,
+                Timestamp   = ts,
                 Source      = "plugin",
                 DeviceId    = Truncate(ev.DeviceId, 100),
             });
         }
 
         if (rows.Count == 0)
-            return BadRequest(new { message = "no valid events in batch" });
+            return BadRequest(new { message = "no valid events in batch", rejected });
 
         _db.AuditLogs.AddRange(rows);
         await _db.SaveChangesAsync();
 
-        return Ok(new { accepted = rows.Count, rejected = req.Events.Count - rows.Count });
+        if (rejected > 0)
+            _log.LogWarning("AuditEvents: {Rejected}/{Total} plugin events rejected (entityType / clock window)",
+                rejected, req.Events.Count);
+
+        return Ok(new { accepted = rows.Count, rejected });
     }
 
     private static string? Truncate(string? s, int max)

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -159,6 +159,8 @@ public class DocumentsController : ControllerBase
         var tenantId = GetTenantId();
         var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId && p.TenantId == tenantId);
         if (project == null) return NotFound();
+        // Phase 177 — match Upload/CreateDocument: ACL on bootstrap state + discipline.
+        if (await RequireAclCreateAsync(projectId, req.Discipline) is { } aclDenied) return aclDenied;
 
         // Verify the upload actually landed in storage.
         if (!await _storage.ExistsAsync(req.ObjectKey))
@@ -222,6 +224,8 @@ public class DocumentsController : ControllerBase
         var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId && p.TenantId == tenantId);
         if (project == null) return NotFound("Project not found");
         if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
+        // Phase 177 — caller must hold WIP + the requested discipline.
+        if (await RequireAclCreateAsync(projectId, req.Discipline) is { } aclDenied) return aclDenied;
 
         var doc = new DocumentRecord
         {
@@ -270,6 +274,8 @@ public class DocumentsController : ControllerBase
             .FirstOrDefaultAsync(p => p.Id == projectId && p.TenantId == tenantId);
         if (project == null) return NotFound("Project not found");
         if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
+        // Phase 177 — block uploads outside the caller's CDE/discipline slice.
+        if (await RequireAclCreateAsync(projectId, discipline) is { } aclDenied) return aclDenied;
 
         // S7 — geofence parity with IssuesController.CreateIssue. A user
         // off-site shouldn't be uploading documents that purport to be
@@ -551,6 +557,7 @@ public class DocumentsController : ControllerBase
         var doc = await _db.Documents
             .FirstOrDefaultAsync(d => d.Id == docId && d.ProjectId == projectId && d.Project!.TenantId == tenantId);
         if (doc == null) return NotFound();
+        if (await RequireAclAsync(projectId, doc) is { } aclDenied) return aclDenied;
 
         var versions = await _db.DocumentVersions
             .Where(v => v.DocumentId == docId)
@@ -581,6 +588,7 @@ public class DocumentsController : ControllerBase
         var doc = await _db.Documents
             .FirstOrDefaultAsync(d => d.Id == docId && d.ProjectId == projectId && d.Project!.TenantId == tenantId);
         if (doc == null) return NotFound();
+        if (await RequireAclAsync(projectId, doc) is { } aclDenied) return aclDenied;
 
         var version = await _db.DocumentVersions
             .FirstOrDefaultAsync(v => v.DocumentId == docId && v.VersionNumber == versionNumber);
@@ -885,6 +893,9 @@ public class DocumentsController : ControllerBase
         var isCreate = doc == null;
         if (isCreate)
         {
+            // Phase 177 — first-time create is gated like a regular upload.
+            if (await RequireAclCreateAsync(projectId, req.Discipline) is { } aclCreateDenied)
+                return aclCreateDenied;
             doc = new DocumentRecord
             {
                 ProjectId       = projectId,
@@ -1005,6 +1016,22 @@ public class DocumentsController : ControllerBase
     {
         var acl = await Planscape.API.Authorization.ProjectMemberAcl.ResolveAsync(_db, projectId, User);
         if (!acl.AllowsDocument(doc)) return NotFound();
+        return null;
+    }
+
+    /// <summary>
+    /// Phase 177 — gate document *creation* on the caller's ACL slice for
+    /// the bootstrap state (always WIP for upload paths) and the requested
+    /// discipline. Users with a discipline allow-list that excludes the
+    /// requested discipline can't smuggle a doc into WIP via upload.
+    /// </summary>
+    private async Task<ActionResult?> RequireAclCreateAsync(Guid projectId, string? discipline, string bootstrapState = "WIP")
+    {
+        var acl = await Planscape.API.Authorization.ProjectMemberAcl.ResolveAsync(_db, projectId, User);
+        if (!acl.AllowsCde(bootstrapState))
+            return StatusCode(403, new { message = $"Your access does not include the {bootstrapState} CDE state." });
+        if (!acl.AllowsDiscipline(discipline))
+            return StatusCode(403, new { message = $"Your access does not include discipline {discipline ?? "(unset)"}." });
         return null;
     }
 

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -658,7 +658,14 @@ public class DocumentsController : ControllerBase
             $"{{\"oldState\":\"{oldState}\",\"newState\":\"{req.NewState}\"}}");
 
         // C2 — real-time push so coordinators in Revit + mobile viewers refresh.
-        _ = _hub.Clients.Group($"project-{projectId}").SendAsync("DocumentUpdated", new
+        // Phase 177 — broadcast to BOTH the source and target CDE subgroups so
+        // a member who could see the doc at oldState (and is therefore tracking
+        // it on their UI) gets the "it just left WIP" event, AND a member who
+        // can only see it now-that-it's-SHARED still receives the arrival.
+        await _hub.Clients.Groups(
+                $"project-{projectId}-cde-{oldState}",
+                $"project-{projectId}-cde-{doc.CdeStatus}")
+            .SendAsync("DocumentUpdated", new
         {
             projectId, documentId = docId,
             fileName = doc.FileName, cdeStatus = doc.CdeStatus,
@@ -971,7 +978,9 @@ public class DocumentsController : ControllerBase
                 revision  = doc.Revision
             }));
 
-        _ = _hub.Clients.Group($"project-{projectId}").SendAsync("DocumentUpdated", new
+        // Phase 177 — broadcast only to members whose ACL covers the new state.
+        await _hub.Clients.Group($"project-{projectId}-cde-{doc.CdeStatus}")
+            .SendAsync("DocumentUpdated", new
         {
             projectId, documentId = doc.Id,
             fileName = doc.FileName, cdeStatus = doc.CdeStatus,

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -205,6 +205,10 @@ public class DocumentsController : ControllerBase
         if (!string.IsNullOrEmpty(cdeStatus)) query = query.Where(d => d.CdeStatus == cdeStatus);
         if (!string.IsNullOrEmpty(discipline)) query = query.Where(d => d.Discipline == discipline);
 
+        // Phase 177 — narrow by per-folder/per-discipline/per-suitability ACL.
+        var acl = await Planscape.API.Authorization.ProjectMemberAcl.ResolveAsync(_db, projectId, User);
+        query = Planscape.API.Authorization.ProjectMemberAcl.ApplyTo(query, acl);
+
         var total = await query.CountAsync();
         var docs = await query.OrderByDescending(d => d.UploadedAt)
             .Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
@@ -504,6 +508,8 @@ public class DocumentsController : ControllerBase
         var doc = await _db.Documents
             .FirstOrDefaultAsync(d => d.Id == docId && d.ProjectId == projectId && d.Project!.TenantId == tenantId);
         if (doc == null) return NotFound();
+        // Phase 177 — per-folder ACL.
+        if (await RequireAclAsync(projectId, doc) is { } aclDenied) return aclDenied;
 
         // S12 — geofence boundary check for mobile downloads
         if (HttpContext.Items.TryGetValue("Latitude", out var latObj) &&
@@ -602,6 +608,10 @@ public class DocumentsController : ControllerBase
         if (doc == null) return NotFound();
         if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
 
+        // Phase 177 — per-folder ACL: source slice + target slice + target suitability.
+        if (await RequireAclTargetAsync(projectId, doc, req.NewState, req.SuitabilityCode) is { } aclDenied)
+            return aclDenied;
+
         // Validate transition
         if (!ValidTransitions.TryGetValue(doc.CdeStatus, out var validTargets))
             return BadRequest($"Unknown current state: {doc.CdeStatus}");
@@ -674,6 +684,10 @@ public class DocumentsController : ControllerBase
         if (doc == null) return NotFound();
         if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
 
+        // Phase 177 — per-folder ACL.
+        if (await RequireAclTargetAsync(projectId, doc, req.NewStatus, null) is { } aclDenied)
+            return aclDenied;
+
         if (!ValidTransitions.TryGetValue(doc.CdeStatus, out var validTargets))
             return BadRequest($"Unknown current state: {doc.CdeStatus}");
 
@@ -717,6 +731,7 @@ public class DocumentsController : ControllerBase
         var doc = await _db.Documents
             .FirstOrDefaultAsync(d => d.Id == docId && d.ProjectId == projectId && d.Project!.TenantId == tenantId);
         if (doc == null) return NotFound();
+        if (await RequireAclAsync(projectId, doc) is { } aclDenied) return aclDenied;
 
         var history = !string.IsNullOrEmpty(doc.StatusHistoryJson)
             ? JsonConvert.DeserializeObject<List<object>>(doc.StatusHistoryJson)
@@ -739,6 +754,7 @@ public class DocumentsController : ControllerBase
             .FirstOrDefaultAsync(d => d.Id == docId && d.ProjectId == projectId && d.Project!.TenantId == tenantId);
         if (doc == null) return NotFound();
         if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
+        if (await RequireAclTargetAsync(projectId, doc, req.TargetState, null) is { } aclDenied) return aclDenied;
 
         var transition = $"{doc.CdeStatus}->{req.TargetState}";
 
@@ -793,6 +809,7 @@ public class DocumentsController : ControllerBase
             .FirstOrDefaultAsync(d => d.Id == docId && d.ProjectId == projectId && d.Project!.TenantId == tenantId);
         if (doc == null) return NotFound();
         if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
+        if (await RequireAclAsync(projectId, doc) is { } aclDenied) return aclDenied;
 
         if (approval.Status != "PENDING")
             return BadRequest($"Approval already decided: {approval.Status}");
@@ -821,6 +838,7 @@ public class DocumentsController : ControllerBase
         var doc = await _db.Documents
             .FirstOrDefaultAsync(d => d.Id == docId && d.ProjectId == projectId && d.Project!.TenantId == tenantId);
         if (doc == null) return NotFound();
+        if (await RequireAclAsync(projectId, doc) is { } aclDenied) return aclDenied;
 
         var approvals = await _db.DocumentApprovals
             .Where(a => a.DocumentId == docId)
@@ -829,6 +847,128 @@ public class DocumentsController : ControllerBase
             .ToListAsync();
 
         return Ok(new { doc.Id, doc.FileName, doc.CdeStatus, approvals });
+    }
+
+    /// <summary>
+    /// Phase 177 — single-call sync from the Revit plugin's
+    /// <c>DeliverableLifecycle</c>. Finds-or-creates a DocumentRecord
+    /// keyed by deliverable number, applies the new lifecycle status, and
+    /// returns the resulting record. Idempotent — safe to retry. Plugin
+    /// drives lifecycle locally first (the .docx is rendered on disk),
+    /// then mirrors the state here so coordinators on web/mobile see the
+    /// same truth without the plugin having to track server-side
+    /// DocumentIds itself.
+    ///
+    /// All ACL + role + approval gates of the regular transition path
+    /// still apply.
+    /// </summary>
+    [HttpPost("sync-from-plugin")]
+    public async Task<ActionResult> SyncFromPlugin(Guid projectId, [FromBody] PluginDeliverableSyncRequest req)
+    {
+        if (string.IsNullOrWhiteSpace(req.DocNumber))
+            return BadRequest(new { message = "docNumber is required" });
+
+        var tenantId = GetTenantId();
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId && p.TenantId == tenantId);
+        if (project == null) return NotFound("Project not found");
+        if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
+
+        var userName = User.FindFirst("display_name")?.Value ?? "Plugin";
+
+        // Find by plugin doc number — the plugin's stable identity. Stored
+        // in FileName so the existing register-list endpoints surface it.
+        var doc = await _db.Documents
+            .FirstOrDefaultAsync(d => d.ProjectId == projectId
+                && d.Project!.TenantId == tenantId
+                && d.FileName == req.DocNumber);
+
+        var isCreate = doc == null;
+        if (isCreate)
+        {
+            doc = new DocumentRecord
+            {
+                ProjectId       = projectId,
+                FileName        = req.DocNumber,
+                Description     = req.Title,
+                DocumentType    = req.TemplateId ?? "DELIVERABLE",
+                CdeStatus       = "WIP",
+                SuitabilityCode = "S0",
+                Discipline      = req.Discipline,
+                Originator      = req.Originator,
+                Revision        = req.Revision ?? "P01",
+                UploadedBy      = userName,
+                StatusHistoryJson = JsonConvert.SerializeObject(new[]
+                {
+                    new { timestamp = DateTime.UtcNow, oldState = "", newState = "WIP",
+                          suitability = "S0", user = userName, source = "plugin" }
+                })
+            };
+            _db.Documents.Add(doc);
+        }
+
+        // Phase 177 — ACL on the *target* state and suitability.
+        if (await RequireAclTargetAsync(projectId, doc, req.NewCdeStatus ?? doc.CdeStatus, req.SuitabilityCode)
+                is { } aclDenied)
+            return aclDenied;
+
+        // Apply transition if requested. We bypass the strict ValidTransitions
+        // table here because the plugin owns the source-of-truth lifecycle —
+        // however role + approval gates still run.
+        if (!string.IsNullOrEmpty(req.NewCdeStatus) && req.NewCdeStatus != doc.CdeStatus)
+        {
+            var roleCheck = CheckTransitionRole(doc.CdeStatus, req.NewCdeStatus);
+            if (roleCheck != null) return roleCheck;
+
+            var approvalCheck = await CheckApprovalGate(doc.CdeStatus, req.NewCdeStatus, doc.Id);
+            if (approvalCheck != null) return approvalCheck;
+
+            var oldState = doc.CdeStatus;
+            doc.CdeStatus = req.NewCdeStatus;
+            doc.SuitabilityCode = req.SuitabilityCode
+                ?? DefaultSuitability.GetValueOrDefault(req.NewCdeStatus, doc.SuitabilityCode);
+            if (!string.IsNullOrEmpty(req.Revision)) doc.Revision = req.Revision;
+            doc.UpdatedAt = DateTime.UtcNow;
+
+            var history = !string.IsNullOrEmpty(doc.StatusHistoryJson)
+                ? JsonConvert.DeserializeObject<List<object>>(doc.StatusHistoryJson) ?? new()
+                : new List<object>();
+            history.Add(new
+            {
+                timestamp = DateTime.UtcNow, oldState, newState = req.NewCdeStatus,
+                suitability = doc.SuitabilityCode,
+                user = userName, source = "plugin",
+                pluginAction = req.Action,
+                reason = req.Reason
+            });
+            doc.StatusHistoryJson = JsonConvert.SerializeObject(history);
+        }
+        else if (!string.IsNullOrEmpty(req.Revision) && req.Revision != doc.Revision)
+        {
+            // Pure revision bump (no state change) — common for ReIssue.
+            doc.Revision = req.Revision;
+            doc.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await _db.SaveChangesAsync();
+        await _audit.LogAsync(isCreate ? "PLUGIN_CREATE" : "PLUGIN_TRANSITION",
+            "Document", doc.Id.ToString(),
+            JsonConvert.SerializeObject(new
+            {
+                docNumber = req.DocNumber,
+                action    = req.Action,
+                state     = doc.CdeStatus,
+                revision  = doc.Revision
+            }));
+
+        _ = _hub.Clients.Group($"project-{projectId}").SendAsync("DocumentUpdated", new
+        {
+            projectId, documentId = doc.Id,
+            fileName = doc.FileName, cdeStatus = doc.CdeStatus,
+            revision = doc.Revision, suitability = doc.SuitabilityCode,
+            kind = "plugin_sync"
+        });
+
+        return Ok(new { doc.Id, doc.FileName, doc.CdeStatus, doc.SuitabilityCode, doc.Revision, isCreate });
     }
 
     /// <summary>
@@ -854,6 +994,36 @@ public class DocumentsController : ControllerBase
 
     private Guid GetTenantId() =>
         Guid.TryParse(User.FindFirst("tenant_id")?.Value, out var id) ? id : Guid.Empty;
+
+    /// <summary>
+    /// Phase 177 — return null when the document is within the caller's
+    /// per-folder ACL slice; otherwise return 404. We deliberately 404
+    /// (not 403) so that listing the project never leaks the existence
+    /// of documents the user is not allowed to see.
+    /// </summary>
+    private async Task<ActionResult?> RequireAclAsync(Guid projectId, DocumentRecord doc)
+    {
+        var acl = await Planscape.API.Authorization.ProjectMemberAcl.ResolveAsync(_db, projectId, User);
+        if (!acl.AllowsDocument(doc)) return NotFound();
+        return null;
+    }
+
+    /// <summary>
+    /// Phase 177 — also gate transition *targets*: a member with WIP-only
+    /// access can't transition a doc INTO SHARED. The source state was
+    /// already validated by the AllowsDocument check.
+    /// </summary>
+    private async Task<ActionResult?> RequireAclTargetAsync(
+        Guid projectId, DocumentRecord doc, string newState, string? newSuitability)
+    {
+        var acl = await Planscape.API.Authorization.ProjectMemberAcl.ResolveAsync(_db, projectId, User);
+        if (!acl.AllowsDocument(doc)) return NotFound();
+        if (!acl.AllowsCde(newState))
+            return StatusCode(403, new { message = $"Your access does not include the {newState} CDE state." });
+        if (!string.IsNullOrEmpty(newSuitability) && !acl.AllowsSuitability(newSuitability))
+            return StatusCode(403, new { message = $"Your access does not include suitability {newSuitability}." });
+        return null;
+    }
 
     private UserRole GetUserRole()
     {
@@ -912,4 +1082,17 @@ public record FinalizeUploadRequest(
 public record CdeTransitionRequest(string NewState, string? SuitabilityCode, string? Revision);
 public record MobileTransitionRequest(string NewStatus);
 public record ApprovalRequestBody(string TargetState, string? Comments = null);
+
+// Phase 177 — DeliverableLifecycle → server mirror.
+public record PluginDeliverableSyncRequest(
+    string  DocNumber,            // Plugin's stable id ("PRJ-A-001")
+    string? Title,
+    string? Discipline,
+    string? Originator,
+    string? Revision,
+    string? TemplateId,           // A01 / A02 / A03 / A04 / B06 …
+    string? NewCdeStatus,         // WIP / SHARED / PUBLISHED / ARCHIVE
+    string? SuitabilityCode,      // S0..S7
+    string? Action,               // issued / reissued / published / cancelled / superseded / replaced
+    string? Reason);
 public record ApprovalDecisionBody(string Decision, string? Comments = null);

--- a/Planscape.Server/src/Planscape.API/Controllers/MyActionsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/MyActionsController.cs
@@ -122,9 +122,33 @@ public class MyActionsController : ControllerBase
         // Pending document approvals on the project — anyone with the permission
         // claim can pick one up, so we surface ALL pending approvals to all
         // members rather than gating on RequestedBy.
+        //
+        // Phase 177 — narrow by the caller's per-folder ACL slice so an
+        // approval for a doc they can't see in the documents list never
+        // appears in the inbox either. Discipline + suitability + target
+        // CDE state of the transition are all checked.
+        var acl = await ProjectMemberAcl.ResolveAsync(_db, projectId, User);
+
         var approvalsQuery = _db.DocumentApprovals
             .AsNoTracking()
+            .Include(a => a.Document)
             .Where(a => a.ProjectId == projectId && a.Status == "PENDING");
+
+        // Apply ACL discipline + suitability + transition-target filters in SQL
+        // to avoid pulling rows the user can't act on.
+        if (!acl.BypassesAcl)
+        {
+            if (acl.Disciplines is { Length: > 0 } disc)
+                approvalsQuery = approvalsQuery.Where(a => a.Document != null
+                    && a.Document.Discipline != null
+                    && disc.Contains(a.Document.Discipline));
+            if (acl.Suitabilities is { Length: > 0 } suit)
+                approvalsQuery = approvalsQuery.Where(a => a.Document != null
+                    && suit.Contains(a.Document.SuitabilityCode));
+            if (acl.Cde is { Length: > 0 } cde)
+                approvalsQuery = approvalsQuery.Where(a => a.Document != null
+                    && cde.Contains(a.Document.CdeStatus));
+        }
 
         var approvalCount = await approvalsQuery.CountAsync();
         var approvals = await approvalsQuery

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -54,12 +54,54 @@ public class ProjectMembersController : ControllerBase
                 m.ProjectRole,
                 m.Iso19650Role,
                 m.JoinedAt,
-                m.InvitedBy
+                m.InvitedBy,
+                // Phase 177 — surface the per-folder ACLs so the admin UI
+                // (BCC Project Members tab + mobile project-settings) can
+                // edit them without an extra round-trip per row.
+                m.AllowedCdeStates,
+                m.AllowedDisciplines,
+                m.AllowedSuitabilities
             })
             .OrderBy(m => m.DisplayName)
             .ToListAsync();
 
         return Ok(members);
+    }
+
+    // ── Phase 177 — return *my* ACL slice for this project ─────────────────
+    //
+    // Plugin (BCC Deliverables tab) and mobile (documents.tsx) call this on
+    // project load to learn which CDE-state tabs / discipline filters /
+    // suitability dropdowns the user is permitted to see, so the UI can hide
+    // controls the server would 404 on anyway.
+
+    [HttpGet("me")]
+    public async Task<ActionResult> GetMyAccess(Guid projectId)
+    {
+        if (!await CanAccessProjectAsync(projectId)) return NotFound();
+
+        var subClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        if (!Guid.TryParse(subClaim, out var userId)) return Unauthorized();
+
+        var role = User.FindFirst("role")?.Value ?? "";
+        var bypass = role is "Admin" or "Owner" or "SecurityOfficer";
+
+        var member = await _db.ProjectMembers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.ProjectId == projectId && m.UserId == userId && m.IsActive);
+
+        return Ok(new
+        {
+            projectId,
+            userId,
+            bypassesAcl          = bypass || member == null,
+            projectRole          = member?.ProjectRole,
+            iso19650Role         = member?.Iso19650Role,
+            allowedCdeStates     = ProjectMember.ParseAllowList(member?.AllowedCdeStates)     ?? Array.Empty<string>(),
+            allowedDisciplines   = ProjectMember.ParseAllowList(member?.AllowedDisciplines)   ?? Array.Empty<string>(),
+            allowedSuitabilities = ProjectMember.ParseAllowList(member?.AllowedSuitabilities) ?? Array.Empty<string>(),
+        });
     }
 
     // ── Add a user to the project ──────────────────────────────────────────────
@@ -90,6 +132,9 @@ public class ProjectMembersController : ControllerBase
             existing.Iso19650Role = req.Iso19650Role ?? "M";
             existing.JoinedAt     = DateTime.UtcNow;
             existing.InvitedBy    = GetCurrentUserName();
+            existing.AllowedCdeStates     = ToCsv(req.AllowedCdeStates);
+            existing.AllowedDisciplines   = ToCsv(req.AllowedDisciplines);
+            existing.AllowedSuitabilities = ToCsv(req.AllowedSuitabilities);
 
             var userId1 = Guid.TryParse(User.FindFirst("sub")?.Value, out var uid1) ? uid1 : (Guid?)null;
             _db.AuditLogs.Add(new AuditLog
@@ -114,7 +159,10 @@ public class ProjectMembersController : ControllerBase
             UserId       = req.UserId,
             ProjectRole  = req.ProjectRole  ?? "Contributor",
             Iso19650Role = req.Iso19650Role ?? "M",
-            InvitedBy    = GetCurrentUserName()
+            InvitedBy    = GetCurrentUserName(),
+            AllowedCdeStates     = ToCsv(req.AllowedCdeStates),
+            AllowedDisciplines   = ToCsv(req.AllowedDisciplines),
+            AllowedSuitabilities = ToCsv(req.AllowedSuitabilities)
         };
         _db.ProjectMembers.Add(member);
 
@@ -217,6 +265,9 @@ public class ProjectMembersController : ControllerBase
         if (existing != null)
         {
             existing.IsActive = true; existing.JoinedAt = DateTime.UtcNow;
+            existing.AllowedCdeStates     = ToCsv(req.AllowedCdeStates);
+            existing.AllowedDisciplines   = ToCsv(req.AllowedDisciplines);
+            existing.AllowedSuitabilities = ToCsv(req.AllowedSuitabilities);
         }
         else
         {
@@ -225,7 +276,10 @@ public class ProjectMembersController : ControllerBase
                 ProjectId    = projectId, UserId = user.Id,
                 ProjectRole  = req.ProjectRole  ?? "Contributor",
                 Iso19650Role = req.Iso19650Role ?? "M",
-                InvitedBy    = GetCurrentUserName()
+                InvitedBy    = GetCurrentUserName(),
+                AllowedCdeStates     = ToCsv(req.AllowedCdeStates),
+                AllowedDisciplines   = ToCsv(req.AllowedDisciplines),
+                AllowedSuitabilities = ToCsv(req.AllowedSuitabilities)
             });
         }
 
@@ -265,6 +319,11 @@ public class ProjectMembersController : ControllerBase
 
         if (req.ProjectRole  != null) member.ProjectRole  = req.ProjectRole;
         if (req.Iso19650Role != null) member.Iso19650Role = req.Iso19650Role;
+        // Phase 177 — pass null array to leave a column unchanged; pass an
+        // empty array to clear it; pass a non-empty array to overwrite.
+        if (req.AllowedCdeStates     != null) member.AllowedCdeStates     = ToCsv(req.AllowedCdeStates);
+        if (req.AllowedDisciplines   != null) member.AllowedDisciplines   = ToCsv(req.AllowedDisciplines);
+        if (req.AllowedSuitabilities != null) member.AllowedSuitabilities = ToCsv(req.AllowedSuitabilities);
 
         var userId3 = Guid.TryParse(User.FindFirst("sub")?.Value, out var uid3) ? uid3 : (Guid?)null;
         _db.AuditLogs.Add(new AuditLog
@@ -369,10 +428,43 @@ public class ProjectMembersController : ControllerBase
         var role = User.FindFirst("role")?.Value ?? "";
         return role is "Manager" or "Admin" or "Owner";
     }
+
+    // Phase 177 — normalise inbound array → CSV; null/empty array means
+    // "no narrowing for this axis" so it persists as null.
+    private static string? ToCsv(string[]? arr)
+    {
+        if (arr == null) return null;
+        var cleaned = arr.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToArray();
+        return cleaned.Length == 0 ? null : string.Join(',', cleaned);
+    }
 }
 
 // ── Request DTOs ───────────────────────────────────────────────────────────────
+//
+// Phase 177 — three optional ACL allow-lists are accepted as either CSV
+// ("WIP,SHARED") or string[] from the mobile JSON serialiser. The
+// controller normalises both to CSV before persisting.
 
-public record AddMemberRequest(Guid UserId, string? ProjectRole, string? Iso19650Role);
-public record InviteByEmailRequest(string Email, string? DisplayName, string? ProjectRole, string? Iso19650Role);
-public record UpdateMemberRequest(string? ProjectRole, string? Iso19650Role);
+public record AddMemberRequest(
+    Guid    UserId,
+    string? ProjectRole,
+    string? Iso19650Role,
+    string[]? AllowedCdeStates     = null,
+    string[]? AllowedDisciplines   = null,
+    string[]? AllowedSuitabilities = null);
+
+public record InviteByEmailRequest(
+    string  Email,
+    string? DisplayName,
+    string? ProjectRole,
+    string? Iso19650Role,
+    string[]? AllowedCdeStates     = null,
+    string[]? AllowedDisciplines   = null,
+    string[]? AllowedSuitabilities = null);
+
+public record UpdateMemberRequest(
+    string? ProjectRole,
+    string? Iso19650Role,
+    string[]? AllowedCdeStates     = null,
+    string[]? AllowedDisciplines   = null,
+    string[]? AllowedSuitabilities = null);

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -127,14 +127,16 @@ public class ProjectMembersController : ControllerBase
         {
             if (existing.IsActive) return Conflict("User is already a member of this project");
             // Re-activate
+            // Phase 177-D — preset baseline; explicit request fields still win.
+            var profileExisting = await ResolveProfileAsync(req.AccessProfileId);
             existing.IsActive     = true;
-            existing.ProjectRole  = req.ProjectRole ?? "Contributor";
-            existing.Iso19650Role = req.Iso19650Role ?? "M";
+            existing.ProjectRole  = req.ProjectRole  ?? profileExisting?.DefaultProjectRole  ?? "Contributor";
+            existing.Iso19650Role = req.Iso19650Role ?? profileExisting?.DefaultIso19650Role ?? "M";
             existing.JoinedAt     = DateTime.UtcNow;
             existing.InvitedBy    = GetCurrentUserName();
-            existing.AllowedCdeStates     = ToCsv(req.AllowedCdeStates);
-            existing.AllowedDisciplines   = ToCsv(req.AllowedDisciplines);
-            existing.AllowedSuitabilities = ToCsv(req.AllowedSuitabilities);
+            existing.AllowedCdeStates     = req.AllowedCdeStates     != null ? ToCsv(req.AllowedCdeStates)     : profileExisting?.AllowedCdeStates;
+            existing.AllowedDisciplines   = req.AllowedDisciplines   != null ? ToCsv(req.AllowedDisciplines)   : profileExisting?.AllowedDisciplines;
+            existing.AllowedSuitabilities = req.AllowedSuitabilities != null ? ToCsv(req.AllowedSuitabilities) : profileExisting?.AllowedSuitabilities;
 
             var userId1 = Guid.TryParse(User.FindFirst("sub")?.Value, out var uid1) ? uid1 : (Guid?)null;
             _db.AuditLogs.Add(new AuditLog
@@ -153,16 +155,18 @@ public class ProjectMembersController : ControllerBase
             return Ok(new { message = "Membership re-activated", memberId = existing.Id });
         }
 
+        // Phase 177-D — resolve preset; explicit request fields still win.
+        var profile = await ResolveProfileAsync(req.AccessProfileId);
         var member = new ProjectMember
         {
             ProjectId    = projectId,
             UserId       = req.UserId,
-            ProjectRole  = req.ProjectRole  ?? "Contributor",
-            Iso19650Role = req.Iso19650Role ?? "M",
+            ProjectRole  = req.ProjectRole  ?? profile?.DefaultProjectRole  ?? "Contributor",
+            Iso19650Role = req.Iso19650Role ?? profile?.DefaultIso19650Role ?? "M",
             InvitedBy    = GetCurrentUserName(),
-            AllowedCdeStates     = ToCsv(req.AllowedCdeStates),
-            AllowedDisciplines   = ToCsv(req.AllowedDisciplines),
-            AllowedSuitabilities = ToCsv(req.AllowedSuitabilities)
+            AllowedCdeStates     = req.AllowedCdeStates     != null ? ToCsv(req.AllowedCdeStates)     : profile?.AllowedCdeStates,
+            AllowedDisciplines   = req.AllowedDisciplines   != null ? ToCsv(req.AllowedDisciplines)   : profile?.AllowedDisciplines,
+            AllowedSuitabilities = req.AllowedSuitabilities != null ? ToCsv(req.AllowedSuitabilities) : profile?.AllowedSuitabilities,
         };
         _db.ProjectMembers.Add(member);
 
@@ -262,24 +266,26 @@ public class ProjectMembersController : ControllerBase
         if (existing != null && existing.IsActive)
             return Conflict("User is already a member of this project");
 
+        // Phase 177-D — apply named preset baseline; explicit fields override.
+        var inviteProfile = await ResolveProfileAsync(req.AccessProfileId);
         if (existing != null)
         {
             existing.IsActive = true; existing.JoinedAt = DateTime.UtcNow;
-            existing.AllowedCdeStates     = ToCsv(req.AllowedCdeStates);
-            existing.AllowedDisciplines   = ToCsv(req.AllowedDisciplines);
-            existing.AllowedSuitabilities = ToCsv(req.AllowedSuitabilities);
+            existing.AllowedCdeStates     = req.AllowedCdeStates     != null ? ToCsv(req.AllowedCdeStates)     : inviteProfile?.AllowedCdeStates;
+            existing.AllowedDisciplines   = req.AllowedDisciplines   != null ? ToCsv(req.AllowedDisciplines)   : inviteProfile?.AllowedDisciplines;
+            existing.AllowedSuitabilities = req.AllowedSuitabilities != null ? ToCsv(req.AllowedSuitabilities) : inviteProfile?.AllowedSuitabilities;
         }
         else
         {
             _db.ProjectMembers.Add(new ProjectMember
             {
                 ProjectId    = projectId, UserId = user.Id,
-                ProjectRole  = req.ProjectRole  ?? "Contributor",
-                Iso19650Role = req.Iso19650Role ?? "M",
+                ProjectRole  = req.ProjectRole  ?? inviteProfile?.DefaultProjectRole  ?? "Contributor",
+                Iso19650Role = req.Iso19650Role ?? inviteProfile?.DefaultIso19650Role ?? "M",
                 InvitedBy    = GetCurrentUserName(),
-                AllowedCdeStates     = ToCsv(req.AllowedCdeStates),
-                AllowedDisciplines   = ToCsv(req.AllowedDisciplines),
-                AllowedSuitabilities = ToCsv(req.AllowedSuitabilities)
+                AllowedCdeStates     = req.AllowedCdeStates     != null ? ToCsv(req.AllowedCdeStates)     : inviteProfile?.AllowedCdeStates,
+                AllowedDisciplines   = req.AllowedDisciplines   != null ? ToCsv(req.AllowedDisciplines)   : inviteProfile?.AllowedDisciplines,
+                AllowedSuitabilities = req.AllowedSuitabilities != null ? ToCsv(req.AllowedSuitabilities) : inviteProfile?.AllowedSuitabilities,
             });
         }
 
@@ -317,10 +323,30 @@ public class ProjectMembersController : ControllerBase
             .FirstOrDefaultAsync(m => m.Id == memberId && m.ProjectId == projectId);
         if (member == null) return NotFound();
 
+        // Phase 177-D — apply preset first (if supplied), then let explicit
+        // request fields override individual axes. AccessProfileId is treated
+        // as a one-shot stamp; we don't store the profile id on the member
+        // because later edits to the profile shouldn't retroactively change
+        // existing member rows (audit hygiene).
+        var profile = await ResolveProfileAsync(req.AccessProfileId);
+        if (profile != null)
+        {
+            member.ProjectRole          = profile.DefaultProjectRole;
+            member.Iso19650Role         = profile.DefaultIso19650Role;
+            member.AllowedCdeStates     = profile.AllowedCdeStates;
+            member.AllowedDisciplines   = profile.AllowedDisciplines;
+            member.AllowedSuitabilities = profile.AllowedSuitabilities;
+        }
+
         if (req.ProjectRole  != null) member.ProjectRole  = req.ProjectRole;
         if (req.Iso19650Role != null) member.Iso19650Role = req.Iso19650Role;
         // Phase 177 — pass null array to leave a column unchanged; pass an
         // empty array to clear it; pass a non-empty array to overwrite.
+        var aclTouched =
+            profile != null ||
+            req.AllowedCdeStates     != null ||
+            req.AllowedDisciplines   != null ||
+            req.AllowedSuitabilities != null;
         if (req.AllowedCdeStates     != null) member.AllowedCdeStates     = ToCsv(req.AllowedCdeStates);
         if (req.AllowedDisciplines   != null) member.AllowedDisciplines   = ToCsv(req.AllowedDisciplines);
         if (req.AllowedSuitabilities != null) member.AllowedSuitabilities = ToCsv(req.AllowedSuitabilities);
@@ -339,6 +365,12 @@ public class ProjectMembersController : ControllerBase
         });
 
         await _db.SaveChangesAsync();
+
+        // Phase 177 — re-shard the member's SignalR subscriptions to match the
+        // new allow-list. Fire-and-forget: the response shouldn't block on
+        // hub fan-out, and the broadcast is idempotent if it races with reconnect.
+        if (aclTouched)
+            _ = _membershipNotifier.NotifyAclChangedAsync(member.UserId, projectId);
 
         return Ok(new { member.Id, member.ProjectRole, member.Iso19650Role });
     }
@@ -437,6 +469,20 @@ public class ProjectMembersController : ControllerBase
         var cleaned = arr.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToArray();
         return cleaned.Length == 0 ? null : string.Join(',', cleaned);
     }
+
+    /// <summary>
+    /// Phase 177-D — resolve an AccessProfile into a snapshot of the four
+    /// fields (CSV allow-lists + default roles) so the caller can fold them
+    /// into a ProjectMember row. Returns null if the profile id is null,
+    /// missing, or belongs to a different tenant.
+    /// </summary>
+    private async Task<AccessProfile?> ResolveProfileAsync(Guid? profileId)
+    {
+        if (profileId is null || profileId == Guid.Empty) return null;
+        var tenantId = GetTenantId();
+        return await _db.AccessProfiles.AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == profileId.Value && p.TenantId == tenantId && p.IsActive);
+    }
 }
 
 // ── Request DTOs ───────────────────────────────────────────────────────────────
@@ -444,6 +490,11 @@ public class ProjectMembersController : ControllerBase
 // Phase 177 — three optional ACL allow-lists are accepted as either CSV
 // ("WIP,SHARED") or string[] from the mobile JSON serialiser. The
 // controller normalises both to CSV before persisting.
+//
+// Phase 177-D — AccessProfileId optionally applies a tenant-scoped preset.
+// When supplied, the preset's allow-lists + default roles are copied onto
+// the member; any explicitly-provided fields on the request still win
+// (so a PM can use a profile as the baseline and override one axis).
 
 public record AddMemberRequest(
     Guid    UserId,
@@ -451,7 +502,8 @@ public record AddMemberRequest(
     string? Iso19650Role,
     string[]? AllowedCdeStates     = null,
     string[]? AllowedDisciplines   = null,
-    string[]? AllowedSuitabilities = null);
+    string[]? AllowedSuitabilities = null,
+    Guid?   AccessProfileId        = null);
 
 public record InviteByEmailRequest(
     string  Email,
@@ -460,11 +512,13 @@ public record InviteByEmailRequest(
     string? Iso19650Role,
     string[]? AllowedCdeStates     = null,
     string[]? AllowedDisciplines   = null,
-    string[]? AllowedSuitabilities = null);
+    string[]? AllowedSuitabilities = null,
+    Guid?   AccessProfileId        = null);
 
 public record UpdateMemberRequest(
     string? ProjectRole,
     string? Iso19650Role,
     string[]? AllowedCdeStates     = null,
     string[]? AllowedDisciplines   = null,
-    string[]? AllowedSuitabilities = null);
+    string[]? AllowedSuitabilities = null,
+    Guid?   AccessProfileId        = null);

--- a/Planscape.Server/src/Planscape.Core/Entities/AccessProfile.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/AccessProfile.cs
@@ -1,0 +1,47 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// Phase 177-D — tenant-scoped named ACL preset for the per-folder
+/// permission model on <see cref="ProjectMember"/>. Lets PMs invite
+/// people with a single dropdown ("Trade subcontractor — M only",
+/// "Reviewer", "Client read-only") rather than ticking three multi-
+/// selects per person.
+///
+/// Profiles live at the tenant level so the same naming applies across
+/// every project in the organisation. Applying a profile copies its
+/// allow-list strings onto the new <see cref="ProjectMember"/> row;
+/// later edits to the profile do NOT retroactively rewrite existing
+/// members (that would be surprising audit-wise — the inviter chose a
+/// snapshot at invite time).
+/// </summary>
+public class AccessProfile : ITenantScoped
+{
+    public Guid Id       { get; set; } = Guid.NewGuid();
+    public Guid TenantId { get; set; }
+
+    /// <summary>Display name shown in the picker. Unique per tenant.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>Optional one-line description shown under the name.</summary>
+    public string? Description { get; set; }
+
+    // CSV allow-lists, identical semantics to ProjectMember:
+    //   null     = "all" (no narrowing on this axis)
+    //   non-null = restrict to the listed codes
+    public string? AllowedCdeStates     { get; set; }
+    public string? AllowedDisciplines   { get; set; }
+    public string? AllowedSuitabilities { get; set; }
+
+    /// <summary>Default ProjectRole stamped on the member when applied.</summary>
+    public string DefaultProjectRole { get; set; } = "Contributor";
+
+    /// <summary>Default ISO 19650 role code stamped on the member when applied.</summary>
+    public string DefaultIso19650Role { get; set; } = "M";
+
+    public bool IsActive { get; set; } = true;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public string? CreatedBy { get; set; }
+
+    // Navigation
+    public Tenant? Tenant { get; set; }
+}

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectMember.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectMember.cs
@@ -18,6 +18,30 @@ public class ProjectMember : ITenantScoped
     /// <summary>ISO 19650-2 role code for this project (A/PM/BC/AR/SE/ME/QS etc.).</summary>
     public string Iso19650Role { get; set; } = "M";
 
+    // ── Per-folder ACLs (Phase 177 — document manager review) ───────────────
+    //
+    // Three orthogonal axes that narrow what this member can see and act on
+    // *within* the project. All three default to null which means "inherit
+    // role-tier defaults" so existing rows behave exactly as before. A
+    // populated CSV string restricts the member to that subset.
+    //
+    // - AllowedCdeStates    "WIP,SHARED,PUBLISHED,ARCHIVE"  (or null = all)
+    // - AllowedDisciplines  "M,E,P"                          (or null = all)
+    // - AllowedSuitabilities "S2,S3,S4"                      (or null = all)
+    //
+    // Stored as comma-separated text rather than a join table so the JWT
+    // /me payload stays compact and DocumentsController.GetAll can apply the
+    // filter inline without a second round-trip.
+
+    /// <summary>Comma-separated CDE states this member may see; null = all.</summary>
+    public string? AllowedCdeStates { get; set; }
+
+    /// <summary>Comma-separated discipline codes this member may see; null = all.</summary>
+    public string? AllowedDisciplines { get; set; }
+
+    /// <summary>Comma-separated suitability codes this member may see; null = all.</summary>
+    public string? AllowedSuitabilities { get; set; }
+
     public bool IsActive   { get; set; } = true;
     public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
     public string? InvitedBy { get; set; }
@@ -25,4 +49,27 @@ public class ProjectMember : ITenantScoped
     // Navigation
     public Project?  Project { get; set; }
     public AppUser?  User    { get; set; }
+
+    // ── Helpers (parse + check ACL membership) ──────────────────────────────
+
+    public static string[]? ParseAllowList(string? csv)
+    {
+        if (string.IsNullOrWhiteSpace(csv)) return null;
+        var parts = csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length == 0 ? null : parts;
+    }
+
+    /// <summary>
+    /// Returns true if the supplied value is contained in the allow-list, OR
+    /// the allow-list is null/empty (which means "all"). Case-insensitive.
+    /// </summary>
+    public static bool IsAllowed(string? csv, string? value)
+    {
+        var parts = ParseAllowList(csv);
+        if (parts == null) return true;                   // null = "all"
+        if (string.IsNullOrEmpty(value)) return false;
+        foreach (var p in parts)
+            if (string.Equals(p, value, StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
 }

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260508000000_AddProjectMemberAcls.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260508000000_AddProjectMemberAcls.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable enable
+
+namespace Planscape.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+/// <remarks>
+/// Phase 177 — adds three nullable allow-list columns to <c>ProjectMembers</c>
+/// so a coordinator can be restricted per-CDE-state, per-discipline, and
+/// per-suitability. Null on all three preserves the previous behaviour
+/// (member sees everything in the project).
+///
+/// Stored as comma-separated text rather than a join table to keep the
+/// JWT /me payload compact and the document query filter a single SQL
+/// round-trip; the entity exposes ParseAllowList / IsAllowed helpers.
+/// </remarks>
+public partial class AddProjectMemberAcls : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "AllowedCdeStates",
+            table: "ProjectMembers",
+            type: "text",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "AllowedDisciplines",
+            table: "ProjectMembers",
+            type: "text",
+            nullable: true);
+
+        migrationBuilder.AddColumn<string>(
+            name: "AllowedSuitabilities",
+            table: "ProjectMembers",
+            type: "text",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(name: "AllowedCdeStates",     table: "ProjectMembers");
+        migrationBuilder.DropColumn(name: "AllowedDisciplines",   table: "ProjectMembers");
+        migrationBuilder.DropColumn(name: "AllowedSuitabilities", table: "ProjectMembers");
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260508100000_AddAccessProfiles.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260508100000_AddAccessProfiles.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable enable
+
+namespace Planscape.Infrastructure.Data.Migrations;
+
+/// <inheritdoc />
+/// <remarks>
+/// Phase 177-D — tenant-scoped named ACL presets so a PM can pick a profile
+/// from a single dropdown when inviting a member instead of ticking three
+/// orthogonal allow-lists. See <see cref="Planscape.Core.Entities.AccessProfile"/>.
+/// </remarks>
+public partial class AddAccessProfiles : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "AccessProfiles",
+            columns: table => new
+            {
+                Id                   = table.Column<System.Guid>(type: "uuid", nullable: false),
+                TenantId             = table.Column<System.Guid>(type: "uuid", nullable: false),
+                Name                 = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false),
+                Description          = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                AllowedCdeStates     = table.Column<string>(type: "text", nullable: true),
+                AllowedDisciplines   = table.Column<string>(type: "text", nullable: true),
+                AllowedSuitabilities = table.Column<string>(type: "text", nullable: true),
+                DefaultProjectRole   = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                DefaultIso19650Role  = table.Column<string>(type: "character varying(8)",  maxLength:  8, nullable: false),
+                IsActive             = table.Column<bool>(type: "boolean", nullable: false),
+                CreatedAt            = table.Column<System.DateTime>(type: "timestamp with time zone", nullable: false),
+                CreatedBy            = table.Column<string>(type: "text", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AccessProfiles", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_AccessProfiles_Tenants_TenantId",
+                    column: x => x.TenantId,
+                    principalTable: "Tenants",
+                    principalColumn: "Id",
+                    onDelete: Microsoft.EntityFrameworkCore.Migrations.ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_AccessProfiles_TenantId_Name",
+            table: "AccessProfiles",
+            columns: new[] { "TenantId", "Name" },
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "AccessProfiles");
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/PlanscapeDbContextModelSnapshot.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/PlanscapeDbContextModelSnapshot.cs
@@ -20,6 +20,59 @@ namespace Planscape.Infrastructure.Data.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63)
                 .UseIdentityByDefaultColumns();
 
+            modelBuilder.Entity("Planscape.Core.Entities.AccessProfile", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uuid");
+
+                b.Property<string>("AllowedCdeStates")
+                    .HasColumnType("text");
+
+                b.Property<string>("AllowedDisciplines")
+                    .HasColumnType("text");
+
+                b.Property<string>("AllowedSuitabilities")
+                    .HasColumnType("text");
+
+                b.Property<DateTime>("CreatedAt")
+                    .HasColumnType("timestamp with time zone");
+
+                b.Property<string>("CreatedBy")
+                    .HasColumnType("text");
+
+                b.Property<string>("DefaultIso19650Role")
+                    .IsRequired()
+                    .HasMaxLength(8)
+                    .HasColumnType("character varying(8)");
+
+                b.Property<string>("DefaultProjectRole")
+                    .IsRequired()
+                    .HasMaxLength(32)
+                    .HasColumnType("character varying(32)");
+
+                b.Property<string>("Description")
+                    .HasMaxLength(500)
+                    .HasColumnType("character varying(500)");
+
+                b.Property<bool>("IsActive")
+                    .HasColumnType("boolean");
+
+                b.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(120)
+                    .HasColumnType("character varying(120)");
+
+                b.Property<Guid>("TenantId")
+                    .HasColumnType("uuid");
+
+                b.HasKey("Id");
+
+                b.HasIndex("TenantId", "Name").IsUnique();
+
+                b.ToTable("AccessProfiles");
+            });
+
             modelBuilder.Entity("Planscape.Core.Entities.AuditLog", b =>
             {
                 b.Property<long>("Id")
@@ -1317,6 +1370,17 @@ namespace Planscape.Infrastructure.Data.Migrations
             });
 
             // ── Relationships ──
+
+            modelBuilder.Entity("Planscape.Core.Entities.AccessProfile", b =>
+            {
+                b.HasOne("Planscape.Core.Entities.Tenant", "Tenant")
+                    .WithMany()
+                    .HasForeignKey("TenantId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Tenant");
+            });
 
             modelBuilder.Entity("Planscape.Core.Entities.AppUser", b =>
             {

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/PlanscapeDbContextModelSnapshot.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/PlanscapeDbContextModelSnapshot.cs
@@ -691,6 +691,15 @@ namespace Planscape.Infrastructure.Data.Migrations
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uuid");
 
+                b.Property<string>("AllowedCdeStates")
+                    .HasColumnType("text");
+
+                b.Property<string>("AllowedDisciplines")
+                    .HasColumnType("text");
+
+                b.Property<string>("AllowedSuitabilities")
+                    .HasColumnType("text");
+
                 b.Property<string>("InvitedBy")
                     .HasColumnType("text");
 

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -101,6 +101,7 @@ public class PlanscapeDbContext : DbContext
     public DbSet<Transmittal> Transmittals => Set<Transmittal>();
     public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
     public DbSet<ProjectMember> ProjectMembers => Set<ProjectMember>();
+    public DbSet<AccessProfile> AccessProfiles => Set<AccessProfile>();
     public DbSet<DevicePushToken> DevicePushTokens => Set<DevicePushToken>();
     public DbSet<UserNotificationPreferences> UserNotificationPreferences => Set<UserNotificationPreferences>();
     public DbSet<IssueAttachment> IssueAttachments => Set<IssueAttachment>();
@@ -527,6 +528,18 @@ public class PlanscapeDbContext : DbContext
             e.HasIndex(m => new { m.ProjectId, m.UserId }).IsUnique();
             e.HasOne(m => m.Project).WithMany().HasForeignKey(m => m.ProjectId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne(m => m.User).WithMany().HasForeignKey(m => m.UserId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // ── AccessProfile (Phase 177-D) ──
+        modelBuilder.Entity<AccessProfile>(e =>
+        {
+            e.HasKey(a => a.Id);
+            e.HasIndex(a => new { a.TenantId, a.Name }).IsUnique();
+            e.HasOne(a => a.Tenant).WithMany().HasForeignKey(a => a.TenantId).OnDelete(DeleteBehavior.Cascade);
+            e.Property(a => a.Name).HasMaxLength(120).IsRequired();
+            e.Property(a => a.Description).HasMaxLength(500);
+            e.Property(a => a.DefaultProjectRole).HasMaxLength(32).IsRequired();
+            e.Property(a => a.DefaultIso19650Role).HasMaxLength(8).IsRequired();
         });
 
         // ── DevicePushToken ──

--- a/Planscape.Server/src/Planscape.Infrastructure/SignalR/NotificationHub.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/SignalR/NotificationHub.cs
@@ -66,6 +66,26 @@ public class NotificationHub : Hub
 
         await Groups.AddToGroupAsync(Context.ConnectionId, $"project-{projectId}");
 
+        // Phase 177 — per-CDE-state sub-groups so CDE transition events
+        // ("DocumentUpdated" with kind in cde_transition / plugin_sync /
+        // approval_decided) only fan out to members whose ACL slice
+        // covers the *target* state. Lookup walks the same allow-list
+        // CSV the documents API enforces; falls open ("subscribe to all
+        // states") for Admin/Owner/SecurityOfficer or members with a
+        // null AllowedCdeStates column.
+        var member = await db.ProjectMembers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.ProjectId == pid && m.UserId == userId.Value && m.IsActive);
+
+        var role = Context.User?.FindFirst("role")?.Value ?? "";
+        var bypass = role is "Admin" or "Owner" or "SecurityOfficer" || member == null;
+        var allowedStates = bypass
+            ? new[] { "WIP", "SHARED", "PUBLISHED", "ARCHIVE" }
+            : (Planscape.Core.Entities.ProjectMember.ParseAllowList(member!.AllowedCdeStates)
+                ?? new[] { "WIP", "SHARED", "PUBLISHED", "ARCHIVE" });
+        foreach (var s in allowedStates)
+            await Groups.AddToGroupAsync(Context.ConnectionId, $"project-{projectId}-cde-{s}");
+
         // T3 — presence: record the user + broadcast the delta.
         var displayName = Context.User?.FindFirst("display_name")?.Value
                        ?? Context.User?.Identity?.Name
@@ -83,6 +103,10 @@ public class NotificationHub : Hub
     public async Task LeaveProject(string projectId)
     {
         await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"project-{projectId}");
+        // Phase 177 — leave every per-CDE-state subgroup we may have joined.
+        // SignalR ignores unknown groups, so a blanket remove is safe.
+        foreach (var s in new[] { "WIP", "SHARED", "PUBLISHED", "ARCHIVE" })
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"project-{projectId}-cde-{s}");
         // T3 — drop from the presence tracker + fire a delta.
         var affected = _presence.Leave(Context.ConnectionId);
         foreach (var pid in affected)

--- a/Planscape.Server/src/Planscape.Infrastructure/SignalR/ProjectMembershipNotifier.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/SignalR/ProjectMembershipNotifier.cs
@@ -17,6 +17,14 @@ namespace Planscape.Infrastructure.SignalR;
 public interface IProjectMembershipNotifier
 {
     Task RevokeProjectAccessAsync(Guid userId, Guid projectId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Phase 177 — called when a member's per-folder ACL CSV changes (CDE /
+    /// discipline / suitability). Pushes a "re-join" cue so the client
+    /// drops + re-issues <c>JoinProject</c>, which rebuilds the per-CDE
+    /// subgroup membership against the new allow-list.
+    /// </summary>
+    Task NotifyAclChangedAsync(Guid userId, Guid projectId, CancellationToken ct = default);
 }
 
 public sealed class ProjectMembershipNotifier : IProjectMembershipNotifier
@@ -73,11 +81,22 @@ public sealed class ProjectMembershipNotifier : IProjectMembershipNotifier
 
         var groupName = $"project-{projectId}";
         var connections = _registry.GetConnections(userId);
+        // Phase 177 — also evict from the per-CDE-state subgroups so the
+        // removed user stops receiving CDE-targeted document events too.
+        var cdeGroups = new[]
+        {
+            $"project-{projectId}-cde-WIP",
+            $"project-{projectId}-cde-SHARED",
+            $"project-{projectId}-cde-PUBLISHED",
+            $"project-{projectId}-cde-ARCHIVE",
+        };
         foreach (var conn in connections)
         {
             try
             {
                 await _hub.Groups.RemoveFromGroupAsync(conn, groupName, ct);
+                foreach (var g in cdeGroups)
+                    await _hub.Groups.RemoveFromGroupAsync(conn, g, ct);
             }
             catch (Exception ex)
             {
@@ -99,6 +118,36 @@ public sealed class ProjectMembershipNotifier : IProjectMembershipNotifier
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to broadcast MemberRevoked to user {UserId}", userId);
+        }
+    }
+
+    public async Task NotifyAclChangedAsync(Guid userId, Guid projectId, CancellationToken ct = default)
+    {
+        // Drop the CDE subgroup memberships server-side; the client will
+        // re-call JoinProject which re-attaches against the new allow-list.
+        var connections = _registry.GetConnections(userId);
+        var cdeGroups = new[]
+        {
+            $"project-{projectId}-cde-WIP",
+            $"project-{projectId}-cde-SHARED",
+            $"project-{projectId}-cde-PUBLISHED",
+            $"project-{projectId}-cde-ARCHIVE",
+        };
+        foreach (var conn in connections)
+        foreach (var g in cdeGroups)
+        {
+            try { await _hub.Groups.RemoveFromGroupAsync(conn, g, ct); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Drop {Conn} from {Group}", conn, g); }
+        }
+
+        try
+        {
+            await _hub.Clients.Group($"user_{userId}").SendAsync(
+                "AclChanged", new { projectId }, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to broadcast AclChanged to user {UserId}", userId);
         }
     }
 }

--- a/Planscape/app/(tabs)/documents.tsx
+++ b/Planscape/app/(tabs)/documents.tsx
@@ -12,7 +12,7 @@ import {
   Alert,
 } from 'react-native';
 import { theme, getCDEColor } from '@/utils/theme';
-import { listProjects, listDocuments, transitionCDE, requestDocumentApproval, decideDocumentApproval } from '@/api/endpoints';
+import { listProjects, listDocuments, transitionCDE, requestDocumentApproval, decideDocumentApproval, getMyProjectAccess, type MyProjectAccess } from '@/api/endpoints';
 import type { DocumentRecord, Project, CDEStatus } from '@/types/api';
 import { crashReporter } from '@/services/crashReporter';
 import { useAuthStore } from '@/stores/authStore';
@@ -65,6 +65,8 @@ export default function DocumentsScreen() {
   const [cdeFilter, setCdeFilter] = useState<CDEFilter>('ALL');
   const [selectedDoc, setSelectedDoc] = useState<DocumentRecord | null>(null);
   const [transitioning, setTransitioning] = useState(false);
+  // Phase 177 — per-folder ACL slice for the active user; null = unloaded.
+  const [acl, setAcl] = useState<MyProjectAccess | null>(null);
 
   const loadData = useCallback(async (projectId?: string) => {
     try {
@@ -79,8 +81,15 @@ export default function DocumentsScreen() {
         ? projectList.find((p) => p.id === projectId) ?? projectList[0]
         : projectList[0];
       setActiveProject(target);
-      const docs = await listDocuments(target.id);
+      // Phase 177 — fetch ACL slice in parallel with docs so the chip filter
+      // can hide CDE states the user has no access to. Falls back to a
+      // bypass slice on error so the screen never breaks on a server hiccup.
+      const [docs, aclSlice] = await Promise.all([
+        listDocuments(target.id),
+        getMyProjectAccess(target.id).catch(() => null),
+      ]);
       setDocuments(docs);
+      setAcl(aclSlice);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to load documents';
       setError(msg);
@@ -257,11 +266,16 @@ export default function DocumentsScreen() {
         />
       )}
 
-      {/* CDE status filter strip */}
+      {/* CDE status filter strip — Phase 177 hides chips the user can't access */}
       <FlatList
         horizontal
         showsHorizontalScrollIndicator={false}
-        data={(['ALL', ...CDE_STATES] as CDEFilter[])}
+        data={(['ALL', ...CDE_STATES] as CDEFilter[]).filter((s) => {
+          if (s === 'ALL') return true;
+          if (!acl || acl.bypassesAcl) return true;
+          if (acl.allowedCdeStates.length === 0) return true; // null = all
+          return acl.allowedCdeStates.includes(s);
+        })}
         keyExtractor={(s) => s}
         style={styles.filterStrip}
         contentContainerStyle={styles.filterStripContent}

--- a/Planscape/app/(tabs)/index.tsx
+++ b/Planscape/app/(tabs)/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/api/endpoints';
 import type { DashboardData, Project, BimIssue } from '@/types/api';
 import { useProjectStore } from '@/stores/projectStore';
+import { useInboxStore } from '@/stores/inboxStore';
 
 export default function DashboardScreen() {
   const router = useRouter();
@@ -103,6 +104,20 @@ export default function DashboardScreen() {
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // Phase 177-C — refresh the My Actions tile after the user approves /
+  // rejects something elsewhere in the app. The store is bumped by the
+  // approvals screen; we re-fetch only the small MyActions slice rather
+  // than the full dashboard which is expensive.
+  const inboxVersion = useInboxStore((s) => s.version);
+  useEffect(() => {
+    if (!activeProject) return;
+    getMyActions(activeProject.id, 1).then(
+      (ma) => { setMyActionsTotal(ma.counts.total); setSlaCount(ma.counts.slaBreached); },
+      () => { /* leave previous values */ },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inboxVersion]);
 
   function onRefresh() {
     setRefreshing(true);

--- a/Planscape/app/inbox/_layout.tsx
+++ b/Planscape/app/inbox/_layout.tsx
@@ -4,6 +4,7 @@ export default function InboxLayout() {
   return (
     <Stack screenOptions={{ headerShown: true }}>
       <Stack.Screen name="index" options={{ title: 'My Actions' }} />
+      <Stack.Screen name="approvals" options={{ title: 'Document Approvals' }} />
     </Stack>
   );
 }

--- a/Planscape/app/inbox/approvals.tsx
+++ b/Planscape/app/inbox/approvals.tsx
@@ -28,13 +28,15 @@ export default function ApprovalsScreen() {
 
   const [approvals, setApprovals] = useState<Approval[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [decidingId, setDecidingId] = useState<string | null>(null);
   const [comments, setComments] = useState<Record<string, string>>({});
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (isRefresh = false) => {
     if (!projectId) return;
     setError(null);
+    if (isRefresh) setRefreshing(true);
     try {
       const data = await getMyActions(projectId, 100);
       setApprovals(data.approvals ?? []);
@@ -43,6 +45,7 @@ export default function ApprovalsScreen() {
       setError(msg);
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
   }, [projectId]);
 
@@ -94,7 +97,7 @@ export default function ApprovalsScreen() {
     <ScrollView
       style={styles.root}
       contentContainerStyle={styles.scroll}
-      refreshControl={<RefreshControl refreshing={false} onRefresh={load} />}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={() => load(true)} />}
     >
       {error && <Text style={styles.error}>{error}</Text>}
 

--- a/Planscape/app/inbox/approvals.tsx
+++ b/Planscape/app/inbox/approvals.tsx
@@ -1,0 +1,218 @@
+// Phase 177 — Document approvals inbox.
+//
+// Lists every PENDING DocumentApproval row on the active project that the
+// signed-in user has Manager+ rights to decide on. Approve / Reject are
+// inline actions backed by PUT /api/projects/{id}/documents/{docId}/approval/{aid}.
+// Approving a SHARED→PUBLISHED record unblocks the publishing transition;
+// the originating coordinator can then run the transition from the Revit
+// plugin or the documents tab and the gate is satisfied.
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  View, Text, ScrollView, RefreshControl, TouchableOpacity,
+  StyleSheet, ActivityIndicator, Alert, TextInput,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { theme } from '@/utils/theme';
+import {
+  getMyActions, decideDocumentApproval, type MyActionsPayload,
+} from '@/api/endpoints';
+import { useProjectStore } from '@/stores/projectStore';
+
+type Approval = MyActionsPayload['approvals'][number];
+
+export default function ApprovalsScreen() {
+  const router = useRouter();
+  const activeProject = useProjectStore((s) => s.active);
+  const projectId = activeProject?.id;
+
+  const [approvals, setApprovals] = useState<Approval[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [decidingId, setDecidingId] = useState<string | null>(null);
+  const [comments, setComments] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    if (!projectId) return;
+    setError(null);
+    try {
+      const data = await getMyActions(projectId, 100);
+      setApprovals(data.approvals ?? []);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function decide(ap: Approval, decision: 'APPROVED' | 'REJECTED') {
+    if (!projectId) return;
+    setDecidingId(ap.id);
+    try {
+      await decideDocumentApproval(projectId, ap.documentId, ap.id, decision, comments[ap.id]);
+      setApprovals((cur) => cur.filter((a) => a.id !== ap.id));
+      setComments((c) => { const next = { ...c }; delete next[ap.id]; return next; });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      Alert.alert('Approval failed', msg);
+    } finally {
+      setDecidingId(null);
+    }
+  }
+
+  function confirmReject(ap: Approval) {
+    Alert.alert(
+      'Reject approval?',
+      `Reject ${ap.transition} for ${ap.fileName}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Reject', style: 'destructive', onPress: () => decide(ap, 'REJECTED') },
+      ],
+    );
+  }
+
+  if (!projectId) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>Select a project to see pending approvals.</Text>
+      </View>
+    );
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.root}
+      contentContainerStyle={styles.scroll}
+      refreshControl={<RefreshControl refreshing={false} onRefresh={load} />}
+    >
+      {error && <Text style={styles.error}>{error}</Text>}
+
+      {approvals.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No pending approvals.</Text>
+          <TouchableOpacity onPress={() => router.back()}>
+            <Text style={styles.link}>Back to inbox</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        approvals.map((ap) => (
+          <View key={ap.id} style={styles.card} accessibilityRole="summary">
+            <View style={styles.cardHeader}>
+              <Text style={styles.fileName} numberOfLines={1}>{ap.fileName}</Text>
+              <Text style={styles.transition}>{ap.transition}</Text>
+            </View>
+
+            <Text style={styles.meta}>
+              Requested {formatDate(ap.requestedAt)} by {ap.requestedBy}
+              {ap.discipline ? ` · ${ap.discipline}` : ''}
+            </Text>
+
+            {ap.comments ? <Text style={styles.requesterComment}>“{ap.comments}”</Text> : null}
+
+            <TextInput
+              style={styles.commentBox}
+              placeholder="Comment (optional)"
+              placeholderTextColor={theme.colors.disabled}
+              value={comments[ap.id] ?? ''}
+              onChangeText={(v) => setComments((c) => ({ ...c, [ap.id]: v }))}
+              multiline
+              numberOfLines={2}
+              accessibilityLabel={`Comment for ${ap.fileName}`}
+            />
+
+            <View style={styles.actions}>
+              <TouchableOpacity
+                style={[styles.btn, styles.btnReject]}
+                onPress={() => confirmReject(ap)}
+                disabled={decidingId === ap.id}
+                accessibilityLabel={`Reject ${ap.fileName}`}
+              >
+                <Text style={styles.btnRejectText}>Reject</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.btn, styles.btnApprove]}
+                onPress={() => decide(ap, 'APPROVED')}
+                disabled={decidingId === ap.id}
+                accessibilityLabel={`Approve ${ap.fileName}`}
+              >
+                {decidingId === ap.id
+                  ? <ActivityIndicator color="#fff" />
+                  : <Text style={styles.btnApproveText}>Approve</Text>}
+              </TouchableOpacity>
+            </View>
+          </View>
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+function formatDate(iso: string): string {
+  try { return new Date(iso).toLocaleDateString(); } catch { return iso; }
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: theme.colors.background },
+  scroll: { padding: theme.spacing.md },
+  loading: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.colors.background },
+  empty: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: theme.spacing.lg },
+  emptyText: { color: theme.colors.textSecondary, fontSize: theme.fontSize.md, marginBottom: theme.spacing.md },
+  link: { color: theme.colors.primary, fontSize: theme.fontSize.sm },
+  error: {
+    backgroundColor: '#FFEBEE', color: theme.colors.danger,
+    padding: theme.spacing.sm, borderRadius: theme.borderRadius.sm,
+    marginBottom: theme.spacing.md,
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.md,
+    padding: theme.spacing.md,
+    marginBottom: theme.spacing.md,
+    borderLeftWidth: 4,
+    borderLeftColor: theme.colors.priorityMedium,
+  },
+  cardHeader: {
+    flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center',
+    marginBottom: theme.spacing.xs,
+  },
+  fileName: { flex: 1, fontSize: theme.fontSize.md, fontWeight: '600', color: theme.colors.text },
+  transition: {
+    fontSize: theme.fontSize.xs, fontWeight: '600',
+    color: theme.colors.primary, marginLeft: theme.spacing.sm,
+  },
+  meta: { fontSize: theme.fontSize.xs, color: theme.colors.textSecondary, marginBottom: theme.spacing.xs },
+  requesterComment: {
+    fontSize: theme.fontSize.sm, color: theme.colors.text,
+    fontStyle: 'italic', marginVertical: theme.spacing.xs,
+  },
+  commentBox: {
+    borderWidth: 1, borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.sm,
+    padding: theme.spacing.sm,
+    marginVertical: theme.spacing.sm,
+    color: theme.colors.text,
+    minHeight: 56,
+    textAlignVertical: 'top',
+  },
+  actions: { flexDirection: 'row', gap: theme.spacing.sm },
+  btn: {
+    flex: 1, paddingVertical: theme.spacing.sm,
+    borderRadius: theme.borderRadius.sm,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnApprove:    { backgroundColor: theme.colors.success ?? '#2E7D32' },
+  btnReject:     { backgroundColor: theme.colors.surface, borderWidth: 1, borderColor: theme.colors.danger },
+  btnApproveText: { color: '#fff', fontWeight: '600' },
+  btnRejectText:  { color: theme.colors.danger, fontWeight: '600' },
+});

--- a/Planscape/app/inbox/approvals.tsx
+++ b/Planscape/app/inbox/approvals.tsx
@@ -18,6 +18,7 @@ import {
   getMyActions, decideDocumentApproval, type MyActionsPayload,
 } from '@/api/endpoints';
 import { useProjectStore } from '@/stores/projectStore';
+import { useInboxStore } from '@/stores/inboxStore';
 
 type Approval = MyActionsPayload['approvals'][number];
 
@@ -58,6 +59,9 @@ export default function ApprovalsScreen() {
       await decideDocumentApproval(projectId, ap.documentId, ap.id, decision, comments[ap.id]);
       setApprovals((cur) => cur.filter((a) => a.id !== ap.id));
       setComments((c) => { const next = { ...c }; delete next[ap.id]; return next; });
+      // Phase 177-C — invalidate sibling MyActions screens so the home tab
+      // count + inbox index list refresh next time they're focused.
+      useInboxStore.getState().bump();
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       Alert.alert('Approval failed', msg);

--- a/Planscape/app/inbox/index.tsx
+++ b/Planscape/app/inbox/index.tsx
@@ -20,6 +20,7 @@ import { useRouter } from 'expo-router';
 import { theme, getPriorityColor } from '@/utils/theme';
 import { getMyActions, type MyActionsPayload } from '@/api/endpoints';
 import { useProjectStore } from '@/stores/projectStore';
+import { useInboxStore } from '@/stores/inboxStore';
 
 export default function InboxScreen() {
   const router = useRouter();
@@ -45,7 +46,10 @@ export default function InboxScreen() {
     }
   }, [projectId]);
 
-  useEffect(() => { load(); }, [load]);
+  // Phase 177-C — re-load when an action elsewhere bumps the inbox version
+  // (currently: approve/reject from /inbox/approvals).
+  const inboxVersion = useInboxStore((s) => s.version);
+  useEffect(() => { load(); }, [load, inboxVersion]);
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);

--- a/Planscape/app/inbox/index.tsx
+++ b/Planscape/app/inbox/index.tsx
@@ -129,14 +129,14 @@ export default function InboxScreen() {
         ))}
       </Section>
 
-      {/* Document approvals */}
+      {/* Document approvals — Phase 177 routes to the inline approve/reject screen */}
       <Section title="Pending document approvals" empty={!data?.approvals.length}>
         {data?.approvals.map((ap) => (
           <TouchableOpacity
             key={ap.id}
             style={styles.row}
-            onPress={() => router.push('/(tabs)/documents')}
-            accessibilityLabel={`Open document ${ap.fileName}`}
+            onPress={() => router.push('/inbox/approvals')}
+            accessibilityLabel={`Approve or reject ${ap.fileName}`}
           >
             <View style={[styles.priorityDot, { backgroundColor: theme.colors.priorityMedium }]} />
             <View style={styles.rowBody}>

--- a/Planscape/src/api/endpoints.ts
+++ b/Planscape/src/api/endpoints.ts
@@ -459,9 +459,28 @@ export function requestDocumentApproval(projectId: string, documentId: string, t
   });
 }
 export function decideDocumentApproval(projectId: string, documentId: string, approvalId: string, decision: 'APPROVED' | 'REJECTED', comment?: string): Promise<unknown> {
-  return apiFetch(`/api/projects/${projectId}/documents/${documentId}/approvals/${approvalId}`, {
-    method: 'PUT', body: JSON.stringify({ decision, comment }),
+  // Phase 177 — server route is `/approval/{id}` (singular) per
+  // DocumentsController.DecideApproval, not /approvals/{id}.
+  return apiFetch(`/api/projects/${projectId}/documents/${documentId}/approval/${approvalId}`, {
+    method: 'PUT', body: JSON.stringify({ decision, comments: comment }),
   });
+}
+
+// Phase 177 — per-folder ACL slice for the active user on a project. Used
+// by the documents tab + project-settings UI to hide CDE-state filters,
+// disciplines and suitability codes the user has no access to.
+export interface MyProjectAccess {
+  projectId: string;
+  userId: string;
+  bypassesAcl: boolean;
+  projectRole: string | null;
+  iso19650Role: string | null;
+  allowedCdeStates: string[];
+  allowedDisciplines: string[];
+  allowedSuitabilities: string[];
+}
+export function getMyProjectAccess(projectId: string): Promise<MyProjectAccess> {
+  return apiFetch(`/api/projects/${projectId}/members/me`);
 }
 
 // ── My Actions (Phase 142) ──────────────────────────────────────────────

--- a/Planscape/src/api/endpoints.ts
+++ b/Planscape/src/api/endpoints.ts
@@ -483,6 +483,34 @@ export function getMyProjectAccess(projectId: string): Promise<MyProjectAccess> 
   return apiFetch(`/api/projects/${projectId}/members/me`);
 }
 
+// Phase 177-D — tenant-scoped named ACL presets. PMs pick a profile from a
+// dropdown when inviting / updating members; the server folds the preset
+// allow-lists onto the member row in one call.
+export interface AccessProfile {
+  id: string;
+  name: string;
+  description: string | null;
+  allowedCdeStates: string[];
+  allowedDisciplines: string[];
+  allowedSuitabilities: string[];
+  defaultProjectRole: string;
+  defaultIso19650Role: string;
+  createdAt: string;
+  createdBy: string | null;
+}
+export function listAccessProfiles(): Promise<AccessProfile[]> {
+  return apiFetch(`/api/access-profiles`);
+}
+export function createAccessProfile(body: Partial<AccessProfile>): Promise<AccessProfile> {
+  return apiFetch(`/api/access-profiles`, { method: 'POST', body: JSON.stringify(body) });
+}
+export function updateAccessProfile(id: string, body: Partial<AccessProfile>): Promise<AccessProfile> {
+  return apiFetch(`/api/access-profiles/${id}`, { method: 'PUT', body: JSON.stringify(body) });
+}
+export function deleteAccessProfile(id: string): Promise<void> {
+  return apiFetch(`/api/access-profiles/${id}`, { method: 'DELETE' });
+}
+
 // ── My Actions (Phase 142) ──────────────────────────────────────────────
 // Aggregator endpoint for the BIM/Construction Manager's morning inbox view.
 // Returns counts + the first N rows from each bucket (issues / meeting actions /

--- a/Planscape/src/services/realtimeClient.ts
+++ b/Planscape/src/services/realtimeClient.ts
@@ -50,9 +50,25 @@ export class RealtimeClient {
       'MeetingCreated',
       'MeetingUpdated',
       'PresenceChanged',
+      // Phase 177 — fired by the server when a member's per-folder ACL
+      // changes; the client re-issues JoinProject below to rebuild
+      // the per-CDE-state subgroup memberships against the new slice.
+      'AclChanged',
+      'MemberRevoked',
     ]) {
       this.connection.on(evName, (p: unknown) => this.fire(evName, p));
     }
+
+    // Phase 177 — when the server pushes AclChanged for the active project,
+    // drop the project subscription and re-join so SignalR rebuilds the
+    // per-CDE-state subgroups against the new allow-list.
+    this.connection.on('AclChanged', async (p: { projectId?: string }) => {
+      if (!p?.projectId || p.projectId !== this.currentProjectId) return;
+      try {
+        await this.connection?.invoke('LeaveProject', this.currentProjectId);
+        await this.connection?.invoke('JoinProject', this.currentProjectId);
+      } catch { /* reconnect path will retry */ }
+    });
 
     await this.connection.start();
     await this.connection.invoke('JoinProject', projectId);

--- a/Planscape/src/stores/inboxStore.ts
+++ b/Planscape/src/stores/inboxStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+/**
+ * Phase 177-C — cross-screen invalidation signal for the My Actions inbox.
+ *
+ * When a user approves / rejects a document on the approvals screen, the
+ * locally-rendered list filters the row out, but the home tab's count
+ * tile and the inbox index's "Pending document approvals" section stay
+ * stale until they refetch. Bumping `version` here lets any screen that
+ * reads MyActions watch this counter and trigger a re-load on change
+ * without coupling the screens directly.
+ *
+ * The store is intentionally tiny — no payload, no per-bucket flags. The
+ * one thing screens need is "did anything that affects MyActions just
+ * happen", which a monotonic counter gives them.
+ */
+interface InboxState {
+  version: number;
+  /** Bump after any action that changes the MyActions response shape. */
+  bump: () => void;
+}
+
+export const useInboxStore = create<InboxState>((set, get) => ({
+  version: 0,
+  bump: () => set({ version: get().version + 1 }),
+}));

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -608,6 +608,60 @@ public sealed class PlanscapeServerClient : IDisposable
         catch (Exception ex) { LastError = ex.Message; return false; }
     }
 
+    /// <summary>
+    /// Phase 177 — mirror a plugin DeliverableLifecycle event into the server's
+    /// DocumentRecord/DocumentApproval state. Idempotent (find-or-create on
+    /// DocNumber). Fail-soft: returns false on any error so the plugin keeps
+    /// working offline; the next sync tick can retry.
+    /// </summary>
+    public async Task<bool> SyncDeliverableFromPluginAsync(Guid projectId, object payload)
+    {
+        if (!await EnsureAuthenticatedAsync()) return false;
+        try
+        {
+            var resp = await PostJsonAsync(
+                $"/api/projects/{projectId}/documents/sync-from-plugin", payload);
+            return resp.ok;
+        }
+        catch (Exception ex) { LastError = ex.Message; return false; }
+    }
+
+    /// <summary>
+    /// Phase 177 — fetch the calling user's per-folder ACL slice for the
+    /// project. Mirrors <c>GET /api/projects/{id}/members/me</c>; the BCC
+    /// uses the result to hide CDE tabs / discipline filters the user
+    /// can't access.
+    /// </summary>
+    public async Task<JObject?> GetMyAccessAsync(Guid projectId)
+    {
+        if (!await EnsureAuthenticatedAsync()) return null;
+        try
+        {
+            var resp = await GetAsync($"/api/projects/{projectId}/members/me");
+            return resp.ok ? JObject.Parse(resp.body) : null;
+        }
+        catch (Exception ex) { LastError = ex.Message; return null; }
+    }
+
+    /// <summary>
+    /// Phase 177 — batch-push audit events recorded by the local
+    /// <c>Planscape.Docs.Workflow.AuditLog</c> JSONL chain so the server's
+    /// AuditLog table has the union, not just server-originated rows.
+    /// Capped at 200 events per call by the server.
+    /// </summary>
+    public async Task<bool> PushAuditEventsAsync(Guid projectId, IEnumerable<object> events)
+    {
+        if (!await EnsureAuthenticatedAsync()) return false;
+        try
+        {
+            var resp = await PostJsonAsync(
+                $"/api/projects/{projectId}/audit-events/batch",
+                new { events });
+            return resp.ok;
+        }
+        catch (Exception ex) { LastError = ex.Message; return false; }
+    }
+
     // ── Meetings ───────────────────────────────────────────────────────────────
 
     public async Task<JArray?> GetMeetingsAsync(Guid projectId, bool upcomingOnly = true)

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -2409,6 +2409,16 @@ namespace StingTools.BIMManager
 
                     queue.Enqueue(payload);
                     StingLog.Info($"PluginSyncTickBridge tick: enqueued payload with {count:N0} tagged elements for {doc.Title} (queue depth: {queue.Count})");
+
+                    // Phase 177-B — reconcile any deliverables.json rows
+                    // whose ServerSyncedAt is missing or stale. Fire-and-
+                    // forget; ReconcileAsync caps each pass at 50 rows.
+                    var docCapture = doc;
+                    _ = Task.Run(async () =>
+                    {
+                        try { await Planscape.Docs.Templates.DeliverableServerSync.ReconcileAsync(docCapture); }
+                        catch (Exception ex) { StingLog.Warn($"DeliverableServerSync.Reconcile: {ex.Message}"); }
+                    });
                 }
                 catch (Exception ex)
                 {

--- a/StingTools/Docs/Templates/DeliverableLifecycle.cs
+++ b/StingTools/Docs/Templates/DeliverableLifecycle.cs
@@ -60,6 +60,8 @@ namespace Planscape.Docs.Templates
                 WriteAudit(doc, "doc.superseded", (string)existing.DocNumber,
                     new JObject { ["superseded_by"] = newDocNumber, ["reason"] = reason, ["user"] = issuedBy });
                 Persist(doc, existing);
+                // Phase 177 — mirror to server (fail-soft).
+                DeliverableServerSync.FireAndForget(doc, existing, "superseded", reason);
                 return new LifecycleResult { Updated = existing, TemplateId = "A03", Message = $"Superseded by {newDocNumber}" };
             }
             catch (Exception ex)
@@ -88,6 +90,9 @@ namespace Planscape.Docs.Templates
                 });
                 Persist(doc, existing);
                 Persist(doc, newReplacing);
+                // Phase 177 — mirror both rows to server.
+                DeliverableServerSync.FireAndForget(doc, existing,    "replaced",   reason);
+                DeliverableServerSync.FireAndForget(doc, newReplacing, "replacing",  reason);
                 return new LifecycleResult { Updated = newReplacing, TemplateId = "A04", Message = $"Replaces {existing.DocNumber}" };
             }
             catch (Exception ex)
@@ -123,6 +128,8 @@ namespace Planscape.Docs.Templates
                     ["reason"]      = reason
                 });
                 Persist(doc, d);
+                // Phase 177 — mirror to server (fail-soft, fire-and-forget).
+                DeliverableServerSync.FireAndForget(doc, d, action, reason);
                 return new LifecycleResult { Updated = d, TemplateId = templateId, Message = newStatus };
             }
             catch (Exception ex)
@@ -213,6 +220,11 @@ namespace Planscape.Docs.Templates
         {
             try { AuditLog.Append(doc, action, docId, payload); }
             catch (Exception ex) { StingLog.Warn($"AuditLog unavailable for {action}: {ex.Message}"); }
+            // Phase 177 — stream the same event to the Planscape server so
+            // cross-workstation audit queries see it. Fire-and-forget so a
+            // network blip never breaks the local audit chain.
+            try { DeliverableServerSync.PushAudit(doc, action, "Deliverable", docId, payload); }
+            catch (Exception ex) { StingLog.Warn($"Audit server push failed: {ex.Message}"); }
         }
 
         private static string ResolveProjectRoot(Document doc)

--- a/StingTools/Docs/Templates/DeliverableServerSync.cs
+++ b/StingTools/Docs/Templates/DeliverableServerSync.cs
@@ -1,0 +1,130 @@
+// DeliverableServerSync.cs — Phase 177 (document manager review).
+//
+// Thin glue between the plugin's DeliverableLifecycle (template-engine v1.1)
+// and the Planscape server's DocumentRecord state machine. Called fire-and-
+// forget from inside Issue/ReIssue/Publish/Cancel/Supersede/Replace so the
+// plugin's existing code path is unchanged when the server is unreachable.
+//
+// Resolution flow:
+//   1. Plugin lifecycle mutates deliverables.json + writes local audit row.
+//   2. This sync attempts to map the deliverable to the server's
+//      DocumentRecord by FileName == DocNumber, creating it if absent.
+//   3. CDE state + suitability + revision mirror across.
+//   4. Failures log a warning and are dropped — the next 5-min SyncScheduler
+//      tick (or the next coordinator action) retries automatically.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+using StingTools.BIMManager;
+
+namespace Planscape.Docs.Templates
+{
+    internal static class DeliverableServerSync
+    {
+        /// <summary>
+        /// Fire-and-forget mirror of a lifecycle event. Returns immediately;
+        /// the actual HTTP call runs on the thread pool.
+        /// </summary>
+        public static void FireAndForget(Document doc, dynamic deliverable, string action, string reason)
+        {
+            try
+            {
+                Guid projectId = ResolvePlanscapeProjectId(doc);
+                if (projectId == Guid.Empty) return; // not connected — nothing to do
+
+                var payload = new
+                {
+                    docNumber       = (string)deliverable.DocNumber ?? (string)deliverable.Code,
+                    title           = SafeProp(deliverable, "Title") ?? SafeProp(deliverable, "Description"),
+                    discipline      = SafeProp(deliverable, "Discipline") ?? SafeProp(deliverable, "DISC"),
+                    originator      = SafeProp(deliverable, "Originator") ?? SafeProp(deliverable, "OrgCode"),
+                    revision        = SafeProp(deliverable, "Revision"),
+                    templateId      = SafeProp(deliverable, "TemplateId"),
+                    newCdeStatus    = SafeProp(deliverable, "CDE"),
+                    suitabilityCode = SafeProp(deliverable, "Suitability"),
+                    action          = action,
+                    reason          = reason
+                };
+                if (string.IsNullOrEmpty(payload.docNumber)) return;
+
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        bool ok = await PlanscapeServerClient.Instance
+                            .SyncDeliverableFromPluginAsync(projectId, payload);
+                        if (!ok)
+                            StingLog.Warn($"DeliverableServerSync {action} for {payload.docNumber} failed: " +
+                                          $"{PlanscapeServerClient.Instance.LastError}");
+                    }
+                    catch (Exception ex) { StingLog.Warn($"DeliverableServerSync exception: {ex.Message}"); }
+                });
+            }
+            catch (Exception ex) { StingLog.Warn($"DeliverableServerSync.FireAndForget: {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// Push a single audit row to the server. Buffered so the next
+        /// successful audit tick mops it up if the server is offline.
+        /// </summary>
+        public static void PushAudit(Document doc, string action, string entityType, string entityId, JObject details)
+        {
+            try
+            {
+                Guid projectId = ResolvePlanscapeProjectId(doc);
+                if (projectId == Guid.Empty) return;
+
+                var ev = new
+                {
+                    action,
+                    entityType,
+                    entityId,
+                    detailsJson = details?.ToString(Newtonsoft.Json.Formatting.None),
+                    timestamp   = DateTime.UtcNow
+                };
+
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await PlanscapeServerClient.Instance.PushAuditEventsAsync(
+                            projectId, new object[] { ev });
+                    }
+                    catch (Exception ex) { StingLog.Warn($"DeliverableServerSync.PushAudit: {ex.Message}"); }
+                });
+            }
+            catch (Exception ex) { StingLog.Warn($"DeliverableServerSync.PushAudit: {ex.Message}"); }
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────
+
+        private static Guid ResolvePlanscapeProjectId(Document doc)
+        {
+            try
+            {
+                string bimDir = ProjectFolderEngine.GetMetaPath(doc, "STING_BIM_MANAGER");
+                if (string.IsNullOrEmpty(bimDir)) return Guid.Empty;
+                string cfgPath = Path.Combine(bimDir, "planscape_connection.json");
+                return PlatformSyncCommand.LoadPlanscapeProjectId(cfgPath);
+            }
+            catch { return Guid.Empty; }
+        }
+
+        private static string SafeProp(dynamic obj, string name)
+        {
+            try
+            {
+                if (obj == null) return null;
+                var t = obj.GetType();
+                var p = t.GetProperty(name);
+                return p?.GetValue(obj) as string;
+            }
+            catch { return null; }
+        }
+    }
+}

--- a/StingTools/Docs/Templates/DeliverableServerSync.cs
+++ b/StingTools/Docs/Templates/DeliverableServerSync.cs
@@ -12,6 +12,11 @@
 //   3. CDE state + suitability + revision mirror across.
 //   4. Failures log a warning and are dropped — the next 5-min SyncScheduler
 //      tick (or the next coordinator action) retries automatically.
+//
+// ReconcileAsync (Phase 177-B): walks deliverables.json and pushes any row
+// whose ServerSyncedAt is missing or older than its row UpdatedAt. Called
+// on login + each SyncScheduler tick so an event that fired while offline
+// still reaches the server even if the user stops touching the project.
 
 using System;
 using System.IO;
@@ -52,15 +57,24 @@ namespace Planscape.Docs.Templates
                 };
                 if (string.IsNullOrEmpty(payload.docNumber)) return;
 
+                string docNumberCapture = payload.docNumber;
+                Document docCapture = doc;
                 _ = Task.Run(async () =>
                 {
                     try
                     {
                         bool ok = await PlanscapeServerClient.Instance
                             .SyncDeliverableFromPluginAsync(projectId, payload);
-                        if (!ok)
-                            StingLog.Warn($"DeliverableServerSync {action} for {payload.docNumber} failed: " +
+                        if (ok)
+                        {
+                            try { StampSyncedAt(docCapture, docNumberCapture, DateTime.UtcNow); }
+                            catch (Exception ex) { StingLog.Warn($"StampSyncedAt failed: {ex.Message}"); }
+                        }
+                        else
+                        {
+                            StingLog.Warn($"DeliverableServerSync {action} for {docNumberCapture} failed: " +
                                           $"{PlanscapeServerClient.Instance.LastError}");
+                        }
                     }
                     catch (Exception ex) { StingLog.Warn($"DeliverableServerSync exception: {ex.Message}"); }
                 });
@@ -101,7 +115,157 @@ namespace Planscape.Docs.Templates
             catch (Exception ex) { StingLog.Warn($"DeliverableServerSync.PushAudit: {ex.Message}"); }
         }
 
+        /// <summary>
+        /// Phase 177-B — pull deliverables.json off disk and push every row
+        /// whose ServerSyncedAt is missing or earlier than its UpdatedAt
+        /// (or its rev-history's most recent timestamp). Called on login
+        /// success and on every periodic sync tick so a lifecycle event
+        /// that fired while offline still reaches the server even if the
+        /// user never touches the project again.
+        ///
+        /// Bounded to 50 rows per call so a never-synced project doesn't
+        /// hammer the server in one go. The next tick mops up the next 50.
+        /// </summary>
+        public static async Task<int> ReconcileAsync(Document doc)
+        {
+            try
+            {
+                Guid projectId = ResolvePlanscapeProjectId(doc);
+                if (projectId == Guid.Empty) return 0;
+
+                string path = DeliverablesJsonPath(doc);
+                if (!File.Exists(path)) return 0;
+
+                JArray arr;
+                try { arr = JArray.Parse(File.ReadAllText(path)); }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"ReconcileAsync — deliverables.json parse failed: {ex.Message}");
+                    return 0;
+                }
+
+                int pushed = 0;
+                foreach (var token in arr)
+                {
+                    if (pushed >= 50) break;
+                    if (token is not JObject row) continue;
+                    if (!NeedsSync(row)) continue;
+
+                    string docNumber = row.Value<string>("DocNumber") ?? row.Value<string>("Code");
+                    if (string.IsNullOrEmpty(docNumber)) continue;
+
+                    var payload = new
+                    {
+                        docNumber       = docNumber,
+                        title           = row.Value<string>("Title")      ?? row.Value<string>("Description"),
+                        discipline      = row.Value<string>("Discipline") ?? row.Value<string>("DISC"),
+                        originator      = row.Value<string>("Originator") ?? row.Value<string>("OrgCode"),
+                        revision        = row.Value<string>("Revision"),
+                        templateId      = row.Value<string>("TemplateId"),
+                        newCdeStatus    = row.Value<string>("CDE"),
+                        suitabilityCode = row.Value<string>("Suitability"),
+                        action          = "reconcile",
+                        reason          = "offline_replay"
+                    };
+
+                    bool ok = await PlanscapeServerClient.Instance
+                        .SyncDeliverableFromPluginAsync(projectId, payload);
+                    if (!ok)
+                    {
+                        StingLog.Warn($"Reconcile {docNumber} failed: " +
+                                      $"{PlanscapeServerClient.Instance.LastError}");
+                        // Stop on first failure so we don't burn round-trips
+                        // when the server is throwing 5xx — next tick retries.
+                        break;
+                    }
+
+                    row["ServerSyncedAt"] = DateTime.UtcNow;
+                    pushed++;
+                }
+
+                if (pushed > 0)
+                {
+                    string tmp = path + ".tmp";
+                    File.WriteAllText(tmp, arr.ToString(Newtonsoft.Json.Formatting.Indented));
+                    if (File.Exists(path)) File.Delete(path);
+                    File.Move(tmp, path);
+                    StingLog.Info($"DeliverableServerSync.Reconcile pushed {pushed} row(s).");
+                }
+                return pushed;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ReconcileAsync: {ex.Message}");
+                return 0;
+            }
+        }
+
         // ── Helpers ────────────────────────────────────────────────────────
+
+        private static bool NeedsSync(JObject row)
+        {
+            DateTime synced = row["ServerSyncedAt"]?.Type == JTokenType.Date
+                ? row["ServerSyncedAt"].Value<DateTime>()
+                : DateTime.MinValue;
+
+            // The lifecycle bumps revision history; treat the latest history
+            // entry's timestamp as the row's "updatedAt" if no explicit field.
+            DateTime updated = row["UpdatedAt"]?.Type == JTokenType.Date
+                ? row["UpdatedAt"].Value<DateTime>()
+                : DateTime.MinValue;
+
+            if (row["RevisionHistory"] is JArray history && history.Count > 0)
+            {
+                var last = history[history.Count - 1] as JObject;
+                if (last?["Timestamp"] != null
+                    && DateTime.TryParse(last["Timestamp"].Value<string>(), out var ts))
+                    if (ts > updated) updated = ts;
+            }
+
+            // Never-synced rows always need a push if we have any signal of activity.
+            if (synced == DateTime.MinValue) return updated > DateTime.MinValue;
+            return updated > synced;
+        }
+
+        private static void StampSyncedAt(Document doc, string docNumber, DateTime ts)
+        {
+            string path = DeliverablesJsonPath(doc);
+            if (!File.Exists(path)) return;
+            JArray arr = JArray.Parse(File.ReadAllText(path));
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] is JObject o
+                    && string.Equals(o.Value<string>("DocNumber") ?? o.Value<string>("Code"),
+                                     docNumber, StringComparison.Ordinal))
+                {
+                    o["ServerSyncedAt"] = ts;
+                    string tmp = path + ".tmp";
+                    File.WriteAllText(tmp, arr.ToString(Newtonsoft.Json.Formatting.Indented));
+                    if (File.Exists(path)) File.Delete(path);
+                    File.Move(tmp, path);
+                    return;
+                }
+            }
+        }
+
+        private static string DeliverablesJsonPath(Document doc)
+        {
+            try
+            {
+                string consolidated = StingTools.Core.ProjectFolderEngine.GetDataPath(doc);
+                if (!string.IsNullOrEmpty(consolidated))
+                    return Path.Combine(consolidated, "_BIM_COORD", "deliverables.json");
+            }
+            catch { /* ignored */ }
+            try
+            {
+                string p = doc?.PathName;
+                if (!string.IsNullOrEmpty(p))
+                    return Path.Combine(Path.GetDirectoryName(p) ?? "", "_BIM_COORD", "deliverables.json");
+            }
+            catch { /* ignored */ }
+            return Path.Combine(Path.GetTempPath(), "Planscape", "BIMCoord", "deliverables.json");
+        }
 
         private static Guid ResolvePlanscapeProjectId(Document doc)
         {

--- a/docs/DOCUMENT_MANAGER_GUIDE.md
+++ b/docs/DOCUMENT_MANAGER_GUIDE.md
@@ -42,9 +42,14 @@ Every document has these pieces, regardless of which door you're using:
 - **Revision** — `P01`, `P02`, … (preliminary), `C01`, `C02`, … (construction).
 - **Status history** — every transition, who did it, when, why.
 - **Approvals** — who signed it off (where required by ISO 19650-2 §5.6).
+- **Versions** — every upload of the same filename creates a new `DocumentVersion` row, so you can roll back or compare.
 - **The file itself** (PDF / DOCX / DWG / IFC / RVT / etc.).
 
 In the plugin you'll also see a **deliverables register** (`deliverables.json`) and **rendered output** (`generated/*.docx` for transmittals, RFIs, MR forms, etc.). These mirror to the server automatically.
+
+**Two sibling features attached to documents:**
+- **Sticky notes** on individual model elements — attached coordination markup that travels with the element (covered in detail below).
+- **Briefcase** — a curated reference library of read-only project documents you can browse without leaving Revit (covered below).
 
 ---
 
@@ -191,9 +196,279 @@ For site-walks, photo evidence, defect reports.
 2. The file lands as an **issue attachment** in WIP.
 3. Promote to SHARED if it needs to feed an RFI, or PUBLISHED if it's a formal handover photo.
 
+**Geofencing**: if the project has a boundary polygon configured, the server checks the device's GPS coordinates on upload and rejects any "site photo" taken outside the geofence. This stops people from claiming office desk-photos as site evidence.
+
+**Antivirus scanning**: every uploaded file is queued for scanning. Until the scan completes, downloads return HTTP 423 (Locked) — a clean retry. If a virus is found, downloads return 451 with the threat name and the file is quarantined.
+
 ---
 
-## Best-practice workflows
+## Sticky notes — per-element coordination markup
+
+Sticky notes are **comments stuck to individual Revit elements**. They're not file documents — they're parameter values on the element itself (`STING_STICKY_NOTE_TXT` + `STING_NOTE_AUTHOR_TXT` + `STING_NOTE_DATE_TXT`) plus a project-level index in `_BIM_COORD/sticky_notes.json`.
+
+Use them for **coordination markup that travels with the model**: "check this clash with M&E", "confirm structural load", "QA review required before issue".
+
+### What you can do
+
+| Action | Where | What it does |
+|---|---|---|
+| **Add note** | Select element(s) → Sticky Notes → Add | Writes a timestamped note to each selected element. Multiple notes pipe-separated (`note1 \| note2`). |
+| **View notes** | Select element(s) → Sticky Notes → View | Shows all notes on the selection in a TaskDialog. |
+| **Clear notes** | Select element(s) → Sticky Notes → Clear | Wipes the note + author + date parameters. |
+| **Quick Note** (dialog) | Document Management dialog → Notes & Briefcase | Single-element inline note from the WPF dialog. |
+| **Bulk Delete** | Document Management dialog → Bulk Delete | Removes every sticky note in the project (use with care — irreversible). |
+| **Export to CSV** | Sticky Notes → Export | All notes across the project, with element id, category, tag, author, date, text. Lands under the chosen output directory. |
+| **Select sticky elements** | Sticky Notes → Select | Selects every element in the project that has a note. Useful for "show me everything that's flagged". |
+| **Categories breakdown** | Sticky Note Categories | Counts notes per discipline/category — quickly answers "where are all the open coordination items?". |
+| **Sticky Dashboard** | Sticky Note Dashboard | Aggregate view: total notes, by author, by date, by discipline. |
+| **Search** | Sticky Note Search | Free-text search across all notes; jumps to matching elements. |
+
+### Best uses
+
+- **Pre-issue QA pass** — coordinator walks the model, drops "QA REVIEW REQUIRED" notes (verification checkbox preset) on flagged elements. Discipline lead clears them as each is fixed. Issue gate: 0 sticky notes outstanding.
+- **Cross-discipline coordination** — M&E coordinator drops "check clash with structural beam" on a duct. Structural lead sees the note when they next select the element. No email thread needed.
+- **Site-to-office feedback loop** — site engineer photos a defect, mobile creates an issue. Office BIM coordinator finds the linked element in Revit, attaches a sticky note for the design team.
+- **Meeting action capture** — during a coordination meeting, drop notes on the elements discussed. Export to CSV at end of meeting → distribute as minutes annex.
+
+### Sticky notes ≠ documents
+
+A sticky note is **on an element**, not in a CDE drawer. It doesn't have suitability or a publishing gate. It's coordination metadata. Don't confuse it with the deliverable register.
+
+---
+
+## Briefcase — read-only project reference library
+
+The briefcase has **two distinct features that share the name** — pay attention to which one you want:
+
+### 1. Briefcase Viewer (`Briefcase` / `View Briefcase`)
+
+An **in-Revit document reader** for project-reference files. Lets you check the BEP, read a transmittal, or browse the COBie spreadsheet **without leaving Revit and without breaking your modeling flow**.
+
+It auto-discovers and indexes:
+
+| Source | Item type | Where it comes from |
+|---|---|---|
+| BIM Execution Plan | BEP | `_BIM_COORD/bim_execution_plan.json` (generated by BEP wizard) |
+| Project dashboard | Dashboard | `_BIM_COORD/project_dashboard.json` |
+| Issue register | Issues | `_BIM_COORD/issues.json` (BCF-compatible) |
+| Document register | DocReg | `_BIM_COORD/documents.json` |
+| Transmittals | Transmittal | `_BIM_COORD/transmittals.json` |
+| Review register | Reviews | `_BIM_COORD/reviews.json` |
+| COBie outputs | COBie | `_BIM_COORD/cobie_*.csv` and `*.xlsx` |
+| User-added files | Reference | Any PDF / spreadsheet dropped into `_BIM_COORD/reference/` |
+| STING reference docs | Reference | Tag Guide V3, Parameter Registry from the plugin's data folder |
+
+**Add file**: click "Add File" to copy any PDF, DOCX, or XLSX into the project's reference folder so the whole team has it without leaving Revit.
+
+**Read mode**: opens the file inline (text + tabular preview, capped at the first 200 lines for safety) or launches the OS default app for the full document.
+
+### 2. Document Briefcase generator (`DocumentBriefcase`)
+
+A **portable handover package** — one click, produces an 8-file folder you can zip and email. Different purpose entirely.
+
+When clicked, exports to `_data/17_BRIEFCASE_<code>/<modelName>_Briefcase_<timestamp>/`:
+
+| # | File | Purpose |
+|---|---|---|
+| 1 | Project Information Summary | Project code, client, organisation, phase, classification |
+| 2 | Tag Register | Every tagged element with full 8-segment tag + element id + category + level |
+| 3 | Compliance Report | ISO 19650 compliance scores per discipline + per phase |
+| 4 | Parameter Audit | Tag completeness — which tokens are missing on which categories |
+| 5 | Model Statistics | Element counts by category, view counts, sheet counts, family counts |
+| 6 | Sheet Index | Every sheet number + name + revision + discipline |
+| 7 | Discipline Breakdown | Counts per discipline (A/S/M/E/P) |
+| 8 | MIDP Register | Master Information Delivery Plan: every deliverable with status |
+
+**When to use which:**
+
+- **Briefcase Viewer**: daily — quick lookup of the BEP or a transmittal while you're modeling.
+- **Document Briefcase generator**: at stage gates and project end — for handover to the client or to a coordinating party. Time-stamped folder, zip it, attach it to a transmittal.
+
+---
+
+## Document Register — your project's master file list
+
+The **Document Register** is the read-only project-wide index of every document tracked by the system. Open from the BIM Coordination Center → **Doc Register** button.
+
+What it shows (per row):
+
+- File name (ISO 19650 8-segment)
+- Document type (drawing, specification, model, schedule, etc.)
+- Discipline
+- Originator
+- Current revision
+- CDE state (WIP / SHARED / PUBLISHED / ARCHIVE) — colour-coded
+- Suitability code
+- Last update date
+- Author / responsible
+
+**Filters**: discipline, type, CDE state, suitability — narrows the view to "all M&E drawings issued for construction" or "everything S3 awaiting review".
+
+**Drawing Register Schedule**: a Revit-native variant lives as `STING - Drawing Register` schedule, populated automatically from sheet parameters. Useful for embedding the register on a sheet itself (e.g. a transmittal cover sheet).
+
+**Add Document**: manual register entry for files that don't go through upload — e.g. an external consultant's PDF received via email.
+
+**Validate Naming**: dry-run check against the ISO 19650 pattern before upload. Returns structured per-segment errors.
+
+---
+
+## CDE Status — health check per drawer
+
+The **CDE Status** screen (BCC button) is a one-screen summary:
+
+```
+WIP        ████████████░░░  240 docs  [last update 14 min ago]
+SHARED     ████░░░░░░░░░░░   75 docs  [last update 2 h ago]
+PUBLISHED  ██░░░░░░░░░░░░░   38 docs  [last update yesterday]
+ARCHIVE    █░░░░░░░░░░░░░░   12 docs
+```
+
+Plus per-discipline breakdown, suitability mix, and "stale" detection (docs sitting in WIP > 30 days, SHARED > 14 days). Click any row to drill into the affected docs.
+
+**Use this to spot bottlenecks**: a queue building up in SHARED means approvals are stuck; a long WIP tail means drafts aren't getting reviewed.
+
+---
+
+## Review Tracker — coordinated-review state
+
+For documents in SHARED awaiting review/comment, the **Review Tracker** maintains a register of who's reviewing what:
+
+- **Per-document review status** — Open / In Review / Commented / Approved / Rejected.
+- **Reviewer assignments** — typically one per discipline (e.g. M&E coordinator reviews structural drawings for clash impact).
+- **Comment threads** — captured against the document, exported with the transmittal acknowledgement.
+- **SLA timers** — review windows (e.g. 5 working days for S2, 10 for S3) automatically tracked; overdue reviews surface on the BCC dashboard.
+
+The review register is a sibling to the document register — the document is the **artefact**, the review is the **process** around it.
+
+---
+
+## MIDP Tracker — the delivery plan
+
+**MIDP** = Master Information Delivery Plan (ISO 19650-2 §5.4). The plan that says: "by milestone X, the team will deliver these N documents at suitability Y."
+
+The MIDP Tracker (BCC button or `MidpTracker` command) shows:
+
+- **Total deliverables** — every row in `deliverables.json` plus published sheets.
+- **Sheets published vs total** — `38/240` style ratio.
+- **Linked models** — models referenced in the federation.
+- **Suitability breakdown** — how many at each S-code.
+- **By discipline** — per-discipline counts.
+- **By status** — WIP / SHARED / PUBLISHED / ARCHIVE / SUPERSEDED.
+
+This is the **report you send to the client** at each gate review. The Document Briefcase exports a copy as file #8.
+
+---
+
+## Distribution Groups — recipient management
+
+Transmittals and issued deliverables go to people. Rather than re-typing the recipient list every time, **distribution groups** let you save named recipient lists:
+
+- **By type/role/suitability**: "Client Distribution — Drawing — Architect — S4" automatically suggests itself when you create a transmittal matching those criteria.
+- **Project Team list** — typically one default group covering the full team (lead designers + coordinator + PM).
+- **Discipline-specific** — "Structural Reviewers", "M&E Subs", etc.
+- **Client distribution** — usually for S4+ only.
+
+Stored in `_BIM_COORD/distribution_groups.json`. Edit via the Document Management dialog → Distribution Groups tab. The transmittal orchestrator suggests the best-match group automatically based on the document's type / role / suitability triple.
+
+---
+
+## Document search — find anything
+
+A **Lucene full-text index** (under `_BIM_COORD/search_index/`) covers the document register + deliverables + transmittals + sticky notes. Open from the dock-panel search bar or from the Document Management dialog.
+
+**Query operators**:
+
+- `discipline:M` — only mechanical
+- `cde:SHARED` — only docs in SHARED
+- `suitability:S3` — only S3
+- `revision:P03` — exact revision
+- `before:2025-04-01` / `after:2025-04-01` — date range
+- Free text — searched across file name + description + author + comments
+
+**Saved searches**: stash a frequently-used query under a name. Stored per-user in `saved_searches.json`. The Sticky Note Search command and the Quick Search bar both use the saved search list.
+
+**Cross-project global search**: `/api/search?q=...` on the server hits all projects the user has access to (subject to ACL slice).
+
+---
+
+## Versions and revision compare
+
+Every upload of the same filename creates a new `DocumentVersion` row. The current `DocumentRecord` always points at the latest; older versions are kept indefinitely (subject to retention policy).
+
+| Action | Result |
+|---|---|
+| **View versions** | `/documents/{id}/versions` lists every version with size, hash, uploader, timestamp |
+| **Download specific version** | `/documents/{id}/versions/{n}/download` gets the historical bytes |
+| **Revision Compare** | Side-by-side diff of two versions for tagged Revit elements (BCC → Revisions tab) |
+| **Track Element Revisions** | Stamps `STING_REVISION_TXT` on every element so a schedule can show what changed between issues |
+| **Revision Cloud Auto-Create** | Generates revision clouds on changed sheet regions automatically |
+
+ACL applies to versions — a user denied on the head document can't read its history either.
+
+---
+
+## COBie — facilities-management handover
+
+COBie (Construction Operations Building Information Exchange, BS 1192-4:2014) is the structured handover format for FM data. The plugin has full COBie support:
+
+| Action | Class | Purpose |
+|---|---|---|
+| **COBie Export** | `COBieExportCommand` | Exports a full COBie 2.4 workbook (19 worksheets — Facility, Floor, Space, Zone, Type, Component, System, Assembly, Connection, Spare, Resource, Job, Document, Attribute, Coordinate, Issue, Impact, Contact + Picklists) as XLSX |
+| **COBie Import** | `COBieImportCommand` | Reads back an external COBie workbook to populate / update the model parameters |
+| **COBie Type Map** | `COBieDataCommands` | Browse the 70+ equipment-type mappings (HVAC, plumbing, electrical, fire, etc.) |
+| **COBie Picklists** | `COBieDataCommands` | View / edit the controlled vocabularies (124 entries) |
+| **COBie Job Templates** | `COBieDataCommands` | SFG20 / BS 8210 maintenance job templates (47 entries) |
+| **COBie Spare Parts** | `COBieDataCommands` | Spare-part templates per equipment type (38 entries) |
+
+**22 project-type presets** ship with the plugin (Office, School, Hospital, Hotel, Retail, Datacenter, etc.) — pick the closest match, the COBie output structure pre-fills with the relevant equipment categories.
+
+**When to run**: at handover (S6 or S7 stage). The output goes to the FM team and feeds the Asset Information Model.
+
+---
+
+## BCF — issue interchange
+
+**BCF** (BIM Collaboration Format) is the cross-tool standard for issue interchange. The plugin can:
+
+- **BCF Export** — every issue in the project becomes a BCF 2.1 topic with viewpoint, screenshot, and comment thread. Output is a `.bcfzip` file for sharing with consultants on different software.
+- **BCF Import** — read incoming BCF zips and create matching issues in the project.
+
+Useful for round-tripping issues with non-Revit consultants (Navisworks, Solibri, Tekla).
+
+---
+
+## Workflow engine — the timed lifecycle
+
+Every transmittal / RFI / TQ / MR creates a **workflow instance** with timed states. The engine ships 5 default workflows:
+
+| Workflow | States | SLAs |
+|---|---|---|
+| `transmittal_default` | Draft → Issued → Acknowledged | 24 / 72 / ∞ hr |
+| `rfi_default` | Open → Reviewed → Responded → Closed | 24 / 48 / 168 / ∞ hr |
+| `tq_default` | Open → Answered | 48 / ∞ hr |
+| `mr_default` | Draft → Submitted → Approved/Rejected | varies |
+| `deliverable_issue_default` | WIP → Shared → Published → Archived | matches CDE |
+
+**SLA breaches** auto-surface on the My Actions inbox + the BCC dashboard. The workflow engine runs a periodic SLA scanner that emits notifications when a step is overdue.
+
+**Custom workflows**: PMs can author project-specific workflows in JSON, drop them in `_BIM_COORD/workflows/`, and the engine picks them up. Useful for project-specific approval chains (e.g. design-review-board sign-off requiring 3 of 5 reviewers).
+
+---
+
+## Audit log — tamper-evident history
+
+Every document operation writes a row to **two places**:
+
+1. **Local JSONL chain** at `_BIM_COORD/audit_log_YYYY_MM.jsonl` — SHA-256 chained, each row references the previous row's hash. Tamper a row and `VerifyChain` fails on the next call.
+2. **Server `AuditLogs` table** — same SHA-256 chaining mechanism server-side, ingested via `POST /audit-events/batch` with action prefix forced to `plugin.` so a malicious client can't spoof admin events.
+
+**What's logged**: every CDE transition, every approval decision, every member ACL change, every transmittal send, every workflow state change, every document upload + delete. **Not** logged: read operations (would 100× the volume).
+
+**Retention**: server side is partitioned monthly; cold partitions detach to object storage. Local JSONL grows by month — old months can be archived but never edited.
+
+**Verification command** on the server: `/api/admin/audit/verify` walks the chain and reports any break. Required for SOC2 / ISO 27001 audits.
+
+---
 
 These are the streamlined recipes that work well in practice. Adapt them to your project structure.
 
@@ -258,11 +533,52 @@ You'll see PUBLISHED + ARCHIVE only.
 2. PDFs / DWGs are downloadable; rendered transmittals and meeting minutes show in a viewer.
 3. No upload, no transitions — the system silently filters everything else out.
 
+### 🔍 QA reviewer — pre-issue model walkthrough
+
+Before any issue, the QA reviewer does a model walkthrough. Sticky notes are the workflow.
+
+1. **Open the briefcase viewer** (`BriefcaseView`) — confirm the BEP, tag guide, and current dashboard are accessible.
+2. **Walk the model** view by view. For each flag, select element(s) → **Sticky Note → Add** → tick "QA Review Required" or write a custom note.
+3. When done, run **Sticky Note Dashboard** — the count is your "blocked items" total.
+4. **Sticky Note Search** with `discipline:M` (or whichever) hands the list to each discipline lead.
+5. As issues are fixed, **Sticky Note → Clear** drops the count.
+6. **Pre-issue gate**: 0 outstanding sticky notes → ready to issue.
+7. **Export Sticky Notes** to CSV at start and end of the cycle as a delta record (paste into the transmittal acknowledgement so the team has a record of what was caught).
+
+### 🏛️ Stage gate handover — the briefcase ritual
+
+At the end of each RIBA stage:
+
+1. **MIDP Tracker** — confirm every planned deliverable for the gate is at SHARED or PUBLISHED.
+2. **CDE Status** — any docs stuck in WIP > 14 days at gate? Decide: drop them or escalate.
+3. **Bulk Issue Deliverables** for every gate deliverable simultaneously (one transaction group, atomic).
+4. **DocumentBriefcase** generates the 8-file handover package. Folder is timestamped — keep it.
+5. **CreateTransmittalOrchestrated** with template C13 (formal letter of transmittal) referencing the briefcase folder.
+6. **Distribution group** auto-suggested by the orchestrator — verify before sending.
+7. **Workflow** auto-starts SLA timer; recipients get push + email; acknowledgements come back to the inbox.
+8. **Audit chain** records the entire sequence, replayable at the next gate.
+
+### 🛠️ FM handover — the COBie ritual
+
+For project end-of-life handover to the FM team:
+
+1. Run **COBie Export** at draft (still in WIP / SHARED state) — review the workbook for missing data.
+2. Open **COBie Type Map** to fix any unmapped equipment categories.
+3. Open **COBie Picklists** to verify controlled vocabularies match the FM team's Asset Information Requirements (AIR).
+4. Re-run **COBie Export** until clean.
+5. **Document Briefcase** + **COBie XLSX** + **As-built drawings** (PUBLISHED + S6) bundled into a final transmittal.
+6. **HandoverManual** command generates the FM operations manual referencing all of the above.
+7. CDE state moves to ARCHIVE (or stays at PUBLISHED + S7 if your project's retention policy keeps it warm).
+
 ---
 
 ## Streamlining tips
 
 These are small habits and configurations that compound to save real time.
+
+### 0. Sticky-note discipline as a pre-issue gate
+
+Treat **0 outstanding sticky notes** as a hard pre-issue requirement. The QA reviewer drops a sticky note on every flag they raise; the discipline lead clears each as they fix it. Use **Sticky Note Dashboard** at the start of each issue cycle to see how many are open per discipline, and **Sticky Note Search** to jump straight to elements when reviewing. This habit alone catches more issues than any other QA mechanism.
 
 ### 1. Use access profiles religiously
 
@@ -304,6 +620,26 @@ The compliance scan (cached, 30-second TTL) tells you what % of elements have co
 
 The plugin's local audit log is SHA-256 chained. **Don't manually edit `audit_log_*.jsonl`** — it'll break the chain and the next `VerifyChain` call will fail. The server gets a copy via `audit-events/batch` so cross-machine queries work, but the local chain is the tamper-evidence anchor.
 
+### 11. Use the briefcase viewer, not Explorer
+
+When you need to check the BEP or read a transmittal mid-modeling, **use the in-Revit briefcase viewer** rather than alt-tabbing to Windows Explorer. It's faster, scoped to the project, and read-only so you can't accidentally edit the file.
+
+### 12. Build distribution groups before you need them
+
+At project kickoff, create the 4–6 distribution groups you'll re-use: "Project Team", "Architects only", "Structural reviewers", "M&E subs", "Client distribution", "Authority Having Jurisdiction". The transmittal orchestrator will then auto-suggest the right group based on the document type / discipline / suitability, and you stop re-typing recipient lists for the rest of the project.
+
+### 13. Generate a Document Briefcase at every stage gate
+
+Don't wait for project end. At each RIBA stage (or equivalent), run **DocumentBriefcase** — the timestamped folder is your stage-gate handover artefact. Zip it, attach to a transmittal, distribute. End-of-project handover then becomes "we have ten of these, here's the latest" rather than a panicked snapshot.
+
+### 14. Save your common searches
+
+If you find yourself repeatedly typing `cde:SHARED discipline:M after:last-month`, save it as "M&E in review this month". Saved searches stash under your user profile and load in one click. The Sticky Note Search tab uses the same store, so QA-flag queries stick around too.
+
+### 15. Run COBie export early, not just at handover
+
+Run a draft COBie export at S2 (review) — most issues with type-mapping or missing FM data show up as red rows. Fixing them at S2 is cheap; fixing them at handover is expensive (the FM team is waiting and you've already moved on).
+
 ---
 
 ## Common pitfalls
@@ -339,6 +675,38 @@ That works locally but the next sync hits the server, which still enforces the g
 ### "The mobile app is missing a tab I see on web."
 
 Mobile is intentionally a subset — focused on field work. If you need full document management, use the BCC in Revit or the web dashboard.
+
+### "Sticky notes don't appear on the same element after I copy it."
+
+Sticky notes live on the **instance** parameter, not the type. Copying an element copies the parameter value (so the note travels with the copy). Mirroring or array-creating an element from the family editor does not. If you've copied an element from a different project, the note doesn't come along — sticky notes are per-document.
+
+### "Briefcase viewer says 'no items'."
+
+You haven't generated the underlying files yet. The viewer surfaces what exists in `_BIM_COORD/`. Run BEP wizard to populate `bim_execution_plan.json`, generate the dashboard from the BCC Overview tab, etc. The viewer is a window — you have to put things in the room first.
+
+### "Document Briefcase generator says it can't write to the output folder."
+
+Likely cause: the model is on a network share and the project root isn't writable, or `_data/` was created with restrictive ACLs. The briefcase falls back to `OutputLocationHelper`'s default (typically `Documents\STING_Output\`) — check the log line for the actual path used.
+
+### "COBie export looks empty for half my equipment."
+
+The equipment categories aren't mapped in `COBIE_TYPE_MAP.csv`. Open **COBie Type Map** to see what's mapped; add rows for missing categories before re-running. Common gap: custom families with non-standard category assignments.
+
+### "My saved search returns documents I shouldn't see."
+
+The search index respects ACL at query time — every result is re-checked against the caller's slice before being returned. If you genuinely see a doc you shouldn't, file it as a bug; it's not supposed to happen.
+
+### "My distribution group keeps suggesting the wrong recipients."
+
+The matcher scores groups by `(type, role, suitability)` triple. If your transmittal is for a deliverable with discipline=M and suitability=S4, it'll prefer a group whose tags include all three. Tighten the group's filters (or untag groups that shouldn't match) — `_BIM_COORD/distribution_groups.json` is the master.
+
+### "MIDP totals don't match my schedule."
+
+The MIDP register counts every row in `deliverables.json` plus published sheets. If your schedule is off, run **Drawing Register Sync** to re-pull from the model — the MIDP is downstream of the document register, which is downstream of the model.
+
+### "I see 'workflow_state.json deserialization failed'."
+
+The schema versioning gate caught a stale file. Don't edit it manually. Either delete the file (workflows reset to default — old in-flight ones lost) or run the Workflow Migrate command to upgrade in place.
 
 ---
 
@@ -384,23 +752,72 @@ Viewer < Contributor < Coordinator < Manager < Admin < Owner
 │       ├── deliverables.json        ← deliverable register
 │       ├── doc_sequences.json       ← per-type sequence counters
 │       ├── transmittals.json        ← transmittal log
+│       ├── reviews.json             ← review tracker register
+│       ├── issues.json              ← issue register (BCF-compatible)
+│       ├── documents.json           ← document register entries
+│       ├── sticky_notes.json        ← project-level sticky-note index
 │       ├── workflow_state.json      ← active workflow instances
-│       ├── audit_log_YYYY_MM.jsonl  ← SHA-256 chained audit
+│       ├── audit_log_YYYY_MM.jsonl  ← SHA-256 chained audit (one per month)
 │       ├── distribution_groups.json ← named recipient groups
 │       ├── saved_searches.json      ← per-user saved queries
-│       ├── search_index/            ← Lucene index
+│       ├── bim_execution_plan.json  ← BEP (briefcase viewer source)
+│       ├── project_dashboard.json   ← live project-status snapshot
+│       ├── search_index/            ← Lucene full-text index
 │       ├── templates/               ← rendered template sources
 │       │   └── *.docx / *.xlsx
 │       ├── workflows/               ← workflow definition JSONs
+│       ├── reference/               ← user-added reference PDFs (briefcase)
 │       └── generated/               ← rendered output
 │           └── YYYYMMDD_{number}_{template}.docx
-├── 01_WIP/                          ← rendered output cache
+├── 17_BRIEFCASE_<code>/             ← Document Briefcase exports
+│   └── <model>_Briefcase_<timestamp>/
+│       ├── 01_ProjectInfo.csv
+│       ├── 02_TagRegister.csv
+│       ├── 03_ComplianceReport.csv
+│       ├── 04_ParameterAudit.csv
+│       ├── 05_ModelStatistics.csv
+│       ├── 06_SheetIndex.csv
+│       ├── 07_DisciplineBreakdown.csv
+│       └── 08_MIDPRegister.csv
+├── 01_WIP/                          ← rendered output cache (per CDE state)
 ├── 02_SHARED/
 ├── 03_PUBLISHED/
 └── 04_ARCHIVE/
 ```
 
 The **server is the system of record** for state. The on-disk folders are just where the rendered files land for distribution.
+
+### All document-related Revit commands at a glance
+
+| Command tag | What it does |
+|---|---|
+| `DocumentRegister` | Open the project document register |
+| `AddDocument` | Manual register entry |
+| `DocumentBriefcase` | Generate the 8-file portable handover package |
+| `Briefcase` / `BriefcaseView` | Open the in-Revit reference document viewer |
+| `BriefcaseRead` | Read a specific briefcase item |
+| `BriefcaseAddFile` | Add a PDF/DOCX/XLSX to the briefcase reference set |
+| `CDEStatus` | One-screen CDE drawer health check |
+| `MidpTracker` | Master Information Delivery Plan summary |
+| `ReviewTracker` | Coordinated-review register |
+| `CreateTransmittal` | Quick transmittal (uses orchestrator) |
+| `CreateTransmittalOrchestrated` | Full pipeline: number → render → workflow → audit |
+| `BulkIssueDeliverables` | Issue every selected deliverable in one transaction group |
+| `IssueDeliverable` / `ReIssueDeliverable` / `PublishDeliverable` / `CancelDeliverable` / `SupersedeDeliverable` / `ReplaceDeliverable` | Lifecycle state machine commands |
+| `ValidateDocNaming` | ISO 19650 naming dry-run |
+| `BriefcaseAddFile` | Drop a reference PDF into the project briefcase |
+| `ElementStickyNote` | Add / view / clear sticky note on selected elements |
+| `ExportStickyNotes` | All notes across project → CSV |
+| `SelectStickyElements` | Select every element with a note |
+| `StickyNoteCategories` | Per-category note counts |
+| `StickyNoteDashboard` | Sticky-note aggregate view |
+| `StickyNoteSearch` | Free-text search across all notes |
+| `COBieExport` / `COBieImport` | Full COBie 2.4 round-trip |
+| `BCFExport` / `BCFImport` | BCF 2.1 issue interchange |
+| `RaiseIssue` / `IssueDashboard` / `UpdateIssue` | Issue tracker (related to documents via issue attachments) |
+| `CreateRevision` / `RevisionDashboard` / `RevisionCompare` | Revision management |
+| `ModelHealthDashboard` / `FullComplianceDashboard` | Project-wide health metrics (briefcase items) |
+| `BriefcaseView` button on dock panel | Quick-launch briefcase viewer |
 
 ### Where things live on the server
 

--- a/docs/DOCUMENT_MANAGER_GUIDE.md
+++ b/docs/DOCUMENT_MANAGER_GUIDE.md
@@ -1,0 +1,434 @@
+# Document Manager — Plain-English Guide
+
+A practical guide to managing project documents across **Revit (the plugin)**, **the cloud server (Planscape)**, and **the mobile app**, with recommended workflows for the most common roles.
+
+If you only read one section, read [The Three-Minute Picture](#the-three-minute-picture) and [Best-Practice Workflows](#best-practice-workflows).
+
+---
+
+## The three-minute picture
+
+Think of the document manager as **one cabinet with four drawers**, opened from **three different doors**.
+
+**Four drawers** (these are the ISO 19650 CDE states — every document lives in exactly one at a time):
+
+| Drawer | Code | What goes in it |
+|---|---|---|
+| 🟡 **Work In Progress** | WIP | Drafts. Only the discipline that owns the file should see them. |
+| 🔵 **Shared** | SHARED | Issued for coordination across the team. Other disciplines can review. |
+| 🟢 **Published** | PUBLISHED | Issued for use — for construction, tender, fabrication, handover. Authoritative. |
+| ⚫ **Archive** | ARCHIVE | Retired. Read-only history. |
+
+**Three doors:**
+
+| Door | Who uses it | Best for |
+|---|---|---|
+| **Revit plugin** (BCC + Document Management dialog) | BIM coordinators, designers | Producing deliverables, transmittals, publishing from Revit |
+| **Web/desktop server** (Planscape) | Project managers, reviewers | Approvals, dashboards, audit |
+| **Mobile app** | Site teams, clients, approvers | Look-up, photo upload, on-site approvals |
+
+The **server is the single source of truth.** The plugin and mobile are views over it. When the network is down, the plugin keeps working locally and re-syncs when it reconnects.
+
+---
+
+## What's actually stored
+
+Every document has these pieces, regardless of which door you're using:
+
+- **File name** — typically the ISO 19650 8-segment name (e.g. `PRJ-XYZ-ZZ-ZZ-DR-A-0001`).
+- **Discipline** — A (Arch), S (Structural), M (Mechanical), E (Electrical), P (Plumbing), FP (Fire), LV (Low Voltage), G (General).
+- **CDE state** — one of WIP / SHARED / PUBLISHED / ARCHIVE (the drawer it's in).
+- **Suitability code** — S0 (initial), S1 (suitable for coordination), S2 (info), S3 (review/comment), S4 (construction), S5 (manufacture), S6 (PIM/AIM), S7 (archive).
+- **Revision** — `P01`, `P02`, … (preliminary), `C01`, `C02`, … (construction).
+- **Status history** — every transition, who did it, when, why.
+- **Approvals** — who signed it off (where required by ISO 19650-2 §5.6).
+- **The file itself** (PDF / DOCX / DWG / IFC / RVT / etc.).
+
+In the plugin you'll also see a **deliverables register** (`deliverables.json`) and **rendered output** (`generated/*.docx` for transmittals, RFIs, MR forms, etc.). These mirror to the server automatically.
+
+---
+
+## The four drawers in detail
+
+### 🟡 WIP — Work In Progress
+
+- **Default state** for any new file.
+- Only the **owning discipline** should see it. (A subcontractor M&E coordinator should never see the architect's WIP.)
+- Suitability is usually **S0**.
+- Revision is usually **P01**, **P02** while drafting.
+- **No coordination assumed** — files may be incomplete, broken, contradictory.
+
+### 🔵 SHARED — Issued for coordination
+
+- The team as a whole can review, mark up, raise RFIs.
+- Suitability moves to **S1, S2, or S3** depending on the issue purpose.
+- A revision typically bumps (P02 → P03) when promoted from WIP.
+- Promotion **WIP → SHARED** requires **Coordinator role** at minimum.
+
+### 🟢 PUBLISHED — Issued for use
+
+- Construction / fabrication / handover. **This is the version that will be built from.**
+- Suitability moves to **S4** (construction), **S5** (manufacture), **S6** (PIM/AIM).
+- Revision typically bumps to a construction code (`C01`).
+- Promotion **SHARED → PUBLISHED** requires:
+  - **Manager role** at minimum, AND
+  - **An approved DocumentApproval record** (someone with sign-off authority has clicked "Approve" on the approval request).
+- This is the **publishing gate.** A coordinator can issue a draft for sharing in seconds, but a draft for construction needs a Manager to bless it. That's the ISO 19650-2 §5.6 rule the system enforces.
+
+### ⚫ ARCHIVE — Retired
+
+- Read-only history. Files don't disappear; they're moved out of active use.
+- Used for superseded revisions and end-of-project handover.
+
+### One-way flow
+
+```
+WIP ──▶ SHARED ──▶ PUBLISHED ──▶ ARCHIVE / SUPERSEDED
+         ▲    │
+         │    └──▶ (back to WIP for rework)
+```
+
+You can't skip drawers. To get from WIP to PUBLISHED, the file goes through SHARED first.
+
+---
+
+## Permissions — who sees what
+
+The system uses **three permission axes** stacked on top of project membership. Each axis has a per-member allow-list:
+
+| Axis | Example values | Effect |
+|---|---|---|
+| **CDE state** | WIP, SHARED, PUBLISHED, ARCHIVE | Which drawers the user can open. |
+| **Discipline** | A, S, M, E, P | Which trades they can see. |
+| **Suitability** | S0–S7 | Which suitability bands they can see. |
+
+If an axis is left blank, the user gets **everything on that axis** (the default before Phase 177 — preserved for old projects).
+
+### Worked examples
+
+| Person | Allowed CDE | Allowed Discipline | Allowed Suit | What they see |
+|---|---|---|---|---|
+| Lead BIM coordinator (in-house) | (all) | (all) | (all) | Everything. Full project. |
+| Discipline lead (M&E sub) | WIP, SHARED, PUBLISHED | M, E | (all) | Their own discipline only, but at every CDE state |
+| Reviewer / external auditor | SHARED, PUBLISHED | (all) | S2, S3, S4 | Issued items only — no drafts |
+| Site engineer | PUBLISHED | (all) | S4, S5 | Current construction issue only |
+| Client representative | PUBLISHED, ARCHIVE | (all) | S4, S6 | Final issued + handover bundle |
+
+The server enforces this on **every** read and write — list, download, version history, approval, transition. A document the user can't see doesn't even appear in their list (we return 404, not 403, so existence isn't leaked).
+
+### Access profiles — pick a preset, don't tick boxes
+
+Rather than configuring three multi-selects per invitee, the system has **named access profiles** at the tenant level. Examples a project manager might create:
+
+- **"Trade subcontractor — M only"** → CDE: WIP+SHARED+PUBLISHED · Disc: M · Suit: (all)
+- **"Reviewer"** → CDE: SHARED+PUBLISHED · Disc: (all) · Suit: S2+
+- **"Client read-only"** → CDE: PUBLISHED+ARCHIVE · Disc: (all) · Suit: S4+
+
+When inviting a new member, pick a profile from the dropdown — the three allow-lists get stamped on the member row in one click. You can still override individual axes if a person needs an exception.
+
+Profiles are **snapshots**. Editing the profile later doesn't retroactively rewrite existing members (that would be a surprising audit hazard). To re-apply a changed profile, edit the affected members manually.
+
+---
+
+## ISO 19650 file naming — the 8-segment tag
+
+Every file follows the `PRJ-ORG-LVL-LOC-TYPE-DISC-NUMBER-REV` shape:
+
+```
+   PRJ-ORG-ZZ-ZZ-DR-A-0001-P03
+   │   │   │  │  │  │ │    └── Revision (P=preliminary, C=construction)
+   │   │   │  │  │  │ └─────── 4-digit sequence number
+   │   │   │  │  │  └───────── Discipline (A/S/M/E/P/FP/LV/G)
+   │   │   │  │  └──────────── Type (DR=drawing, SP=spec, MR=material req, etc.)
+   │   │   │  └─────────────── Location code (ZZ if whole-building)
+   │   │   └────────────────── Level code (ZZ if not level-specific)
+   │   └────────────────────── Originator code (e.g. company short code)
+   └────────────────────────── Project code
+```
+
+The plugin **enforces this convention on upload** if the project's "Enforce ISO 19650 naming" flag is on (PM toggles it under project settings). If a file doesn't match, the upload is rejected with a structured error explaining which segment is wrong.
+
+---
+
+## The four production paths
+
+There are four end-to-end flows for getting a document out the door. Pick the one that matches what you're producing.
+
+### Path 1 — Manual upload (any file)
+
+Use when you have an existing PDF/DWG/DOCX from outside the BIM tooling that needs to land on the CDE.
+
+1. **Mobile or web** → Documents → Upload → fill in discipline / type / revision.
+2. The file lands in **WIP** with suitability **S0**.
+3. Promote through SHARED → PUBLISHED as the document matures (each step needs the right role).
+
+### Path 2 — Drawing production (Revit)
+
+The bread-and-butter flow for design teams.
+
+1. In Revit, produce sheets via the Sheet Manager + Drawing Template Manager.
+2. Open the **BIM Coordination Center** → **Deliverables** tab.
+3. Click **Issue Deliverable**: the plugin renders an A01 cover sheet (DOCX), bumps the revision, writes a row to `deliverables.json`, mirrors to the server.
+4. Click **Publish Stage 3** when ready for construction issue: the plugin moves the deliverable to PUBLISHED + S4. The server requires a Manager role plus an approved DocumentApproval.
+
+### Path 3 — Transmittals + RFIs + MRs (template engine)
+
+For produced documents like transmittal memos, RFIs, technical queries, material requisitions, meeting minutes.
+
+1. **BIM Coordination Center** → choose the template (B06 Transmittal, B08 RFI, C10 Material Requisition, D14 Meeting Minutes, etc.).
+2. Fill in the form. The plugin:
+   - Mints a unique document number from the project's `doc_sequences.json`.
+   - Renders the DOCX from the template.
+   - Starts a workflow instance (e.g. transmittal Draft → Issued → Acknowledged with SLAs).
+   - Mirrors the lifecycle event + audit row to the server.
+3. The recipient gets the rendered file + a workflow notification.
+
+### Path 4 — On-site capture (mobile)
+
+For site-walks, photo evidence, defect reports.
+
+1. **Mobile app** → Issues → Create → take photos → assign discipline / priority / location.
+2. The file lands as an **issue attachment** in WIP.
+3. Promote to SHARED if it needs to feed an RFI, or PUBLISHED if it's a formal handover photo.
+
+---
+
+## Best-practice workflows
+
+These are the streamlined recipes that work well in practice. Adapt them to your project structure.
+
+### 🧑‍💼 BIM Coordinator — daily routine
+
+**Morning (5 min):**
+1. Open the **BIM Coordination Center** → **Overview** tab.
+2. Check the compliance gauge + warnings count + open issues count.
+3. If any pending approvals are sitting on you — go to the mobile **Inbox → Document Approvals** screen, approve/reject from there (it's faster than the desktop dialog).
+
+**During the day:**
+- Use **Tag & Combine** in Revit to keep ISO 19650 tags up to date as you place elements.
+- Run the **Auto-Tag** updater on geometry-changed elements to mark stales.
+- Issue deliverables from the BCC Deliverables tab as work matures.
+
+**End of day:**
+- Hit the **Sync** button on the dock panel (or let the 5-min auto-tick do it).
+- The reconcile pass will push any deliverables that drifted while you were offline.
+
+### 🏗️ Discipline lead — preparing a package
+
+**Plan ahead** of issue date:
+1. Confirm your file naming matches the ISO 19650 convention (use `validate-name` on the server, or just upload — the server will reject and tell you what's wrong).
+2. Confirm your CDE access includes WIP + SHARED for your discipline (look at **Documents tab** chip strip — if SHARED isn't there, ping your PM).
+
+**Issue cycle:**
+1. Render sheets in Revit.
+2. **BIM Coordination Center → Deliverables → Issue Deliverable**.
+3. Plugin renders the cover sheet, bumps revision, mirrors to server. Document is now in WIP.
+4. When the package is ready for the team: **Publish Stage 1** (S2) or **Publish Stage 2** (S3) — moves it to SHARED.
+5. When the team has signed off: **Publish Stage 3** — server requires Manager approval first.
+
+### ✅ Project Manager — approvals + governance
+
+**Once a day** (or when push notification fires):
+1. **Mobile or web** → **Inbox → Document Approvals**.
+2. Each pending approval shows: file name, transition (e.g. SHARED→PUBLISHED), discipline, who requested it, when, their comment.
+3. Approve or reject inline. Comment optional.
+4. Approved? The originating coordinator can now run the SHARED→PUBLISHED transition from their plugin or the documents tab.
+
+**Weekly:**
+- Review the **Project Members** tab in the BCC: are anyone's allow-lists drifting from what they should be? (E.g. a sub-contractor whose package finished should be moved to a "client read-only" profile.)
+- Check the **audit log** for any unusual transitions (server `/api/admin/audit`).
+
+**End of stage:**
+- Run **Bulk Issue Deliverables** for the whole package.
+- Generate a transmittal (template B06) listing the package.
+
+### 👷 Trade subcontractor — limited slice
+
+You'll see only your discipline (e.g. M for mechanical), all four CDE states for that discipline.
+
+1. **Documents tab** shows your discipline only — chips for WIP / SHARED / PUBLISHED / ARCHIVE.
+2. Use **Issue Deliverable** when your draft is ready for the lead coordinator.
+3. After the lead promotes to SHARED and PM approves to PUBLISHED, you'll see the new state via SignalR push within seconds.
+
+### 🏢 Client / external reviewer — read-only
+
+You'll see PUBLISHED + ARCHIVE only.
+
+1. **Mobile app** → Documents tab — only published+archived material renders.
+2. PDFs / DWGs are downloadable; rendered transmittals and meeting minutes show in a viewer.
+3. No upload, no transitions — the system silently filters everything else out.
+
+---
+
+## Streamlining tips
+
+These are small habits and configurations that compound to save real time.
+
+### 1. Use access profiles religiously
+
+Don't tick three multi-selects every time you invite someone. Define 5–7 profiles upfront for the project (Coordinator, Discipline lead, Sub, Reviewer, Client, Auditor) and pick one per invite. You'll save 30 seconds per invite × every invite for the project life.
+
+### 2. Let the auto-tag updater carry the load
+
+Turn on the **Auto-Tag IUpdater** in the dock panel. Every time you place a new element, it gets the 7-token tag automatically. Every time geometry changes, the element gets marked stale. You'll never have to remember to re-tag.
+
+### 3. Issue early, publish late
+
+Promote to SHARED **as soon as** the file is reviewable, even if it's not final — let the team coordinate against it. Publish only when truly construction-ready. The cost of a too-early publish is rework; the cost of a too-late share is missed coordination.
+
+### 4. Use templates for transmittals — never hand-write them
+
+The template engine has 16 standard documents (A01–A04 deliverables, B06–B09 transmittals/RFIs/TQs/responses, C10–C13 materials/submittals/variations/letters, D14–D16 meetings/progress/handover). Pick the right one and let the plugin fill the tokens. The doc number, project code, dates, distribution list, signature block all populate from project info.
+
+### 5. Trust the workflow engine for SLAs
+
+When you create a transmittal, the workflow starts a timer (24 hr / 72 hr / unlimited). The server tracks who's overdue and surfaces it on the My Actions inbox. Don't rebuild this in a spreadsheet.
+
+### 6. Approve from your phone
+
+The on-site approvals inbox is **faster** than opening the BCC dialog on a workstation. If you're a PM, install the app and turn on push.
+
+### 7. Use the conflict triage
+
+If two people edit the same row offline (rare but possible with the plugin's offline buffer), the conflict triage screen lets you pick which wins. Don't bypass it — that's how silent data corruption happens.
+
+### 8. Promote through CDE — don't move files
+
+Never drag a file out of `01_WIP` into `02_SHARED` on disk. The folders are **output**, not the source of truth. Use the transition button. The server records the audit row, the SignalR event fires, the audit log chains. Direct file moves bypass all that.
+
+### 9. Review compliance before a big issue
+
+The compliance scan (cached, 30-second TTL) tells you what % of elements have complete tags. Don't issue at < 80% — you're shipping incomplete data.
+
+### 10. Keep your audit chain healthy
+
+The plugin's local audit log is SHA-256 chained. **Don't manually edit `audit_log_*.jsonl`** — it'll break the chain and the next `VerifyChain` call will fail. The server gets a copy via `audit-events/batch` so cross-machine queries work, but the local chain is the tamper-evidence anchor.
+
+---
+
+## Common pitfalls
+
+### "I can't see a document I know exists."
+
+You don't have access to its CDE state, discipline, or suitability. Check **Documents tab → chip strip** — if a chip is missing, that whole drawer is hidden. Ask the PM to extend your access profile.
+
+### "Publish failed — approval required."
+
+Someone with Manager role hasn't approved the SHARED→PUBLISHED transition. Click **Request Approval** on the document detail screen, fill in why, and a Manager will see it on their approvals inbox.
+
+### "Plugin says synced but server doesn't see it."
+
+The fire-and-forget mirror failed silently. Two recovery paths:
+1. Hit the dock panel **Sync** button — this runs `ReconcileAsync` immediately, which scans `deliverables.json` for unsynced rows and pushes them.
+2. Wait for the next 5-min tick — same effect, automatic.
+
+If both fail, check `StingTools.log` for `DeliverableServerSync … failed` lines. Server unreachable, expired token, or rate-limited are the usual culprits.
+
+### "Two people edited the same deliverable while offline."
+
+Open the **Conflicts** screen on mobile. It shows the diff and lets you pick a winner. The unchosen side becomes a superseded revision in the audit log.
+
+### "Why does my mobile app keep showing PUBLISHED docs I'm not supposed to see?"
+
+It shouldn't. If it does, you either have an old build (without ACL filters) or your member row hasn't been updated. Force-quit the app, sign out and back in — it re-fetches `/members/me` and re-renders the chip strip.
+
+### "I tried to bypass the approval gate by editing the JSON."
+
+That works locally but the next sync hits the server, which still enforces the gate, and your row is rejected. Don't bother — the gate exists for a reason (ISO 19650-2 §5.6).
+
+### "The mobile app is missing a tab I see on web."
+
+Mobile is intentionally a subset — focused on field work. If you need full document management, use the BCC in Revit or the web dashboard.
+
+---
+
+## Quick reference
+
+### Roles, in order of authority
+
+```
+Viewer < Contributor < Coordinator < Manager < Admin < Owner
+                                              SecurityOfficer (read-only audit)
+```
+
+### Required role per transition
+
+| Transition | Minimum role | Approval required? |
+|---|---|---|
+| WIP → SHARED | Coordinator | No |
+| SHARED → WIP (rework) | Coordinator | No |
+| **SHARED → PUBLISHED** | **Manager** | **Yes (DocumentApproval)** |
+| PUBLISHED → ARCHIVE | Manager | No |
+| PUBLISHED → SUPERSEDED | Manager | No |
+
+### Suitability codes (UK BS EN ISO 19650-2)
+
+| Code | Meaning | Typical CDE state |
+|---|---|---|
+| S0 | Initial | WIP |
+| S1 | Suitable for coordination | SHARED |
+| S2 | Suitable for information | SHARED |
+| S3 | Suitable for review/comment | SHARED |
+| S4 | Suitable for construction | PUBLISHED |
+| S5 | Suitable for manufacture | PUBLISHED |
+| S6 | Suitable for PIM/AIM authorisation | PUBLISHED |
+| S7 | As-built | ARCHIVE |
+
+### Where things live on disk (per project)
+
+```
+<project>/
+├── _data/                           ← consolidated metadata root
+│   └── _BIM_COORD/
+│       ├── manifest.json            ← project info + doc engine config
+│       ├── deliverables.json        ← deliverable register
+│       ├── doc_sequences.json       ← per-type sequence counters
+│       ├── transmittals.json        ← transmittal log
+│       ├── workflow_state.json      ← active workflow instances
+│       ├── audit_log_YYYY_MM.jsonl  ← SHA-256 chained audit
+│       ├── distribution_groups.json ← named recipient groups
+│       ├── saved_searches.json      ← per-user saved queries
+│       ├── search_index/            ← Lucene index
+│       ├── templates/               ← rendered template sources
+│       │   └── *.docx / *.xlsx
+│       ├── workflows/               ← workflow definition JSONs
+│       └── generated/               ← rendered output
+│           └── YYYYMMDD_{number}_{template}.docx
+├── 01_WIP/                          ← rendered output cache
+├── 02_SHARED/
+├── 03_PUBLISHED/
+└── 04_ARCHIVE/
+```
+
+The **server is the system of record** for state. The on-disk folders are just where the rendered files land for distribution.
+
+### Where things live on the server
+
+| Table | Purpose |
+|---|---|
+| `Documents` | The current state of every document. CDE / suitability / revision / file path. |
+| `DocumentVersions` | Per-version history. |
+| `DocumentApprovals` | Approval requests + decisions, ISO 19650-2 §5.6. |
+| `ProjectMembers` | Project membership + role + per-folder ACL allow-lists. |
+| `AccessProfiles` | Tenant-level named ACL presets. |
+| `AuditLogs` | Tamper-evident audit (SHA-256 chained server-side too). |
+| `Transmittals` / `Meetings` / `WorkflowRuns` | Lifecycle artefacts mirrored from the plugin. |
+
+---
+
+## What this guide doesn't cover
+
+- **Family library + tag schema setup** — see `TAGGING_PROCEDURES_GUIDE.md`.
+- **Drawing template profiles + view style packs** — see `AEC_PRODUCTION_SET_STRATEGY.md`.
+- **CDE filter library** — see `AEC_FILTER_LIBRARY.md`.
+- **Per-tenant filter / role customisation** — admin / DBA territory.
+- **Off-network NTFS folder ACL mirroring** — separate desktop sync agent, not part of the document manager.
+- **Detailed BIM Execution Plan (BEP) authoring** — see `BIM_MANAGEMENT_GUIDE.md`.
+
+---
+
+## Further reading
+
+- [ISO 19650-2:2018 — Information management using BIM, delivery phase](https://www.iso.org/standard/68080.html) (the standard the CDE state machine implements)
+- [UK BIM Framework — Guidance Part D: Information Production Methods](https://www.ukbimframework.org/) (the suitability code definitions in plain English)
+- The in-repo guides linked above for the technical layers behind the document manager.


### PR DESCRIPTION
## Summary

Implements Phase 177 document manager review, introducing per-folder access control lists (ACLs) for project members and a document approval workflow. Members can now be restricted by CDE state, discipline, and suitability code. Document approvals gate state transitions (e.g., SHARED→PUBLISHED), and a new inbox screen lets managers approve/reject requests inline.

## Key Changes

**Server-side Authorization & ACLs**
- Added `ProjectMemberAcl` helper to resolve and enforce per-folder restrictions (CDE states, disciplines, suitabilities)
- Extended `ProjectMember` entity with three nullable CSV columns: `AllowedCdeStates`, `AllowedDisciplines`, `AllowedSuitabilities`
- Created `AccessProfile` entity for tenant-scoped named ACL presets, reducing friction when inviting members
- Updated `DocumentsController` to enforce ACL checks on upload, download, version access, and state transitions
- Added `GET /api/projects/{id}/members/me` endpoint to surface the calling user's ACL slice for UI filtering
- Modified `MyActionsController` to narrow approval lists by the caller's ACL slice

**Document Approval Workflow**
- New `AuditEventsController` accepts batched audit events from the plugin with hardened validation (action prefix, entity type whitelist)
- `DocumentsController.TransitionState` now broadcasts to both source and target CDE subgroups so members tracking either state see the transition
- `ProjectMembershipNotifier` added `NotifyAclChangedAsync` to push re-join cues when a member's ACL changes

**Plugin Integration**
- New `DeliverableServerSync` class mirrors plugin lifecycle events (Issue/Publish/Supersede/etc.) to server's `DocumentRecord` state
- `ReconcileAsync` walks `deliverables.json` and pushes any row whose `ServerSyncedAt` is stale, ensuring offline events reach the server
- `PlanscapeServerClient` added `SyncDeliverableFromPluginAsync` and `GetMyAccessAsync` methods
- Plugin audit events are pushed via `PushAudit` and stamped with `ServerSyncedAt` on success

**Mobile & Web UI**
- New `approvals.tsx` screen lists pending document approvals with inline approve/reject actions and optional comments
- `inboxStore.ts` provides cross-screen invalidation so approving a document refreshes the home tab count and inbox index
- `documents.tsx` and `index.tsx` integrated `getMyProjectAccess` to fetch and respect the user's ACL slice
- `RealtimeClient` listens for `AclChanged` events to trigger re-join when permissions shift

**Database Migrations**
- `AddProjectMemberAcls` migration adds three nullable text columns to `ProjectMembers`
- `AddAccessProfiles` migration creates the `AccessProfiles` table with tenant scoping and default role presets

## Notable Implementation Details

- ACL nulls preserve backward compatibility: members without populated allow-lists see the entire project (pre-Phase 177 behavior)
- Tenant Admins/Owners/SecurityOfficers bypass member-row narrowing to retain cross-project audit reach
- Plugin sync is fire-and-forget with automatic retry on the next 5-minute scheduler tick or coordinator action
- Audit events from the plugin are prefixed with `plugin.` namespace and validated against a whitelist to prevent spoofing
- Per-CDE-state SignalR subgroups ensure document transition events only fan out to members whose ACL covers the target state
- Access profiles are snapshots at invite time; later profile edits do not retroactively rewrite existing members

https://claude.ai/code/session_01Y1G8B4RxxoGVWQ1u1ijTaX