### PR TITLE
Fix duplicate PanelId property and variable name in BatchAssignCircuitsCommand

### DIFF
--- a/StingTools/Commands/Electrical/BatchAssignCircuitsCommand.cs
+++ b/StingTools/Commands/Electrical/BatchAssignCircuitsCommand.cs
@@ -349,7 +349,6 @@ namespace StingTools.Commands.Electrical
             public ElementId SystemId;
             public ElementId PanelId;     // Revit 2024+ SelectPanel takes FamilyInstance, not string
             public string SystemName;
-            public ElementId PanelId;
             public string PanelName;
             public string Group;
             public string Reason;

--- a/StingTools/Commands/Electrical/BatchAssignCircuitsCommand.cs
+++ b/StingTools/Commands/Electrical/BatchAssignCircuitsCommand.cs
@@ -184,7 +184,6 @@ namespace StingTools.Commands.Electrical
                     SystemId = sys.Id,
                     PanelId  = fit.Id,
                     SystemName = sys.Name ?? "(?)",
-                    PanelId = fit.Id,
                     PanelName = fit.Name,
                     Group = circuitGroup,
                     Reason = $"fit slots={fit.RemainingSlots} after, panelLoad={fit.ConnectedVa/1000:F1} kVA" +
@@ -257,8 +256,8 @@ namespace StingTools.Commands.Electrical
                             // collector by name now that PanelId is on Assignment.
                             try
                             {
-                                if (panelInst != null)
-                                    ParameterHelpers.SetString(panelInst, "ELC_PNL_CIRCUIT_GROUP_TXT", a.Group, overwrite: false);
+                                if (panelFi != null)
+                                    ParameterHelpers.SetString(panelFi, "ELC_PNL_CIRCUIT_GROUP_TXT", a.Group, overwrite: false);
                             }
                             catch (Exception ex2) { StingLog.Warn($"Stamp panel group: {ex2.Message}"); }
                         }


### PR DESCRIPTION
## Summary
Fixes two bugs in `BatchAssignCircuitsCommand.cs`:
1. Duplicate `PanelId` property declaration in the `Assignment` class
2. Incorrect variable reference (`panelInst` instead of `panelFi`) when stamping panel group information

## Changes
- **Line 187**: Removed duplicate `PanelId = fit.Id,` assignment in the `Assignment` object initializer (the property was already assigned on line 185)
- **Line 259**: Fixed variable name from `panelInst` to `panelFi` in the null check and `ParameterHelpers.SetString()` call to match the actual variable in scope
- **Line 351**: Removed duplicate `PanelId` property declaration from the `Assignment` class definition

## Details
The duplicate `PanelId` assignment would have caused a compiler error. The variable name mismatch (`panelInst` vs `panelFi`) would have resulted in a runtime null reference or undefined variable error when attempting to stamp the circuit group parameter on panel instances.

https://claude.ai/code/session_01241XHR4ReM2MjTNjCYEkJV