### PR TITLE
Implement dynamic theme support for BCC and DMD

### DIFF
--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -44,10 +44,13 @@ namespace StingTools.UI
         // user cycles themes. The `darken` helper produces a navy nav
         // panel that's visibly subordinate to the brand-navy header.
         private static Color CHeaderBg    => BrushColor("HeaderBg");
+        private static Color CHeaderFg    => BrushColor("HeaderFg");
         private static Color CAccent      => BrushColor("AccentBrush");
         private static Color CCardBg      => BrushColor("CardBg");
         private static Color CPageBg      => BrushColor("PrimaryBg");
+        private static Color CSecondaryBg => BrushColor("SecondaryBg");
         private static Color CBorder      => BrushColor("BorderColor");
+        private static Color CSubtleFg    => BrushColor("SubtleFg");
         private static Color CNavBg       => Darken(BrushColor("HeaderBg"), 0.85);
         private static Color CNavHover    => Darken(BrushColor("HeaderBg"), 0.92);
         private static Color CNavSelected => BrushColor("AccentBrush");
@@ -775,52 +778,7 @@ namespace StingTools.UI
                 catch { /* best effort */ }
             };
 
-            var root = new Grid();
-            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(56) });   // Header
-            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(34) });   // Share toolbar
-            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }); // Body
-            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(28) });   // Status
-
-            // ── HEADER ──
-            root.Children.Add(BuildHeader());
-
-            // ── SHARE TOOLBAR ──
-            var shareToolbar = BuildShareToolbar();
-            Grid.SetRow(shareToolbar, 1);
-            root.Children.Add(shareToolbar);
-
-            // ── BODY (Nav + Content) ──
-            var body = new Grid();
-            body.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(190) }); // Nav
-            body.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // Content
-            Grid.SetRow(body, 2);
-
-            _navPanel = BuildNavPanel();
-            body.Children.Add(_navPanel);
-
-            _contentArea = new ContentControl { Margin = new Thickness(0) };
-            Grid.SetColumn(_contentArea, 1);
-            body.Children.Add(_contentArea);
-
-            root.Children.Add(body);
-
-            // ── STATUS BAR ──
-            var statusBorder = new Border
-            {
-                Background = Br(Color.FromRgb(0x37, 0x47, 0x4F)),
-                Padding = new Thickness(12, 4, 12, 4)
-            };
-            _statusBar = new TextBlock
-            {
-                Foreground = Brushes.White, FontSize = 11,
-                VerticalAlignment = VerticalAlignment.Center,
-                Text = BuildStatusText()
-            };
-            statusBorder.Child = _statusBar;
-            Grid.SetRow(statusBorder, 3);
-            root.Children.Add(statusBorder);
-
-            Content = root;
+            BuildLayout();
 
             // Keyboard shortcuts (Phase 77 Item 11A)
             KeyDown += (s, e) =>
@@ -882,6 +840,77 @@ namespace StingTools.UI
             // Phase 76: Register singleton instance
             CurrentInstance = this;
             Closed += OnClosed;
+
+            // Refresh code-behind brushes when the user cycles the theme
+            // from the dock panel (DynamicResource bindings would handle
+            // themselves, but BCC builds its tree imperatively).
+            ThemeManager.ThemeChanged += OnThemeChanged;
+        }
+
+        private void BuildLayout()
+        {
+            // Window chrome tracks the active palette
+            Background = Br(CPageBg);
+
+            var root = new Grid();
+            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(56) });   // Header
+            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(34) });   // Share toolbar
+            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }); // Body
+            root.RowDefinitions.Add(new RowDefinition { Height = new GridLength(28) });   // Status
+
+            // ── HEADER ──
+            root.Children.Add(BuildHeader());
+
+            // ── SHARE TOOLBAR ──
+            var shareToolbar = BuildShareToolbar();
+            Grid.SetRow(shareToolbar, 1);
+            root.Children.Add(shareToolbar);
+
+            // ── BODY (Nav + Content) ──
+            var body = new Grid();
+            body.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(190) }); // Nav
+            body.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }); // Content
+            Grid.SetRow(body, 2);
+
+            _navPanel = BuildNavPanel();
+            body.Children.Add(_navPanel);
+
+            _contentArea = new ContentControl { Margin = new Thickness(0) };
+            Grid.SetColumn(_contentArea, 1);
+            body.Children.Add(_contentArea);
+
+            root.Children.Add(body);
+
+            // ── STATUS BAR — derives from header palette so it tracks the theme ──
+            var statusBorder = new Border
+            {
+                Background = Br(Darken(CHeaderBg, 0.55)),
+                Padding = new Thickness(12, 4, 12, 4)
+            };
+            _statusBar = new TextBlock
+            {
+                Foreground = Brushes.White, FontSize = 11,
+                VerticalAlignment = VerticalAlignment.Center,
+                Text = BuildStatusText()
+            };
+            statusBorder.Child = _statusBar;
+            Grid.SetRow(statusBorder, 3);
+            root.Children.Add(statusBorder);
+
+            Content = root;
+        }
+
+        private void OnThemeChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                // Stale tab content carries old brushes — drop the cache so
+                // every tab re-renders with the new palette on next visit.
+                _tabCache.Clear();
+                BuildLayout();
+                NavigateTo(_currentTab ?? _lastViewedTab ?? TabOverview);
+            }
+            catch (Exception ex) { StingLog.Warn($"BCC.OnThemeChanged: {ex.Message}"); }
         }
 
         private string BuildStatusText()
