### PR TITLE
docs: CLAUDE.md default branch is main, not master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1588,9 +1588,12 @@ dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:\Program Files\Auto
 
 ### Branching
 
-- The default branch is `master`
+- The default branch is `main`
 - Feature branches: `feature/<description>` or `claude/<session-id>`
-- Always create feature branches from the latest `master`
+- Always create feature branches from the latest `main`
+- Never commit directly to local `main` — branch off it, PR back. Direct
+  commits drift the local copy from origin and surface as "diverged" the
+  next time you try to pull or push.
 
 ### Commits
 


### PR DESCRIPTION
## Summary

Two-line doc fix to `CLAUDE.md`:

- The Branching section claimed the default branch was `master`, but the repo's actual trunk is `main`. Updated.
- Added an explicit warning against committing to local `main` — direct commits drift the local copy from origin and surface as "diverged" the next time anyone tries to pull or push (this was the root cause of the 14-commit divergence we ran into while sorting out the CompiledPlugin/Data untrack work).

## What about the 12 build warnings?

Investigated and not bundled here. The warnings (CS0618 on `ElementId.IntegerValue` / `ElementId(int)`, CS4014 unawaited async) target code that doesn't exist on `main` yet:

| File | On main? |
|---|---|
| `StingTools/Core/Calc/SlopeAutoCorrector.cs` (line 299 warning) | File exists but the line in question lives in a feature branch — main's copy is shorter |
| `StingTools/Commands/Electrical/Routing/ConduitConsolidator.cs` | ✗ not on main |
| `StingTools/Commands/Electrical/Routing/ConduitAutoRouteCommand.cs` | ✗ not on main |
| `StingTools/UI/SitePhotosTab.cs` | ✗ not on main |

The fixes are commit `b5fd6a45` on `claude/resolve-issue-uVXmZ` if anyone wants to cherry-pick them onto the appropriate feature branches before those branches PR to main.

## Test plan

- [x] CLAUDE.md edit only, no code touched
- [ ] `git remote show origin` shows `HEAD branch: main` after merging this PR (will need someone with admin to flip `origin/HEAD` from the current `claude/claude-md-mm3e3rr0h3nqaf6c-hAOJn` setting via Settings → Branches → Default branch)

## Related

- Supersedes #209 (which was 666 commits + 1359 files because of an old fork point)
- Follow-up to #208 (CompiledPlugin untrack)

https://claude.ai/code/session_01XRZXo8fYxYVexZipT69jxN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRZXo8fYxYVexZipT69jxN)_