@@ -909,13 +938,13 @@ namespace StingTools.UI
             leftStack.Children.Add(new TextBlock
             {
                 Text = "BIM COORDINATION CENTER",
-                Foreground = Brushes.White, FontSize = 16, FontWeight = FontWeights.Bold,
+                Foreground = Br(CHeaderFg), FontSize = 16, FontWeight = FontWeights.Bold,
                 VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 20, 0)
             });
             leftStack.Children.Add(new TextBlock
             {
                 Text = _data.ProjectName,
-                Foreground = Br(Color.FromRgb(0xBB, 0xDE, 0xFB)), FontSize = 12,
+                Foreground = Br(CHeaderFg), Opacity = 0.7, FontSize = 12,
                 VerticalAlignment = VerticalAlignment.Center
             });
             hGrid.Children.Add(leftStack);
@@ -935,7 +964,7 @@ namespace StingTools.UI
                 Content = "\u21BB  Refresh",
                 FontSize = 11,
                 FontWeight = FontWeights.SemiBold,
-                Background = Br(Color.FromRgb(0x1E, 0x88, 0xE5)),
+                Background = Br(CAccent),
                 Foreground = Brushes.White,
                 BorderThickness = new Thickness(0),
                 Padding = new Thickness(10, 3, 10, 3),
@@ -953,14 +982,14 @@ namespace StingTools.UI
             rightStack.Children.Add(ragCircle);
             rightStack.Children.Add(new TextBlock
             {
-                Text = $"{_data.TagPct:F0}%", Foreground = Brushes.White, FontSize = 18,
+                Text = $"{_data.TagPct:F0}%", Foreground = Br(CHeaderFg), FontSize = 18,
                 FontWeight = FontWeights.Bold, VerticalAlignment = VerticalAlignment.Center,
                 Margin = new Thickness(0, 0, 8, 0)
             });
             rightStack.Children.Add(new TextBlock
             {
                 Text = $"compliant  |  {DateTime.Now:dd MMM yyyy HH:mm}",
-                Foreground = Br(Color.FromRgb(0x90, 0xCA, 0xF9)), FontSize = 11,
+                Foreground = Br(CHeaderFg), Opacity = 0.7, FontSize = 11,
                 VerticalAlignment = VerticalAlignment.Center
             });
 
@@ -979,8 +1008,8 @@ namespace StingTools.UI
         {
             var toolbar = new Border
             {
-                Background = Br(Color.FromRgb(0xF8, 0xF9, 0xFB)),
-                BorderBrush = Br(Color.FromRgb(0xD0, 0xD5, 0xE0)),
+                Background = Br(CSecondaryBg),
+                BorderBrush = Br(CBorder),
                 BorderThickness = new Thickness(0, 0, 0, 1),
                 Padding = new Thickness(8, 0, 8, 0)
             };
@@ -994,7 +1023,7 @@ namespace StingTools.UI
             {
                 Text = "Share:",
                 FontSize = 10,
-                Foreground = Br(Color.FromRgb(0x88, 0x88, 0x99)),
+                Foreground = Br(CSubtleFg),
                 VerticalAlignment = VerticalAlignment.Center,
                 Margin = new Thickness(0, 0, 8, 0)
             };
@@ -1100,7 +1129,7 @@ namespace StingTools.UI
                 HorizontalContentAlignment = HorizontalAlignment.Left,
                 Height = 36, Padding = new Thickness(16, 0, 8, 0),
                 Margin = new Thickness(0, 1, 0, 1),
-                Background = Brushes.Transparent, Foreground = Brushes.White,
+                Background = Brushes.Transparent, Foreground = Br(CHeaderFg),
                 BorderThickness = new Thickness(0), FontSize = 12,
                 Cursor = Cursors.Hand
             };
@@ -1123,12 +1152,14 @@ namespace StingTools.UI
             // Phase 77 Item 11A: Track current tab for F5 refresh
             _currentTab = tabName;
 
-            // Reset all nav buttons
+            // Reset all nav buttons (reset Foreground too so previously-active
+            // buttons return to the theme's HeaderFg instead of staying white)
             foreach (var child in _navPanel.Children)
             {
                 if (child is Button nb)
                 {
                     nb.Background = Brushes.Transparent;
+                    nb.Foreground = Br(CHeaderFg);
                     nb.FontWeight = FontWeights.Normal;
                 }
             }
@@ -6660,6 +6691,7 @@ namespace StingTools.UI
             ActionDispatcher = null;
             CurrentInstance = null;
             _tabCache.Clear();
+            ThemeManager.ThemeChanged -= OnThemeChanged;
             StingLog.Info("BIMCoordinationCenter closed and resources released.");
         }
 

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -87,9 +87,9 @@ namespace StingTools.UI
 
         // ── Data ──
         internal CoordData _data;
-        private readonly ContentControl _contentArea;
-        private readonly TextBlock _statusBar;
-        private readonly StackPanel _navPanel;
+        private ContentControl _contentArea;
+        private TextBlock _statusBar;
+        private StackPanel _navPanel;
         private Button _activeNav;
 
         // Phase 75: Persist last-viewed tab across dialog reopens

--- a/StingTools/UI/DocumentManagementDialog.cs
+++ b/StingTools/UI/DocumentManagementDialog.cs
@@ -93,28 +93,33 @@ namespace StingTools.UI
 
     internal static class DocumentManagementDialog
     {
-        // ── Theme (frozen for thread safety) ─────────────────────────
+        // ── Theme (routed through ThemeManager so DMD tracks the active palette) ─
+        // Theme-driven brushes resolve live from the active theme on each
+        // access; theme-agnostic tints stay as frozen static fields. The
+        // dialog re-reads these per Show(), so cycling the theme via the
+        // dock-panel toggle propagates here on the next open.
         private static SolidColorBrush FZ(byte r, byte g, byte b) { var br = new SolidColorBrush(Color.FromRgb(r, g, b)); br.Freeze(); return br; }
-        private static readonly SolidColorBrush BrHeader  = FZ(0x1A, 0x23, 0x7E);
-        private static readonly SolidColorBrush BrAccent  = FZ(0xE8, 0x91, 0x2D);
-        private static readonly SolidColorBrush BrBg      = FZ(0xF5, 0xF5, 0xF5);
-        private static readonly SolidColorBrush BrWhite   = Brushes.White;
-        private static readonly SolidColorBrush BrFgDark  = FZ(0x22, 0x22, 0x22);
-        private static readonly SolidColorBrush BrFgSub   = FZ(0x88, 0x88, 0x88);
-        private static readonly SolidColorBrush BrBorder  = FZ(0xD0, 0xD0, 0xD0);
-        private static readonly SolidColorBrush BrGreen   = FZ(0x2E, 0x7D, 0x32);
-        private static readonly SolidColorBrush BrOrange  = FZ(0xE6, 0x51, 0x00);
-        private static readonly SolidColorBrush BrRed     = FZ(0xC6, 0x28, 0x28);
+        private static SolidColorBrush BrHeader  => ThemeManager.GetBrush("NavyHeader");
+        private static SolidColorBrush BrAccent  => ThemeManager.GetBrush("OrangeAccent");
+        private static SolidColorBrush BrBg      => ThemeManager.GetBrush("PrimaryBg");
+        private static SolidColorBrush BrWhite   => ThemeManager.GetBrush("CardBg");
+        private static SolidColorBrush BrFgDark  => ThemeManager.GetBrush("PanelFg");
+        private static SolidColorBrush BrFgSub   => ThemeManager.GetBrush("SubtleFg");
+        private static SolidColorBrush BrBorder  => ThemeManager.GetBrush("BorderColor");
+        private static SolidColorBrush BrGreen   => ThemeManager.GetBrush("SuccessColor");
+        private static SolidColorBrush BrOrange  => ThemeManager.GetBrush("WarningColor");
+        private static SolidColorBrush BrRed     => ThemeManager.GetBrush("ErrorColor");
+        private static SolidColorBrush BrRowAlt  => ThemeManager.GetBrush("AltRowBg");
+        // Theme-agnostic accent palette — semantic tints used as decoration
         private static readonly SolidColorBrush BrPurple  = FZ(0x6A, 0x1B, 0x9A);
         private static readonly SolidColorBrush BrTeal    = FZ(0x00, 0x69, 0x5C);
         private static readonly SolidColorBrush BrAmber     = FZ(0xFF, 0x8F, 0x00);
-        private static readonly SolidColorBrush BrHeaderSub  = FZ(0xBB, 0xDE, 0xFB); // DMD-MEDIUM-01: frozen header subtitle brush
+        private static readonly SolidColorBrush BrHeaderSub  = FZ(0xBB, 0xDE, 0xFB);
         private static readonly SolidColorBrush BrLightGreen = FZ(0xE8, 0xF5, 0xE9);
         private static readonly SolidColorBrush BrLightGrey  = FZ(0xF0, 0xF0, 0xF0);
         private static readonly SolidColorBrush BrNearWhite  = FZ(0xF8, 0xF8, 0xF8);
         private static readonly SolidColorBrush BrBlueGrey   = FZ(0xF0, 0xF4, 0xF8);
         private static readonly SolidColorBrush BrLegendHdr  = FZ(0xE8, 0xEE, 0xF5);
-        private static readonly SolidColorBrush BrRowAlt     = FZ(0xF8, 0xF8, 0xFA);
         private static readonly SolidColorBrush BrRowRed     = FZ(0xFF, 0xEB, 0xEE);
         private static readonly SolidColorBrush BrRowAmber   = FZ(0xFF, 0xF3, 0xE0);
         private static readonly SolidColorBrush BrLightE8    = FZ(0xE8, 0xE8, 0xE8);

--- a/StingTools/UI/ThemeManager.cs
+++ b/StingTools/UI/ThemeManager.cs
@@ -19,14 +19,13 @@ namespace StingTools.UI
     /// </summary>
     public static class ThemeManager
     {
-        // Phase 101: default theme is "Corporate" — the StingTools brand
-        // (navy #1A237E header + orange #E8912D accents) matches the BCC and
-        // Document Management Centre, so the dockable panel opens in the same
-        // house theme the user sees everywhere else. Users can still cycle
-        // with the theme toggle button; the order below starts with Corporate.
-        public static string CurrentTheme { get; private set; } = "Corporate";
+        // Default theme is "Cool" — light blue-grey body with bright blue
+        // accents. The BCC, Document Management Centre, and dockable panel
+        // all open in the same house theme. Users can still cycle with the
+        // theme toggle button; the order below starts with Cool.
+        public static string CurrentTheme { get; private set; } = "Cool";
 
-        private static readonly string[] ThemeOrder = { "Corporate", "Light", "Warm", "Cool" };
+        private static readonly string[] ThemeOrder = { "Cool", "Light", "Warm", "Corporate" };
 
         /// <summary>
         /// Reference to the host Page/FrameworkElement for direct resource setting.
@@ -58,6 +57,14 @@ namespace StingTools.UI
                         { "TabFg", "#555555" },
                         { "TabSelectedBg", "#FFFFFF" },
                         { "TabSelectedFg", "#333333" },
+                        // Brand + dashboard extras (shared with DMD / BCC)
+                        { "NavyHeader", "#1A237E" },
+                        { "OrangeAccent", "#E88A1A" },
+                        { "CardBg", "#FFFFFF" },
+                        { "AltRowBg", "#F5F5F5" },
+                        { "SubtleFg", "#888888" },
+                        { "InfoBlue", "#1976D2" },
+                        { "RowHover", "#FDF0E0" },
                     }
                 },
                 {
@@ -81,6 +88,14 @@ namespace StingTools.UI
                         { "TabFg", "#5D4E3C" },
                         { "TabSelectedBg", "#FFFDF8" },
                         { "TabSelectedFg", "#3E3428" },
+                        // Brand + dashboard extras (shared with DMD / BCC)
+                        { "NavyHeader", "#5D4037" },
+                        { "OrangeAccent", "#D46A14" },
+                        { "CardBg", "#FFFDF8" },
+                        { "AltRowBg", "#F5EDE0" },
+                        { "SubtleFg", "#8D7B66" },
+                        { "InfoBlue", "#5D7B9C" },
+                        { "RowHover", "#F5E6D3" },
                     }
                 },
                 {
@@ -104,6 +119,14 @@ namespace StingTools.UI
                         { "TabFg", "#4A5568" },
                         { "TabSelectedBg", "#F8FAFC" },
                         { "TabSelectedFg", "#2D3748" },
+                        // Brand + dashboard extras (shared with DMD / BCC)
+                        { "NavyHeader", "#1A365D" },
+                        { "OrangeAccent", "#3182CE" },
+                        { "CardBg", "#FFFFFF" },
+                        { "AltRowBg", "#F2F6FA" },
+                        { "SubtleFg", "#718096" },
+                        { "InfoBlue", "#3182CE" },
+                        { "RowHover", "#E3EEF8" },
                     }
                 },
                 {

--- a/StingTools/UI/ThemeManager.cs
+++ b/StingTools/UI/ThemeManager.cs
@@ -206,7 +206,21 @@ namespace StingTools.UI
 
             CurrentTheme = themeName;
             StingLog.Info($"ThemeManager: applied '{themeName}' theme");
+
+            // Notify subscribers (modeless windows like BCC) so they can
+            // refresh code-behind brushes that don't go through DynamicResource.
+            try { ThemeChanged?.Invoke(null, EventArgs.Empty); }
+            catch (Exception ex) { StingLog.Warn($"ThemeManager.ThemeChanged: {ex.Message}"); }
         }
+
+        /// <summary>
+        /// Fires after a successful <see cref="ApplyTheme"/>. Modeless windows
+        /// that build their visual tree in code-behind (BCC, DMD) can subscribe
+        /// to rebuild their brushes when the user cycles themes from the dock
+        /// panel. DynamicResource bindings update automatically and don't need
+        /// this event.
+        /// </summary>
+        public static event EventHandler ThemeChanged;
 
         private static void ApplyToTarget(Dictionary<string, string> theme, ResourceDictionary resources)
         {


### PR DESCRIPTION
## Summary
Refactored the BIM Coordination Center (BCC) and Document Management Dialog (DMD) to dynamically respond to theme changes, enabling real-time UI updates when users cycle themes from the dock panel. Previously, theme changes only affected XAML-bound resources; code-behind-built UI elements retained stale brushes until the window was reopened.

## Key Changes

- **ThemeManager Enhancement**: Added `ThemeChanged` event that fires after successful theme application, allowing modeless windows to subscribe and refresh their imperative UI trees.

- **BCC Layout Refactoring**: Extracted layout construction into a new `BuildLayout()` method that can be called both during initialization and when the theme changes, ensuring all brushes are recalculated with the active palette.

- **BCC Theme Color Properties**: Added new static color properties (`CHeaderFg`, `CSecondaryBg`, `CSubtleFg`) that resolve from the active theme on each access, replacing hardcoded RGB values throughout the UI.

- **BCC Theme Change Handler**: Implemented `OnThemeChanged()` callback that clears the tab cache (forcing re-renders with new brushes) and rebuilds the layout when the user cycles themes.

- **DMD Theme Integration**: Converted DMD's frozen brush fields to properties that resolve live from `ThemeManager`, allowing the dialog to reflect theme changes on the next `Show()` call.

- **Default Theme Change**: Switched default theme from "Corporate" to "Cool" and reordered the theme cycle sequence to start with "Cool".

- **Status Bar Styling**: Updated status bar background to derive from the header palette (`Darken(CHeaderBg, 0.55)`) so it tracks theme changes instead of using a hardcoded color.

- **Header and Navigation Updates**: Replaced hardcoded colors in header text, buttons, and navigation elements with theme-aware brush properties, ensuring consistent appearance across theme cycles.

## Implementation Details

- Theme-driven brushes in DMD are now resolved on-demand via `ThemeManager.GetBrush()` rather than frozen at startup, enabling live updates.
- BCC's tab cache is cleared on theme change to force content re-rendering with new brushes.
- Navigation buttons now properly reset their foreground color when deselected, preventing them from staying white after a theme cycle.
- All theme-agnostic accent colors (purple, teal, amber) remain as frozen static fields for performance.

https://claude.ai/code/session_017E1GdUtzCWQDunBNNWGjKb