### PR TITLE
docs: consolidate guides into docs/guides/ with integration index

### DIFF
--- a/StingTools/Data/DRAWING_TEMPLATE_GUIDE.md
+++ b/StingTools/Data/DRAWING_TEMPLATE_GUIDE.md
@@ -1,3 +1,7 @@
+> **This document has been consolidated.** See `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md` for the complete, up-to-date guide. The content below is kept for historical reference only.
+
+---
+
 # STING Drawing Template Manager — Layman's Guide
 
 A plain-English handbook to making every drawing in your project look right

--- a/docs/DOCUMENT_MANAGER_GUIDE.md
+++ b/docs/DOCUMENT_MANAGER_GUIDE.md
@@ -1,3 +1,7 @@
+> **This document has been moved.** The up-to-date version is at `docs/guides/DOCUMENT_MANAGER_GUIDE.md`. The content below is kept for historical reference only.
+
+---
+
 # Document Manager — Plain-English Guide
 
 A practical guide to managing project documents across **Revit (the plugin)**, **the cloud server (Planscape)**, and **the mobile app**, with recommended workflows for the most common roles.

--- a/docs/MEP_SYMBOL_GUIDE.md
+++ b/docs/MEP_SYMBOL_GUIDE.md
@@ -1,3 +1,7 @@
+> **This document has been consolidated.** See `docs/guides/MEP_FOUNDATION_GUIDE.md` for the complete, up-to-date guide. The content below is kept for historical reference only.
+
+---
+
 # MEP symbol library — companion guide
 
 Companion to `CompiledPlugin/Data/mep_symbols.csv`.

--- a/docs/PLACEMENT_FAMILY_AUTHORING.md
+++ b/docs/PLACEMENT_FAMILY_AUTHORING.md
@@ -1,3 +1,7 @@
+> **This document has been consolidated.** See `docs/guides/MEP_FOUNDATION_GUIDE.md` for the complete, up-to-date guide. The content below is kept for historical reference only.
+
+---
+
 # Placement Family Authoring & Setup Requirements (Phase 139.6)
 
 How every Revit family + project setting must be authored for the

--- a/docs/STING_MANAGED_TEMPLATES_DESIGN.md
+++ b/docs/STING_MANAGED_TEMPLATES_DESIGN.md
@@ -1,3 +1,7 @@
+> **This document has been consolidated.** See `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md` for the complete, up-to-date guide. The content below is kept for historical reference only.
+
+---
+
 # Design — STING-Managed View Templates
 
 ## The proposal in one line

--- a/docs/guides/DOCUMENT_MANAGER_GUIDE.md
+++ b/docs/guides/DOCUMENT_MANAGER_GUIDE.md
@@ -1,0 +1,1426 @@
+# STING Document Manager — Complete Guide
+
+> **Who wrote this?** The STING Document Manager is built into the STING Tools Revit plugin.
+> This guide explains how to use it. If you are new to the plugin entirely, start with the
+> BIM Coordination Center guide first, then come back here.
+
+> **Cross-references**
+> - **Drawings that become deliverables**: `docs/guides/DRAWING_TYPE_MANAGER_GUIDE.md`
+> - **Tagging elements before issuing**: `docs/TAGGING_PROCEDURES_GUIDE.md`
+> - **BIM Management (BEP, MIDP)**: `docs/BIM_MANAGEMENT_GUIDE.md`
+> - **Healthcare workflows**: `docs/HEALTHCARE_PACK_DESIGN.md`
+
+---
+
+## Who this guide is for
+
+This guide is written for someone who manages files and paperwork but has never used a CDE
+(Common Data Environment) before. If you have run a paper filing system, you already understand
+the concepts — the software just does the same thing faster, with a record of every step.
+
+You do not need to be a software specialist to follow this guide. Every step names the exact
+button to click, the exact field to fill in, and what you will see on screen.
+
+If you are an experienced BIM coordinator who wants a technical reference, jump straight to
+Part 4 (every button) and the Quick Reference at the end.
+
+---
+
+## The Big Picture — Your Project's Filing System
+
+Imagine a **very organised office filing cabinet**. Before the digital age, a project office
+kept physical drawings in a filing room. The filing room had four distinct drawers:
+
+- A **yellow drawer** labelled "DRAFTS — Do Not Distribute." Nobody outside your team
+  was allowed to take anything from it. Files in here might be incomplete, wrong, or
+  changing daily.
+- A **blue drawer** labelled "ISSUED FOR COORDINATION." The whole project team could
+  read these but not use them for construction yet. They were there so different consultants
+  could coordinate their work against each other.
+- A **green drawer** labelled "ISSUED FOR CONSTRUCTION." These were the authorised,
+  official drawings that builders would work from. Nothing went in here without a senior
+  partner's signature.
+- A **grey drawer** labelled "SUPERSEDED / ARCHIVE." Old versions that had been replaced.
+  You kept them so you could answer the question "what did the drawing say on 12 March?"
+  but nobody built from them.
+
+STING's Document Manager is that filing cabinet, but digital. Instead of physical drawers,
+the system calls them **CDE states** (CDE stands for Common Data Environment). There are
+the same four:
+
+| The Drawer | CDE State | Colour in STING | Who can see it |
+|---|---|---|---|
+| Drafts | WIP — Work In Progress | Yellow | Your discipline team only |
+| For coordination | SHARED | Blue | The whole project team |
+| For construction | PUBLISHED | Green | Everyone, including clients |
+| Old versions | ARCHIVE | Grey | Anyone (read-only) |
+
+Every single document in the system lives in exactly one drawer at any given time. When you
+"issue" a document, you are moving it from one drawer to another. That move is recorded,
+dated, and signed against your login — exactly as the senior partner's signature worked in
+the paper world.
+
+The key difference from paper: **you cannot skip a drawer**. A drawing must go through
+SHARED before it can reach PUBLISHED. This is the ISO 19650 rule — it exists because
+"Issued for Construction" drawings that never went through a coordination review are
+a building site hazard.
+
+---
+
+## Part 1 — Setup
+
+### First-time setup: what happens when you first open a project
+
+The very first time you open a Revit project file with STING Tools loaded, the system does
+a silent setup task in the background. You will not see a dialog pop up. You will not be
+asked to do anything. But the following happens automatically:
+
+1. **STING checks** whether the `_BIM_COORD` folder exists inside your project's folder.
+   (The project folder is wherever you saved the `.rvt` file — for example,
+   `\\server\Projects\BuildingA\BIM\`)
+
+2. If the folder does not exist, STING creates it and copies 16 template files and
+   5 workflow files into it. This is called "extracting embedded resources." The files
+   are baked into the plugin itself; STING is basically unpacking them for your project.
+
+3. STING reads basic information from Revit's **Project Information** (the dialog you reach
+   from Revit's Manage tab) — things like the project name, project number, and organisation
+   code — and writes them into a file called `manifest.json`. This file becomes the
+   "project settings" for all the document templates.
+
+4. STING also creates a `doc_sequences.json` file, which is your auto-numbering system.
+   Every document number the system ever generates for this project comes from this file.
+   It starts at zero and counts up forever; you never need to manage it manually.
+
+**How to verify the setup worked:**
+
+1. Open Windows Explorer.
+2. Navigate to the folder where your `.rvt` file is saved.
+3. You should see a `_BIM_COORD` folder there.
+4. Inside it, open the `templates` folder. You should see 16 `.docx` and `.xlsx` files.
+5. Open the `workflows` folder. You should see 5 `.json` files.
+
+If those folders and files are there, setup succeeded.
+
+> **Stuck?** If you cannot find the `_BIM_COORD` folder at all, it means STING did not
+> run setup. The most common cause is that Revit was already open when you loaded STING
+> for the first time — the document-opened event did not fire. Close the project and
+> re-open it. If it still does not appear, check the STING log file (`StingTools.log`
+> in the same folder as the STING DLL) for any error messages.
+
+> **Stuck?** If the folder is there but the `templates` subfolder is empty, the file
+> extraction failed partway through. Delete the `_BIM_COORD` folder entirely and re-open
+> the project. STING will re-extract from scratch.
+
+**What if Project Information is empty?**
+
+If your project's Project Information dialog (Manage tab → Project Information) does not
+have a project number or organisation code filled in, STING will still create `manifest.json`
+but the fields will be blank. Your document templates will then show blank fields where
+the project name should appear. Fill in Project Information as early as possible — it feeds
+every template in the system.
+
+---
+
+### The folder structure: what lives where and why
+
+Here is the complete map of everything STING creates under your project folder. This section
+exists so that if anything ever goes wrong, you know exactly what to look for and whether
+you need to worry about it.
+
+```
+<Your Revit project folder>  (wherever your .rvt file is saved)
+│
+└── _BIM_COORD/                       ← the Document Manager's home base
+    │
+    ├── templates/                    ← the 16 reusable document templates
+    │   ├── manifest.json             ← project settings for all templates
+    │   ├── deliverable_standard.docx ← A01: deliverable cover sheet
+    │   ├── deliverable_cancelled.docx← A02: cancellation notice
+    │   ├── deliverable_superseded.docx ← A03: superseded notice
+    │   ├── deliverable_replacing.docx← A04: replacing notice
+    │   ├── deliverable_tabular.xlsx  ← A05: tabular deliverable list
+    │   ├── transmittal.docx          ← B06: transmittal memo
+    │   ├── technical_query.docx      ← B07: technical query
+    │   ├── rfi.docx                  ← B08: request for information
+    │   ├── technical_response.docx   ← B09: response to TQ or RFI
+    │   ├── material_requisition.docx ← C10: material requisition
+    │   ├── submittal_cover.docx      ← C11: submittal cover sheet
+    │   ├── variation.docx            ← C12: variation / change order
+    │   ├── letter_transmittal.docx   ← C13: formal letter of transmittal
+    │   ├── meeting_minutes.docx      ← D14: meeting minutes
+    │   ├── progress_report.docx      ← D15: progress report
+    │   └── handover_certificate.docx ← D16: handover certificate
+    │
+    ├── workflows/                    ← the 5 built-in workflow definitions
+    │   ├── transmittal_default.json  ← steps for a standard transmittal
+    │   ├── rfi_default.json          ← steps for an RFI
+    │   ├── tq_default.json           ← steps for a technical query
+    │   ├── mr_default.json           ← steps for a material requisition
+    │   └── deliverable_issue_default.json ← steps for issuing a deliverable
+    │
+    ├── generated/                    ← rendered documents (output)
+    │   └── 20260514_PRJ-001_transmittal.docx  ← example output file
+    │
+    ├── healthcare/                   ← (healthcare projects only)
+    │   └── mgas_verifications/       ← medical gas verification logs
+    │
+    ├── deliverables.json             ← the master deliverable register
+    ├── transmittals.json             ← log of every transmittal created
+    ├── workflow_state.json           ← currently open workflows
+    ├── doc_sequences.json            ← the auto-numbering counter store
+    ├── audit_log_2026_05.jsonl       ← tamper-evident audit log (one per month)
+    ├── distribution_groups.json      ← email recipient groups
+    ├── saved_searches.json           ← your saved document search queries
+    ├── search_index/                 ← fast search database (folder of index files)
+    ├── drawing_types.json            ← project drawing type overrides (if set)
+    ├── panel_schedule_templates.json ← panel schedule config (electrical projects)
+    ├── aec_filters.json              ← project filter overrides (if set)
+    ├── bim_execution_plan.json       ← generated BEP (if BEP wizard was run)
+    ├── project_dashboard.json        ← live project status snapshot
+    ├── issues.json                   ← issue register
+    ├── documents.json                ← document register entries
+    ├── sticky_notes.json             ← element-level coordination notes index
+    ├── reviews.json                  ← review tracker register
+    └── reference/                   ← user-added reference PDFs and documents
+        └── (any PDFs you add via "Add File" in the Briefcase)
+```
+
+**What each item is, and whether you ever need to touch it manually:**
+
+---
+
+**`templates/manifest.json`**
+
+This is the project's configuration file for all 16 document templates. It contains the
+project name, project number, originator code, company name, client name, and other
+fields that appear on every document header.
+
+Do you need to touch it? Yes — once. When you first set up the project, review `manifest.json`
+in a text editor (Notepad works fine) and check that the project code, company name, and
+client name are correct. If they came in blank from Project Information, fill them in here.
+
+If this file gets corrupted (unreadable) or deleted, STING will recreate it from Project
+Information when you re-open the project. You will lose any custom fields you added manually.
+
+---
+
+**`templates/*.docx` and `templates/*.xlsx`**
+
+These are the 16 document templates. They look like normal Word documents when you open them.
+They contain special `{{token}}` placeholders that STING replaces with real project data when
+it renders a document.
+
+Do you need to touch them? Only if you want to customise the look. For example, if you want
+to add your company logo to the transmittal, open `transmittal.docx` in Word, add the logo
+to the header, save it, and close it. STING will use your modified version from then on.
+
+**Warning**: Do not delete the `{{token}}` placeholders. Those curly-brace codes are how STING
+inserts the date, document number, recipient name, and other data. If you delete them, the
+rendered document will show blank fields.
+
+If a template file gets deleted, STING will re-extract the original factory version from
+inside the plugin the next time you open the project. You will lose your customisations.
+
+---
+
+**`workflows/*.json`**
+
+These define the steps and time limits for each type of workflow. For example,
+`transmittal_default.json` says: "Step 1 is Draft. Step 2 is Issued (must happen within
+24 hours). Step 3 is Acknowledged (must happen within 72 hours)."
+
+Do you need to touch them? Rarely. If your project has unusual approval chains — for example,
+a client who requires sign-off within 5 business days rather than the standard 72 hours —
+a BIM manager can edit these files in a text editor. Otherwise, leave them alone.
+
+---
+
+**`generated/`**
+
+Every time STING renders a document (creates a transmittal, issues a deliverable, etc.), it
+saves the output Word file here. The filename includes the date and the document number so
+you can always find it.
+
+Do you need to touch it? No. STING writes here; you read from here if you need a copy of a
+specific rendered document. Never edit files in this folder — if the document needs to change,
+re-issue it through STING so the new version is tracked.
+
+---
+
+**`deliverables.json`**
+
+This is your project's deliverable register. Every time you issue a deliverable through STING,
+a row is added or updated here. It records the document number, current state (WIP / SHARED /
+PUBLISHED / ARCHIVE), revision, suitability code, and when each transition happened.
+
+Do you need to touch it? No. This is a system file. If it gets corrupted, you may lose the
+state history of your deliverables. Back it up alongside your `.rvt` file.
+
+---
+
+**`transmittals.json`**
+
+A log of every transmittal created on this project. Each entry records the transmittal number,
+date, recipient, document list, and workflow state.
+
+Do you need to touch it? No. If it gets deleted, you lose the transmittal history but can
+recreate new transmittals normally.
+
+---
+
+**`workflow_state.json`**
+
+A record of every workflow currently in progress. For example, if you created a transmittal
+an hour ago and the recipient has not yet acknowledged it, there is an open workflow instance
+in this file tracking that.
+
+Do you need to touch it? No. If it gets corrupted, you may see an error message on the STING
+dock panel. The safest recovery is to delete the file — STING will create a fresh one. In-flight
+workflows will be lost (you will need to re-create them manually), but nothing else is damaged.
+
+> **Stuck?** If you see "workflow_state.json deserialization failed" in the STING log or on
+> screen, delete `workflow_state.json` from the `_BIM_COORD` folder and re-open the project.
+
+---
+
+**`doc_sequences.json`**
+
+The auto-numbering counter. Every document number STING generates for this project comes from
+here. It stores the highest number used for each document type.
+
+Do you need to touch it? Almost never. The only time you might need to is if you are migrating
+from another system and need the numbering to continue from a specific number rather than 001.
+In that case, a BIM manager can edit the relevant counter by hand. If this file gets deleted,
+the next document STING creates will start from 001 again — potentially creating duplicate
+numbers if some already exist.
+
+---
+
+**`audit_log_YYYY_MM.jsonl`**
+
+The tamper-evident audit trail. Every document action is recorded here. A new file is created
+each calendar month (hence the `YYYY_MM` in the filename). The file uses a SHA-256 chain
+(explained in detail in Part 5).
+
+Do you need to touch it? Never. This file is read-only from your perspective. Editing it
+manually breaks the tamper-evidence chain.
+
+---
+
+**`distribution_groups.json`**
+
+Your named recipient lists. Each group has a name, a list of email addresses, and tags
+that describe what documents it should receive.
+
+Do you need to touch it? Only to add or edit distribution groups. See Part 7 for instructions.
+
+---
+
+**`saved_searches.json`**
+
+Your personal saved searches from the document search bar. Stored per-user.
+
+Do you need to touch it? No. If it gets deleted, you lose your saved searches but can
+recreate them.
+
+---
+
+**`search_index/`**
+
+A folder containing the fast search database (built using a technology called Lucene). STING
+uses it to find documents in milliseconds.
+
+Do you need to touch it? No. If it gets corrupted, STING will automatically rebuild it. If
+search is returning wrong results, you can force a rebuild by deleting this folder — STING
+will recreate it the next time you search.
+
+---
+
+### The 16 document templates explained
+
+These are the pre-built forms that STING can fill in and produce for you automatically. Think
+of them as headed notepaper with blanks that STING fills in. You choose the right form, fill
+in a few extra details, and STING does the rest.
+
+| ID | File | What it produces | When you would use it |
+|---|---|---|---|
+| A01 | `deliverable_standard.docx` | Deliverable cover sheet | Every time you formally issue a drawing or document. Goes on top of the package like a cover letter. |
+| A02 | `deliverable_cancelled.docx` | Cancellation notice | When a document is being formally cancelled — for example, a drawing that is no longer needed. Puts the project team on notice that this document is void. |
+| A03 | `deliverable_superseded.docx` | Superseded notice | When a document has been replaced by a newer revision. Explains what the new document number is. |
+| A04 | `deliverable_replacing.docx` | Replacing notice | The other side of A03 — this goes with the new document, stating what it replaces. |
+| A05 | `deliverable_tabular.xlsx` | Tabular deliverable list | A formatted spreadsheet listing multiple deliverables in one package. Useful for large issue packages (20+ drawings). |
+| B06 | `transmittal.docx` | Transmittal memo | A short formal letter listing documents being sent. Use this every time you send drawings or documents to anyone outside your immediate team. |
+| B07 | `technical_query.docx` | Technical query (TQ) | When you need a formal written answer to a design question. Creates a numbered TQ that can be tracked to resolution. |
+| B08 | `rfi.docx` | Request for Information (RFI) | Similar to a TQ but typically raised from site — "the drawing says X but on site we see Y, what do we do?" |
+| B09 | `technical_response.docx` | Response to a TQ or RFI | The formal written answer to a B07 or B08. Cross-referenced to the original query number automatically. |
+| C10 | `material_requisition.docx` | Material requisition (MR) | A formal request to procure specific materials or equipment. Contains a list of items with quantities and specifications. |
+| C11 | `submittal_cover.docx` | Submittal cover sheet | When a contractor submits product data, shop drawings, or samples for approval, this form wraps the submission. |
+| C12 | `variation.docx` | Variation / change order | Documents a change to the agreed scope of work. Required by most contracts when design changes affect cost or programme. |
+| C13 | `letter_transmittal.docx` | Formal letter of transmittal | A more formal version of B06 — used for stage-gate handovers or sending to the client/authority. On headed paper with a full signature block. |
+| D14 | `meeting_minutes.docx` | Meeting minutes | Records attendees, agenda items, discussion, and action items from a coordination meeting. |
+| D15 | `progress_report.docx` | Progress report | A periodic summary of where the project stands — deliverables issued, issues open, SLAs outstanding, compliance score. |
+| D16 | `handover_certificate.docx` | Handover certificate | The formal sign-off document at project completion. Has a three-party signature block (client, lead designer, contractor). |
+
+---
+
+## Part 2 — The Four Drawers (CDE States)
+
+### WIP — Work In Progress (the Yellow Drawer)
+
+WIP is the default state for any new document. Think of it as your desk — work in progress,
+visible only to you and your immediate team.
+
+**What WIP means in practice:**
+- The document may be incomplete, inconsistent, or just plain wrong. That is fine — it is
+  a draft.
+- Nobody outside your discipline should be working from a WIP drawing. If a structural
+  engineer is co-ordinating against your M&E layout and your M&E layout is still WIP,
+  they are coordinating against a draft that may change tomorrow.
+- The suitability code is usually S0 (Initial).
+- The revision is usually P01 (first preliminary), P02, P03 as you iterate.
+
+**Who can see WIP?**
+Only members of the owning discipline team, plus project managers and administrators.
+A client, an external reviewer, or a subcontractor from another discipline should not
+see your WIP.
+
+**How long should something stay in WIP?**
+As short as possible. WIP items that sit for more than 30 days without moving are flagged
+as "stale" in the CDE Status screen — a signal that something is stuck.
+
+---
+
+### Shared — Ready for Review (the Blue Drawer)
+
+Shared means the document is in the blue drawer — the whole project team can read it.
+It is not yet authorised for construction, but it is in good enough shape that other
+disciplines can coordinate their work against it.
+
+**What Shared means in practice:**
+- The M&E engineer can now coordinate their ductwork against the structural drawings
+  because the structural drawings have moved to Shared.
+- Reviewers can raise comments and RFIs against Shared documents.
+- The revision typically bumps up when you move from WIP to Shared (e.g. P02 → P03)
+  to signal that a new milestone has been reached.
+- The suitability code moves to S1 (suitable for coordination), S2 (suitable for information),
+  or S3 (suitable for review and comment).
+
+**Who can move a document from WIP to Shared?**
+You need at least Coordinator role. A drafter or technician in Contributor role cannot
+do this — they need to ask a coordinator to promote the document.
+
+**Who can see Shared?**
+The whole project team, including subcontractors for all disciplines. Typically not
+the client unless they have been given access.
+
+---
+
+### Published — Officially Released (the Green Drawer)
+
+Published is the green drawer — the authoritative version used for construction, fabrication,
+or handover. Think of it as the drawing stamped "FOR CONSTRUCTION" hanging on the site hut wall.
+
+**What Published means in practice:**
+- These are the drawings that builders, fabricators, and installers work from.
+- Moving a document to Published requires a Manager role AND a formal approval record
+  (someone with sign-off authority has clicked Approve).
+- The suitability code is S4 (suitable for construction), S5 (suitable for manufacture),
+  or S6 (suitable for PIM/AIM authorisation).
+- The revision typically changes format from preliminary (P-series) to construction (C01, C02).
+
+**The publishing gate:**
+This is the most important safeguard in the system. A coordinator can issue a drawing for
+team sharing in about 30 seconds. But getting that drawing to Published — the state where
+someone will build from it — requires a manager to formally approve it. This mirrors the
+real-world process where a senior engineer or director stamps a drawing for issue.
+
+If you try to move a document to Published without an approval in place, the system will
+say "Publish failed — approval required." This is not a bug. It is the system doing its job.
+
+> **Stuck?** If you see "Publish failed — approval required" and you know the document
+> has been reviewed, it means the approval record has not been created yet. Click
+> "Request Approval" on the document, write a brief note to the manager explaining why
+> it is ready, and they will receive a notification on their phone or email.
+
+---
+
+### Archive — Locked Away (the Grey Drawer)
+
+Archive is the grey drawer — superseded revisions and end-of-project handover material.
+Files in Archive are read-only. They are there so you can answer "what did the drawing
+look like before the change?" — but nobody is building from them.
+
+**What Archive means in practice:**
+- When you issue revision C02 of a drawing, revision C01 moves to Archive automatically.
+- At project handover, all superseded documents are moved to Archive as part of the close-out.
+- Archive documents can still be downloaded and read. They just cannot be edited, promoted,
+  or used as the "current" version.
+
+**Why not just delete old versions?**
+Because the Building Regulations, most construction contracts, and ISO 19650 require you
+to be able to demonstrate what the design said at any given point in time. If a dispute
+arises years after handover — "the wall was built 50mm out of position" — you need to
+show which drawing was current on the day the wall was poured. Archive is how you do that.
+
+---
+
+### Moving between states: the rules
+
+The four drawers have a strict movement sequence. You cannot skip steps.
+
+```
+WIP ──────────────────▶ SHARED ──────────────────▶ PUBLISHED ──────▶ ARCHIVE
+ ▲                         │
+ │   (rework)              │
+ └─────────────────────────┘
+
+Special cases:
+PUBLISHED ──────────────────▶ SUPERSEDED ──────▶ ARCHIVE
+                                    │
+                                    └──▶ replaced by a new document ──▶ PUBLISHED
+```
+
+**The full transition table:**
+
+| Move | What triggers it | Minimum role | Needs approval? |
+|---|---|---|---|
+| WIP → Shared | You are ready for the team to review | Coordinator | No |
+| Shared → WIP | Document needs more work (rework) | Coordinator | No |
+| Shared → Published | Ready for construction/handover | Manager | Yes — formal approval required |
+| Published → Archive | Superseded by a newer version | Manager | No |
+| Published → Superseded | Formally superseded (comes with an A03 notice) | Manager | No |
+| Superseded → Archive | After the replacing document is published | Automatic | — |
+
+**What happens when a document is superseded and replaced:**
+
+1. You create a new document (the replacement).
+2. You run SupersedeDeliverable on the old document — STING generates an A03 notice.
+3. STING also generates an A04 notice on the new document showing what it replaces.
+4. When the new document is Published, the old document moves to Archive.
+5. The A03 and A04 notices are stored alongside the documents in the generated folder.
+
+---
+
+## Part 3 — Daily Workflows
+
+### Issuing a deliverable (step by step)
+
+A deliverable is any document you formally issue — a drawing, a report, a specification.
+Here is the complete process from start to finish.
+
+**Before you start:**
+- Your drawing or document must be in a state you are happy to issue. For most Revit
+  drawings, this means sheets are complete, notes are checked, revision triangle is placed.
+- Project Information in Revit must have the project number and organisation code filled in.
+
+**Step 1: Open the Document Management Center**
+
+In the STING dock panel, click the **BIM** tab. Then click the **Document Management Center**
+button (it shows a filing-cabinet icon). A large dialog with 8 tabs along the top will appear.
+
+Alternatively, in the STING dock panel's BIM tab, look for the **Deliverables** section and
+click **Issue Deliverable** directly if you just want to issue a single document quickly.
+
+**Step 2: Fill in the issue form**
+
+A dialog will appear asking for:
+- **Document number**: STING will suggest the next number automatically from `doc_sequences.json`.
+  You can override it if needed, but use the suggested number unless you have a specific reason
+  not to.
+- **Title**: A plain-English description of the document (e.g. "Ground Floor MEP Services Plan").
+- **Discipline**: Pick from the dropdown — A (Architectural), S (Structural), M (Mechanical),
+  E (Electrical), P (Plumbing), FP (Fire Protection), LV (Low Voltage), G (General).
+- **Suitability**: Pick the code that describes what this issue is for. S1 for coordination,
+  S3 for review and comment, S4 for construction. If unsure, ask your project manager.
+- **Revision**: The system will suggest the next revision letter (P01, P02, etc.). Confirm
+  or override.
+- **Issue purpose**: A short note about why this is being issued.
+- **Recipient / distribution group**: Who should receive this (see Part 7 for distribution groups).
+
+**Step 3: Click "Issue"**
+
+When you click Issue, STING does the following automatically — you will see a progress bar:
+
+1. Mints the document number (increments the counter in `doc_sequences.json`).
+2. Renders the A01 deliverable cover sheet from `templates/deliverable_standard.docx`,
+   filling in all the token fields.
+3. Saves the rendered `.docx` file into the `generated/` folder with a date-stamped filename.
+4. Writes a new row (or updates the existing row) in `deliverables.json`.
+5. Starts the `deliverable_issue_default` workflow — which begins timing the SLA for
+   the recipient to acknowledge receipt.
+6. Writes a row to the audit log.
+7. Mirrors everything to the cloud server (if you are connected).
+
+**Step 4: Check the output**
+
+After STING finishes, it shows you a summary: the document number, the path to the rendered
+DOCX, and whether the server sync succeeded.
+
+Open the `generated/` folder to find your rendered cover sheet. It is a normal Word document
+that you can print, email, or attach to a transmittal.
+
+**What CDE state is the document in now?**
+
+After Issue, the document is in **WIP**. Issuing creates the document and assigns it a number,
+but it does not yet move it to Shared or Published. Those are separate steps:
+
+- To move to Shared: click **Publish to Shared** (or the appropriate button in the
+  Document Management Center). This requires Coordinator role.
+- To move to Published: the document must first be in Shared, an approval must be created
+  and approved by a Manager, and then you click **Publish for Construction**.
+
+---
+
+### Re-issuing (when something changes)
+
+If a document has already been issued and something changes — a design update, a correction,
+or a client comment addressed — you re-issue it with a new revision number.
+
+**Step 1: Find the document in the deliverable register.**
+In the Document Management Center, click the **DOCS/CDE** tab. You will see a list of
+all documents. Find the one you want to re-issue.
+
+**Step 2: Click Re-Issue Deliverable.**
+This opens the same form as Issue, but pre-filled with the existing details. The revision
+number is already incremented (e.g. P01 → P02).
+
+**Step 3: Review and confirm.**
+Check that the issue purpose explains what changed (e.g. "Coordination revision — duct route
+amended to avoid structural beam at G.03").
+
+**Step 4: Click Re-Issue.**
+STING repeats the same steps as Issue — renders a new A01 cover sheet with the new revision
+number, saves it, updates `deliverables.json`, continues the workflow (or starts a new one),
+and writes the audit row.
+
+The old revision is automatically moved to Archive. The new revision becomes the current one.
+
+---
+
+### Creating a transmittal (step by step)
+
+A transmittal is a formal cover letter that lists the documents you are sending and why.
+In paper days, every package of drawings came with a transmittal slip listing what was in
+the envelope. STING generates these automatically.
+
+**Scenario**: You have produced five drawings and need to send them to the structural engineer
+for coordination review.
+
+**Step 1: Gather the drawings.**
+
+Make sure all five drawings have been issued in STING (they should have document numbers).
+If they have not been issued yet, do that first (see "Issuing a deliverable" above).
+
+**Step 2: Open Create Transmittal.**
+
+In the STING dock panel BIM tab, click **Create Transmittal (Orchestrated)**. This is the
+full version — it generates the document, starts the workflow, and records everything in one
+step.
+
+> **Note**: There is also a simpler **Create Transmittal** button. That is the quick version
+> for informal internal transmittals. For anything going to a consultant or client, use the
+> Orchestrated version.
+
+**Step 3: Fill in the transmittal form.**
+
+The dialog asks for:
+- **Transmittal number**: Auto-generated from `doc_sequences.json`. Do not change unless
+  you have a specific reason.
+- **Date**: Today's date, pre-filled.
+- **Recipient name and organisation**: The structural engineer's name and company.
+- **Recipient email**: Used if the system is configured to send notifications.
+- **Purpose**: A short description — e.g. "Issued for coordination — MEP services coordination
+  drawings, first issue."
+- **Document list**: A table where you add each drawing. Click "Add Document" for each one,
+  pick it from the deliverable register, and its number, title, revision, and suitability
+  will auto-fill.
+- **Distribution group**: If you have a "Structural Team" group set up (see Part 7), pick it
+  here and the recipient list auto-fills.
+
+**Step 4: Click "Create Transmittal."**
+
+STING does the following:
+1. Mints the transmittal number.
+2. Renders the B06 transmittal memo from the template, filling in all details including the
+   document table.
+3. Saves the rendered `.docx` to the `generated/` folder.
+4. Adds a row to `transmittals.json`.
+5. Starts the `transmittal_default` workflow — SLA timer begins (24 hours for you to issue
+   it, then 72 hours for the recipient to acknowledge).
+6. Writes the audit row.
+7. Syncs to the server.
+
+**Step 5: Send the transmittal.**
+
+STING generates the document but does not send emails itself (STING is a Revit plugin, not
+an email client). Open the generated `.docx` file from the `generated/` folder, save it
+as a PDF if needed, and attach it along with the drawings to your normal email.
+
+> **Stuck?** If you cannot find the generated file, check the `generated/` folder inside
+> `_BIM_COORD/`. The filename starts with today's date (YYYYMMDD) followed by the transmittal
+> number and "transmittal".
+
+**Step 6: Track acknowledgement.**
+
+The workflow is now waiting for the recipient to acknowledge receipt. In a fully configured
+system with the Planscape server and mobile app, the recipient gets a notification and can
+acknowledge from their phone. If you are using STING without the server, you track this
+manually — when the recipient confirms receipt, open the BIM Coordination Center and close
+the workflow step.
+
+---
+
+### Raising an RFI
+
+An RFI (Request for Information) is a formal question from site or from a consultant that
+needs a formal answer. The question and its answer are both recorded.
+
+**Step 1: Click "Raise Issue" or navigate to the ISSUES tab** in the Document Management Center.
+
+**Step 2: Fill in the RFI form:**
+- Issue type: RFI
+- Subject: A clear one-line description of the question.
+- Body: The full question in enough detail that the person answering has everything they need.
+- Discipline: Which discipline the question is about.
+- Priority: Low / Medium / High / Critical. Be honest — "Critical" should mean "work is stopped."
+- Assignee: Who should answer it.
+
+**Step 3: Click "Raise."**
+
+STING renders an B08 RFI document from the template, assigns a number, starts the
+`rfi_default` workflow (SLA: 48 hours for first response), and records everything.
+
+**Step 4: Receive and record the response.**
+
+When the answer comes back, click **Create Technical Response** to generate a B09 document
+cross-referencing the original RFI number. The workflow moves to Responded state.
+
+**Step 5: Close the RFI.**
+
+Once the response is accepted and any drawing changes are made, click to close the RFI.
+The workflow reaches Closed state and the SLA timer stops.
+
+---
+
+### Recording meeting minutes
+
+**Step 1: Before the meeting**, click **Create Meeting** in the Document Management Center's
+COORDINATION tab. Give it a name, date, and location.
+
+**Step 2: During the meeting**, add agenda items and discussion notes in the meeting record.
+STING is not a live meeting tool — you can take notes in Word or paper and enter them after.
+
+**Step 3: After the meeting**, open the meeting record, fill in:
+- Attendees (who was there)
+- Agenda items and discussion
+- Action items — each action has an owner and a due date
+
+**Step 4: Generate the minutes.**
+
+Click **Generate Minutes**. STING renders a D14 meeting minutes document from the template,
+including all the above.
+
+**Step 5: Distribute.**
+
+Create a transmittal (B06) wrapping the minutes and send via email.
+
+---
+
+### Running a progress report
+
+At the end of each reporting period (weekly or monthly), a progress report summarises where
+the project stands.
+
+In the Document Management Center, click **Progress Report** in the HANDOVER tab (or from
+the BIM tab of the dock panel). STING renders a D15 progress report from the template,
+automatically pulling:
+- Number of deliverables in each CDE state
+- Open issues count and overdue count
+- SLA breaches this period
+- Compliance score from the tag system
+- Upcoming milestones
+
+Review the rendered document, save as PDF, attach to a B06 transmittal, and distribute.
+
+---
+
+## Part 4 — The Document Management Center (every button)
+
+The Document Management Center (DMC) is the main window for all document management in STING.
+Open it from the BIM tab of the dock panel by clicking **Document Management Center**.
+
+It opens as a large dialog with **8 tabs** along the top. Here is every button on every tab.
+
+---
+
+### Tab 1 — FILE/BULK
+
+This tab handles batch operations — doing the same thing to many documents at once.
+
+| Button | What it does | When to use it |
+|---|---|---|
+| **Issue Deliverable** | Creates and issues a single deliverable. Opens a form to fill in document details. | Every time you formally issue one document. |
+| **Re-Issue Deliverable** | Re-issues an existing deliverable with a new revision. Pre-fills details from the existing record. | When a document needs a revision issued. |
+| **Publish Deliverable** | Moves a Shared document to Published. Requires Manager role and an existing approval record. | When a document is ready for construction issue. |
+| **Cancel Deliverable** | Formally cancels a document. Generates an A02 cancellation notice. The document moves to Archive. | When a document is no longer needed — for example, a room was removed from the project. |
+| **Supersede Deliverable** | Formally supersedes a document. Generates an A03 notice. Use when issuing a replacement. | When you are replacing a document with a new version and want a formal record of the supersession. |
+| **Replace Deliverable** | Marks the new document as replacing the old one. Generates an A04 notice cross-referencing the superseded document. | Use alongside Supersede — this goes on the new document. |
+| **Bulk Issue Deliverables** | Issues all selected deliverables simultaneously. All succeed or all fail together (atomic). | At a stage gate when you are issuing a large package of drawings at once. |
+| **Import Documents** | Manually registers documents that exist outside STING (e.g. external consultant PDFs) in the document register. | When you receive drawings from another party and want to track them in the same register. |
+| **Export Register** | Exports the complete document register to a CSV spreadsheet. | For reporting, for sharing with parties who do not have access to STING. |
+
+---
+
+### Tab 2 — DOCS/CDE
+
+This is the main browser for all documents. Think of it as the view into all four drawers.
+
+| Control / Button | What it does |
+|---|---|
+| **Drawer chips (WIP / SHARED / PUBLISHED / ARCHIVE)** | Click a chip to filter the document list to that drawer only. A chip appears greyed out if you do not have access to that drawer. |
+| **Discipline filter** | Dropdown to filter by discipline (A, S, M, E, P, etc.). |
+| **Suitability filter** | Dropdown to filter by suitability code (S0 through S7). |
+| **Search bar** | Free-text search across document names, titles, and authors. |
+| **Document list** | Shows all documents matching the current filters. Click a row to see its detail in the right panel. |
+| **Detail panel (right)** | Shows all fields for the selected document: number, title, discipline, revision, suitability, CDE state, who last changed it, and when. |
+| **Version history** | In the detail panel, shows every past revision of the selected document. Click a row to download that specific version. |
+| **Transition buttons** | In the detail panel: WIP→Shared, Shared→WIP (rework), Shared→Published, Published→Archive. Only the valid next transitions for the selected document and your role are enabled. |
+| **Request Approval** | Creates a formal approval request directed at a Manager. Appears when you try to move to Published without an existing approval. |
+| **Download** | Downloads the current version of the selected document. |
+| **Add Version** | Uploads a new version of an existing document. |
+| **CDE Status** | Opens the CDE health-check screen: how many documents are in each drawer, how long they have been there, and any stale warnings. |
+| **Validate Naming** | Checks whether a filename matches the ISO 19650 naming convention before you upload it. Shows which segments are wrong and what they should be. |
+
+---
+
+### Tab 3 — ISSUES
+
+Issues are formal tracked problems — RFIs from site, coordination clashes, design queries.
+
+| Button | What it does |
+|---|---|
+| **Raise Issue** | Opens the issue creation form. Fill in type (RFI, NCR, SI, Coordination), subject, body, discipline, priority, and assignee. |
+| **Issue Dashboard** | A summary view: total issues, open by priority, overdue by assignee. Shows which disciplines are generating the most issues. |
+| **Update Issue** | Edits the status, comment, or assignee on an existing issue. |
+| **Select Issue Elements** | Selects the Revit elements linked to the selected issue directly in the model. |
+| **BCF Export** | Exports all issues as a BCF 2.1 zip file — the standard format for sharing issues with consultants using other software (Navisworks, Solibri). |
+| **BCF Import** | Imports issues from a BCF zip received from another party. |
+| **Close Issue** | Formally closes an issue. Records the resolution. |
+| **Issue filter chips** | Filter by status (Open, In Progress, Resolved, Closed), by discipline, by priority, by assignee. |
+| **Link to Document** | Links the selected issue to a document in the document register — for example, an RFI that led to a drawing change. |
+| **Issue list** | All issues matching the current filter. Click to see detail. |
+
+---
+
+### Tab 4 — REVISIONS
+
+This tab manages drawing revisions across the project.
+
+| Button | What it does |
+|---|---|
+| **Create Revision** | Creates a new revision entry in Revit (the Revit Revisions table). |
+| **Revision Dashboard** | Summary of all revisions: which drawings are at which revision, how many revisions have been issued. |
+| **Auto Revision Cloud** | Automatically creates revision clouds on drawing sheets based on elements that have changed since the last issue. |
+| **Revision Schedule** | Creates a Revit schedule showing all elements and their current revision. |
+| **Track Element Revisions** | Stamps a parameter on each element recording which revision it was current at. |
+| **Revision Compare** | Shows a side-by-side comparison of two revisions of the same document — what changed. |
+| **Issue Sheets for Revision** | Issues all sheets associated with the selected revision as a batch. |
+| **Revision Naming Enforce** | Checks that revision naming conventions (P01, P02, C01, etc.) are being followed consistently. |
+| **Revision Tag Integration** | Links revision triangles on drawings to STING's revision tracking parameters. |
+| **Export Revisions** | Exports the full revision history to a spreadsheet. |
+| **Bulk Revision Stamp** | Stamps a revision code on multiple selected elements at once. |
+| **Auto Revision on Tag Change** | Marks elements for revision automatically when their STING tag parameters change. |
+
+---
+
+### Tab 5 — COORDINATION
+
+Coordination is the process of checking that all disciplines' designs work together without
+clashing.
+
+| Button | What it does |
+|---|---|
+| **Review Tracker** | Opens the coordinated-review register. Shows which documents are under review, by whom, and whether they are overdue. |
+| **MIDP Tracker** | Opens the Master Information Delivery Plan view — the list of every planned deliverable for the project with its current status and target date. |
+| **Clash Detection** | Runs a basic in-Revit clash check between disciplines and reports clashes as issues. |
+| **Platform Sync** | Synchronises with an external BIM platform (Autodesk Construction Cloud, Procore, etc.) — pushes issues and document records outward. |
+| **BCF Export / Import** | As in the Issues tab — issue interchange in BCF format. |
+| **BIM Coordination Center** | Opens the full BIM Coordination Center dialog (the 13-tab version) for deeper coordination work. |
+| **LAN Collaboration** | Enables local-network collaboration for teams working without internet access. |
+| **Workset Audit** | Checks worksets are set up correctly for collaborative working in a workshared model. |
+| **Link Manager** | Manages Revit link files (linked models from other disciplines). |
+| **Create Meeting** | Creates a meeting record and ultimately generates D14 minutes. |
+| **Meeting list** | Lists all meetings recorded for the project. Click to open a meeting record. |
+
+---
+
+### Tab 6 — HANDOVER
+
+Handover is what happens at project completion when you hand over all the information to
+the client and FM team.
+
+| Button | What it does |
+|---|---|
+| **Document Briefcase** | Generates the 8-file portable handover package (project info, tag register, compliance report, parameter audit, model statistics, sheet index, discipline breakdown, MIDP register). Saves to a timestamped folder. |
+| **COBie Export** | Exports a full COBie V2.4 workbook (19 worksheets) for the FM team. This is the structured data handover that feeds asset management systems. |
+| **COBie Import** | Imports back a COBie workbook to update model parameters from FM team corrections. |
+| **FM Handover Manual** | Generates a readable operations and maintenance manual referencing all the project's documents. |
+| **O&M Manual** | Similar to FM Handover Manual — a more technically detailed operations manual. |
+| **Asset Health Report** | A snapshot of all assets' current condition and maintenance status. |
+| **Space Handover Report** | A room-by-room report of what is being handed over, suitable for signing by all parties. |
+| **Export Maintenance Schedule** | Exports the SFG20 / BS 8210 maintenance schedule for the FM team. |
+| **COBie Type Map** | Opens the browser for the 70+ equipment category mappings — use this to fix any unmapped equipment before running COBie Export. |
+| **COBie Picklists** | Shows and lets you edit the controlled vocabularies used in the COBie workbook. |
+
+---
+
+### Tab 7 — NOTES/BEP
+
+Notes covers sticky notes (element-level coordination markup) and the Briefcase viewer.
+BEP covers the BIM Execution Plan.
+
+| Button | What it does |
+|---|---|
+| **Add Note** | Adds a timestamped sticky note to the selected Revit element(s). |
+| **View Notes** | Shows all sticky notes on the selected element(s) in a list. |
+| **Clear Notes** | Removes sticky notes from the selected element(s). |
+| **Bulk Delete Notes** | Removes all sticky notes from the entire project. Use with care — this is not undoable. |
+| **Export Notes** | Exports all sticky notes to a CSV, with element ID, category, tag, author, date, and note text. |
+| **Select Noted Elements** | Selects all elements in the project that have a sticky note. |
+| **Note Dashboard** | Shows aggregate sticky-note counts by author, discipline, and category. |
+| **Note Search** | Free-text search across all sticky notes. |
+| **Note Categories** | Per-category note counts. |
+| **Briefcase Viewer** | Opens the in-Revit document browser — read BEP, transmittals, and reference documents without leaving Revit. |
+| **Add to Briefcase** | Adds a PDF, DOCX, or XLSX to the project's reference set (the `_BIM_COORD/reference/` folder). |
+| **Read Briefcase Item** | Opens a specific item in the briefcase viewer. |
+| **Create BEP** | Launches the BEP (BIM Execution Plan) wizard — generates a project BEP from a template. |
+| **Update BEP** | Opens the BEP for editing and update. |
+| **Export BEP** | Exports the BEP as a document. |
+| **Generate BEP** | Generates a full BEP document from the BEP data. |
+
+---
+
+### Tab 8 — BIM Execution Plan (BEP)
+
+The BIM tab also includes BIM management commands covered in depth in `BIM_MANAGEMENT_GUIDE.md`.
+The key document-management buttons on this tab:
+
+| Button | What it does |
+|---|---|
+| **Full Compliance Dashboard** | A complete project-wide health summary: tag compliance, document completeness, issue counts, workflow status. |
+| **Model Health Dashboard** | Focused on model quality: warning counts, unused views, parameter completeness. |
+| **ISO 19650 Reference** | Opens the in-Revit quick reference for ISO 19650 codes and conventions. |
+| **Bulk BIM Export** | Exports multiple formats at once: IFC, COBie, BCF, and PDF drawings as a single batch. |
+| **Stage Compliance Gate** | Checks whether all required deliverables for the current RIBA stage are in the correct CDE state. Use at every stage gate. |
+
+---
+
+### The standalone document commands (outside the DMC)
+
+These buttons appear directly on the BIM tab of the STING dock panel and do not require
+opening the Document Management Center:
+
+| Button | What it does |
+|---|---|
+| **Issue Deliverable** | Quick issue — same as the FILE/BULK tab button but one click faster. |
+| **Re-Issue Deliverable** | Quick re-issue. |
+| **Publish Deliverable** | Move to Published. Requires approval in place. |
+| **Cancel Deliverable** | Formally cancel. Generates A02 notice. |
+| **Supersede Deliverable** | Formally supersede. Generates A03 notice. |
+| **Replace Deliverable** | Mark as replacing another document. Generates A04 notice. |
+| **Create Transmittal (Orchestrated)** | Full pipeline — number, render, workflow, audit. |
+| **Bulk Issue Deliverables** | Issue all selected deliverables together. |
+
+---
+
+## Part 5 — The Audit Trail
+
+### Why every action is logged
+
+Imagine a senior partner in a paper-based office. Every time a drawing leaves the office,
+they write in a ledger: the date, what was sent, who it went to, and their initials.
+That ledger is the audit trail.
+
+STING keeps exactly this kind of ledger, but digitally. Every document action is recorded:
+- When a document was issued
+- Who issued it
+- When it moved from WIP to Shared
+- When an approval was granted (or denied) and by whom
+- When it was published
+- When it was superseded
+- When a transmittal was created and who received it
+
+This log is stored in `audit_log_YYYY_MM.jsonl` (one file per calendar month). The `.jsonl`
+format means each line is a separate JSON record — readable in any text editor.
+
+**Why does this matter?**
+
+If a dispute arises about whether a drawing was issued before a certain date, the audit log
+shows the exact timestamp and who clicked Issue. If a building inspector asks "when did you
+change that wall specification?", the audit log shows the supersession event. If an insurance
+claim hinges on whether a handover certificate was signed, the audit log shows who approved it.
+
+This is not optional paperwork — it is the digital equivalent of the senior partner's ledger.
+
+---
+
+### Reading the audit log
+
+Open `_BIM_COORD/audit_log_2026_05.jsonl` (or whichever month you need) in Notepad.
+Each line looks something like this:
+
+```json
+{"timestamp":"2026-05-14T09:23:41Z","action":"deliverable.issue","user":"j.smith","documentNumber":"PRJ-XYZ-ZZ-ZZ-DR-M-0001","revision":"P01","previousState":null,"newState":"WIP","hash":"a3f5...","prevHash":"8c2d..."}
+```
+
+In plain English: On 14 May 2026 at 09:23, Jane Smith issued document PRJ-XYZ-ZZ-ZZ-DR-M-0001
+at revision P01. The document moved from nothing (first issue) to WIP state.
+
+**The fields:**
+- `timestamp`: When the action happened (UTC time).
+- `action`: What happened — examples: `deliverable.issue`, `deliverable.publish`,
+  `workflow.transition`, `transmittal.create`, `approval.grant`.
+- `user`: Who did it (their login name).
+- `documentNumber`: Which document.
+- `revision`: Which revision.
+- `previousState` / `newState`: Which drawer the document moved from and to.
+- `hash`: A unique fingerprint of this log entry.
+- `prevHash`: The fingerprint of the entry before this one.
+
+---
+
+### What the SHA-256 tamper-evidence chain means
+
+The `hash` and `prevHash` fields are the key to tamper-evidence. Here is how it works
+in plain English:
+
+Imagine each audit log entry is a link in a chain. Each link is stamped with a seal,
+and that seal includes a picture of the seal on the previous link. If you break open
+the middle of the chain and swap a link for a different one, the seal on that new link
+will not match the seal on the next link — because the next link's seal includes a
+picture of the original link's seal, not the replacement.
+
+In digital terms: the `hash` of each entry is calculated from the content of that entry
+PLUS the `hash` of the previous entry. If you change anything in any entry — even a
+single character — the hash no longer matches, and every entry after it also fails to
+verify. The chain is broken and detectable.
+
+This means: if anyone edits the audit log to hide a document action, STING can detect it.
+
+**How STING verifies the chain:**
+
+STING includes a VerifyChain function that walks through every entry in the audit log and
+checks that each hash is correct. If any entry fails verification, STING reports exactly
+which entry is suspect.
+
+For day-to-day use, you do not need to verify the chain manually. The server does this
+automatically as part of its periodic audit. If you need to verify it yourself (for an
+inspection or ISO 27001 audit), run `POST /api/admin/audit/verify` on the Planscape server
+and it returns a pass/fail result with the first failed entry if any.
+
+**Do not edit the audit log files manually.** Even correcting a typo will break the chain.
+If an entry is wrong (for example, the wrong username was logged), the correct response is
+to add a new entry recording the correction, not to edit the original.
+
+---
+
+## Part 6 — Workflows and SLAs
+
+### What a workflow is
+
+When you create a transmittal or issue an RFI, it is not just a document — it is a process.
+Someone needs to receive it, acknowledge it, review it, and close it. Those steps need to
+happen in a specific order, and some of them have time limits.
+
+A workflow is a description of those steps. Think of it as a checklist with a clock on it:
+"Step 1: Draft. Step 2: Issue within 24 hours. Step 3: Recipient acknowledges within 72 hours."
+
+STING ships five built-in workflows that cover the most common processes. Each workflow is
+defined in a JSON file in the `_BIM_COORD/workflows/` folder. When you create a transmittal,
+STING starts an instance of the relevant workflow — it begins tracking which step you are on
+and whether the time limits are being met.
+
+---
+
+### The 5 built-in workflows
+
+**`transmittal_default`** — Standard transmittal
+
+| Step | Name | What it means | Time limit |
+|---|---|---|---|
+| 1 | Draft | Transmittal created but not yet sent | 24 hours |
+| 2 | Issued | Transmittal sent to recipient | — |
+| 3 | Acknowledged | Recipient has confirmed receipt | 72 hours after issue |
+| Done | Complete | Transmittal closed | — |
+
+If you create a transmittal and do not send it within 24 hours, the SLA for the Draft step
+is breached. STING will show this on the dashboard and send a notification.
+
+If the recipient does not acknowledge within 72 hours of you issuing it, the Acknowledged
+SLA is breached.
+
+---
+
+**`rfi_default`** — Request for Information
+
+| Step | Name | Time limit |
+|---|---|---|
+| 1 | Open | 24 hours (to assign) |
+| 2 | Reviewed | 48 hours (to review) |
+| 3 | Responded | 168 hours / 7 days (to respond) |
+| 4 | Closed | — |
+
+---
+
+**`tq_default`** — Technical Query
+
+| Step | Name | Time limit |
+|---|---|---|
+| 1 | Open | — |
+| 2 | Answered | 48 hours |
+| Done | Closed | — |
+
+---
+
+**`mr_default`** — Material Requisition
+
+| Step | Name | Time limit |
+|---|---|---|
+| 1 | Draft | — |
+| 2 | Submitted | — |
+| 3 | Approved or Rejected | Varies by project |
+| Done | Complete | — |
+
+---
+
+**`deliverable_issue_default`** — Deliverable lifecycle
+
+This workflow tracks the lifecycle of a formal deliverable through the four CDE drawers.
+Its states mirror the CDE states:
+
+| Step | Matches CDE State |
+|---|---|
+| WIP | WIP |
+| Shared | SHARED |
+| Published | PUBLISHED |
+| Archived | ARCHIVE |
+
+Unlike the other workflows, this one does not have fixed SLA times by default — the timing
+is governed by the project programme.
+
+---
+
+### What happens when an SLA is breached
+
+An SLA (Service Level Agreement) is a promise that a step will be completed within a certain
+time. When that time passes without the step being completed, the SLA is breached.
+
+When a breach occurs, STING does the following:
+
+1. **On the BIM Coordination Center dashboard**: The overdue workflow step appears in red
+   in the "Open Workflows" section. The document number, step name, and how long overdue
+   it is are all shown.
+
+2. **On the mobile app**: If you have the Planscape mobile app and are assigned to the
+   workflow, you receive a push notification: "Transmittal T-0042 is overdue — Acknowledged
+   step is 18 hours past deadline."
+
+3. **In the audit log**: The SLA breach is recorded as an audit event.
+
+4. **Via email**: If the Planscape server is configured with SMTP email, a reminder email
+   is sent to the assignee.
+
+SLA breaches do not automatically fail the workflow — the step can still be completed after
+the deadline. The breach is a warning and a record, not a hard block. However, if your
+contract specifies SLA compliance requirements, the audit log provides evidence of any breaches.
+
+**What to do when an SLA is breached:**
+
+If you see a breach notification, the correct response is:
+1. Complete the overdue step as quickly as possible.
+2. Add a comment explaining the delay.
+3. If the delay was the other party's fault (e.g. the client did not respond), record that
+   in the comment so the audit log reflects the actual cause.
+
+---
+
+## Part 7 — Distribution Groups
+
+### What a distribution group is
+
+A distribution group is a named list of people who should receive a particular category of
+documents. Instead of typing the same list of email addresses every time you create a transmittal,
+you create a group once and then pick it from a dropdown.
+
+For example, you might create:
+- **"Project Team"** — everyone on the project (lead designers, coordinator, PM)
+- **"Structural Reviewers"** — the structural engineering team
+- **"M&E Subcontractors"** — the mechanical and electrical subcontractors
+- **"Client Distribution — Issued for Construction"** — client and quantity surveyor,
+  for S4 drawings only
+
+Distribution groups are stored in `_BIM_COORD/distribution_groups.json`.
+
+---
+
+### How STING matches recipients to documents
+
+When you create a transmittal, STING looks at the document's properties (type, discipline,
+suitability code) and scores all your distribution groups to find the best match. The group
+with the highest score is suggested automatically, but you can override it.
+
+The scoring works like this:
+
+| Match | Score |
+|---|---|
+| Document type matches group's type tag | +3 |
+| Document discipline matches group's discipline tag | +3 |
+| Document suitability matches group's suitability tag | +2 |
+| Group has a matching project code | +1 |
+
+The group with the highest total score is suggested. If two groups tie, the one that was
+used most recently is preferred.
+
+**In plain English**: if you are issuing a Mechanical drawing at S4 (for construction),
+and you have a group tagged with "Discipline: M, Suitability: S4", that group will be
+suggested automatically. You just click Confirm rather than re-typing the recipient list.
+
+---
+
+### Setting up distribution groups
+
+**Method 1 — via the Document Management Center (recommended):**
+
+1. Open the Document Management Center (BIM tab → Document Management Center).
+2. Click on the **NOTES/BEP** tab.
+3. Scroll down to the **Distribution Groups** section.
+4. Click **Add Group**.
+5. Fill in:
+   - **Name**: Something clear, like "Structural Team" or "Client — S4 Only"
+   - **Members**: Click Add Member and type each person's name and email address.
+   - **Tags**: What this group should receive. Click the dropdown and select the applicable
+     types (Drawing), disciplines (M, E, P etc.), and suitability codes (S3, S4, etc.).
+     Leave a tag blank to mean "all values" — so a group tagged only with S4 will receive
+     all disciplines' S4 documents.
+6. Click **Save Group**.
+
+**Method 2 — by editing `distribution_groups.json` directly:**
+
+For advanced users, open `_BIM_COORD/distribution_groups.json` in a text editor.
+The file is an array of group objects. Each object looks like this:
+
+```json
+{
+  "name": "Structural Team",
+  "members": [
+    { "name": "Alice Brown", "email": "alice@structuralengineers.com" },
+    { "name": "Bob Green", "email": "bob@structuralengineers.com" }
+  ],
+  "tags": {
+    "type": "Drawing",
+    "discipline": "S",
+    "suitability": ["S3", "S4"]
+  }
+}
+```
+
+Save the file. STING picks up changes the next time you create a transmittal.
+
+> **Stuck?** If you save `distribution_groups.json` and STING does not seem to use the
+> new group, check that the file is valid JSON (no missing commas or quotes). Open it in
+> a web browser — Chrome will show a red error if the JSON is malformed. Fix any errors
+> and try again.
+
+---
+
+### Tips for distribution group management
+
+1. **Create groups at the start of the project** — not when you first need them. During
+   the first project kick-off meeting, while you have all the consultant contact details
+   in front of you, set up the groups. Saves time every single transmittal for the rest
+   of the project.
+
+2. **Keep groups specific** — a group tagged "all disciplines, all suitabilities" will
+   always be suggested, even when it is not appropriate. Specific tags give better
+   auto-suggestions.
+
+3. **Update groups when consultants change** — if the structural engineer is replaced
+   mid-project, update the group. All future transmittals will go to the right person;
+   past ones remain in the audit log going to the old contact.
+
+4. **Use the suitability tag carefully** — a client should typically only be in groups
+   tagged S4 or above. They should not receive S1 or S2 coordination drawings that are
+   not yet fit for client review.
+
+---
+
+## Part 8 — Troubleshooting
+
+The following table covers the most common problems and how to fix them.
+
+| Problem | What caused it | How to fix it |
+|---|---|---|
+| **`_BIM_COORD` folder does not exist** | STING did not run setup on this project. | Close the project, wait 5 seconds, re-open it. If it still does not appear, check `StingTools.log` for errors. |
+| **Template files missing from `templates/`** | Setup ran partially and failed during file extraction. | Delete the entire `_BIM_COORD` folder and re-open the project. STING will re-extract everything. |
+| **`manifest.json` contains blank project name** | Project Information in Revit was empty when setup ran. | Fill in Manage → Project Information in Revit, then delete `_BIM_COORD/templates/manifest.json` and re-open the project. |
+| **Rendered document shows `{{token}}` instead of real data** | A template was edited and a token was accidentally deleted. | Open the template (e.g. `transmittal.docx`) in Word. The missing token should be typed back in exactly as it appeared — curly braces included. |
+| **"Publish failed — approval required"** | The document is in Shared but no Manager has approved the SHARED→PUBLISHED transition. | Click "Request Approval" on the document, write a note to the manager, and wait for them to approve. |
+| **Transmittal rendered but not in `generated/`** | Output folder path changed or a permissions error. | Check `StingTools.log` for the actual path used. Try running Create Transmittal again — the second attempt usually succeeds. |
+| **"workflow_state.json deserialization failed"** | The workflow state file was corrupted (manual edit, crash during write, or schema version mismatch). | Delete `_BIM_COORD/workflow_state.json`. STING creates a fresh one. In-flight workflows are lost. |
+| **Document appears in wrong CDE state** | A transition was made by someone with wrong role permissions, or the server sync failed in an inconsistent state. | Check the audit log for the last transition event. If wrong, use the CDE transition buttons to move the document to the correct state — this creates a new audit entry. |
+| **Audit chain broken** | Someone edited an `audit_log_*.jsonl` file manually, or a crash corrupted the last entry. | The chain is broken but the data is not lost. Do not edit the file further. Run audit chain verify on the server. The first bad entry will be identified. For regulatory audits, the break itself must be disclosed. |
+| **Deliverables not appearing on server** | The sync failed. | Click the Sync button on the STING dock panel. This forces a reconcile pass. Check `StingTools.log` for "DeliverableServerSync failed" if it keeps failing. |
+| **Distribution group not suggested** | The group's tags do not match the document being transmitted. | Review the group's tags in the Document Management Center. Make sure discipline and suitability tags match. |
+| **COBie export missing equipment** | Equipment categories are not mapped in `COBIE_TYPE_MAP.csv`. | Open COBie Type Map in the HANDOVER tab. Find the missing category and add a mapping. |
+| **"Search returns no results"** | The search index is empty or corrupted. | Delete the `_BIM_COORD/search_index/` folder. STING rebuilds the index automatically on next search. |
+| **"Document number skipped — gap in sequence"** | A document was partially created and then cancelled before the number was written to `deliverables.json`, or the counter was manually edited. | The gap in numbering is not a functional problem. Do not try to reuse the skipped number — it may have been reserved. Continue from the current counter. |
+| **Cannot move to Published — user does not have Manager role** | The person trying to publish has Coordinator role but not Manager. | Ask the project manager to either promote the user's role or run the transition themselves. |
+| **RFI shows as overdue but recipient says they responded** | The workflow step was not closed in STING when the response was received. | Open the RFI in the Issues tab, find the overdue step, and mark it as complete. Add a comment noting the actual response date. |
+| **Mobile app shows documents user should not see** | Old app version without ACL filters, or the member record has not been updated. | Force-quit and re-open the app. Sign out and sign back in. The app re-fetches the ACL on login. |
+| **Briefcase viewer shows "no items"** | The underlying files in `_BIM_COORD/` have not been generated yet. | Run BEP wizard to create `bim_execution_plan.json`. Generate the dashboard from the BCC Overview tab. The viewer shows what exists — generate the items first. |
+
+---
+
+## Quick Reference
+
+### All document commands (complete table)
+
+| Command tag | What it does | Where to find it |
+|---|---|---|
+| `IssueDeliverable` | Issue a single deliverable (A01 cover sheet) | BIM tab, FILE/BULK tab |
+| `ReIssueDeliverable` | Re-issue with new revision | BIM tab, FILE/BULK tab |
+| `PublishDeliverable` | Move to Published (requires approval) | BIM tab, FILE/BULK tab |
+| `CancelDeliverable` | Formally cancel (A02 notice) | BIM tab, FILE/BULK tab |
+| `SupersedeDeliverable` | Formally supersede (A03 notice) | BIM tab, FILE/BULK tab |
+| `ReplaceDeliverable` | Mark as replacing another (A04 notice) | BIM tab, FILE/BULK tab |
+| `BulkIssueDeliverables` | Issue all selected deliverables together | BIM tab, FILE/BULK tab |
+| `CreateTransmittalOrchestrated` | Full transmittal pipeline | BIM tab |
+| `CreateTransmittal` | Quick transmittal (informal) | BIM tab |
+| `DocumentRegister` | Open document register | BIM tab, DOCS/CDE tab |
+| `AddDocument` | Manual register entry | DOCS/CDE tab |
+| `CDEStatus` | CDE drawer health check | DOCS/CDE tab |
+| `ValidateDocNaming` | ISO 19650 naming check | DOCS/CDE tab |
+| `RaiseIssue` | Create an issue (RFI, NCR, SI) | ISSUES tab |
+| `IssueDashboard` | Issue summary dashboard | ISSUES tab |
+| `UpdateIssue` | Edit an issue | ISSUES tab |
+| `SelectIssueElements` | Select Revit elements linked to issue | ISSUES tab |
+| `BCFExport` | Export issues as BCF file | ISSUES tab |
+| `BCFImport` | Import BCF issues | ISSUES tab |
+| `CreateRevision` | Create Revit revision entry | REVISIONS tab |
+| `RevisionDashboard` | Revision summary | REVISIONS tab |
+| `AutoRevisionCloud` | Auto-generate revision clouds | REVISIONS tab |
+| `RevisionCompare` | Compare two revisions | REVISIONS tab |
+| `ReviewTracker` | Open review register | COORDINATION tab |
+| `MidpTracker` | Open MIDP delivery plan | COORDINATION tab |
+| `ClashDetection` | Run in-Revit clash check | COORDINATION tab |
+| `DocumentBriefcase` | Generate 8-file handover package | HANDOVER tab |
+| `COBieExport` | Export COBie V2.4 workbook | HANDOVER tab |
+| `COBieImport` | Import COBie workbook | HANDOVER tab |
+| `HandoverManual` | Generate FM handover manual | HANDOVER tab |
+| `ElementStickyNote` | Add/view/clear sticky note | NOTES/BEP tab |
+| `ExportStickyNotes` | Export all notes to CSV | NOTES/BEP tab |
+| `SelectStickyElements` | Select all noted elements | NOTES/BEP tab |
+| `StickyNoteDashboard` | Sticky note aggregate view | NOTES/BEP tab |
+| `StickyNoteSearch` | Search all notes | NOTES/BEP tab |
+| `BriefcaseView` | Open in-Revit document viewer | NOTES/BEP tab |
+| `BriefcaseAddFile` | Add file to briefcase | NOTES/BEP tab |
+| `CreateBEP` | Launch BEP wizard | NOTES/BEP tab |
+| `FullComplianceDashboard` | Project-wide health summary | BIM tab |
+| `ModelHealthDashboard` | Model quality dashboard | BIM tab |
+| `StageComplianceGate` | Stage gate deliverable check | BIM tab |
+| `BulkBIMExport` | Export IFC, COBie, BCF, PDF together | BIM tab |
+
+---
+
+### CDE state transitions table
+
+| From | To | Trigger | Role needed | Approval? |
+|---|---|---|---|---|
+| (new) | WIP | Issue Deliverable | Contributor | No |
+| WIP | SHARED | Publish to Shared | Coordinator | No |
+| SHARED | WIP | Rework | Coordinator | No |
+| SHARED | PUBLISHED | Publish for Construction | Manager | Yes |
+| PUBLISHED | ARCHIVE | Document superseded | Manager | No |
+| PUBLISHED | SUPERSEDED | Supersede Deliverable | Manager | No |
+| SUPERSEDED | ARCHIVE | Automatic after replacement published | System | — |
+
+---
+
+### Template ID reference table
+
+| ID | Template file | Produces | Used by command |
+|---|---|---|---|
+| A01 | `deliverable_standard.docx` | Deliverable cover sheet | `IssueDeliverable`, `ReIssueDeliverable` |
+| A02 | `deliverable_cancelled.docx` | Cancellation notice | `CancelDeliverable` |
+| A03 | `deliverable_superseded.docx` | Superseded notice | `SupersedeDeliverable` |
+| A04 | `deliverable_replacing.docx` | Replacing notice | `ReplaceDeliverable` |
+| A05 | `deliverable_tabular.xlsx` | Tabular deliverable list | `BulkIssueDeliverables` |
+| B06 | `transmittal.docx` | Transmittal memo | `CreateTransmittalOrchestrated` |
+| B07 | `technical_query.docx` | Technical query | Raise Issue (TQ type) |
+| B08 | `rfi.docx` | Request for Information | `RaiseIssue` (RFI type) |
+| B09 | `technical_response.docx` | Response to TQ or RFI | Close Issue with response |
+| C10 | `material_requisition.docx` | Material requisition | Raise Issue (MR type) |
+| C11 | `submittal_cover.docx` | Submittal cover sheet | `IssueDeliverable` (submittal) |
+| C12 | `variation.docx` | Variation / change order | Issue change order |
+| C13 | `letter_transmittal.docx` | Formal letter of transmittal | `CreateTransmittalOrchestrated` (formal) |
+| D14 | `meeting_minutes.docx` | Meeting minutes | Create Meeting → Generate Minutes |
+| D15 | `progress_report.docx` | Progress report | Progress Report command |
+| D16 | `handover_certificate.docx` | Handover certificate | `HandoverManual` / end-of-project |
+
+---
+
+### Suitability code reference
+
+| Code | Full name | Typical CDE state | Use |
+|---|---|---|---|
+| S0 | Initial | WIP | First draft, internal only |
+| S1 | Suitable for coordination | SHARED | Ready for other disciplines to coordinate against |
+| S2 | Suitable for information | SHARED | For client information — not for construction |
+| S3 | Suitable for review and comment | SHARED | Formal review period — comments invited |
+| S4 | Suitable for construction | PUBLISHED | Builders and fabricators work from this |
+| S5 | Suitable for manufacture | PUBLISHED | Shop drawings, fabrication |
+| S6 | Suitable for PIM/AIM authorisation | PUBLISHED | Asset information model — FM handover |
+| S7 | As-built | ARCHIVE | Final record of what was built |
+
+---
+
+### Role hierarchy
+
+```
+Viewer      Can read Published and Archive only
+Contributor Can read WIP, Shared, Published, Archive (own discipline)
+Coordinator Can promote WIP→Shared and Shared→WIP. Can issue, re-issue.
+Manager     Can promote Shared→Published (requires approval). Can approve.
+Admin       Full access to all settings, members, and access profiles.
+Owner       Full control including billing and tenant management.
+```
+
+---
+
+## Cross-references
+
+The STING Document Manager does not operate in isolation. Other parts of the system produce
+the documents that flow through it:
+
+- **DRAWING_TYPE_MANAGER_GUIDE** (`docs/guides/DRAWING_TYPE_MANAGER_GUIDE.md`): Drawing
+  types produce the Revit sheets and views that become deliverables. The Drawing Type
+  Manager determines which title block, scale, and sheet layout a drawing uses before
+  it is issued through the Document Manager.
+
+- **TAGGING_PROCEDURES_GUIDE** (`docs/TAGGING_PROCEDURES_GUIDE.md`): Every element that
+  appears on an issued drawing needs a complete ISO 19650 tag before the compliance
+  gate allows issue. Read this guide to understand how tagging works before you try
+  to issue documents.
+
+- **BIM_MANAGEMENT_GUIDE** (`docs/BIM_MANAGEMENT_GUIDE.md`): The BEP, MIDP, and stage
+  gate processes that govern when documents are issued. The Document Manager is the
+  mechanism; BIM Management is the plan.
+
+- **HEALTHCARE_PACK_DESIGN** (`docs/HEALTHCARE_PACK_DESIGN.md`): Healthcare projects
+  have additional document workflows (MGPS verification, RDS issue, HTM maintenance
+  records) that flow through the same document system.
+
+- **AEC_FILTER_LIBRARY** (`docs/AEC_FILTER_LIBRARY.md`): The view style packs and
+  filters that control how drawings look before they are issued. Drawings that look
+  wrong should be fixed at the filter/template level before issuing.

--- a/docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md
+++ b/docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md
@@ -1,0 +1,1206 @@
+# STING Drawing Production System — Complete Guide
+
+> **Who this guide is for:** anyone who has opened Revit at least once and wants to understand how STING automates drawing production — from the blank-sheet title block all the way to a stamped, scaled, annotated, ISO-compliant drawing sheet. No coding required.
+>
+> **What you will be able to do after reading this:** set up a title block, configure a drawing type recipe, produce a batch of coordinated sheets at the press of one button, and understand what to do when something looks wrong.
+>
+> **This guide consolidates:** `SLOT_TAXONOMY.md`, `TITLE_BLOCK_CREATION_GUIDE.md`, `DRAWING_TYPE_MANAGER_GUIDE.md`, `STING_MANAGED_TEMPLATES_DESIGN.md`, and `DRAWING_TEMPLATE_GUIDE.md`. All five documents remain available for historical reference, but this guide is the current, single source of truth.
+
+---
+
+## How to use this guide
+
+Read the sections in order the first time. The system has four stages that build on each other — skipping one makes the next stage confusing. Once you understand the whole picture, each stage chapter works as a standalone reference.
+
+If you are in a hurry:
+- **Just want to produce sheets now** using existing corporate settings: go to Stage 3, section "Quick start: your first profile-driven sheet."
+- **Need to make your own title block**: read Stage 2 in full.
+- **Something looks wrong on a produced sheet**: go to the "Troubleshooting" callouts inside each stage, and the Quick Reference at the end.
+
+---
+
+## The Big Picture (read this first)
+
+Imagine you run a busy kitchen. Every morning your head chef makes four decisions, once, and writes them on the whiteboard:
+
+1. **What the plate looks like** (size, shape, where the garnish goes) — this is the **title block**.
+2. **What slots on the plate are available** (main dish area, side dish spot, sauce cup corner) — these are the **slot taxonomy**.
+3. **The recipe card for each dish** (what goes in it, how long it cooks, which plating standard it follows) — this is the **drawing type**.
+4. **The kitchen's plating standard** (line weights, colours, which sauce goes with which dish) — this is the **view style pack**.
+
+Once the whiteboard is written, every cook in the kitchen can produce that dish identically — without guessing, without arguing, without phoning the chef. You change one line on the whiteboard and every dish updates.
+
+STING's drawing production system works exactly like that kitchen:
+
+| Kitchen analogy | STING equivalent |
+|---|---|
+| The plate | Title block family (`.rfa`) |
+| Slots on the plate | Slot taxonomy (purposeTag vocabulary) |
+| Recipe card | Drawing Type (JSON record in `STING_DRAWING_TYPES.json`) |
+| Plating standard | View Style Pack (JSON record in `STING_VIEW_STYLE_PACKS.json`) |
+| The head chef writes the whiteboard once | BIM coordinator sets up the catalogue once |
+| Every cook follows the whiteboard | Every STING batch command reads the catalogue |
+| Change the whiteboard, every dish updates | Edit a recipe or pack, Sync Styles re-applies to all sheets |
+
+**The four-decision chain, as one sentence:** STING reads the *slot vocabulary* on your *title block*, picks the right *drawing type recipe*, applies the *view style pack*, and produces the sheet — you watch.
+
+---
+
+## Stage 1 — Slot Taxonomy: Understanding What Spaces Exist
+
+### What is a slot?
+
+A slot is a named rectangle on a sheet. Think of a sheet of paper as a picture frame. Inside the frame there is the big glass area where you hang the picture — that is the **primary** slot. But there is also a small plaque at the bottom for the caption, a corner for the gallery label, maybe a mat area around the picture. Each of those areas is a slot.
+
+In STING, every slot has two key properties:
+- A **category** that controls how it is drawn in previews (solid outline, dashed, dotted).
+- A **purposeTag** that tells the auto-placer *what kind of view goes here*.
+
+When you build a title block (Stage 2) you declare which slots exist. When STING places viewports (Stage 3), it reads those slot declarations and routes the right views to the right rectangles automatically.
+
+> **Stuck?** If you wonder "why can't I just drag viewports manually?" — you can! But STING's auto-placer routes 50 views to 50 sheets in the time it takes you to drag one. Slots are what make that automation reliable.
+
+### The four slot types
+
+| Category | What it means in plain English | Visual in preview | When to use it |
+|---|---|---|---|
+| `primary` | The main drawing area — where the plan, section, 3D or spool isometric goes | Solid outline, 5% colour fill | For the biggest rectangle on the sheet where the actual view lives |
+| `auxiliary` | A supporting content area — notes panel, key plan, legend, revision table | Dashed outline, 10% colour fill | For anything that frames or explains the main view |
+| `symbol` | A tiny graphic element — north arrow, scale bar, discipline chip, QR code | Dotted outline, no fill | For small families (less than 40 × 40 mm) |
+| `overlay` | A transparent layer on top of another slot — RFI markup over a plan, caption over a render | Dot-dash outline, transparent | For review clouds, mark-ups, or captions that sit on top of the main view |
+
+### Purpose tags — the vocabulary the auto-placer speaks
+
+A purposeTag is a short label like `main-plan` or `key-plan`. The auto-placer reads it to decide "which view should I put here?" Think of purpose tags as job descriptions posted on the wall of each slot: "WANTED: one main plan view" or "WANTED: one key plan showing the building at small scale."
+
+#### Primary tags (main drawing content)
+
+| Purpose tag | Colour code | Plain-English description | When you see this tag on a sheet |
+|---|---|---|---|
+| `main-plan` | Deep blue | Full-size main drawing area — plan, 3D, section | Standard plan, RCP, section, elevation sheets |
+| `main-plan-half-left` | Light blue | Left half of the sheet | When two views share the sheet side by side |
+| `main-plan-half-right` | Light blue | Right half of the sheet | As above, right side |
+| `quad-top-left` | Light blue | Top-left quadrant (4-up layout) | Coordination sheets with 4 views |
+| `quad-top-right` | Light blue | Top-right quadrant | As above |
+| `quad-bottom-left` | Light blue | Bottom-left quadrant | As above |
+| `quad-bottom-right` | Light blue | Bottom-right quadrant | As above |
+| `fabrication-isometric` | Magenta | Isometric view area on a spool sheet | Pipe/duct/conduit fabrication sheets |
+| `rfi-sketch` | Cyan | Primary sketch area on a clarification sheet | RFI and mark-up sheets |
+| `presentation-render` | Yellow | Full-bleed render (no margins) | Client render boards |
+| `presentation-perspective` | Amber | Architectural perspective area | Client presentation sheets |
+
+#### Auxiliary tags (supporting content)
+
+| Purpose tag | Colour code | Plain-English description | Toggle parameter |
+|---|---|---|---|
+| `key-plan` | Green | Small thumbnail showing where this area sits in the building | `TB_SHOW_KEY_PLAN_BOOL` |
+| `aerial-key` | Light green | Aerial view showing site context | — |
+| `notes` | Slate | General notes panel | — |
+| `discipline-legend` | Orange | Symbol legend for one discipline | — |
+| `material-legend` | Light orange | Material colours / hatching key | — |
+| `fire-legend` | Red | Fire compartmentation legend | — |
+| `accessibility-legend` | Purple | Part M / wayfinding legend | — |
+| `falls-legend` | Blue | Drainage falls key | — |
+| `lighting-legend` | Amber | Luminaire schedule | — |
+| `schedule` | Deep purple | Generic Revit schedule view | — |
+| `bom` | Deep purple | Bill of Materials (alias of `schedule`) | — |
+| `cut-list` | Dark pink | Lengths and cut summary for fabrication | — |
+| `revision-history` | Red | Revit revision schedule table | `TB_SHOW_REV_TABLE_BOOL` |
+| `caption` | Brown | Drawing title caption (presentation sheets) | — |
+| `recipient-to` | Slate | Transmittal "To" address block | — |
+| `recipient-from` | Slate | Transmittal "From" address block | — |
+| `regulator-stamp` | Brown | Authority seal placeholder | — |
+| `discipline-band` | Orange | Discipline-coloured banner strip | `TB_SHOW_DISCIPLINE_COLOR_STRIP_BOOL` |
+
+#### Symbol tags (tiny graphics)
+
+| Purpose tag | Colour code | Plain-English description | Toggle parameter |
+|---|---|---|---|
+| `north-arrow` | Teal | North arrow nested family | `TB_SHOW_NORTH_ARROW_BOOL` |
+| `scale-bar` | Teal | Scale bar nested family | `TB_SHOW_SCALEBAR_BOOL` |
+| `qr-code` | Dark grey | QR code post-export stamp | `TB_SHOW_QR_CODE_BOOL` |
+
+#### Overlay and specialty tags
+
+| Purpose tag | Colour code | Plain-English description |
+|---|---|---|
+| `spool-refs` | Dark pink | Cross-spool reference list overlaid on a fabrication sheet |
+| `markup-plan` | Cyan | Review-cloud overlay on a base plan |
+| `rfi-query` | Deep orange | RFI question text legend |
+
+### Why you must understand slots before building a title block
+
+Here is the key insight: **a slot is a promise**. When you put a slot labelled `key-plan` in your title block, you are promising STING: "I have reserved this rectangle for a key plan view." When the auto-placer runs, it looks for that promise, and if it finds it, it fills the rectangle with the right view — automatically.
+
+If you do not declare a slot, the auto-placer cannot fill it. If you declare a slot with the wrong purposeTag, the auto-placer puts the wrong view there. Getting the slot vocabulary right once means every sheet the engine produces is correctly laid out.
+
+---
+
+## Stage 2 — Title Block Creation: Building the Frame
+
+### What is a title block family and why does it matter?
+
+In Revit, every sheet must have a title block — the printable border, the company logo strip, the project information panel, the sheet number, the revision table. The title block is a special Revit family (file extension `.rfa`) that lives inside your project and appears on every sheet that uses it.
+
+Think of the title block as the **frame on a picture**. The frame itself does not change — it is always the same size, same colour, same style. What changes is the picture inside it (the views you place). STING treats the title block as more than decoration: it is a **map of the sheet** that the engine reads at runtime to know where it can place viewports, which cells to fill with project data, and which features to show or hide.
+
+### BIM vs Non-BIM families — what is the difference and which do you need?
+
+STING ships title block families in two variants:
+
+| Variant | File name pattern | What it does |
+|---|---|---|
+| BIM family | `STING_TB_<SIZE>_BIM_v<MAJOR>.<MINOR>.rfa` | Auto-fills labels from shared parameters (`PRJ_ORG_*`, `TB_*`). The engine reads slot JSON from `TB_VIEWPORT_SLOTS_JSON_TXT` and fills title-block cells from Project Information automatically. |
+| Non-BIM family | `STING_TB_<SIZE>_NONBIM_v<MAJOR>.<MINOR>.rfa` | Simpler layout; the engineer types project info by hand. No slot JSON. Engine still places viewports in the drawable zone but does not route by purposeTag. |
+
+**Which one do you need?** For any project where STING will auto-produce sheets, always use the BIM family. The Non-BIM variant exists for legacy situations where hand-typed info is acceptable. On a new project, start with BIM.
+
+Every sheet stamped by a BIM title block carries the parameter `STING_SHEET_BIM_MODE_TXT` = `"BIM"`. Audit commands flag mismatches (e.g., someone swapped a BIM family for a Non-BIM one on an existing sheet).
+
+### The 20-stage title block workflow
+
+This is the complete recipe for authoring one title block family from scratch. Follow every stage in order; each stage exists because skipping it breaks something downstream.
+
+**Before you start — checklist:**
+
+| Step | Action | Why |
+|---|---|---|
+| 1 | Revit 2025, 2026, or 2027 installed | STING targets these three releases only |
+| 2 | STING plugin loaded (`StingTools.dll` + `StingTools.addin` in the Revit Addins folder) | Validator and placement commands live in the plugin |
+| 3 | `MR_PARAMETERS.txt` set as the active Shared Parameter file in Revit (Manage > Shared Parameters > Browse) | All `TB_*` and `PRJ_TB_*` GUIDs come from this file |
+| 4 | `STING_DRAWING_TYPES.json` reachable in `StingTools/Data/` | The engine reads it for routing |
+| 5 | A test Revit project with 1 sheet, 1 plan view, 1 section | For dry-running the auto-placement engine |
+| 6 | Company logo as `.png` at 300 dpi, transparent background, max 200 × 60 mm | Embedded in cover and project-information pages |
+
+> **Stuck?** If you can answer "yes" to "can I open Revit, see STING in the ribbon, and pick a title block type from the Type Selector?" you are 90% through the pre-requisites.
+
+**The 20 stages:**
+
+**Stage 1 — Plan your title block family tree.**
+You are not authoring one title block — you are authoring one family per *purpose × paper size* combination, then shipping them as a kit. A typical corporate kit has 15 families covering every deliverable surface the office produces (cover page, project info page, fabrication sheets for each discipline, technical presentation, client presentation, issued-for-construction, issued-for-tender, as-built, authority submissions, marketing).
+
+Before opening the Family Editor, draw a table on paper: rows are purposes (Cover / Startup / Spool / Technical / Client / IFC / IFT / AsBuilt / Submission / Marketing), columns are paper sizes (A3 / A2 / A1 / A0). Mark every cell your office uses. That table is your build list.
+
+**Stage 2 — Choose orientation and strip convention.**
+STING uses a "bottom strip, both orientations" convention. The company information, sheet number, revision number, drawn-by/checked-by signatures, and scale all live in a horizontal strip across the bottom of the sheet. For landscape sheets the main drawable area sits above this strip. For A3/A4 portrait sheets, the same strip convention applies. The right-edge discipline colour band (for technical-presentation sheets) is an *additional* strip, not a change to the bottom strip.
+
+**Stage 3 — Open the Revit Family Editor for the correct template.**
+Go to `File > New > Family > Title Block`. Pick the metric template matching your paper size (`A0 metric.rft`, `A1 metric.rft`, etc.). Never start from a non-metric template if your project uses millimetres.
+
+**Stage 4 — Set sheet size in Family Types.**
+Inside the Family Editor, open `Create > Family Types`. Set the Sheet Size to the correct ISO paper size. For landscape A1: 594 × 841 mm. For portrait A3: 297 × 420 mm.
+
+**Stage 5 — Draw the border and bottom strip.**
+Draw the outer border as a thin line (0.25 mm). Draw a horizontal fill region at the bottom, 110 mm tall for A1, 90 mm for A3. This is the company information strip. Lock it to the bottom of the sheet with a dimension and a `EQ` constraint.
+
+**Stage 6 — Insert the company logo.**
+`Insert > Image`. Browse to your `LOGO.png`. Size it to fit the left side of the strip (approximately 80 mm wide). Lock its position with two dimensions — one from the left edge, one from the bottom of the strip.
+
+**Stage 7 — Load shared parameters from `MR_PARAMETERS.txt`.**
+`Manage > Shared Parameters`. Click `Browse` and navigate to `MR_PARAMETERS.txt`. You will now bind labels to the parameters in this file. Every `PRJ_TB_*` and `TB_*` parameter your title block needs lives here.
+
+**Stage 8 — Drop the project-information labels.**
+`Create > Label`. Place a label and click `Add Parameter` in the label dialog. Bind it to the shared parameter for project name (`PRJ_NAME_TXT`). Repeat for: project number, client name, CDE status, revision number, revision date, drawn-by, checked-by, approved-by, scale, sheet number, sheet name, sheet total. Use Arial Narrow or your corporate font. Set sizes: project name 14 pt bold, most other fields 8-10 pt.
+
+**Stage 9 — Declare the drawable zone.**
+This is the most important step for STING automation. The drawable zone is the rectangle inside the title block where viewports may be placed. Store its position and size in four Family Type parameters:
+
+| Parameter | Meaning |
+|---|---|
+| `TB_DRAWZONE_X_MM` | Distance from left edge of sheet to left edge of drawable zone |
+| `TB_DRAWZONE_Y_MM` | Distance from bottom edge of sheet to bottom edge of drawable zone |
+| `TB_DRAWZONE_W_MM` | Width of drawable zone in millimetres |
+| `TB_DRAWZONE_H_MM` | Height of drawable zone in millimetres |
+
+For a cover page or startup page where no viewports are allowed, set `TB_DRAWZONE_W_MM = 0` and `TB_DRAWZONE_H_MM = 0`. The engine reads these values to refuse viewport placement on covers.
+
+**Stage 10 — Declare the slot JSON.**
+For BIM title blocks, encode the slot table in the `TB_VIEWPORT_SLOTS_JSON_TXT` family parameter. Each slot has: a label, a normalised position (0..1 over the drawable zone), a purposeTag, a view type hint, and an optional scale hint.
+
+Example for a fabrication sheet with 5 slots:
+```json
+[
+  {"label":"PLAN",   "normX":0.00,"normY":0.50,"normW":0.65,"normH":0.50,
+   "purposeTag":"fabrication-isometric","viewType":"FloorPlan","scale":25},
+  {"label":"ISO",    "normX":0.65,"normY":0.50,"normW":0.35,"normH":0.50,
+   "purposeTag":"fabrication-isometric","viewType":"ThreeD","scale":25},
+  {"label":"ELEV0",  "normX":0.00,"normY":0.00,"normW":0.32,"normH":0.50,
+   "purposeTag":"main-plan","viewType":"Elevation","scale":25},
+  {"label":"ELEV90", "normX":0.32,"normY":0.00,"normW":0.33,"normH":0.50,
+   "purposeTag":"main-plan","viewType":"Elevation","scale":25},
+  {"label":"3D",     "normX":0.65,"normY":0.00,"normW":0.35,"normH":0.50,
+   "purposeTag":"fabrication-isometric","viewType":"ThreeD","scale":25}
+]
+```
+
+The `normX/Y/W/H` values are fractions of the drawable zone (not the whole paper). So `normX=0.65` means "65% of the way across the drawable zone from the left."
+
+**Stage 11 — Add the visibility toggle parameters.**
+STING controls which features appear on each sheet using a family of `TB_SHOW_*_BOOL` parameters. Add these to your family as Family Type parameters (Integer, 0 or 1):
+
+| Parameter | Controls |
+|---|---|
+| `TB_SHOW_COMPANY_STRIP_BOOL` | The company logo and info strip |
+| `TB_SHOW_KEY_PLAN_BOOL` | The key plan slot |
+| `TB_SHOW_NORTH_ARROW_BOOL` | The north arrow symbol |
+| `TB_SHOW_SCALEBAR_BOOL` | The scale bar symbol |
+| `TB_SHOW_REV_TABLE_BOOL` | The revision history table |
+| `TB_SHOW_QR_CODE_BOOL` | The QR code stamp |
+| `TB_SHOW_DISCIPLINE_COLOR_STRIP_BOOL` | The discipline colour band on the right edge |
+
+Set each to `1` (visible) or `0` (hidden) in Family Types. These defaults can be overridden per sheet instance.
+
+**Stage 12 — Nest the symbol families.**
+The north arrow, scale bar, key plan thumbnail, grid bubble, section marker, elevation marker, callout tag, and revision cloud tag are all separate nested families that live inside your title block family. `Insert > Load Family` and browse to the STING family library for each. Once loaded, place them in the appropriate slot positions.
+
+Store the nested family names in the corresponding `TB_NESTED_*_FAMILY_TXT` parameters so the engine knows which family name to expect:
+
+| Parameter | Nested family |
+|---|---|
+| `TB_NESTED_NORTH_ARROW_FAMILY_TXT` | e.g. `STING_NORTH_ARROW_STD` |
+| `TB_NESTED_SCALEBAR_FAMILY_TXT` | e.g. `STING_SCALEBAR_METRIC` |
+| `TB_NESTED_GRID_BUBBLE_FAMILY_TXT` | e.g. `STING_GRID_M` (discipline-specific) |
+| `TB_NESTED_SECTION_MARKER_FAMILY_TXT` | e.g. `STING_SECTION_M` |
+| `TB_NESTED_ELEVATION_MARKER_FAMILY_TXT` | e.g. `STING_ELEVATION_M` |
+| `TB_NESTED_CALLOUT_TAG_FAMILY_TXT` | e.g. `STING_CALLOUT_M` |
+| `TB_NESTED_REV_CLOUD_TAG_FAMILY_TXT` | e.g. `STING_REVCLOUD_STD` |
+
+**Stage 13 — Add the purpose and identity parameters.**
+These parameters tell the engine what this title block is for:
+
+| Parameter | Example values | What it means |
+|---|---|---|
+| `TB_PURPOSE_TXT` | `Cover` / `Startup` / `Spool` / `Plan` | The role of this title block in the deliverable stack |
+| `TB_PAPER_SIZE_TXT` | `A1` / `A2` / `A3` | ISO paper size |
+| `TB_ORIENTATION_TXT` | `Landscape` / `Portrait` | Sheet orientation |
+| `TB_DISCIPLINE_LIST_TXT` | `M;E;P;A;S;FP;LV` or `PIPE` | Which disciplines may use this title block (semicolon-separated) |
+| `TB_DRAWING_TYPE_ID_TXT` | `pipe-spool-A1-1to50` | The drawing type recipe this title block is bound to |
+| `TB_TEMPLATE_VERSION_TXT` | `1.0.0` | Version number — bump when the engine-visible structure changes |
+| `TB_MAX_VIEWPORTS_INT` | `5` for spool, `0` for cover | How many viewports this sheet may hold |
+
+**Stage 14 — Add the reserved regions JSON (optional).**
+For startup pages and any sheet where specific rectangles must not be overlapped by viewports, encode them in `TB_RESERVED_REGIONS_JSON_TXT`:
+```json
+[
+  {"name":"sheet_index","x":8,"y":180,"w":280,"h":80,"kind":"schedule"},
+  {"name":"rev_history","x":8,"y":100,"w":280,"h":70,"kind":"schedule"}
+]
+```
+The engine reads this list and keeps those areas free when placing viewports.
+
+**Stage 15 — Draw the revision history table.**
+The revision table is a simple grid inside the company strip. Typical columns: Rev / Description / Date / By. 8 rows is enough for most deliverables (older revisions archive to the start-up page's revision schedule). Bind the row fields to `TB_REV_1_CODE_TXT`, `TB_REV_1_DATE_TXT`, etc. from `MR_PARAMETERS.txt`.
+
+Wrap the whole table in a visibility parameter linked to `TB_SHOW_REV_TABLE_BOOL`.
+
+**Stage 16 — Add the BIM mode marker parameter.**
+Add `STING_SHEET_BIM_MODE_TXT` as a family parameter with default value `"BIM"`. This is what audit commands check to confirm the right family type is loaded on each sheet.
+
+**Stage 17 — Add the authority-code parameter (for submission families only).**
+For authority submission families (KCCA, ERA, NEMA), add `TB_AUTHORITY_CODE_TXT` with the authority name as the default. Also ensure the required project-information parameters for that authority are listed in `TB_REQUIRED_PRJ_PARAMS_JSON_TXT` — the validator reads this list and fails the pre-flight check if any are empty.
+
+**Stage 18 — Set up the last-validated parameter.**
+Add `TB_LAST_VALIDATED_DT_TXT` as a family parameter (Text, blank default). The validator writes today's date here when it passes. Any title block with a date more than one major version behind the corporate baseline shows a warning.
+
+**Stage 19 — Save and name the family file.**
+File name convention: `STING_TB_{PURPOSE}_{PAPER}.rfa`
+
+Examples:
+- `STING_TB_COVER_A3.rfa`
+- `STING_TB_ASSEMBLY_PIPE.rfa`
+- `STING_TB_TECHNICAL_A1.rfa`
+- `STING_TB_IFC_A1.rfa`
+- `STING_TB_SUBMISSION_KCCA.rfa`
+
+Save into `Families/AssemblyTitleBlocks/` (your corporate family library folder).
+
+**Stage 20 — Test the title block in a live project.**
+Load the family into your test project: `Insert > Load Family`. Create a new sheet and select the new title block from the Type Selector. Then:
+1. Run `DOCS > Drawing Types > Inspect` — confirm the validator recognises the new family and reports no critical errors.
+2. Run `TitleBlock_AutoPlaceViewports` — drag a plan view onto the sheet and confirm it lands in the `main-plan` slot, not somewhere random.
+3. Run `DOCS > Drawing Types > Sync Styles` — confirm the style pack applies without warnings.
+4. Check every label auto-filled from Project Information.
+
+> **Stuck?** If a label shows `???` instead of project data, the shared parameter GUID in your family does not match the GUID in `MR_PARAMETERS.txt`. Re-bind the label: click it, click the label button in Properties, remove the old parameter and re-add it from `MR_PARAMETERS.txt`.
+
+### Naming conventions — the exact naming pattern and why it matters
+
+The naming pattern `STING_TB_{PURPOSE}_{PAPER}` is a contract between three systems:
+
+1. The **title block family** declares `TB_DRAWING_TYPE_ID_TXT` pointing to a recipe.
+2. The **drawing type recipe** declares `titleBlockFamily` pointing to this family name.
+3. The **engine** resolves the family by name from the project's loaded title-block types.
+
+If any of the three names diverge, the engine falls back to the first available title block and logs a warning. Keep names consistent across all three systems. Never rename a family after it has been used in a project without updating both the JSON recipe and re-loading the family.
+
+### Embedding slots in your title block — the link between Stage 1 and Stage 2
+
+The connection between Stage 1 (the slot vocabulary) and Stage 2 (the title block) happens in `TB_VIEWPORT_SLOTS_JSON_TXT`. Each slot you declare in that JSON string must use a `purposeTag` from the Stage 1 vocabulary. The engine reads this JSON at runtime; it does not look inside the `.rfa` geometry. So:
+
+- Getting the purposeTag right matters. `main-plan` routes plan views; `key-plan` routes key plans. Mistyping the tag means the auto-placer skips that slot.
+- The normalised coordinates (0..1 over the drawable zone) let the layout work across paper sizes. If you later change the drawable zone dimensions in `TB_DRAWZONE_*_MM`, the slot positions remain correct because they are fractions, not absolute millimetres.
+
+### Common mistakes and how to avoid them
+
+| Mistake | Symptom | Fix |
+|---|---|---|
+| Not setting `TB_DRAWZONE_W_MM` | Engine cannot find the drawable zone; viewports land at sheet origin | Set all four `TB_DRAWZONE_*_MM` parameters. Set to 0 for cover pages. |
+| Wrong purposeTag in slot JSON | Auto-placer skips the slot; you see "No slot found for view" in the log | Check the purposeTag against the Stage 1 vocabulary table |
+| Missing nested family | North arrow / scale bar does not appear | Load the nested family into the title block family, or clear `TB_NESTED_*_FAMILY_TXT` if you are not using it |
+| Version not bumped after structural change | Validator accepts stale title blocks | Bump `TB_TEMPLATE_VERSION_TXT` any time drawable zone or slot JSON changes |
+| Corporate family renamed in a project | Engine falls back to first available title block | Restore the original file name or update the drawing type recipe's `titleBlockFamily` field |
+
+### Testing your title block before you use it
+
+Run these three tests before deploying a new title block family to your project team:
+
+1. **Validation test**: `DOCS > Drawing Types > Inspect` — all title block entries in the catalogue should show green, not red.
+2. **Auto-placement test**: create a new sheet with the title block, then run `TitleBlock_AutoPlaceViewports` with a plan view selected. The plan should land in the `main-plan` slot, not at (0,0).
+3. **Fill test**: run `DOCS > Drawing Types > Sync Styles` on a view already stamped with this title block's recipe. Confirm all 10 pipeline steps complete without errors in the result dialog.
+
+---
+
+## Stage 3 — Drawing Type Manager: Wiring the Recipe
+
+### What is a Drawing Type?
+
+A Drawing Type is a recipe card for one kind of drawing. Imagine a recipe for pasta: it tells you what ingredients you need (sheet size, title block), how long to cook it (scale, detail level), what steps to follow (view template, crop strategy, annotation rules), and what the plate should look like (view style pack). Once the recipe is written, anyone can make the same pasta — every time, identically.
+
+A Drawing Type answers every question the engine needs to produce one drawing:
+
+| Question the engine asks | Field in the recipe |
+|---|---|
+| What kind of drawing is this? | `purpose` (Plan, RCP, Section, Elevation, Detail, Schedule, Spool, Coordination, Legend, 3D) |
+| Which discipline? | `discipline` (A = Architectural, S = Structural, M = Mechanical, E = Electrical, P = Plumbing, etc.) |
+| What paper size? | `paperSize` (A0, A1, A2, A3) |
+| Which title block family? | `titleBlockFamily` |
+| What scale? | `scale` (1:N integer) |
+| Which view template? | `viewTemplateName` |
+| How is the view cropped? | `crop` strategy |
+| Where do viewports land? | `slots[]` (normalised 0..1 rectangles) |
+| What gets auto-tagged and auto-dimensioned? | `annotation.rules[]` |
+| How does it look (line weights, colours)? | `viewStylePackId` (links to a View Style Pack) |
+| What is the sheet number format? | `sheetNumberPattern` |
+| What text goes in the title block cells? | `titleBlockParams` (declarative cell-fill map) |
+
+STING ships **40 ready-made drawing types** covering every common deliverable. You rarely start from scratch — you clone the closest match and adjust.
+
+### The three concentric layers
+
+The system has three layers that nest inside each other like Russian dolls:
+
+```
+ROUTING TABLE
+  → picks the right drawing type based on (discipline, phase, docType)
+    ↓
+DRAWING TYPE
+  → answers every layout and content question
+  → points to a View Style Pack
+    ↓
+VIEW STYLE PACK
+  → answers every visual-appearance question
+  → inherits from a parent pack via the extends chain
+```
+
+Think of it as a **restaurant**:
+- The **routing table** is the head waiter: "Table for 4, MEP coordination, please" → tells the kitchen which dish to cook.
+- The **drawing type** is the menu item: "MEP Coord A1 1:50" — the dish, with all its ingredients and cooking instructions.
+- The **view style pack** is the plating standard: "MEP coord plates have blue ducts, green pipes, amber electrics, halftoned walls."
+
+One waiter, one menu, one kitchen — every plate looks the same.
+
+### The 40 corporate drawing types — what they are and when to use each
+
+#### Architectural (12 types)
+
+| ID | Paper | Scale | When you use it |
+|---|---|---|---|
+| `arch-plan-A1-1to100` | A1 | 1:100 | Standard architectural floor plan — the most common sheet in any building project |
+| `arch-rcp-A1-1to100` | A1 | 1:100 | Reflected ceiling plan — showing what you see looking up at the ceiling |
+| `arch-section-A1-1to50` | A1 | 1:50 | Building section cut — shows the inside of the building from top to bottom |
+| `arch-elev-A1-1to100` | A1 | 1:100 | Exterior elevation — the front, back, or side face of the building |
+| `arch-detail-A3-1to20` | A3 | 1:20 | Construction detail — a zoomed-in drawing of a specific junction or connection |
+| `arch-site-A1-1to500` | A1 | 1:500 | Site or context plan — the building shown in relation to the surrounding plot and streets |
+| `arch-roof-A1-1to100` | A1 | 1:100 | Roof plan — looking down at the roof from above |
+| `arch-floor-finishes-A1-1to100` | A1 | 1:100 | Floor finishes layout — which tiles, carpets, or materials go where |
+| `arch-fire-strategy-A1-1to100` | A1 | 1:100 | Fire strategy plan — showing fire compartments, escape routes, sprinkler zones |
+| `arch-accessibility-A1-1to100` | A1 | 1:100 | Accessibility plan — Part M / BS 8300 wheelchair routes, ramps, turning circles |
+| `arch-interior-elev-A1-1to50` | A1 | 1:50 | Interior elevation — the finished surface of an interior wall (bathrooms, kitchens, lobbies) |
+| `arch-window-schedule-A2` | A2 | — | Window schedule — a table listing every window type, size, and specification |
+
+#### Structural (4 types)
+
+| ID | Paper | Scale | When you use it |
+|---|---|---|---|
+| `struct-plan-A1-1to100` | A1 | 1:100 | Structural layout plan — showing columns, beams, slabs with their sizes and grid references |
+| `struct-section-A1-1to50` | A1 | 1:50 | Structural section — detailed cross-section through a structural frame or floor build-up |
+| `struct-foundation-A1-1to100` | A1 | 1:100 | Foundation plan — pad footings, strip footings, pile caps and their sizes |
+| `struct-rebar-detail-A3-1to20` | A3 | 1:20 | Rebar detail — reinforcement bar arrangement for concrete elements |
+
+#### MEP — Mechanical, Electrical, Plumbing (4 types)
+
+| ID | Paper | Scale | When you use it |
+|---|---|---|---|
+| `mep-plan-A1-1to100` | A1 | 1:100 | General MEP services plan — all disciplines overlaid, used for early-stage coordination |
+| `mep-coord-A1-1to50` | A1 | 1:50 | MEP coordination plan — detailed clash resolution drawing for IDR/TDR meetings |
+| `mep-hvac-duct-A1-1to100` | A1 | 1:100 | HVAC ductwork plan — duct sizes, routes, air terminal locations |
+| `mep-plantroom-A1-1to50` | A1 | 1:50 | Plant room layout — major mechanical equipment in a plant room at 1:50 |
+
+#### Electrical (4 types)
+
+| ID | Paper | Scale | When you use it |
+|---|---|---|---|
+| `elec-riser-A2-1to100` | A2 | 1:100 | Electrical riser diagram — vertical distribution of electrical systems floor by floor |
+| `elec-power-A1-1to100` | A1 | 1:100 | Power layout plan — socket outlets, distribution boards, cable routes |
+| `elec-lighting-A1-1to100` | A1 | 1:100 | Lighting layout plan — luminaire positions, circuit references, switch locations |
+| `elec-fire-alarm-A1-1to100` | A1 | 1:100 | Fire alarm layout — detector, call point, and sounder positions |
+
+#### Public Health / Plumbing (1 type)
+
+| ID | Paper | Scale | When you use it |
+|---|---|---|---|
+| `plumb-drainage-A1-1to100` | A1 | 1:100 | Drainage layout plan — soil, waste, and rainwater pipe routes |
+
+#### Fabrication / Spool (2 types)
+
+| ID | Paper | Scale | When you use it |
+|---|---|---|---|
+| `pipe-spool-A1-1to50` | A1 | 1:50 | Pipe spool fabrication sheet — plan + isometric + elevations + BOM strip for one pre-fabricated pipe assembly |
+| `duct-spool-A1-1to50` | A1 | 1:50 | Duct spool fabrication sheet — same format for pre-fabricated ductwork |
+
+#### Coordination and Handover (3 types)
+
+| ID | Paper | Scale | When you use it |
+|---|---|---|---|
+| `coord-clash-A1-1to50` | A1 | 1:50 | Clash report sheet — shows a specific clash location with views from multiple disciplines |
+| `fm-asset-location-A1-1to100` | A1 | 1:100 | FM asset location plan — for the facilities management team, showing equipment positions for maintenance |
+| `handover-A1` | A1 | — | Handover sheet — general purpose handover / O&M documentation sheet |
+
+#### Schedules and Legends (3 types)
+
+| ID | Paper | When you use it |
+|---|---|---|
+| `door-schedule-A2` | A2 | Door schedule — listing every door by mark number with its type, size, and hardware |
+| `legend-A2` | A2 | General legend sheet — symbol keys, colour codes, general notes |
+
+#### Presentation Pack — Client-Facing (5 types)
+
+These types print in full colour with lighter line weights and no grid/dimension clutter. Route to them by setting the project phase to `PRESENTATION`.
+
+| ID | Paper | When you use it |
+|---|---|---|
+| `pres-3d-axon-A1` | A1 | 3D axonometric overview with a key plan and caption block — for client steering committee meetings |
+| `pres-perspective-A1` | A1 | Full-bleed architectural perspective — for brochures, planning presentations |
+| `pres-exterior-elev-A1` | A1 | Exterior elevation with material callouts — for client reviews of the building facade |
+| `pres-render-board-A1` | A1 | Four-up render board — four rendered images with captions for a design presentation |
+| `pres-context-site-A1` | A1 | Aerial context plan with legend and caption — for planning authority submissions |
+
+#### Clarification / RFI Pack (3 types)
+
+| ID | Paper | When you use it |
+|---|---|---|
+| `clar-markup-A1` | A1 | Mark-up sheet with query log and revision strip — for issuing a formal comment on another party's drawing |
+| `clar-rfi-A3` | A3 | Single-issue A3 RFI sketch — a self-contained one-page request for information |
+| `clar-design-intent-A1` | A1 | Design intent sheet — plan + 3D + narrative + materials strip for explaining a design decision |
+
+### Every field in a Drawing Type explained
+
+Each drawing type is a JSON record. Here is every field in plain English:
+
+| JSON field | Plain English | Example |
+|---|---|---|
+| `id` | The permanent name of this recipe. Never change it after it is used in a project. | `"mep-coord-A1-1to50"` |
+| `name` | Human-readable label that appears in the editor picker. | `"MEP Coord A1 1:50"` |
+| `description` | Two-sentence description of when to use this type. | `"MEP coordination plan at 1:50..."` |
+| `purpose` | The category of drawing this produces. | `"Coordination"` |
+| `discipline` | Which discipline owns this drawing (or `*` for any). | `"M"` for Mechanical |
+| `phase` | Which RIBA stage or project phase this applies to (or `*` for any). | `"*"` |
+| `paperSize` | ISO paper size. | `"A1"` |
+| `titleBlockFamily` | The exact name of the title block family to load (must match the `.rfa` file name without the extension). | `"STING_TB_TECHNICAL_A1"` |
+| `orientation` | Sheet orientation. | `"Landscape"` |
+| `scale` | View scale as a 1:N integer. The engine sets `view.Scale` to this value. | `50` (meaning 1:50) |
+| `detailLevel` | How much geometric detail to show. | `"Fine"` / `"Medium"` / `"Coarse"` |
+| `viewTemplateName` | The name of a Revit view template to apply. Can be overridden by managed mode (see Stage 4). | `"STING - MEP Coordination"` |
+| `viewportTypeName` | Which Revit viewport type to use (controls whether a viewport title strip is shown). | `"With Line"` / `"No Title"` |
+| `viewStylePackId` | Which visual style pack governs this drawing's appearance. | `"corp-coordination"` |
+| `sheetNumberPattern` | The formula for the sheet number. Tokens like `{disc}`, `{lvl}`, `{seq:D3}` are substituted at sheet-creation time. | `"M-{lvl}-{seq:D3}"` |
+| `sheetNamePattern` | The formula for the sheet name. | `"{discipline} Coord L{lvl}"` |
+| `crop` | How the view's crop box is computed. | `"ScopeBoxOrBbox"` |
+| `cropMarginMm` | The breathing room around the cropped content. | `150` |
+| `sectionMarker.family` | Name of the section/elevation/callout marker family. | `"STING_SECTION_M"` |
+| `sectionMarker.markPrefix` | The letter prefix before the section number. | `"S"` |
+| `sectionMarker.farClipMm` | How far behind the section cut the view extends. | `3000` |
+| `slots[]` | List of viewport slots on the sheet (see "Slots" below). | — |
+| `annotation.rules[]` | List of auto-annotation actions (see "Annotation Rules" below). | — |
+| `annotation.tagFamilies` | Which tag family to use per Revit category. | `{"Mechanical Equipment": "STING_EQP_TAG"}` |
+| `annotation.tagDepths` | How much information to show in the TAG7 rich tag per category (1 = name only, 10 = everything). | `{"Pipes": 5}` |
+| `annotation.denseUntilScale` | If the drawing is at a scale coarser than this, skip per-element annotation (prevents clutter on overview sheets). | `100` |
+| `annotation.dimensionStrategy` | How dimensions are placed. | `"Linear"` / `"Ordinate"` / `"Chain"` |
+| `titleBlockParams` | A map of title-block cell names to value formulas. The engine writes each entry into the title block instance at sheet-creation time. | `{"Client Name": "${PRJ_ORG_CLIENT_NAME}"}` |
+| `origin` | Whether this record came from the corporate catalogue or was overridden per-project. Set automatically; do not edit. | `"corporate"` / `"project"` |
+| `extends` | If this type inherits from another type, put the parent's `id` here. The engine merges parent fields first, child fields override. | `"arch-plan-A1-1to100"` |
+
+### How routing works — how STING picks the right type automatically
+
+The routing table is a list of rules. Each rule is a simple "if this, then that" statement:
+
+```
+If discipline = "M" AND phase = "*" AND docType = "PLAN"
+→ use drawing type "mep-plan-A1-1to100"
+```
+
+The engine walks the routing table from top to bottom and uses the **first rule that matches**. This is called "first-match-wins."
+
+**Where the routing table lives:** at the bottom of `StingTools/Data/STING_DRAWING_TYPES.json`. It is a JSON array called `"routing"`.
+
+**How project-specific routing works:** Project-level routing rules (from `<project>/_BIM_COORD/drawing_types.json`) are **prepended** to the corporate rules. That means your project rules always win over the corporate defaults. You can add a rule for "basement levels use 1:50 instead of 1:100" without touching the corporate catalogue.
+
+**Conditional rules (Week 6 capability):** A routing rule can carry extra filters called "predicates." A rule fires only if ALL predicates match:
+
+| Predicate | What it matches | Example |
+|---|---|---|
+| `disciplineMatches` | Regex against discipline code | `"^M$"` matches only Mechanical |
+| `phaseMatches` | Regex against phase name | `"PRESENTATION"` |
+| `docTypeMatches` | Regex against document type | `"SPOOL"` |
+| `levelMatches` | Regex against level code | `"^B\\d+"` matches basement levels |
+| `projectCodeMatches` | Regex against project code | `"^PLNS"` |
+
+A typical use: "MEP plans on basement levels always use 1:50 instead of 1:100." Write one routing rule with `levelMatches: "^B\\d+"` and `docType: "PLAN"` → point it at a custom `mep-basement-plan-A1-1to50` recipe.
+
+> **Stuck?** If the wrong drawing type is being applied, go to `DOCS > Drawing Types > Inspect`. Look at the routing table dump. Find the rule that covers your `(discipline, phase, docType)` combination. Is your project rule missing? Is it misspelled? The Inspect output will show you which rule matched.
+
+### Token substitution — {disc}, {lvl}, {sys}, {spool} explained with examples
+
+Tokens are placeholders in a pattern string. When the engine creates a sheet, it replaces every token with the real value for that sheet. Think of tokens like mail-merge fields in a letter template.
+
+**Example:** Pattern `M-{lvl}-{seq:D3}` for a Mechanical plan on Level 02 (the third sheet produced):
+→ Result: `M-L02-003`
+
+**Full token reference:**
+
+| Token | Replaced with | Source |
+|---|---|---|
+| `{project}` | Project code | Project Information parameter `PRJ_ORG_PROJECT_CODE` |
+| `{originator}` | Originator code | Project Information parameter `PRJ_ORG_ORIGINATOR_CODE` |
+| `{vol}` | Volume / system group | `DrawingType.IsoNaming.Volume` |
+| `{type}` | Document type code | `DrawingType.IsoNaming.Type` (DR = drawing, SH = schedule, SP = spool, etc.) |
+| `{role}` | Discipline role code | `DrawingType.IsoNaming.Role` (A, S, M, E, P, FP) |
+| `{suit}` | Suitability code | `DrawingType.IsoNaming.Suitability` (S0–S7, A1–A5) |
+| `{rev}` | Revision code | `DrawingType.IsoNaming.Revision` (P01, C01, etc.) |
+| `{disc}` | Discipline letter | Derived from the view's category distribution |
+| `{discipline}` | Full discipline name | Derived (e.g. `Pipe`, `Electrical`) |
+| `{sys}` | System code | From the element or spool (e.g. `HWS`, `SAN`) |
+| `{lvl}` | Level code | Derived from the view's level (e.g. `L02`, `GF`, `B1`) |
+| `{spool}` | Spool number | From the fabrication assembly (`ASS_SPOOL_NR_TXT`) |
+| `{mark}` | Section or detail mark | From the view's Mark property |
+| `{seq}` | 4-digit zero-padded counter | Auto-incremented per (drawing type, level) pair |
+| `{seq:D2}` | 2-digit counter | As above with 2-digit padding |
+| `{seq:D3}` | 3-digit counter | As above with 3-digit padding |
+| `{seq:D4}` | 4-digit counter | As above with 4-digit padding |
+
+**In `titleBlockParams` only:** `${PRJ_ORG_PROJECT_CODE}` style references (using dollar-brace syntax) read directly from any Project Information parameter.
+
+> **Stuck?** If your sheet number shows `--L02-DR-A-003-S2-P01` with two hyphens at the start, the `{project}` or `{originator}` token resolved to an empty string. Go to Project Information and fill `PRJ_ORG_PROJECT_CODE` and `PRJ_ORG_ORIGINATOR_CODE`.
+
+### Project-scoped overrides — how to customise without breaking the corporate baseline
+
+This is a critical concept: **you never edit the corporate drawing types or style packs directly.** Instead:
+
+1. The corporate baseline lives in `StingTools/Data/STING_DRAWING_TYPES.json` — this file is locked (the engine watches its SHA-256 checksum).
+2. When you edit a corporate entry in the editor dialog and click Save, the engine copies it to `<project>/_BIM_COORD/drawing_types.json` with `origin: "project"`. The corporate file on disk is untouched.
+3. On the next document open, the engine loads the corporate file first, then layers the project file on top. Project entries win by `id`.
+
+Why this matters: when the BIM manager updates the corporate drawing types next month, your project-scoped overrides survive. You do not have to re-apply your changes. The corporate update only affects entries you have NOT overridden per-project.
+
+**The SHA-256 drift detection** is the mechanism that notices when a corporate entry has been modified. If the checksum of an entry in the loaded JSON does not match the checksum of the same entry in the on-disk corporate file, the entry's `origin` flips to `"project"` automatically. You can see this happen the first time you edit a corporate entry in the editor.
+
+### The Drawing Type Editor dialog — every button and card explained
+
+Open the editor from the STING dock panel: **DOCS tab > Drawing Types section > Edit Types.**
+
+The editor has two tabs: **Drawing Types** (left tab) and **View Style Packs** (right tab). Each tab has the same three-column layout:
+
+- **Left column:** search box, New/Clone/Delete buttons, list of types/packs ordered by discipline and purpose.
+- **Right column:** a scrollable form with multiple "cards" (expandable sections).
+- **Footer:** Save and Close buttons, always visible (never clipped by window resize).
+
+#### Drawing Types tab — card by card:
+
+**Identity card**
+
+| Field | What to fill in |
+|---|---|
+| Id | Stable identifier — fill once and never change. Convention: `<discipline>-<purpose>-<paper>-<scale>` |
+| Name | Human-readable label for the picker list |
+| Description | Two lines explaining when to use this type |
+| Purpose | Pick from the dropdown: Plan / RCP / Section / Elevation / Detail / Schedule / Spool / Coordination / Legend / 3D / Cover / Startup / Render / Submission / Clarification / ClientReview / DesignReview |
+| Discipline | ISO 19650 single-letter code or `*` for any |
+| Phase | RIBA stage number (0–7) or `*` |
+| Origin | Read-only — shows `corporate` or `project`. You cannot edit this. |
+
+**Sheet card**
+
+| Field | What to fill in |
+|---|---|
+| Paper size | A0 / A1 / A2 / A3 / A4 |
+| Title block family | Pick from the dropdown — populated from title block families loaded in the active project |
+| Orientation | Landscape / Portrait |
+
+**Views card**
+
+| Field | What to fill in |
+|---|---|
+| Scale | The 1:N scale (type the number N, e.g. `50` for 1:50) |
+| Detail level | Coarse / Medium / Fine |
+| View template name | Pick from the dropdown (live list of templates in the project, merged with STING corporate templates) |
+| Viewport type name | Pick from the dropdown (controls whether viewport title strip is shown) |
+| View style pack id | Pick which visual style pack to use (see Stage 5 for the full pack list) |
+
+**Numbering card**
+
+| Field | Supported tokens |
+|---|---|
+| Sheet number pattern | `{project}`, `{originator}`, `{vol}`, `{lvl}`, `{type}`, `{role}`, `{seq}`, `{seq:D2}`, `{seq:D3}`, `{seq:D4}`, `{disc}`, `{discipline}`, `{sys}`, `{mark}`, `{spool}`, `{suit}`, `{rev}` |
+| Sheet name pattern | Same token set |
+
+The dropdown is pre-populated with five common ISO 19650 patterns. You can also type your own.
+
+**Crop card**
+
+| Crop kind | What happens |
+|---|---|
+| `ScopeBox` | Uses the named scope box; shows an error if the scope box is missing |
+| `ScopeBoxOrBbox` | Uses the scope box if one exists; otherwise computes a tight bounding box of model elements with your margin |
+| `TightBbox` | Always uses the bounding box of model elements, plus your margin |
+| `RoomBoundary` | Uses the union of room boundaries (plan views only; falls back to TightBbox if no rooms are placed) |
+| `None` | Leaves the view's crop box exactly as it is |
+
+Margin field: the extra breathing room in millimetres added around the crop boundary.
+
+**Section/Elevation marker card**
+
+Bind a section marker, elevation marker, or callout marker family from the live list. Set:
+- Family name (dropdown of `OST_SectionHeads / OST_ElevationMarks / OST_CalloutHeads` element types)
+- Mark prefix (the letter before the number, e.g. `S` for sections, `EL` for elevations, `D` for details)
+- Far clip distance: how far behind the cut plane the section view extends. 3000 mm is the default; raise it for large-volume sections like atria.
+
+**Annotation rule pack card**
+
+This is the most powerful card — it tells the engine what to auto-tag and auto-dimension.
+
+Three sub-sections:
+
+1. **Automation rules grid** — one row per action. Columns: Enabled tick, Category (dropdown), Rule type (dropdown of 21 types — see table below), Tag family override, Depth, Delete. Click `+ Add rule` to add a row.
+
+2. **Dimension settings** — Strategy (Linear / Ordinate / Chain), dimension style name (dropdown), Dense-until-scale threshold.
+
+3. **Tag families grid** — one row per category override. Columns: Category, tag family name, TAG7 paragraph depth (1–10).
+
+**The 21 annotation rule types:**
+
+| Rule type | Plain English |
+|---|---|
+| `AutoTag` | Place a default tag on every visible element in this category |
+| `AutoDim` | Run an automatic dimension chain |
+| `AutoDimOrdinate` | Ordinate-style automatic dimension |
+| `AutoDimChain` | Continuous chain dimension |
+| `AutoTagWithLeader` | AutoTag but force a leader line on every tag |
+| `AutoTagHideIfEmpty` | AutoTag but skip elements where the tag value would be blank |
+| `AutoTagTypeMark` | Tag using the Type Mark parameter (not instance mark) |
+| `AutoTagRoomName` | Tag rooms showing name only |
+| `AutoTagRoomNumber` | Tag rooms showing number only |
+| `AutoTagDoorNumber` | Door schedule mark tag |
+| `AutoTagWindowMark` | Window schedule mark tag |
+| `AutoTagEquipmentTag` | Equipment tag (mechanical / electrical / plumbing equipment) |
+| `AutoTagGridBubble` | Place grid bubbles at every visible grid intersection |
+| `AutoDimWallLength` | Linear dimension along every wall |
+| `AutoDimColumnGrid` | Column-to-column grid spacing dimensions |
+| `AutoDimOpenings` | Dimension door and window openings |
+| `AutoDimElevation` | Floor and ceiling elevation dimensions |
+| `AutoAnnotateSlope` | Add slope annotation on pipes, drainage, ramps, or roofs |
+| `AutoAnnotateFlowArrow` | Add flow direction arrows on ducts and pipes |
+| `AutoAnnotateSpaceNumber` | Number every space (HVAC zone numbering) |
+| `AutoAnnotateAreaBoundary` | Tag area boundary lines |
+
+**Slots card**
+
+Each slot is a named rectangle on the sheet's drawable zone. Add as many as needed.
+
+| Column | What to fill in |
+|---|---|
+| Label | A descriptive name, e.g. "Main Plan", "Key Plan", "Notes" |
+| ViewType | Which type of Revit view goes in this slot (FloorPlan / CeilingPlan / Section / Elevation / ThreeD / Detail / DraftingView / Legend / Schedule) |
+| X | Left edge of slot, as a fraction of drawable zone width (0.0 = far left, 1.0 = far right) |
+| Y | Bottom edge of slot, as a fraction of drawable zone height (0.0 = bottom, 1.0 = top) |
+| W | Width as a fraction of drawable zone width |
+| H | Height as a fraction of drawable zone height |
+| Scale | Optional per-slot scale override (overrides the drawing type's main scale) |
+
+**Title-block parameter binding card**
+
+One row per title-block cell. Columns: cell name (the parameter name on the title-block instance), value template (which tokens to write).
+
+Example row: `| Client Name | ${PRJ_ORG_CLIENT_NAME} |`
+This writes the project's client name from Project Information into the title block's `Client Name` parameter when the sheet is created.
+
+**Save semantics:** Clicking Save writes only entries with `origin: "project"` to `<project>/_BIM_COORD/drawing_types.json`. The corporate file on disk is never changed. If you edit a corporate entry and click Save, the entry's origin flips to `"project"` automatically and your edits land in the project file.
+
+### Scope-box auto-binding — the STING:: naming trick
+
+This is the fastest way to produce a coordinated set of plans:
+
+1. In a plan view, go to `View > Scope Boxes` and create scope boxes covering each zone or level area you need drawings for.
+2. Name each scope box using this pattern: `STING::<drawing-type-id>::<level-code>::<optional-tag>`
+
+   Examples:
+   ```
+   STING::arch-plan-A1-1to100::L01
+   STING::arch-plan-A1-1to100::L02
+   STING::mep-coord-A1-1to50::L01::east-wing
+   STING::mep-coord-A1-1to50::L01::west-wing
+   STING::pipe-spool-A1-1to50::L03::HWS
+   ```
+
+3. Go to **DOCS > Drawing Types > From Scope Boxes** in the STING dock panel.
+4. Click the button. The engine scans every scope box, finds the ones named with the `STING::` prefix, creates a view for each, applies the matching drawing type recipe, and crops the view to the scope box boundary.
+5. The command is **idempotent** — if you run it again, it finds the existing stamped views and re-applies the profile instead of creating duplicates.
+
+> **Stuck?** If "From Scope Boxes" did nothing, check that your scope box names match the pattern exactly. The `::` separators must be double colons. The drawing type id must match exactly — copy it from the editor list rather than typing it.
+
+### SyncStyles — what drift is and how to fix it
+
+**What is drift?** Drift happens when a view no longer matches the recipe that created it. This can happen because:
+- Someone changed the view's scale by hand.
+- Someone changed the view template manually.
+- The BIM coordinator updated a drawing type recipe after the view was created.
+- A style pack was edited after the view was produced.
+
+Think of drift like a piece of furniture that has been moved from its designated spot. It does not belong where it is. Sync Styles puts it back.
+
+**How to detect drift:**
+1. Click **DOCS > Drawing Types > Inspect**. The headline shows "Drift: N view(s) drifted."
+2. A drifted view is one whose `STING_DRAWING_TYPE_ID_TXT` stamp points to a recipe, but the view's actual scale / detail level / template no longer matches that recipe.
+
+**How to fix drift:**
+1. Click **DOCS > Drawing Types > Sync Styles**.
+2. A preview dialog shows the first 10 drifted views.
+3. Click Confirm. The engine re-applies each recipe's settings inside one Revit Transaction. Annotation pass is skipped (to avoid re-tagging already-tagged views).
+4. Views with `STING_STYLE_LOCKED_BOOL = 1` are skipped — use this to protect hand-tuned views.
+
+> **Stuck?** If Sync Styles ran but the view still looks wrong, check whether the view has an active view template that locks the categories the pack is trying to override. An active template's locked settings beat the pack's overrides. Either remove the lock on those categories in the template, or (in managed mode — see Stage 4) let STING manage the template itself.
+
+### The pipeline order (Steps 1–10) explained in plain English
+
+When STING produces a sheet, it runs these 10 steps in order. Knowing the order tells you which step to investigate when something looks wrong:
+
+| Step | What happens | Where to look if it fails |
+|---|---|---|
+| 1 | Lock check — if the view is locked (`STING_STYLE_LOCKED_BOOL = 1`), skip the whole pipeline for this view | Check the lock parameter on the view |
+| 2 | Stamp the drawing type id — write `STING_DRAWING_TYPE_ID_TXT` to the view so the browser organizer and Sync Styles know which recipe owns this view | Usually never fails |
+| 3 | Set scale — `view.Scale = recipe.scale` | Check that the recipe's scale is a valid Revit scale |
+| 4 | Set detail level — Coarse / Medium / Fine | Check recipe's `detailLevel` field |
+| 5 | Apply view template — look up the template by name and apply it | Check the template name exists; validator will warn if it is missing |
+| 6 | Apply crop strategy — compute crop boundary (scope box, bounding box, room boundary, or none) | Check scope box exists if using `ScopeBox` strategy |
+| 7 | Apply view style pack — graphic overrides, filters, line weights, colours | Check the pack's `extends` chain for missing entries |
+| 8 | Annotation pass — run auto-dim and auto-tag rules | Check tag family names exist; check category names are spelled correctly |
+| 9 | (Sheet creation only) Stamp the sheet — write the drawing type id to the sheet itself | Usually never fails |
+| 10 | (Sheet creation only) Fill title-block cells — write every entry in `titleBlockParams` into the title-block instance | Check parameter names match the title-block family's shared parameter names |
+
+Every step is wrapped in a `try/catch` — a failure in one step becomes a warning, not a crash. The engine reports warnings in the result dialog after the run. Read the warnings from top to bottom; fix the first one, re-run, repeat.
+
+---
+
+## Stage 4 — Managed View Templates: Letting STING Take the Wheel
+
+### Why managed templates exist (the problem they solve)
+
+Revit view templates are the traditional way to control how views look. A view template is a saved collection of graphic overrides — which categories are visible, what colour, what line weight, what filters are on. When you apply a template to a view, the view looks like the template.
+
+The problem: **hand-authored view templates drift, diverge, and multiply.** Here is the typical failure pattern:
+
+1. Jane creates view template "STING - MEP Coordination" and sets duct colour to blue, pipe to green.
+2. John opens another project, cannot find Jane's template, creates "MEP Coordination Plan" with duct colour dark blue, pipe colour teal.
+3. The BIM coordinator decides pipe should be lime green. They open 6 templates across 4 projects and change it in each. They miss one.
+4. Three months later, nobody remembers which templates are authoritative. Two new team members create two more templates.
+
+**How managed mode solves this:**
+
+In managed mode, you do not hand-author view templates in Revit at all. Instead:
+
+1. You author a **View Style Pack** in the STING editor (a JSON record describing all the visual settings).
+2. You flip the pack's `templateMode` switch to `managed`.
+3. STING automatically generates a Revit view template named `STING:<pack-id>:<ViewType>` in your project.
+4. Whenever a drawing type uses that pack, STING binds the view to the auto-generated template.
+5. When you later edit the pack in the editor and click Save, the auto-generated template is updated to match — instantly, without you having to open the view templates dialog in Revit.
+6. If someone manually edits the auto-generated template in Revit, the drift detector notices the mismatch and Sync Styles fixes it on next run.
+
+The result: **one JSON pack → one auto-generated Revit template, always in sync.** You never open Revit's Visibility/Graphics dialog to manage templates again.
+
+### Managed mode vs External mode — when to use each
+
+Each view style pack carries a `templateMode` setting with two options:
+
+| Mode | What it means | When to use it |
+|---|---|---|
+| `managed` | STING auto-generates and maintains the Revit view template. Pack JSON is the source of truth. | For all new packs and most corporate work. Use this for maximum consistency. |
+| `external` | Pack names a Revit template by name. STING applies VG overrides on top of it. | For legacy projects where a team has already invested heavily in custom Revit templates, or for Revit template features STING does not yet model (e.g. sun settings, photographic exposure). |
+
+> **Layman tip:** if you are starting a new project, use `managed`. If you are adopting STING on a project that already has 30 hand-crafted templates the structural team spent weeks on, use `external` to keep their work and layer STING's automation on top.
+
+### How STING auto-generates and maintains Revit view templates
+
+The `ManagedTemplateSyncer.EnsureTemplate(doc, pack, viewType)` function is the engine behind managed mode. Here is what it does, in plain English:
+
+**When the template does not yet exist in the project:**
+1. Create a stub Revit view of the correct type (e.g. a FloorPlan for a plan view, a Section for a section).
+2. Detach it from any active template.
+3. Apply all the pack's visual settings: VG overrides, filter overrides, detail level, phase filter, visual style, view range, underlay, annotation crop, far clip, etc.
+4. Stamp the template with two shared parameters: `STING_PACK_ID_TXT` (the pack's id) and `STING_PACK_CHECKSUM_TXT` (a hash of the pack's JSON content).
+5. Convert the stub view into a Revit view template.
+6. Cache the template's ElementId for reuse.
+
+**When the template already exists and matches (no drift):**
+- Check the checksum. If `STING_PACK_CHECKSUM_TXT` matches the current pack JSON, do nothing. This is a no-op — very fast.
+
+**When the template exists but has drifted (someone edited it in Revit's UI, or the pack was updated):**
+- Re-apply only the fields listed in `managedFields` (see next section).
+- Update the checksum stamp.
+- The template is now in sync with the pack again.
+
+STING generates **one template per (pack-id, view type) pair**. The template names follow this pattern:
+- `STING:corp-coordination:Plan`
+- `STING:corp-coordination:Section`
+- `STING:corp-fabrication-shop:Plan`
+- `STING:corp-standard-plan:Plan`
+
+These templates appear in the Revit Project Browser under the Templates section, prefixed with `STING:`. You can see them there, but you should not edit them by hand — any manual edits will be overwritten by the next `EnsureTemplate` call.
+
+### The fields STING controls (the managed fields whitelist)
+
+One of the smartest features of managed mode is the `managedFields` list. This is a list of which settings STING owns and will overwrite on sync. Any setting NOT in this list is left alone — you can tweak it manually in Revit's template UI and STING will not touch it.
+
+| Managed field | What it controls | Which view types |
+|---|---|---|
+| `vg` | All Visibility/Graphics overrides (category line weights, colours, patterns, halftone, transparency) | All |
+| `filters` | Which parameter filters are applied and their VG overrides | All |
+| `detailLevel` | Coarse / Medium / Fine | All |
+| `discipline` | Architectural / Structural / Mechanical / Electrical / Plumbing / Coordination | All |
+| `visualStyle` | Wireframe / Hidden Line / Shaded / Consistent Colors / Realistic | All |
+| `phaseFilter` | Which phase filter is active (Show All, Show New, Show Complete, etc.) | All |
+| `phaseName` | Which project phase the view is set to | All |
+| `annotationCrop` | Whether the annotation crop box is separate from the model crop box | All |
+| `farClipMm` | How far behind the cut plane a section or elevation extends | Sections, Elevations |
+| `viewRange` | The top, cut plane, bottom, and view depth of a plan view | Plans |
+| `underlay` | Whether to show a level below as an underlay, and whether it is halftoned | Plans |
+
+**Tip:** the `managedFields` list can be configured per pack. If you only want STING to control VG and filters but leave phase and view range to the project team, remove those fields from the list. STING will control only what you tell it to.
+
+### Drift detection — what it is, how to read it, what to do
+
+Drift detection for managed templates adds a new drift kind to the existing detector: `MANAGED_TEMPLATE`.
+
+A `MANAGED_TEMPLATE` drift is detected when:
+1. A view is bound to a STING-managed template (identifiable by `STING_PACK_ID_TXT` on the template).
+2. The template's `STING_PACK_CHECKSUM_TXT` no longer matches the current pack JSON checksum.
+
+This means the pack was edited after the template was generated, but the template has not been updated yet.
+
+**How to read drift in the Inspect output:**
+
+When you run `DOCS > Drawing Types > Inspect`, look for lines like:
+```
+MANAGED_TEMPLATE drift: 3 template(s)
+  - STING:corp-coordination:Plan (checksum mismatch)
+  - STING:corp-standard-plan:Plan (checksum mismatch)
+  - STING:corp-fabrication-shop:Plan (checksum mismatch)
+```
+
+This means three managed templates need to be regenerated from their packs.
+
+**What to do:** Click `DOCS > Drawing Types > Sync Styles`. The sync engine detects `MANAGED_TEMPLATE` drift and calls `EnsureTemplate` on each drifted template with the updated pack settings. The templates are updated in one Transaction.
+
+Alternatively, use `Regenerate Pack Templates` (see command table below) to force-regenerate all managed templates for a specific pack, regardless of drift status.
+
+### Step-by-step: Converting a pack to Managed mode
+
+Follow these steps to switch a View Style Pack from `external` mode to `managed` mode:
+
+1. Go to **DOCS > Drawing Types > Edit Types** in the STING dock panel.
+2. Click the **View Style Packs** tab.
+3. Find the pack you want to convert in the list on the left (e.g. `corp-coordination`).
+4. On the **Identity card**, find the `Template Mode` toggle. Switch it from `External` to `Managed`.
+5. New fields appear below (they are hidden in external mode): Visual Style, View Discipline, Phase Filter, Phase, View Range sub-card, Far Clip, Annotation Crop, Managed Fields multi-select.
+6. Fill in the managed-mode fields (see section below).
+7. Click **Save**.
+8. Alternatively, click the **Convert Pack to Managed** button in the toolbar above the pack form. This button opens a picker: "Choose an existing Revit template to import settings from." STING reads the chosen template's settings and populates the pack fields, then sets `templateMode = managed` and removes the `ViewTemplate` name pointer. The original Revit template is renamed to `<original-name>_legacy` for safety.
+
+> **Stuck?** After converting a pack to managed mode, the pack's `ViewTemplate` field will be blank (or show "(STING-managed)"). This is correct — STING now generates the template from the JSON. If you see "template not found" warnings, run `Regenerate Pack Templates` to force-create the templates in the active project.
+
+### Step-by-step: Detaching from Managed mode
+
+Sometimes you want to hand the template back to Revit and stop STING managing it:
+
+1. In the **View Style Packs** tab of the editor, find the managed pack.
+2. Click the **Detach from STING Management** button in the toolbar.
+3. A dialog asks: "Create a new Revit view template from current pack settings? Yes / No." Click Yes.
+4. STING creates a new plain Revit view template named `<pack-name> (Detached)`, copies the managed template's current settings into it, and switches the pack's `templateMode` to `external`, pointing `ViewTemplate` at the new detached template.
+5. Click Save.
+
+From this point, the view template is a regular Revit template. STING still applies it (because `ViewTemplate` field points to it) but will not overwrite manual edits.
+
+### Step-by-step: Regenerating pack templates
+
+If you want to force STING to regenerate all managed templates for a pack (for example, after a major pack edit or on a new project where the templates do not yet exist):
+
+1. In the **View Style Packs** tab, select the pack.
+2. Click the **Regenerate Pack Templates** button in the toolbar.
+3. A confirmation dialog shows which templates will be created or updated.
+4. Click Confirm.
+5. STING creates or updates `STING:<pack-id>:Plan`, `STING:<pack-id>:Section`, `STING:<pack-id>:Elevation`, `STING:<pack-id>:3D`, `STING:<pack-id>:Detail`, and `STING:<pack-id>:Drafting` in the active project.
+
+> **Stuck?** If regeneration fails with "cannot create view template," check that the project does not already have a non-STING template with the same name (`STING:corp-coordination:Plan`). If it does, rename or delete it before regenerating.
+
+### The two shared parameters STING stamps (STING_PACK_ID_TXT, STING_PACK_CHECKSUM_TXT) — what they mean
+
+Every STING-managed view template carries two shared parameters stamped on it:
+
+| Parameter | What it stores | What it looks like |
+|---|---|---|
+| `STING_PACK_ID_TXT` | The id of the View Style Pack that owns this template | `corp-coordination` |
+| `STING_PACK_CHECKSUM_TXT` | A SHA-256 hash of the pack's JSON, limited to the `managedFields` content | `a3f7c9d2e1b8...` (64 hex characters) |
+
+**How the checksum works in plain English:**
+
+Think of the checksum like a fingerprint of the pack's settings. When STING generates the template, it takes a fingerprint of the pack JSON and stamps it on the template. Next time STING checks the template, it takes a new fingerprint of the pack JSON and compares it to the stamped fingerprint. If they match, the template is up to date. If they differ, the pack was edited — the template needs to be updated.
+
+This is exactly like the "file integrity check" on a downloaded software installer — you verify the file has not changed by checking its hash.
+
+You can read the `STING_PACK_CHECKSUM_TXT` parameter on any managed template in Revit's Properties panel (switch to the template view and look in instance properties). It is a 64-character hexadecimal string. You do not need to read or edit it manually — it is managed by the engine.
+
+### Editor controls for managed mode — every field in the View Style Packs tab explained
+
+When `templateMode = managed`, additional fields appear in the Appearance card of the View Style Packs tab:
+
+| Field | What it does | Typical value |
+|---|---|---|
+| Visual Style | Controls how geometry is rendered — how "3D" the view looks | `HiddenLine` for production drawings; `Shaded` for presentation; `Wireframe` for coordination |
+| View Discipline | Filters which categories are visible by discipline | `Architectural`, `Structural`, `Mechanical`, `Electrical`, `Plumbing`, `Coordination` |
+| Phase Filter | Which phase filter is active | `Show All`, `Show New`, `Show Complete`, `Show Previous + New` |
+| Phase | Which project phase the view is set to | `New Construction`, `Existing`, `Demolition` |
+| View Range sub-card | Sets the cut plane height (where the view is sliced horizontally) and the view depth (how far down the view extends) | Cut plane: 1200 mm above level. Bottom: 0 mm. View depth: -300 mm. Only applies to plan views. |
+| Far Clip (mm) | How far behind the cut the view looks in sections and elevations | `30000` mm for exterior elevations; `5000` mm for interior sections |
+| Annotation Crop | Whether the annotation crop box is independent of the model crop box | `true` (separate annotation crop) or `false` (linked) |
+| Managed Fields multi-select | Which settings STING owns and will re-apply on sync. Uncheck any field you want to control manually. | Default: all managed fields ticked |
+
+> **Important:** `displayOptions` (shadows, sketchy lines, ambient shadows) are flagged as warnings in the editor because Revit's API does not expose them programmatically. These must still be set by hand in the Revit view template dialog if you need them.
+
+### When things go wrong — MANAGED_TEMPLATE drift kind explained
+
+There are four drift kinds the detector can report. Here is what each one means and what to do:
+
+| Drift kind | What it means | Fix |
+|---|---|---|
+| `SCALE` | View's scale does not match the recipe's `scale` field | Click Sync Styles |
+| `DETAIL` | View's detail level does not match the recipe's `detailLevel` field | Click Sync Styles |
+| `TEMPLATE` | View's active template is not the one the recipe specifies | Click Sync Styles |
+| `MANAGED_TEMPLATE` | A STING-managed template's checksum does not match the current pack JSON | Click Sync Styles, or click Regenerate Pack Templates for that pack |
+| `TOKEN_PROFILE_DRIFT` | View's tag style or segment mask does not match the recipe's token profile | Click Sync Styles |
+
+After clicking Sync Styles, run Inspect again to confirm drift count dropped to 0. If it did not, check the log file (`StingTools.log`) for warnings from `ManagedTemplateSyncer` — they usually name the specific field that could not be applied and why.
+
+---
+
+## Stage 5 — View Style Packs: Controlling How Drawings Look
+
+### What is a View Style Pack?
+
+A View Style Pack is the "plating standard" from the kitchen analogy. It answers every visual question:
+- How thick are the wall lines?
+- What colour are the ducts?
+- Are existing elements shown halftoned?
+- What text style is used for dimensions?
+- Which categories are visible and which are hidden?
+
+By separating visual rules from layout rules (which are in the Drawing Type), STING allows many drawing types to share one set of visual rules. You have 40 drawing types but only 11 visual packs — because most plan drawings share the same visual standard, and most fabrication drawings share another.
+
+### The 11 corporate packs — table with id, name, and purpose
+
+| Pack id | Extends | Purpose | What makes it distinctive |
+|---|---|---|---|
+| `corp-base` | (root — inherits nothing) | The corporate house style baseline, shared by all other packs | Line weight 1.0 baseline; 2.5 mm Arial Narrow text; ISO 13567 monochrome palette; 5 universal phase filters (Existing / Demolished / New / Temporary / Out-of-Scope); grids and levels visible at weight 3; reference planes hidden |
+| `corp-standard-plan` | `corp-base` | Architectural plan | Walls cut at weight 5; doors and windows at weight 2; floors halftoned; ceilings hidden; rooms transparent fill at 80%; structural columns cut at weight 5; pipes and ducts hidden |
+| `corp-standard-rcp` | `corp-standard-plan` | Reflected ceiling plan | Walls halftoned; floors hidden; ceilings shown at weight 3; lighting at weight 2; air terminals blue weight 2; mechanical equipment shown |
+| `corp-standard-section` | `corp-base` | Building section | Walls cut at weight 5; floors cut at weight 4; structural columns cut at weight 5; insulation halftoned; rooms and furniture hidden |
+| `corp-standard-elevation` | `corp-base` | Exterior elevation | Walls at weight 3; structural columns at weight 4; topography halftoned; curtain panels and mullions at weight 2 |
+| `corp-standard-detail` | `corp-base` | Construction detail | Text 2.0 mm; walls cut at weight 6; structural framing cut at weight 5; rebar red at weight 2; insulation halftoned |
+| `corp-clarification` | `corp-base` | RFI and mark-up sheets | RFI query filter: red weight 3; design intent filter: blue weight 2; generic annotations: red weight 2 |
+| `corp-coordination` | `corp-base` | MEP coordination | Ducts: blue weight 3; pipes: green weight 3; electrical: amber weight 3; mechanical equipment: purple weight 3; fire alarm: red weight 3; structural: halftoned purple |
+| `corp-fabrication-shop` | `corp-coordination` | Fabrication spool shop drawing | Text 2.0 mm Shop font; ordinate dimensions; pipes weight 5; ducts weight 5; walls and structural framing hidden |
+| `corp-presentation-rich` | `corp-standard-plan` | Internal design review (IDR / TDR) | Text 3.0 mm Presentation font; walls deep slate cut at weight 6; floors light grey; rooms desaturated; topography halftoned green; grids and dimensions hidden |
+| `corp-presentation-mono` | `corp-presentation-rich` | Client greyscale presentation | All colours collapse to greyscale (walls black, floors light grey, furniture mid grey) |
+
+### Pack inheritance — the extends chain explained
+
+Think of inheritance like a family tree of style rules. `corp-base` is the great-grandparent. Every other pack is a child or grandchild that inherits all the great-grandparent's rules and adds its own.
+
+When the engine applies a pack, it walks the `extends` chain from root to leaf:
+1. Apply `corp-base` settings.
+2. Apply `corp-standard-plan` settings (overriding any `corp-base` settings where they clash).
+3. (If the view is a reflected ceiling plan) Apply `corp-standard-rcp` settings.
+
+A child pack only needs to record the fields that **differ** from its parent. Everything else is inherited silently.
+
+**Why this matters in practice:** If the BIM coordinator decides next month that all drawings should use 2.8 mm text instead of 2.5 mm, they edit **one field in `corp-base`** — and every drawing type that descends from it automatically inherits the change. That is 40 drawing types updated with one edit.
+
+Resist the urge to duplicate settings from the parent into the child. Every field you duplicate is one more place to maintain.
+
+> **Layman tip:** if you find yourself editing 11 packs to make the same change, you have put the setting in the wrong pack. Move it to `corp-base`.
+
+### Corporate vs project packs — the SHA-256 drift detection explained in plain English
+
+The SHA-256 mechanism that protects the corporate packs works exactly like a digital tamper seal on medicine packaging:
+- When the corporate catalogue ships, every pack has its "seal" computed (a 64-character hash of the pack's JSON content).
+- When the engine loads the catalogue, it computes the seal again and compares it to the stored value.
+- If they match, the entry is `origin: "corporate"` — untouched.
+- If they differ, someone has edited the corporate file directly — the entry's origin flips to `origin: "project"`.
+
+**Why you cannot accidentally corrupt the corporate baseline:** even if you edit `STING_VIEW_STYLE_PACKS.json` directly on disk, the engine detects the mismatch on next load and treats the changed entries as project-level overrides. The "corporate" designation is re-earned only when the BIM manager deliberately updates the corporate file and bumps the kit version.
+
+**What happens to your project when corporate updates:**
+- Corporate packs you have NOT overridden per-project: they update automatically.
+- Corporate packs you HAVE overridden per-project: your override stays; the corporate update does not reach those packs.
+- To pick up a corporate update for an overridden pack: delete your project override for that pack, reload, then re-apply only the project-specific fields.
+
+### Editing a pack via the editor — every card explained
+
+All pack editing happens in the **View Style Packs** tab of the Drawing Type Editor (`DOCS > Drawing Types > Edit Types`).
+
+**Identity card**
+
+| Field | What to fill in |
+|---|---|
+| Id | Stable identifier — never change once a pack is in use |
+| Name | Human-readable label |
+| Description | Two-line synopsis of what this pack is for |
+| Extends (parent pack id) | Pick the parent from the dropdown. Leave blank for root packs. |
+| Origin | Read-only — `corporate` or `project`. |
+
+**Appearance card**
+
+| Field | What to fill in |
+|---|---|
+| Line-weight scale | A multiplier on all line weights. `0.8` = lighter, `1.0` = default, `1.5` = heavier (for fabrication shop drawings where bold lines aid readability on the workshop floor) |
+| Text style name | Pick from the dropdown of loaded text note types, merged with STING corporate styles (`STING - 2.0mm`, `STING - 2.5mm`, `STING - 3.0mm Presentation`, `STING - 2.0mm Shop`, `STING - 3.5mm Large Format`) |
+| Dimension style name | Pick from the dropdown of loaded dimension types, merged with STING corporate styles (`STING - Linear`, `STING - Ordinate`, `STING - Chain`) |
+| Hatch palette | `ISO 13567 monochrome` / `ISO 13567 colour` / `AIA NCS` / `BS 1192 mono` / `Project custom` |
+| Colour scheme | `Monochrome` / `Discipline` / `Pastel` / `RAG` / `Spectral` / `Warm` / `Cool` / `High Contrast` / `PresentationRich` / `ClarificationRed` |
+
+**Filter rules grid**
+
+One row per parameter filter rule. Columns:
+
+| Column | What to fill in |
+|---|---|
+| Filter name | Pick from the dropdown of `ParameterFilterElement` names in the project, merged with 20 common STING filters |
+| Visible | Tick to show elements matching this filter; untick to hide them |
+| Halftone | Tick to render matching elements at half opacity |
+| Proj-Col | Projection line colour as hex `#RRGGBB` (e.g. `#C00000` for red) |
+| Proj-Wt | Projection line weight 1–16 |
+| Cut-Col | Cut line colour |
+| Cut-Wt | Cut line weight |
+| Trans% | Surface transparency 0 (opaque) to 100 (invisible) |
+
+Click `+ Add row` to add a filter rule. Click `×` on a row to delete it.
+
+**VG overrides grid**
+
+One row per category VG override. Columns are identical to the filter rules grid, but the first column is **Category** (pick from a merged list of Revit category names and known engineering categories). The category dropdown is editable — type `OST_Walls` or `<Room Separation>` for subcategories not in the default list.
+
+**Tag families map**
+
+One row per category → tag family mapping. Columns: Category (dropdown), Tag family name (text, must match a loaded tag family name exactly).
+
+This map is what the annotation rules `AutoTag` rule type uses when it needs to know which tag family to place. If a category is not in this map, the engine uses the default tag family for that category.
+
+---
+
+## Quick Reference
+
+### All Drawing Type commands
+
+| Button label in STING panel | Panel tab | What it does | When to use it |
+|---|---|---|---|
+| **Edit Types** | DOCS > Drawing Types | Opens the two-tab editor for Drawing Types and View Style Packs | Set up or adjust drawing types, style packs, annotation rules, slots, token patterns |
+| **Inspect** | DOCS > Drawing Types | Read-only report: all drawing types, routing table, validator results, drift count | Weekly check; first step when troubleshooting a wrong-looking sheet |
+| **Reload JSON** | DOCS > Drawing Types | Re-reads `STING_DRAWING_TYPES.json` and `STING_VIEW_STYLE_PACKS.json` from disk, clears cache | After hand-editing the JSON files, or after the BIM manager pushes a corporate update |
+| **Group Browser** | DOCS > Drawing Types | Reports whether the "STING - by Drawing Type" browser organisation exists and is active; gives instructions for creating it (one-time per project) | First-time project setup; when the browser grouping disappears |
+| **Sync Styles** | DOCS > Drawing Types | Re-applies each drifted view's drawing type recipe settings inside one Transaction | After editing a pack or drawing type; after discovering drift in Inspect |
+| **From Scope Boxes** | DOCS > Drawing Types | Walks every scope box named `STING::<id>::<level>::<tag>`, creates views, applies recipes, crops to boxes | Fastest way to produce a coordinated set of plans across multiple zones and levels |
+
+### All Managed Template commands
+
+| Button label in STING panel | Panel tab | What it does | When to use it |
+|---|---|---|---|
+| **Convert Pack to Managed** | DOCS > Drawing Types (View Style Packs editor toolbar) | Reads an existing Revit template's settings into the pack JSON, then sets `templateMode = managed`; renames the original to `<name>_legacy` | Migrating an existing project from hand-authored templates to STING-managed |
+| **Detach from STING Management** | DOCS > Drawing Types (View Style Packs editor toolbar) | Creates a new plain Revit template from the current pack settings; switches the pack to `external` mode | When you want to hand-author the template going forward without STING overwriting it |
+| **Regenerate Pack Templates** | DOCS > Drawing Types (View Style Packs editor toolbar) | Force-creates or force-updates all managed templates for the selected pack in the active project | On a new project where managed templates do not yet exist; after a major pack edit |
+
+### All View Style Pack commands
+
+These are accessed via the View Style Packs tab in the Drawing Type Editor (DOCS > Drawing Types > Edit Types > View Style Packs tab).
+
+| Action | How to trigger it | What it does |
+|---|---|---|
+| New pack | Click **+ New** in the left column | Creates a blank project-origin pack |
+| Clone pack | Select a pack, click **Clone** | Copies the selected pack to a new project-origin pack (useful for starting from a corporate pack without modifying the original) |
+| Delete pack | Select a project-origin pack, click **Delete** | Removes the pack from the project override file (cannot delete corporate packs) |
+| Save pack | Click **Save** in the footer | Writes all project-origin packs to `<project>/_BIM_COORD/view_style_packs.json` |
+| Push template to bound types | Click **Push template → bound types** | Copies this pack's view template name to every drawing type that references this pack |
+| Use pack template | Click **Use pack template** (on Drawing Types tab) | Sets the drawing type's view template to the one declared in its associated pack |
+| Push to pack | Click **↑ Push to pack** (on Drawing Types tab) | Copies the drawing type's view template name up to the pack |
+
+### Glossary of terms used in this guide
+
+| Term | Plain-English meaning |
+|---|---|
+| **Drawing Type** | A named JSON recipe describing how one kind of drawing should look — sheet size, scale, slots, annotation, numbering. 40 ship corporate; you clone and edit. |
+| **View Style Pack** | A reusable collection of graphic style settings (line weights, filters, VG overrides) shared by many drawing types. 11 ship corporate. |
+| **Slot** | A named rectangle on the drawable zone of a sheet. Declares "the main plan view goes here" or "the key plan goes here." The auto-placer routes views to slots by matching purposeTag. |
+| **Purpose tag** | A vocabulary label assigned to each slot (e.g. `main-plan`, `key-plan`, `fabrication-isometric`). The auto-placer matches incoming views to slots by reading this label. |
+| **Routing rule** | A `(discipline, phase, docType)` → DrawingType mapping. The dispatcher walks rules in order and picks the first match. |
+| **Annotation rule pack** | The "what to auto-tag and how to auto-dim" payload inside a Drawing Type. Consumed by the AnnotationRunner at pipeline step 8. |
+| **Crop strategy** | How a view's crop box is computed: scope box, tight bounding box, room boundary, or none. |
+| **Style stamp** | The `STING_DRAWING_TYPE_ID_TXT` parameter written onto every STING-produced view, recording which recipe produced it. Used by browser organisation and Sync Styles. |
+| **Style lock** | The `STING_STYLE_LOCKED_BOOL` parameter. When set to 1, Sync Styles skips the view. Use it to protect hand-tuned views. |
+| **Drift** | A stamped view whose actual scale, detail level, or template no longer matches its recipe. Found by `DrawingDriftDetector`, fixed by Sync Styles. |
+| **Project override** | A JSON file at `<project>/_BIM_COORD/drawing_types.json` (or `view_style_packs.json`) holding project-specific variants of corporate entries. Never mutates the corporate baseline on disk. |
+| **Token** | A `{disc}` / `{lvl}` / `{seq:D4}` placeholder in a pattern string, resolved at sheet-creation time using the context (current discipline, current level, etc.). |
+| **Managed template** | A Revit view template auto-generated and maintained by STING from a View Style Pack in managed mode. Named `STING:<pack-id>:<ViewType>`. |
+| **External template** | A hand-authored Revit view template; STING applies VG overrides on top of it but does not overwrite it. |
+| **STING_PACK_CHECKSUM_TXT** | A 64-character SHA-256 fingerprint stamped on each managed template. The engine compares this to the current pack JSON to detect drift. |
+| **extends chain** | The parent-child inheritance tree of View Style Packs. `corp-base` is the root; child packs inherit all parent settings and add or override specific fields. |
+| **BIM family** | A title block family that auto-fills labels from shared parameters and declares slot JSON. The engine reads it fully. |
+| **Non-BIM family** | A simpler title block where the drafter fills in project information by hand. The engine still places viewports but does not route by purposeTag. |
+| **Drawable zone** | The rectangle inside the title block where viewports may be placed. Declared by `TB_DRAWZONE_X/Y/W/H_MM` parameters on the title block family. |
+| **ISO 19650** | The British and European standard for naming and managing construction documents. Defines the 9-segment sheet number STING can produce. |
+| **Suitability** | The ISO 19650 status code — `S0` (work in progress) through `S7` (issued for tender), plus `A1`–`A5` and `B1`–`B5` variants for published deliverables. |
+| **Spool** | A pre-fabricated assembly of pipework, ductwork, or conduit shipped as one unit. STING creates one fabrication sheet per spool. |
+| **Inspect** | The read-only diagnostic command that shows the full catalogue, routing table, validator results, and drift count. Run it first when troubleshooting. |
+| **Sync Styles** | The propagate-changes command that re-applies each stamped view's recipe after a recipe or pack edit. |
+
+---
+
+## Cross-references
+
+> **This guide uses:**
+> - `docs/title_blocks/SLOT_TAXONOMY.md` — canonical purpose tag vocabulary
+> - `docs/guides/TITLE_BLOCK_CREATION_GUIDE.md` — detailed title block authoring steps
+> - `docs/guides/DRAWING_TYPE_MANAGER_GUIDE.md` — detailed drawing type manager reference
+> - `docs/STING_MANAGED_TEMPLATES_DESIGN.md` — managed templates architecture design
+> - `StingTools/Data/DRAWING_TEMPLATE_GUIDE.md` — quick-start template guide
+>
+> **This guide is referenced by:**
+> - `docs/guides/ELECTRICAL_WORKFLOW_GUIDE.md` — references electrical drawing types (`elec-power-A1-1to100`, `elec-lighting-A1-1to100`, `elec-fire-alarm-A1-1to100`, `elec-riser-A2-1to100`)
+> - `docs/guides/PLUMBING_WORKFLOW_GUIDE.md` — references plumbing drawing type (`plumb-drainage-A1-1to100`)
+> - `docs/guides/HEALTHCARE_WORKFLOW_GUIDE.md` — references healthcare-specific drawing types and the managed template pattern for clinical facility drawings
+> - `docs/guides/MEP_FOUNDATION_GUIDE.md` — uses drawing types to annotate MEP views after production

--- a/docs/guides/ELECTRICAL_WORKFLOW_GUIDE.md
+++ b/docs/guides/ELECTRICAL_WORKFLOW_GUIDE.md
@@ -1,0 +1,1711 @@
+# STING Electrical Workflow Guide
+
+> **Version note:** This guide reflects the STING Tools plugin as shipped on branch
+> `claude/merge-branches-update-docs-SvA31` (Phase 176 + v4 MVP). All button names,
+> dialog labels, and parameter names are written exactly as they appear in STING.
+
+---
+
+## How to use this guide
+
+Read it from beginning to end the first time. Each chapter builds on the one before it.
+After that, use the chapter headings as a reference — you can jump straight to "Chapter 4 —
+Panel Schedules" or "Chapter 6 — Conduit Routing" without reading everything again.
+
+Every step in a numbered list tells you exactly which button to press, which field to fill
+in, and what you will see when it works. Every time a step could go wrong, there is a
+`> **Stuck?**` blockquote that tells you what the confusing screen means and what to do.
+
+Code-style text like `ELC_PANEL_ID_TXT` means a parameter name — it is written exactly as
+it appears in Revit's parameter list.
+
+---
+
+## Who this guide is for
+
+You are a qualified electrician or electrical engineer. You understand what a distribution
+board is, what a circuit breaker does, and what voltage drop means. You may have used Revit
+before, but you have never used STING's electrical tools. You want to produce a proper set
+of electrical drawings — panel schedules, lighting plans, fire alarm layouts, and riser
+diagrams — for a building project.
+
+This guide does not assume you know anything about BIM software conventions, shared
+parameters, or drawing type registries. All of those are explained as they come up.
+
+---
+
+## The Big Picture
+
+Here is the complete electrical workflow, from an empty Revit model to issued drawings.
+Every box in this diagram is covered by at least one chapter in this guide.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  BEFORE YOU START                                           │
+│  Load shared parameters → Create view templates             │
+│  (Chapter 2 — Project Setup)                                │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 3 — PLACE EQUIPMENT                                │
+│  Load families → Place panels, fixtures, devices            │
+│  → Auto-tag everything with DISC / SYS / PROD codes         │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 5 — ASSIGN CIRCUITS                                │
+│  BatchAssignCircuits → assign every fixture to a panel       │
+│  PhaseBalance → spread load across A/B/C phases              │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 4 — PANEL SCHEDULES  ← most important chapter      │
+│  BatchPanelSchedules → one schedule per distribution board   │
+│  Audit → Export to Excel → Contractor fills in → Import     │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 6 — CONDUIT ROUTING                                │
+│  AutoConduitDrop → route conduits between panel and device   │
+│  Junction boxes auto-placed → slab penetrations detected     │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 7 — LIGHTING DESIGN                                │
+│  LightingGrid → automatic layout → emergency designation     │
+│  → lighting schedules                                        │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 8 — WIRE ANNOTATIONS                               │
+│  Add homerun callouts, circuit labels, conductor marks       │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 11 — VALIDATION AND QA                             │
+│  ValidateTags → BS 7671 validation → RunAllValidators         │
+└───────────────────────┬─────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  CHAPTER 12 — PRODUCE AND ISSUE DRAWINGS                    │
+│  → See DRAWING_PRODUCTION_SYSTEM_GUIDE.md                   │
+│  → See DOCUMENT_MANAGER_GUIDE.md                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Prerequisites (before you start any electrical work)
+
+Before you place a single socket outlet, three things must be in place in your Revit
+project. If any of them are missing, STING's electrical tools will either fail silently
+or produce tags and schedules that look wrong.
+
+### Shared parameters must be loaded
+
+**What shared parameters are:** Revit has a concept called "shared parameters." Think of
+them as a standardised list of data fields — like columns in a spreadsheet — that all
+STING projects use in exactly the same way. `ELC_PANEL_ID_TXT` is a shared parameter that
+stores which distribution board a device belongs to. `ELC_BREAKER_SIZE_A` stores the
+breaker rating. Without these fields existing in the project, STING cannot write to them
+or read from them.
+
+**The parameter file lives at:** `StingTools/Data/MR_PARAMETERS.txt`
+
+**Which parameter groups matter for electrical work:**
+
+| Prefix | What it covers |
+|--------|----------------|
+| `ELC_*` | Electrical power: panels, circuits, conduit, cable |
+| `LTG_*` | Lighting: lumens, lux targets, emergency flag, controls |
+| `ELE_*` | Large electrical equipment: switchgear, transformers, UPS |
+| `SEC_*` | Security systems: CCTV, access control, intruder |
+| `FLS_*` | Fire and life safety: detectors, call points, sounders |
+| `COM_*` | Communications and data: network, patch panels |
+
+**To load shared parameters:**
+
+1. Open your Revit project.
+2. Find the STING dockable panel on the right side of the screen. If it is not visible,
+   go to the ribbon, find the **STING Tools** tab, and click the **STING Panel** button.
+3. In the STING panel, click the **TEMP** tab.
+4. Find the **Setup** section at the top of the TEMP tab.
+5. Click **Load Shared Params**.
+6. A progress dialog will appear. STING runs two passes — the first pass binds universal
+   parameters to all categories; the second pass binds discipline-specific parameters to
+   the correct MEP categories.
+7. When it finishes, a summary appears. You should see several hundred parameters bound
+   successfully. For a full electrical project expect 200–400 electrical parameters.
+
+> **Stuck?** If you see "0 parameters bound" or an error saying the shared parameter
+> file could not be found, STING cannot locate `MR_PARAMETERS.txt`. This usually means
+> the plugin was not installed correctly. Contact your BIM manager and ask them to
+> verify the `StingTools/Data/` folder is in the plugin's assembly path.
+
+**To verify it worked:**
+
+1. Select any piece of electrical equipment already in your model (or place a temporary
+   Electrical Equipment family just for this test).
+2. Open its Properties panel (press `E` on the keyboard or use the Properties sidebar).
+3. Scroll down until you see parameter groups starting with `ELC_`. If you can see
+   `ELC_PANEL_ID_TXT`, `ELC_BREAKER_SIZE_A`, and `ELC_CIRCUIT_NUM_TXT` in the list,
+   the parameters loaded correctly.
+
+### Electrical view templates must exist in the project
+
+**What a view template is:** A view template in Revit is a saved set of display rules for
+a particular type of drawing. An electrical power plan template turns off structural
+elements, shows cables and panels clearly, and sets a scale of 1:100. Without view
+templates, every new plan you create looks identical — a cluttered mess of every element
+in the building all at once.
+
+STING ships four electrical view templates. To create them:
+
+1. In the STING panel, go to the **TEMP** tab.
+2. Find the **Templates** section.
+3. Click **View Templates**.
+4. STING creates 23 standard view templates including the four electrical ones:
+   - `STING - Electrical Plan` (for power and distribution drawings)
+   - `STING - Lighting Plan` (for lighting layout drawings)
+   - `STING - Fire Alarm Plan` (for fire detection and alarm drawings)
+   - `STING - Electrical Riser` (for riser diagrams and schematic views)
+
+> **Stuck?** If the command runs but you cannot find the templates, go to
+> **View → View Templates → Manage View Templates** in the Revit ribbon. Sort by name
+> and look for entries starting with `STING -`. If they are there, the command worked.
+
+**Electrical drawing types** — STING also ships pre-configured drawing type profiles that
+define paper size, scale, and annotation rules for each electrical output. To verify they
+are registered:
+
+1. In the STING panel, go to the **DOCS** tab.
+2. Find the **Drawing Types** section.
+3. Click **Inspect Drawing Types**.
+4. A result panel opens. Scroll through the list and look for these IDs:
+   - `elec-power-A1-1to100` (electrical power plan, A1, 1:100)
+   - `elec-lighting-A1-1to100` (lighting layout, A1, 1:100)
+   - `elec-fire-alarm-A1-1to100` (fire alarm drawing, A1, 1:100)
+   - `elec-riser-A2-1to100` (electrical riser, A2, 1:100)
+   - `elec-panel-schedule-A3` (panel schedule sheet, A3)
+
+If those five appear in the list, your drawing type registry is ready.
+
+### Electrical filters must exist in the project
+
+STING uses Revit filters — colour-coded rules that highlight or hide categories of
+elements — to make electrical elements visible and distinct in each view type.
+
+1. In the STING panel, go to the **TEMP** tab.
+2. In the **Templates** section, click **Create Filters**.
+3. STING creates 28 standard filters. The ones relevant to electrical work are:
+   - `STING - Electrical Equipment` (orange fill, electrical panels and gear)
+   - `STING - Lighting Fixtures` (yellow fill, light fittings)
+   - `STING - Electrical Fixtures` (blue fill, sockets, switches, outlets)
+   - `STING - Fire Alarm Devices` (red fill, detectors and call points)
+   - `STING - Communication Devices` (purple fill, data and telecom)
+   - `STING - Conduits` (grey lines, conduit runs)
+
+---
+
+## Chapter 1 — Understanding STING's Electrical Disciplines
+
+Before you start clicking, it helps to understand how STING categorises electrical work.
+The tagging system uses short code words to identify what discipline an element belongs to,
+what system it is part of, and what the element actually is. These codes show up everywhere:
+in tags on the drawing, in parameter values, in schedule columns.
+
+### The three electrical discipline codes
+
+STING uses single or double letters to identify each engineering discipline. For electrical
+work, three codes matter:
+
+| Code | Discipline | What it covers |
+|------|-----------|----------------|
+| `E` | Electrical | All power distribution: panels, distribution boards, socket outlets, switches, conduit, cable tray |
+| `ELC` | Electrical (long form) | Same as `E` — used in parameter names (e.g. `ELC_PANEL_ID_TXT`) rather than tag fields |
+| `FLS` | Fire and Life Safety | Fire detection, sprinklers, sounders, call points, emergency lighting circuits |
+| `SEC` | Security | CCTV, door access, intruder detection |
+| `ICT` | ICT / Data | Network cabling, Wi-Fi access points, patch panels |
+| `LV` | Low Voltage | General LV systems not covered by the above codes |
+
+When STING auto-tags an element, it looks at the Revit category of the element and assigns
+the discipline code automatically. A `Lighting Fixtures` category element gets `DISC = E`
+(or `FLS` if it is an emergency luminaire). A `Fire Alarm Devices` category element gets
+`DISC = FLS`.
+
+### System codes for electrical work
+
+The system code tells you which specific system an element belongs to within its
+discipline. An electrical engineer reading a drawing needs to know not just that a device
+is "electrical" but whether it is on the lighting system, the power system, the UPS, or
+the generator.
+
+| System code | What it means | Typical elements | When to use |
+|-------------|---------------|-----------------|-------------|
+| `LV` | Low-voltage power distribution | Distribution boards, sub-boards, final circuits, socket outlets, switches | General building electrical power |
+| `HV` | High-voltage supply | HV switchgear, transformers, incoming supply equipment | When the project includes HV infrastructure |
+| `UPS` | Uninterruptible power supply | UPS units, UPS panels, critical circuit outlets | Server rooms, operating theatres, critical plant |
+| `GEN` | Standby generator | Generator sets, auto-transfer switches, generator-fed panels | Buildings with standby generation |
+| `EMS` | Energy metering and monitoring | Sub-meters, BMS-linked metering panels, smart meters | Projects with energy management requirements |
+| `LTG` | Lighting | Light fittings, dimmer panels, lighting control panels | All artificial lighting — both normal and emergency |
+| `FLS` | Fire and life safety | Smoke detectors, heat detectors, call points, sounders, fire alarm panels | Fire alarm and emergency systems |
+| `FP` | Fire protection | Sprinklers, dry risers (used in some project configurations) | Sprinkler systems |
+| `SEC` | Security | CCTV cameras, door access readers, intruder alarm panels | Security systems |
+| `ICT` | Information and communications | Network switches, Wi-Fi APs, patch panels, structured cabling | Data and telecommunications |
+| `COM` | Communications | Intercom, PA, nurse call | Building communications |
+| `NCL` | Nurse call / clinical comms | Nurse call panels, bedhead units (healthcare projects) | Healthcare nursing stations |
+
+### Parameter families used in electrical work
+
+STING's parameters are named with a prefix that tells you which group they belong to.
+Here are the groups you will use most often in electrical work:
+
+| Prefix | Purpose | Key parameters |
+|--------|---------|----------------|
+| `ELC_` | Panel and circuit data | `ELC_PANEL_ID_TXT`, `ELC_CIRCUIT_NUM_TXT`, `ELC_BREAKER_SIZE_A`, `ELC_LOAD_KW`, `ELC_WIRE_GAUGE_TXT`, `ELC_PNL_PHASE_TXT`, `ELC_PNL_TYPE_TXT`, `ELC_PNL_LOCATION_TXT`, `ELC_PNL_VOLTAGE_TXT`, `ELC_PNL_RATING_A` |
+| `ELC_CDT_` | Conduit routing data | `ELC_CDT_BEND_COUNT_NR`, `ELC_CDT_RUN_LENGTH_M`, `ELC_CDT_CABLE_COUNT_NR`, `ELC_CDT_INSTALL_METHOD_TXT` |
+| `ELC_JB_` | Junction box data | `ELC_JB_TYPE_TXT`, `ELC_JB_SIZE_MM`, `ELC_JB_IP_RATING_TXT`, `ELC_JB_AUTO_PLACED_BOOL` |
+| `LTG_` | Lighting design data | `LTG_EMERG_BOOL`, `LTG_FIX_TAG`, `ELC_PHOTO_LUMENS`, `ELC_LIGHTING_UF_FACTOR`, `ELC_LIGHTING_TARGET_LUX_TXT` |
+| `FLS_` | Fire and life safety device data | `FLS_DEV_TAG`, fire device type and zone identifiers |
+| `SEC_` | Security device data | `SEC_DEV_TAG`, zone and access-level identifiers |
+| `PEN_` | Penetration (fire-stop) records | `PEN_FIRE_RATING_TXT`, `PEN_OD_MM`, `PEN_CONTROL_NUMBER_TXT`, `PEN_INSTALL_STATUS_TXT` |
+| `STING_PENETRATION_` | Conduit crossing records | `STING_PENETRATION_REF_TXT`, `STING_PENETRATION_FIRE_RATING_TXT` |
+
+---
+
+## Chapter 2 — Setting Up Your Electrical Project
+
+### Step 1: Use Master Setup (recommended for new projects)
+
+The quickest way to set up a new project for electrical work is to use STING's
+Master Setup command. This runs all the setup steps in the correct order, in a single
+operation.
+
+1. In the STING panel, go to the **TEMP** tab.
+2. In the **Setup** section, click **Master Setup**.
+3. A progress dialog runs through 15 steps automatically. These include loading shared
+   parameters, creating filters, creating view templates, creating worksets, setting up
+   phases, and checking the data files.
+4. When it finishes, read the summary. Any steps that failed are listed in red with a
+   reason. Most failures at this stage are because certain families are not yet loaded —
+   that is normal; the families come later.
+
+**Manual alternative** (if you need more control):
+
+Run these three commands in order, each from the **TEMP** tab:
+
+| Step | Button | What it does |
+|------|--------|-------------|
+| 1 | **Load Shared Params** | Binds all electrical shared parameters to the correct categories |
+| 2 | **Create Filters** | Creates the VG filters that highlight electrical elements |
+| 3 | **View Templates** | Creates the four electrical view templates |
+
+### Step 2: Verify your electrical drawing types
+
+1. In the STING panel, go to the **DOCS** tab.
+2. Click **Inspect Drawing Types**.
+3. In the result panel that appears, look for the five electrical drawing type IDs listed
+   in the Prerequisites section above. If all five appear, you are ready.
+
+> **Stuck?** If the command shows zero drawing types, the `STING_DRAWING_TYPES.json`
+> data file is not being found. Go to **TEMP → Check Data Files** — this lists every
+> expected data file and flags any that are missing or have the wrong checksum.
+
+### Step 3: Verify the tag configuration for electrical elements
+
+STING uses a lookup table to assign the correct DISC, SYS, and PROD codes to each element
+automatically. Before you start tagging, confirm that this lookup is working:
+
+1. In the STING panel, go to the **CREATE** tab.
+2. Click **Tag Config**.
+3. A TaskDialog shows the loaded configuration: number of discipline mappings, system
+   mappings, and product code mappings. For a standard electrical project you should see
+   at least 41 discipline mappings and 17 system codes.
+
+If the numbers are very low (single digits), the config file did not load correctly. In
+this case, go to **CREATE → Configure** to open the configuration editor and check the
+path to `project_config.json`.
+
+---
+
+## Chapter 3 — Placing Electrical Equipment
+
+This chapter is deliberately short. The mechanics of building families, loading them,
+and placing them are covered in depth in separate guides that apply to all MEP disciplines.
+This chapter points you to those guides and tells you what is specifically important for
+electrical work.
+
+### Families must be placement-ready
+
+Before STING can auto-tag or auto-route from an electrical element, the family must be
+set up correctly. The things that matter for electrical families are:
+
+- The family must be in the correct Revit **category** — for example, a distribution board
+  must be in the `Electrical Equipment` category, not `Generic Models`. STING uses the
+  category to assign the DISC code automatically.
+- The family must have a **connector** attached (for panels, distribution boards, and
+  any element that circuit assignment will attach to).
+- The family must have a **hosting type** that matches its real installation context —
+  wall-hosted for wall-mounted panels, face-based for ceiling-mounted detectors.
+
+> See **MEP_FOUNDATION_GUIDE.md, Chapter 2 — Placement Family Authoring** for the
+> complete guide to setting up families correctly.
+
+### Creating or sourcing electrical symbols
+
+STING ships a set of seed families — basic placeholder shapes for every electrical
+category. You can use these seeds to start working immediately, then swap them for real
+manufacturer families when procurement decisions are made.
+
+To build the seed families:
+
+1. In the STING panel, go to the **TEMP** tab.
+2. In the **Templates** section, click **Build Seed Families**.
+3. STING creates 11 seed families and loads them into the project. The ones relevant to
+   electrical work are:
+   - `STING_SEED_LightingFixture` (with 5 type variants: RECESSED_LED_600x600, DOWNLIGHT,
+     PENDANT, LINEAR_LED, EMERGENCY)
+   - `STING_SEED_ElectricalFixture` (SOCKET_2G, SOCKET_1G, SWITCH_2G, DATA_OUTLET_2G,
+     FLOOR_BOX, FCU)
+   - `STING_SEED_ElectricalEquipment` (DISTRIBUTION_BOARD_DB, MAIN_SWITCHBOARD_MSB,
+     CONSUMER_UNIT, ISOLATOR, TRANSFORMER)
+   - `STING_SEED_FireAlarmDevice` (SMOKE_OPTICAL, HEAT_DETECTOR, CALL_POINT_MCP,
+     SOUNDER_BEACON_VAD)
+   - `STING_SEED_CommunicationDevice` (WIFI_AP, DATA_OUTLET_RJ45, CCTV_CAMERA)
+   - `STING_SEED_JunctionBox` (PULL_BOX, DRAW_IN_BOX, ADAPTABLE_BOX)
+
+> See **MEP_FOUNDATION_GUIDE.md, Chapter 1 — MEP Symbol Creation** for guidance on
+> creating custom electrical symbols if the seed shapes do not match your drawing standard.
+
+### Placing equipment using the Placement Centre
+
+For large projects with many rooms, the Placement Centre lets you write rules like "place
+one DISTRIBUTION_BOARD_DB per electrical cupboard at 1800 mm above floor level" and
+execute them across hundreds of rooms automatically.
+
+> See **MEP_FOUNDATION_GUIDE.md, Chapter 3 — The Placement Centre** for the complete
+> guide to rule-based placement.
+
+For smaller projects, you can place families manually using Revit's standard placement
+tools (`Insert → Load Family`, then click in the view). STING will tag them the same way
+regardless of how they were placed.
+
+### Tagging after placement
+
+After you place electrical equipment, tag it immediately. Tagging writes the ISO 19650
+identifier codes onto each element — these codes are what link elements to panel schedules,
+circuit assignments, and the cable schedule.
+
+1. In the STING panel, go to the **CREATE** tab.
+2. Click **Auto Tag**.
+3. A dialog asks for the scope: **Active View**, **Selection**, or **Entire Project**.
+   For a first pass on a new project, use **Entire Project**.
+4. STING tags every untagged electrical element. For each element it writes:
+   - `DISC = E` (or `FLS` for fire alarm, `SEC` for security, `ICT` for data)
+   - `SYS` = derived from the MEP system name (e.g. `LV` for power, `LTG` for lighting)
+   - `LOC` = detected from the room the element sits in
+   - `ZONE` = detected from the room's department or zone
+   - `LVL` = the floor level code (e.g. `GF`, `L01`, `L02`)
+   - `PROD` = product code derived from the family name (e.g. `DB` for distribution board,
+     `SOCKET` for socket outlet, `DET` for detector)
+   - `SEQ` = a 4-digit sequence number unique within the group
+
+5. To verify the tags are correct, select a few elements and press `E` to open Properties.
+   Scroll to the parameter group starting with `ASS_` — you should see `ASS_TAG_1`
+   showing a tag like `E-BLD1-Z01-GF-LV-PWR-DB-0001`.
+
+To check all tags at once:
+
+1. In the STING panel, go to the **CREATE** tab.
+2. Click **Validate Tags**.
+3. The validation report shows any elements with missing or incorrect codes. Common
+   electrical issues: wrong DISC code (usually because the family is in the wrong
+   category), or blank SYS code (usually because the element is not connected to an
+   MEP system yet).
+
+---
+
+## Chapter 4 — Panel Schedules: The Core of Electrical Documentation
+
+This is the most important chapter in the guide. Panel schedules are the document that an
+electrician carries when working on a distribution board. The law requires them to be
+accurate, up to date, and readable. STING automates their creation, filling in, and
+maintenance — but you need to understand what they are and how the automation works.
+
+### What is a panel schedule?
+
+A panel schedule is like a register for a single distribution board. Imagine a distribution
+board with 20 circuit breakers in it. The panel schedule is a table that lists every one of
+those 20 breakers: which circuit number it is, what it powers (e.g. "Ground floor office
+lighting — Zone A"), what size breaker it has (e.g. 16A), and how much current the circuit
+actually draws.
+
+An electrician uses the panel schedule to:
+- Identify which breaker controls which circuit before switching anything off
+- Verify that the load on each circuit is within limits
+- Record the installed state of the distribution board for the O&M manual
+- Plan future circuit additions (which slots are spare)
+
+A building regulations inspector uses the panel schedule to verify that the installation
+complies with BS 7671 (the IET Wiring Regulations).
+
+In a Revit BIM model, a panel schedule is a special type of Revit view called a
+`PanelScheduleView`. It is linked directly to the Revit electrical systems in the model —
+so when you assign a circuit to a panel, the panel schedule updates automatically.
+
+### How STING panel schedules work
+
+STING does not just create a blank panel schedule and leave you to fill it in manually.
+It automates the entire chain:
+
+1. **Creates the schedule:** STING calls `PanelScheduleView.CreateInstanceView` for every
+   electrical panel in the model that does not already have a schedule.
+2. **Chooses the right template:** Every panel schedule in Revit uses a template that
+   defines its layout — how many columns it has, whether it shows three phases or one,
+   whether it has a summary section. STING picks the right template automatically based on
+   the type of panel (see the template selection rules below).
+3. **Fills in panel-level data:** STING reads the panel's parameters and writes them into
+   the schedule: panel name, voltage, total load, main breaker rating, which board it is
+   fed from, and how many ways it has.
+4. **Writes circuit back-references:** For every circuit connected to the panel, STING
+   stamps the parameter `ELC_PANEL_SCHEDULE_REF_TXT` on that circuit, so you can trace
+   from any element in the model back to its panel schedule.
+5. **Stamps the drawing type:** Every created schedule gets stamped with the drawing type
+   `elec-panel-schedule-A3` — this means STING's Browser Organiser groups all panel
+   schedules together, and the SyncStyles command keeps them visually consistent.
+
+### The panel schedule template selection system
+
+Revit requires you to choose a panel schedule template before creating a schedule. The
+template defines the table layout. STING automates this choice using a rules file called
+`STING_PANEL_SCHEDULE_TEMPLATES.json`. The rules are checked in priority order — the first
+rule that matches the panel wins.
+
+| Priority | Rule name | Panel type it matches | Template name needed in Revit |
+|----------|----------|----------------------|-------------------------------|
+| 1 | Switchboard | Panel name contains "MSB", "SWBD", "switchboard", or "MAINS" | `STING - Switchboard Schedule` |
+| 2 | Three-phase DB | Panel name contains "DB" and panel is 3-phase | `STING - 3Ph Distribution Board` |
+| 3 | One-phase consumer unit | Panel name contains "CU", "consumer unit", or single-phase panel | `STING - Consumer Unit Schedule` |
+| 4 | Data / comms panel | Panel name contains "UPS", "ICT", "DATA", or "COMMS" | `STING - Data Panel Schedule` |
+| 5 | Catch-all | Everything else | `STING - General Panel Schedule` |
+
+**The important implication:** These five Revit panel schedule templates must exist in your
+project before you run Batch Panel Schedules. If they do not exist, STING falls back to
+"first available template" — which may give you the wrong layout.
+
+**How to check:** Go to **View → View Templates → Panel Schedule Templates** in the Revit
+ribbon. You should see at least the five names listed above. If they are missing, your
+office BIM manager or template author needs to add them to the project template (`.rte`
+file) or load them from a template file.
+
+**Project-level override:** If your project uses non-standard panel names, you can override
+the rules for just this project. Create a file called `panel_schedule_templates.json` in
+the folder `<project>/_BIM_COORD/` alongside your `.rvt` file. Copy the format from the
+corporate file and add rules that match your project's naming convention.
+
+**The global fallback:** If no rule matches and no template can be found at all, STING
+shows a warning in the result panel saying "GlobalFallback — no matching template found.
+Using first available." The schedule is still created but may have the wrong layout.
+
+### Step by step: Creating panel schedules with Batch Panel Schedules
+
+This is the main command for panel schedule creation. Run it once at the start of the
+project to create all the schedules, and again whenever you add new panels to the model.
+
+**Before you run this command, make sure:**
+- Your panels are placed in the model as `Electrical Equipment` families
+- Each panel has its `ELC_PANEL_ID_TXT` parameter filled in (e.g. "DB-L01-A")
+- The five STING panel schedule templates exist in the project (see above)
+- You have run Auto Tag at least once so the panels have STING tag codes
+
+**Steps:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. Scroll down to the **Panel Schedules** section.
+3. Click **Batch Panel Schedules**.
+4. STING scans the model for all `Electrical Equipment` elements. For each one it checks
+   whether a `PanelScheduleView` already exists with that panel as its base equipment.
+5. For panels without a schedule, STING:
+   a. Matches the panel against the template rules (priority 1 to 5)
+   b. Creates a `PanelScheduleView` named after the panel
+   c. Fills in the schedule header: panel name, voltage (from `ELC_PNL_VOLTAGE_TXT`),
+      main breaker rating (from `ELC_PNL_RATING_A`), total load (from `ELC_PNL_LOAD_KW`),
+      fed-from reference (from `ELC_PNL_FED_FROM_TXT`), and number of ways
+   d. Stamps the drawing type `elec-panel-schedule-A3`
+   e. Writes `ELC_PANEL_SCHEDULE_REF_TXT` on every `ElectricalSystem` whose base
+      equipment is this panel
+6. A result panel shows the outcome: schedules created, schedules already existing
+   (skipped), and any errors.
+
+> **Stuck?** If you see "0 schedules created, N panels found but skipped — template not
+> available," the named templates are not loaded in your project. See the template
+> selection section above and add the five templates. Then run Batch Panel Schedules again
+> (it is idempotent — safe to run multiple times).
+
+> **Stuck?** If you see "0 panels found," check that your distribution boards are in the
+> `Electrical Equipment` Revit category. Select one, press `E` to open Properties, and
+> look for the **Category** line near the top. If it says `Generic Models` or
+> `Specialty Equipment`, the family is in the wrong category and STING cannot find it.
+
+**Finding the created schedules in the Project Browser:**
+
+After the command runs, open the Project Browser (View → Browser Organisation → select
+"STING - by Drawing Type" if it is available, otherwise use the default). Look for a
+group called **Panel Schedules** or scroll through the **Schedules/Quantities** section.
+Each schedule will be named after its panel, for example "DB-L01-A Panel Schedule."
+
+**Placing panel schedules on sheets:**
+
+Revit does not allow automatic placement of panel schedule views onto sheets through the
+API (this is a known Revit limitation). You must drag each schedule onto a sheet manually:
+
+1. Open the sheet where the panel schedule should appear.
+2. In the Project Browser, find the panel schedule view.
+3. Drag it from the Project Browser onto the sheet.
+4. Position it in the available space.
+
+> **Why does STING not do this automatically?** The Revit API method
+> `PanelScheduleSheetInstance.Create` is broken in Revit 2024, 2025, and 2026 — it
+> raises a Revit exception. Autodesk has not fixed this. The result panel that appears
+> after Batch Panel Schedules runs will remind you of this and tell you to place manually.
+
+**What the completed schedule looks like:**
+
+Once placed on a sheet, a panel schedule shows:
+- A header row with the panel name, voltage, and main breaker rating
+- One row per circuit breaker slot showing: slot number, phase, circuit number,
+  description, load in watts/kW, and breaker size in amps
+- Empty slots shown as SPARE or SPACE depending on how you have configured them
+- A summary section showing total connected load and the balance across A, B, and C phases
+
+---
+
+### Auditing panel schedules (Panel Schedule Audit)
+
+The audit command is a read-only check that tells you what is missing or out of date
+without making any changes. Run it at the start of a project to see the current state,
+and again before issue to confirm everything is complete.
+
+**To run the audit:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. Click **Panel Schedule Audit**.
+3. A result panel opens with three sections:
+
+**Section 1 — Panels without schedules:**
+Every `Electrical Equipment` element that does not have a `PanelScheduleView` linked to
+it. These panels need to be run through Batch Panel Schedules.
+
+**Section 2 — Template drift:**
+Schedules whose layout template no longer matches the rule that would select them today.
+This happens when someone renames a panel after its schedule was created, or when the
+template rules change. The fix is to delete the drifted schedule and re-run Batch Panel
+Schedules, which will re-create it with the correct template.
+
+**Section 3 — Missing panel parameters:**
+Panels that have a schedule but are missing key parameter data — for example, the
+`ELC_PNL_VOLTAGE_TXT` is blank, so the schedule header cannot show the voltage. The
+fix is to fill in the missing parameters on the panel element. Select the panel in the
+model, press `E` to open Properties, and fill in the blank `ELC_PNL_*` fields.
+
+**Reading the audit traffic-light status:**
+
+| Colour | Meaning |
+|--------|---------|
+| Green | This panel has a schedule with all parameters filled in. No action needed. |
+| Amber | This panel has a schedule but some parameters are missing or template has drifted. |
+| Red | This panel has no schedule at all, or the schedule exists but the template is unavailable. |
+
+---
+
+### Exporting panel schedules to Excel (Export Panel Schedules to Excel)
+
+This is for sending panel schedule data to a contractor for them to fill in circuit
+descriptions and load data, or for including in a client report or quantity surveyor
+submission.
+
+**Steps:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. Click **Export Panel Schedules to Excel**.
+3. A file dialog opens. Choose a location and name for the Excel file.
+4. STING creates an `.xlsx` file with:
+   - One worksheet per panel, named after the panel (e.g. "DB-L01-A")
+   - A **Header** section on each worksheet with the panel name, voltage, rating, and
+     fed-from reference
+   - A **Body** section with one row per circuit slot: slot number, phase, circuit number,
+     description, load, breaker size
+   - A **Summary** section with totals and phase balance
+   - An **INDEX** worksheet listing all panels with links to their worksheets
+
+**Typical uses:**
+- Send to the contractor with the message "please fill in circuit descriptions and
+  measured load values in the Body section"
+- Send to the QS for take-off of breaker sizes and ratings
+- Attach to the O&M manual as a deliverable
+
+---
+
+### Importing panel schedules from Excel (Import Panel Schedules from Excel)
+
+After a contractor has filled in circuit descriptions, measured loads, or breaker sizes in
+the Excel workbook, import it back into Revit.
+
+**The anti-erasure guard — read this before importing:**
+
+STING will NOT overwrite a Revit cell with a blank Excel cell. This is intentional. It
+means that if the contractor receives a file with some data already filled in and they
+accidentally delete it, the import will not wipe out what was in Revit. The rule is:
+
+> **If the Excel cell is blank and the Revit cell has data, keep the Revit data.**
+> **If the Excel cell has data, write it to Revit regardless.**
+
+This prevents disasters from partial edits. If you genuinely need to clear a cell in
+Revit, do it directly in the Revit panel schedule view — do not try to blank it in Excel
+and import.
+
+**Steps:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. Click **Import Panel Schedules from Excel**.
+3. A file dialog opens. Navigate to the filled-in Excel workbook.
+4. STING opens the file, reads each worksheet, and matches it to the corresponding
+   `PanelScheduleView` by name.
+5. For each body cell in the worksheet, STING writes the value into the corresponding
+   cell in the Revit schedule using `TableSectionData.SetCellText`.
+6. A result panel shows:
+   - **Cells updated:** how many schedule cells were written
+   - **Cells skipped (blank in Excel):** how many cells were protected by the anti-erasure
+     guard
+   - **Cells rejected:** cells that Revit refused to write — these are computed fields
+     like total load (calculated automatically by Revit from connected circuit data) and
+     cannot be written manually. This is normal and expected.
+   - **Worksheets not matched:** panel names in the Excel file that do not correspond to
+     any panel schedule in the project. Check the spelling matches exactly.
+
+> **Stuck?** If you see a large number of "Cells rejected," do not be alarmed. Revit
+> computes certain schedule cells itself (total apparent load, power factor, phase totals)
+> and blocks any attempt to write to them from the API. This is Revit's design, not a
+> STING bug. The rejected cells will show the correct computed values automatically once
+> the circuit data is in Revit.
+
+---
+
+### Managing spare and space slots
+
+When a distribution board has more slots than active circuits, the empty slots should be
+declared as either SPARE (a circuit breaker is fitted but the circuit goes nowhere — ready
+for future use) or SPACE (the slot is physically empty — no breaker fitted). This
+distinction matters for safety and for the O&M manual.
+
+| Button | What it does | When to use |
+|--------|-------------|-------------|
+| **Fill Empty Slots (Spares)** | Marks every empty slot in the active panel schedule as SPARE using `AddSpare` | When all unfitted slots have breakers installed, just no circuits connected |
+| **Fill Empty Slots (Spaces)** | Marks every empty slot in the active panel schedule as SPACE using `AddSpace` | When the slots are physically empty (no breakers) |
+| **Fill All Spares (Project-Wide)** | Marks every empty slot in every panel schedule in the project as SPARE | One-click operation to fill all empty slots across the whole building — run this as part of the Panel Schedule Production Workflow |
+| **Convert Spaces to Spares** | Changes SPACE declarations to SPARE using `RemoveSpace` then `AddSpare` | When breakers have been fitted to previously empty slots |
+| **Clear Spares and Spaces** | Removes all SPARE and SPACE declarations from the active schedule | When you need to reset and start again — use with care |
+
+**Where to find these buttons:**
+
+All five are in the **BIM** tab of the STING panel, in the **Panel Schedules** section.
+
+---
+
+### The Panel Schedule Production Workflow (all steps in order)
+
+This is the end-to-end sequence that takes you from raw panels in the model to fully
+populated, contractor-approved panel schedules ready to go on drawings. Run these steps
+in order.
+
+```
+Step 1 — Audit
+   Button: Panel Schedule Audit
+   Purpose: Find which panels have no schedule, which have template drift,
+            and which are missing parameter data.
+   What to do with the result: fix any red items (missing templates, wrong
+   family categories) before proceeding.
+
+Step 2 — Batch Create
+   Button: Batch Panel Schedules
+   Purpose: Create one PanelScheduleView for every panel that does not have one.
+   Expected result: "N schedules created" where N = number of panels with
+   no existing schedule.
+
+Step 3 — Fill Spares
+   Button: Fill All Spares (Project-Wide)
+   Purpose: Mark all empty slots as SPARE so the schedule looks complete.
+   Expected result: Every panel schedule shows SPARE in the unfilled rows.
+
+Step 4 — Export to Excel
+   Button: Export Panel Schedules to Excel
+   Purpose: Send the schedules to the contractor or client for data fill-in.
+   Expected result: One .xlsx file with one worksheet per panel.
+
+Step 5 — Contractor fills in data
+   (manual step — outside of Revit)
+   Contractor fills in: circuit descriptions, measured loads, confirmed
+   breaker sizes, and any corrections to phase assignments.
+
+Step 6 — Import from Excel
+   Button: Import Panel Schedules from Excel
+   Purpose: Write the contractor's data back into the Revit schedules.
+   Expected result: Circuit descriptions and loads populated in all schedules.
+
+Step 7 — Re-Audit
+   Button: Panel Schedule Audit
+   Purpose: Confirm that all panels are green — schedules created, parameters
+   filled, no template drift.
+   Expected result: All panels green.
+```
+
+**Running the workflow as a single preset:**
+
+You can run the entire Batch Create → Fill Spares → Export → Re-Audit chain as an
+automated workflow preset:
+
+1. In the STING panel, go to the **BIM** tab.
+2. In the **Workflows** section, click **Workflow Preset**.
+3. In the list that appears, select **PanelScheduleProduction**.
+4. Click **Run**.
+5. The workflow engine runs each step in sequence, pausing between steps to show you
+   the result of each one. You can cancel at any point.
+
+Note that the Import step is not included in the preset because it requires you to supply
+an Excel file — you run that separately after the contractor returns the workbook.
+
+---
+
+## Chapter 5 — Circuit Assignment
+
+### What circuit assignment means
+
+Every light fitting, socket outlet, and electrical device in a building is powered by a
+circuit. That circuit connects to a breaker in a distribution board. Circuit assignment
+is the process of recording which device is on which circuit and which circuit connects
+to which panel.
+
+This matters for three reasons:
+1. The panel schedule cannot be complete until every circuit is assigned to a panel.
+2. The voltage drop calculation (BS 7671 Appendix 4) needs to know the circuit length,
+   which STING calculates from the conduit route — but it can only calculate the route
+   if it knows which panel the circuit goes to.
+3. BS 7671 requires circuit identification: every circuit must be identifiable from
+   the panel schedule. Without assignment, this is impossible.
+
+### How STING records circuit assignment
+
+The two key parameters:
+
+| Parameter | What it stores | Example value |
+|-----------|---------------|---------------|
+| `ELC_CIRCUIT_NUM_TXT` | The circuit identifier — the number as it appears on the breaker | `L1.1` (meaning: panel L, section 1, circuit 1) |
+| `ELC_PANEL_ID_TXT` | Which panel this circuit belongs to | `DB-L01-A` |
+| `ELC_PANEL_REF_TXT` | Written on the Revit ElectricalSystem — links the circuit object to the panel | Set automatically by BatchAssignCircuits |
+
+When `ELC_CIRCUIT_NUM_TXT` and `ELC_PANEL_ID_TXT` are filled in on an element, that
+element's row in the panel schedule will show its circuit identifier automatically.
+
+### Automatic circuit assignment with Batch Assign Circuits
+
+For large projects with dozens of panels and hundreds of circuits, manual assignment is
+impractical. STING's automatic assignment algorithm places every unassigned circuit onto
+the most suitable panel.
+
+**Before running auto-assignment:**
+- All panels must be placed in the model and tagged
+- Panels must have their `ELC_PNL_VOLTAGE_TXT` and number-of-circuits parameters filled
+
+**Steps:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. In the **Circuit Management** section, click **Batch Assign Circuits**.
+3. STING scans every `ElectricalSystem` in the model. For any circuit with no
+   `BaseEquipment` (no assigned panel), it runs the assignment algorithm.
+4. A **preview** panel appears first showing you the proposed assignments. For each
+   circuit it shows: circuit name → proposed panel, reasoning (same room, same voltage
+   band, available slots).
+5. Review the preview. If any assignment looks wrong, note it — you can correct it
+   manually after the main run.
+6. Click **Apply** to commit the assignments. STING calls
+   `ElectricalSystem.SelectPanel` for each circuit, which is the Revit API call that
+   actually attaches the circuit to the panel.
+7. After apply, STING stamps:
+   - `ELC_PANEL_REF_TXT` on every `ElectricalSystem` with the panel ID
+   - `ELC_CIRCUIT_GROUP_TXT` on elements to record which logical group they belong to
+
+**The grouping rules:**
+
+STING uses four built-in grouping rules to keep circuits together:
+
+| Group | How it identifies elements | Why it matters |
+|-------|--------------------------|----------------|
+| `kitchen` | Room name contains "kitchen", "kitchenette", "tea point", or "pantry" | Kitchen circuits should share a panel for HVAC zoning |
+| `emergency-lighting` | System name contains "emergency" or "EM_" | Emergency lighting must be on a dedicated supply per BS 5266-1 |
+| `fire-alarm` | Category is Fire Alarm Devices | Fire alarm supply must be dedicated per BS 5839-1 |
+| `comms-room` | Room name contains "server", "MER", "IDF", "comms", or "patch" | Critical IT circuits share a UPS-backed panel |
+
+Circuits in the same group are assigned to the same panel wherever possible.
+
+> **Stuck?** If the preview shows "No fit — no panel with matching voltage band has
+> free slots," you have run out of panel capacity. Either add more panels to the model,
+> or expand the `Number of Circuits` parameter on an existing panel, then run the command
+> again.
+
+### Phase balance
+
+A three-phase distribution board has three buses: A, B, and C. If most circuits are on
+phase A and few are on phase C, the supply transformer is unbalanced — it runs hotter
+on one phase and cooler on the others. BS 7671 and good engineering practice require
+the load to be distributed roughly equally across all three phases.
+
+**To balance phases:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. Click **Phase Balance**.
+3. The command shows a **preview** of the current imbalance (the difference in kVA between
+   the most-loaded and least-loaded phase) and the proposed improvement.
+4. Review the preview. If the improvement looks reasonable, click **Apply best-effort**.
+5. STING redistributes 1-pole circuits across phases A, B, and C.
+
+> **Important limitation:** The Revit API does not allow direct writing of a circuit's
+> starting phase through code (it is a read-only computed value). After applying, STING
+> reports how many circuits it could reassign. For circuits where the reassignment failed,
+> you need to move them to the correct slot column in the panel schedule view manually
+> (left column = Phase A, middle = Phase B, right = Phase C in a standard 3-phase layout).
+
+### Manual circuit assignment
+
+For small projects or corrections to auto-assignment:
+
+1. Select the element you want to assign (e.g. a lighting fixture).
+2. In the STING panel, go to the **CREATE** tab.
+3. In the **Tokens** section, use the **Bulk Parameter Write** button to open the
+   bulk operations dialog.
+4. Set `ELC_CIRCUIT_NUM_TXT` to the circuit number (e.g. `L1.1`).
+5. Set `ELC_PANEL_ID_TXT` to the panel ID (e.g. `DB-L01-A`).
+6. Click **Apply to Selection**.
+
+Alternatively, you can use Revit's native Electrical Systems tools to connect a fixture
+directly to a panel via a circuit — STING will read the resulting `ElectricalSystem` link
+automatically.
+
+---
+
+## Chapter 6 — Conduit and Cable Tray Routing
+
+### The two routing approaches
+
+STING supports two ways to create the conduit and cable tray runs that connect distribution
+boards to devices:
+
+| Approach | What it does | Best for |
+|----------|-------------|---------|
+| **AutoConduitDrop** (Auto Drop) | Automatically calculates and creates conduit runs from the panel to each connected device | Large projects where manual routing would take days; design-stage coordination drawings |
+| **Manual routing** with STING tagging | You draw conduits using Revit's native MEP tools; STING tags them and records their data | Small projects, complex routing situations where the algorithm cannot find a good path |
+
+### Using Auto Drop to route conduits automatically
+
+Auto Drop creates conduit elements in the model based on the circuit assignments you
+completed in Chapter 5. For each unrouted cable in the manifest, it calculates a
+Manhattan L or Z path between the device and its panel, then creates the conduit segments.
+
+**Before running Auto Drop:**
+- Circuit assignment must be complete (Chapter 5)
+- At least one `ConduitType` family must be loaded in the project
+- The seed junction box family (`STING_SEED_JunctionBox`) should be loaded — if it is
+  not, Auto Drop will still route conduits but cannot place junction boxes automatically
+
+**Steps:**
+
+1. In the STING panel, go to the **TAGS** tab.
+2. Click the **Routing** sub-tab.
+3. Click **Auto Drop**.
+4. A dialog asks for routing settings:
+   - **Drop type:** Conduit (rigid), Conduit (flexible), or Cable Tray — choose the
+     appropriate containment for the cable type
+   - **Offset from ceiling:** the distance the conduit runs below the ceiling slab or
+     within the ceiling void (in mm, default 300 mm)
+   - **Conduit type family:** select from the loaded `ConduitType` families
+5. Click **Route All** to route every unrouted cable, or **Route Selected** to route
+   only the circuits connected to selected elements.
+6. STING creates the conduit segments and runs three post-processing passes:
+
+**Pass 1 — Junction box placement:**
+For every conduit run that exceeds 3 bends between pull-points (per BS 7671 §522.8.5)
+or exceeds 6 metres between pull-points (per BS 7671 §522.8.4), STING places a
+`STING_SEED_JunctionBox` family instance at the violation point. Each placed box gets
+stamped with `ELC_JB_AUTO_PLACED_BOOL = 1` and `ELC_JB_REASON_TXT` (either
+`BENDS_EXCESS` or `RUN_TOO_LONG`).
+
+**Pass 2 — Slab penetration detection:**
+For every conduit segment that passes vertically through a floor slab, STING records the
+penetration and places a fire-stop symbol (`STING_SEED_SpecialityEquipment`) on the slab
+face. Each penetration gets a sequential control number in `PEN_CONTROL_NUMBER_TXT`
+(e.g. `FRP-0001`, `FRP-0002`) and a fire rating read from the slab's
+`STING_FIRE_RATING_TXT` parameter (default `FR60` if not set).
+
+**Pass 3 — Cable fill stamping:**
+STING calculates the fill percentage of each conduit (how much of its internal area is
+used by the cables inside it) and stamps this in `ELC_CDT_CBL_FILL_PCT`. Conduits over
+the BS EN 61386 limit (40% for a single cable, 35% with bends, 31% for two cables) are
+flagged in red.
+
+> **Stuck?** If "Auto Drop: 0 cables routed" appears and all cables are skipped with
+> "no panel," circuit assignment is not complete. Go back to Chapter 5 and run
+> **Batch Assign Circuits** first.
+
+> **Stuck?** If junction boxes are not being placed ("Junction boxes auto-placed: 0"
+> in the result), the `STING_SEED_JunctionBox` family is not loaded. Go to
+> **TEMP → Build Seed Families** to create and load it.
+
+### Creating conduit runs manually (and tagging them)
+
+When you draw conduits using Revit's native `Systems → Electrical → Conduit` tool, STING
+can tag them and record their data automatically:
+
+1. Draw the conduit run using Revit's standard tools.
+2. Select the drawn conduit elements.
+3. In the STING panel, go to the **CREATE** tab.
+4. Click **Auto Tag**.
+5. Choose **Selection** scope.
+6. STING tags the conduits with:
+   - `DISC = E` (electrical conduit)
+   - `SYS = LV` (or the system code matching the circuit carried)
+   - `ELC_CDT_INSTALL_METHOD_TXT` (the installation method — surface, flush, soffit, etc.)
+   - `ELC_CDT_RUN_LENGTH_M` (calculated from the conduit geometry)
+
+### Conduit consolidation
+
+When multiple circuits share the same route between a panel and a zone, it is inefficient
+(and physically wrong) to have a separate conduit for each one. Conduit consolidation
+groups circuits sharing the same route and merges them into a single larger conduit.
+
+1. In the STING panel, go to the **TAGS** tab.
+2. In the **Routing** sub-tab, click **Consolidate Conduits**.
+3. A **preview** panel shows consolidation opportunities: groups of cables going to the
+   same panel from the same source equipment, with the proposed single conduit size and
+   fill percentage.
+4. Review the preview to confirm the groupings make sense.
+5. Click **Apply Consolidation** to merge the conduits.
+
+> The apply operation is a single undo step — if the result looks wrong, press `Ctrl+Z`
+> once to undo the entire consolidation.
+
+### Cable tray routing
+
+Cable trays follow the same workflow as conduits. The **Auto Drop** command offers cable
+tray as a routing option. When you choose cable tray:
+- STING creates `CableTray` elements instead of `Conduit` elements
+- The fill calculation uses the cable tray's cross-section area
+- The resulting elements are tagged with `ELC_CTR_*` parameters instead of `ELC_CDT_*`
+
+Cable tray is typically used for large bundles of cables in plant rooms, risers, and
+main distribution routes. Individual final circuits to devices (sockets, lights) normally
+use conduit.
+
+---
+
+## Chapter 7 — Lighting Design
+
+### The lighting workflow at a glance
+
+```
+1. Place light fitting families (Placement Centre or manual)
+2. LightingGrid — automatic layout across rooms
+3. Auto Tag — DISC=E, SYS=LTG, PROD=fitting type
+4. Assign emergency lighting (LTG_EMERG_BOOL)
+5. Assign circuits (Chapter 5)
+6. Create lighting schedule (MEP Schedules)
+7. Produce lighting plan drawings (Chapter 12)
+```
+
+### LightingGridCommand — automatic lighting layout
+
+The Lighting Grid command calculates how many light fittings a room needs to meet its
+target illuminance (measured in lux — lux is a unit of light intensity, like how bright
+something is). It then places fittings at an even grid across the room floor area.
+
+**How it calculates the number of fittings:**
+
+STING uses the lumen method — the standard calculation method from BS EN 12464-1
+(the British Standard for workplace lighting). The formula is:
+
+```
+Number of fittings = ceiling((target lux × room area m²) ÷ (lumens per fitting × UF × MF))
+```
+
+Where:
+- **Target lux** — the required illuminance for the room type, from BS EN 12464-1.
+  STING looks up the room type from its name (e.g. "Office" → 500 lux, "Corridor" → 100
+  lux, "Operating Theatre" → 1000 lux).
+- **Lumens per fitting** — the light output of the chosen fitting, read from the
+  family's `ELC_PHOTO_LUMENS` parameter. If this parameter is not set, STING uses a
+  conservative default of 3500 lm.
+- **UF (Utilisation Factor)** — how efficiently the light reaches the working plane.
+  Default 0.60 (60%). Can be overridden per family with `ELC_LIGHTING_UF_FACTOR`.
+- **MF (Maintenance Factor)** — accounts for dirt and ageing. Default 0.80 (80%).
+  Can be overridden per family with `ELC_LIGHTING_MF_FACTOR`.
+
+**Steps to use Lighting Grid:**
+
+1. Select the rooms you want to illuminate. You can select room elements in the model,
+   or leave nothing selected to run across all rooms in the project.
+2. In the STING panel, go to the **TAGS** tab.
+3. Click the **Fixtures** sub-tab.
+4. Click **Lighting Grid**.
+5. A dialog appears with the following settings:
+   - **Fixture family:** select which `Lighting Fixtures` family to use. This should
+     be the family with `ELC_PHOTO_LUMENS` filled in.
+   - **Grid spacing X (mm):** the distance between fitting centres in the long direction
+     of the room. Leave at 0 to let STING calculate the spacing from the lumen method
+     automatically.
+   - **Grid spacing Y (mm):** spacing in the short direction. Leave at 0 for automatic.
+   - **Boundary type:** how STING defines the area to fill. `Room boundary` uses the
+     Revit room boundary lines (most accurate). `Crop region` uses the view crop boundary.
+   - **Offset from boundary (mm):** keeps fittings this far from walls (default 600 mm,
+     matching CIBSE guidance for edge-of-room fittings).
+6. Click **Place Fittings**.
+7. STING calculates the grid and places the fittings. Fittings that would clash with
+   existing ceiling MEP (sprinkler heads, diffusers, detectors) are automatically moved
+   to the nearest clear position.
+8. The result panel shows: rooms processed, fittings placed, average lux achieved
+   (based on the lumen method calculation), and any rooms where the target could not be
+   achieved (because the fitting output is too low or the room too large).
+
+> **Stuck?** If the command places fittings but they all land at the wrong height (e.g.
+> on the floor instead of the ceiling), the fitting family's origin is at the bottom of
+> the element rather than the top. This needs to be corrected in the Family Editor.
+> See **MEP_FOUNDATION_GUIDE.md, Chapter 2** for how to check and correct the family
+> origin point.
+
+**The lux target lookup:**
+
+STING classifies rooms by matching the room name against patterns in its internal
+`ROOM_TYPE_CLASSIFIER.csv` file. Common mappings:
+
+| Room name pattern | Target lux | Standard reference |
+|-------------------|-----------|-------------------|
+| Office, open plan | 500 lux | BS EN 12464-1 Table 5.3 |
+| Meeting room | 500 lux | BS EN 12464-1 |
+| Reception, lobby | 300 lux | BS EN 12464-1 |
+| Corridor, stairway | 100 lux | BS EN 12464-1 |
+| Toilet, WC | 200 lux | BS EN 12464-1 |
+| Warehouse, store | 100 lux | BS EN 12464-1 |
+| Workshop, laboratory | 500 lux | BS EN 12464-1 |
+| Plant room, roof | 200 lux | CIBSE LG7 |
+| Classroom | 300 lux | BS EN 12464-1 |
+| Operating theatre | 1000 lux | BS EN 12464-1 healthcare annex |
+
+### Emergency lighting
+
+Emergency lighting must be on a dedicated supply circuit, separate from the normal
+lighting circuits, per BS 5266-1. STING tracks which fittings are emergency fittings
+using the `LTG_EMERG_BOOL` parameter (1 = emergency, 0 = normal).
+
+**To designate fittings as emergency:**
+
+1. Select the fittings that are emergency luminaires.
+2. In the STING panel, go to the **CREATE** tab.
+3. Click **Bulk Parameter Write**.
+4. In the dialog:
+   - **Operation:** Set Value
+   - **Parameter:** `LTG_EMERG_BOOL`
+   - **Value:** `1`
+5. Click **Apply to Selection**.
+
+**What changes after setting this flag:**
+- The element's `DISC` tag includes an emergency marker
+- Auto-assign circuits will route emergency fittings to an emergency-lighting group panel
+  (or flag them if no dedicated panel exists)
+- The lighting schedule shows these fittings in a separate section
+
+### Creating a lighting schedule
+
+A lighting schedule is a table listing all light fittings in the project: their type,
+location, circuit, lux level, and emergency status.
+
+1. In the STING panel, go to the **BIM** tab.
+2. In the **MEP Schedules** section, click **Lighting Fixture Schedule**.
+3. STING creates a Revit schedule named "STING - Lighting Fixtures" with columns for:
+   - Room name and level
+   - Fitting type and model
+   - Circuit number (`ELC_CIRCUIT_NUM_TXT`)
+   - Panel ID (`ELC_PANEL_ID_TXT`)
+   - Emergency status (`LTG_EMERG_BOOL`)
+   - Target lux (`ELC_LIGHTING_TARGET_LUX_TXT`)
+   - Lumens per fitting (`ELC_PHOTO_LUMENS`)
+4. The schedule appears in the Project Browser under **Schedules/Quantities**.
+
+---
+
+## Chapter 8 — Wire Annotations
+
+### What wire annotations add to an electrical drawing
+
+A floor plan shows you where electrical devices are located in a room. But it does not
+tell you how the wiring runs between them, which way the homerun (the cable going back
+to the panel) goes, how many conductors are in the cable, or what size the conductors
+are. Wire annotations add this information directly onto the drawing.
+
+An electrician on site reads wire annotations to know:
+- Which cables to pull through which conduits
+- How many conductors to use and what size
+- Where the circuit feeds from (the homerun direction)
+- Which circuit number the cable carries
+
+Wire annotations are 2D line symbols placed directly over the conduit route on the floor
+plan, with text showing the circuit number and conductor count.
+
+### Creating wire annotation families
+
+Wire annotation families are specialised Revit annotation families (`.rfa` files with the
+Generic Annotation template) that display circuit information next to a conduit or cable
+route.
+
+> See **MEP_FOUNDATION_GUIDE.md, Chapter 1, Section 1.4 — Wire Annotation Workflow** for
+> the complete guide to creating wire annotation families from scratch, including the
+> standard slash-mark symbols for 3-conductor, 4-conductor, and 5-conductor cables, and
+> the homerun arrow symbol.
+
+### Placing wire annotations in your electrical drawings
+
+Wire annotations should be placed after circuit assignment is complete (Chapter 5) and
+after Auto Drop has created the conduit runs (Chapter 6), because the annotations label
+the conduits and circuits.
+
+**Sequence:**
+
+1. Open the electrical floor plan view at the correct level. Ensure the view uses the
+   `STING - Electrical Plan` view template.
+2. Place the homerun annotation first. The homerun annotation goes at the point where
+   a group of circuits leaves a room and heads back toward the panel. This is typically
+   at the room wall closest to the panel.
+   - Go to **Annotate → Component → Detail Component** in the Revit ribbon.
+   - Select your homerun arrow annotation family.
+   - Click at the homerun departure point.
+   - Rotate to show the direction toward the panel.
+   - Type the circuit numbers in the annotation's parameter field.
+3. Add conductor slash marks. These short diagonal marks across a conduit line show
+   how many conductors are in the cable.
+   - Use the same **Detail Component** placement tool.
+   - Select the conductor-count annotation family (3-slash for a 3-core cable, etc.).
+   - Click on the conduit line.
+4. Verify the circuit number label populates. If `ELC_CIRCUIT_NUM_TXT` is filled in on
+   the conduit (written by Auto Tag), the annotation should display the circuit number
+   automatically. If it shows "?" or is blank, the parameter binding in the annotation
+   family may not be set up correctly — see the wire annotation guide referenced above.
+
+### Batch wire annotation
+
+For large plans with many circuits, placing annotations one by one is slow. STING's Smart
+Tag Placement system can place annotation families in bulk:
+
+1. In the STING panel, go to the **CREATE** tab.
+2. In the **Smart Placement** section, click **Smart Place Tags**.
+3. In the scope dialog, choose **Active View**.
+4. The command uses the tag placement template. If you have set up a placement template
+   that includes your wire annotation family (see the Smart Placement section in the
+   MEP_FOUNDATION_GUIDE.md), it will place annotations at the correct positions along
+   conduit runs automatically.
+5. A result panel shows how many annotations were placed and how many positions were
+   skipped due to collision with existing annotations or elements.
+
+---
+
+## Chapter 9 — Fire Alarm and Security Systems
+
+### STING disciplines for safety systems
+
+Fire alarm and security systems use different Revit categories and different STING
+discipline codes from general electrical power, even though they are fed from the same
+incoming supply.
+
+| System | STING discipline code | Revit category | Tag container |
+|--------|----------------------|----------------|---------------|
+| Fire alarm | `FLS` | Fire Alarm Devices | `FLS_DEV_TAG` |
+| Sprinklers | `FP` | Sprinklers | (general tag) |
+| Security CCTV | `SEC` | Communication Devices | `SEC_DEV_TAG` |
+| Door access | `SEC` | Communication Devices | `SEC_DEV_TAG` |
+| Nurse call | `NCL` | Nurse Call Devices | `NCL_DEV_TAG` |
+
+### The fire alarm workflow
+
+**Step 1 — Place fire alarm devices:**
+
+Use the Placement Centre or manual placement to place detector, call point, sounder, and
+beacon families. All fire alarm families must be in the `Fire Alarm Devices` Revit
+category (not `Specialty Equipment` or `Generic Models`).
+
+> See **MEP_FOUNDATION_GUIDE.md, Chapter 3 — The Placement Centre** for the placement
+> workflow.
+
+**Step 2 — Auto-tag fire alarm elements:**
+
+1. In the STING panel, go to the **CREATE** tab.
+2. Click **Auto Tag**.
+3. Choose scope: **Active View** or **Entire Project**.
+4. STING assigns:
+   - `DISC = FLS` to all `Fire Alarm Devices` elements
+   - `SYS = FLS` (fire and life safety system)
+   - `PROD` codes from the family name: `DET` for detectors, `CPT` for call points,
+     `SND` for sounders, `BCN` for beacons, `FAP` for fire alarm panels
+
+**Step 3 — Create fire alarm drawings:**
+
+Fire alarm drawings use the drawing type `elec-fire-alarm-A1-1to100`. This drawing type
+applies:
+- The `corp-standard-plan` view style pack with fire alarm device categories highlighted
+  in red
+- Scale 1:100 on A1 paper
+- The `STING - Fire Alarm Plan` view template
+
+To produce the drawing:
+
+> See **DRAWING_PRODUCTION_SYSTEM_GUIDE.md** for the complete drawing production workflow.
+
+**Step 4 — Create a fire alarm device schedule:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. In the **MEP Schedules** section, click **Fire Alarm Schedule** (or use the generic
+   **Device Schedule** and filter for `DISC = FLS`).
+3. The schedule lists every fire alarm device with its tag, type, room location, and zone.
+
+### Security system workflow
+
+The security system workflow follows the same steps as fire alarm, with these differences:
+- Families must be in the `Communication Devices` Revit category
+- DISC code is `SEC`
+- Tag container is `SEC_DEV_TAG`
+- Parameters use the `SEC_*` prefix group
+
+For CCTV cameras, the most important security-specific parameter is the coverage zone:
+stamp `SEC_CAM_COVERAGE_TXT` with the zone identifier (e.g. "Zone A - Ground Floor
+Reception") using **Bulk Parameter Write**.
+
+---
+
+## Chapter 10 — Riser Diagrams
+
+### What a riser diagram is
+
+A riser diagram (also called a schematic or single-line diagram) shows how electrical
+power flows through the building from the incoming supply down to every distribution
+board on every floor. Unlike floor plans — which show where things are physically located
+in plan view — a riser diagram is schematic: it is a logical diagram showing the
+connections and relationships.
+
+Imagine the building's electrical system as a tree. The root of the tree is the mains
+incoming supply. The trunk is the main switchboard. The branches are the sub-main cables
+going to distribution boards on each floor. The leaves are the final circuits going to
+individual sockets and lights. A riser diagram draws this tree from top to bottom,
+showing the cable size, the breaker rating, and the protection device at each junction.
+
+An electrical engineer uses the riser diagram to:
+- Verify that the protection discrimination is correct (each downstream breaker is smaller
+  than the upstream one, so only the correct breaker trips on a fault)
+- Calculate voltage drop from the supply to each final circuit
+- Show the building owner and the distribution network operator how the supply is
+  distributed
+- Provide a schematic to accompany the panel schedules in the O&M manual
+
+### The elec-riser-A2-1to100 drawing type
+
+Riser diagrams in STING use the drawing type `elec-riser-A2-1to100`:
+- Paper size: A2
+- Scale: 1:100
+- Orientation: typically landscape
+- View type: **Drafting View** (not a floor plan) — because a riser diagram is a 2D
+  schematic, not a model view
+
+### Creating a riser diagram in STING
+
+Because riser diagrams are schematic rather than model-based, they are created as
+Drafting Views with 2D detail components:
+
+1. In the Revit ribbon, go to **View → Drafting View**. Give it a meaningful name
+   such as "Electrical Riser Diagram — Ground Floor to Roof."
+2. In the STING panel, go to the **DOCS** tab.
+3. Click **Inspect Drawing Types** and confirm `elec-riser-A2-1to100` is in the list.
+4. With your new Drafting View open, go to the **DOCS** tab.
+5. In the **Drawing Types** section, click **Sync Styles**. This applies the correct
+   view style (line weights, annotation standards) to the active view based on its
+   drawing type stamp.
+6. Place 2D detail components from your electrical symbol library into the Drafting View.
+   Use:
+   - Rectangle or filled region for distribution boards
+   - Lines for cables/conduits between boards
+   - Text or tag annotations for cable sizes and breaker ratings
+   - The detail component symbol families from your office standard
+
+> **Tip:** Your office's riser diagram symbol families should be loaded in the project
+> before you start. If you are using the STING seed families, the
+> `STING_SEED_ElectricalEquipment` family with the `DISTRIBUTION_BOARD_DB` type can be
+> placed in a Drafting View as a 2D schematic symbol.
+
+---
+
+## Chapter 11 — Electrical Validation and QA
+
+Before a set of electrical drawings is issued, you need to verify that everything is
+complete and correct. STING provides several validation commands for electrical work.
+
+### ValidateTagsCommand — checking all electrical elements are tagged correctly
+
+This is the basic completeness check: every electrical element in the model must have all
+8 tag segments filled in correctly.
+
+**Steps:**
+
+1. In the STING panel, go to the **CREATE** tab.
+2. Click **Validate Tags**.
+3. The validation report opens with a table. Each row is a finding. The columns are:
+   - **Element ID:** the Revit element's unique ID — you can click this to zoom to the
+     element in the model
+   - **Category:** what kind of element it is
+   - **Tag:** the current tag value (may be partial or empty)
+   - **Issue:** what is wrong
+   - **Severity:** Error (must fix) or Warning (should review)
+
+**Common electrical validation errors:**
+
+| Error message | What it means | Fix |
+|---------------|--------------|-----|
+| DISC code invalid: "M" for Electrical Equipment | The element got a mechanical discipline code because its family is in the wrong Revit category | Change the family category to `Electrical Equipment` in the Family Editor |
+| SYS code blank | The element is not connected to a Revit MEP system | Connect it to a system, or manually set `ELC_CIRCUIT_NUM_TXT` and re-run Auto Tag |
+| PROD code "GEN" (generic) | The family name doesn't match any known product code pattern | Set the family name to include a recognisable product abbreviation (see the Tag Configuration for the list) |
+| SEQ duplicate: 0042 | Two elements have the same sequence number in the same DISC/SYS/LVL group | Run **Repair Duplicate Seq** in the CREATE tab to auto-fix duplicates |
+
+### Panel Schedule Audit — checking panel schedules are complete
+
+This was covered in detail in Chapter 4. Run it again before issue as the final check.
+
+> See **Chapter 4 — Panel Schedules, Auditing panel schedules** for full instructions.
+
+### RunAllValidatorsCommand — the full validation chain
+
+This is the comprehensive QA run. It executes every validator in sequence and produces a
+single combined report.
+
+1. In the STING panel, go to the **TAGS** tab.
+2. In the **Routing** sub-tab, click **Run All Validators**.
+3. The validators run in this sequence:
+   - Connectivity validator (checks all MEP connections are valid)
+   - Fill validator (checks conduit and tray fill percentages)
+   - Spec validator (checks parameters against project specs)
+   - Termination validator (checks all circuits terminate at a panel)
+   - Slope validator (applies to pipework, not electrical — completes quickly)
+   - BS 7671 standards validator (runs the electrical-specific checks below)
+4. A result panel shows the total finding count by severity, with a breakdown by
+   validator. Click any finding to zoom to the element in the model.
+
+### BS 7671 Validation — the electrical-specific standards check
+
+The BS 7671 validator specifically checks IET Wiring Regulations compliance for conduit
+installations.
+
+1. In the STING panel, go to the **TAGS** tab.
+2. In the **Routing** sub-tab, click **Validate Fills**.
+3. The validator checks every conduit in the model:
+
+| Finding code | Severity | What it means | Fix |
+|-------------|----------|--------------|-----|
+| `ELEC.RUN.LONG` | Warning | A conduit run is longer than 6 metres between pull-in points (BS 7671 §522.8.4) | Add a junction box or draw-in point along the run |
+| `ELEC.BENDS.EXCESS` | Error | A conduit has more bends than allowed between pull-in points (BS 7671 §522.8.5) | Add a junction box at the violation point — the result panel tells you where |
+| `ELEC.FILL.OVER` | Error | Cable fill in the conduit exceeds the BS EN 61386 limit (40% for 1 cable, 31% for 2 cables, 35% for 3+ cables) | Either increase the conduit diameter or reduce the number of cables in the conduit |
+| `ELEC.FILL.NEAR` | Warning | Fill is within 10% of the limit — marginal | Consider upsizing the conduit |
+| `ELEC.BEND.ANGLE` | Warning | A fitting has a non-standard bend angle | Swap the fitting for the nearest standard angle (11.25°, 22.5°, 30°, 45°, 90°) |
+
+**Fill rate standards explained:**
+
+The BS EN 61386 fill limits exist to make sure you can actually pull cables through the
+installed conduit. The more cables you put in a conduit, the harder they are to pull, and
+the more heat builds up inside. The limits differ based on how many cables are in the
+conduit:
+
+| Cables in conduit | Maximum fill (straight run) | Maximum fill (with bends) |
+|-------------------|-----------------------------|--------------------------|
+| 1 cable | 53% | 43% |
+| 2 cables | 31% | 20% |
+| 3 or more cables | 40% | 35% |
+
+### ValidateFillsCommand — dedicated fill check
+
+For a project where you only want to check the fill rates without running the full
+validation chain:
+
+1. In the STING panel, go to the **TAGS** tab.
+2. In the **Routing** sub-tab, click **Validate Fills**.
+3. STING calculates fill for every conduit and cable tray, stamps the value in
+   `ELC_CONDUIT_FILL_PCT`, and highlights failing elements in red in the active view.
+4. The result panel shows a summary table: conduit size → number passing → number failing
+   → worst-case fill percentage.
+
+---
+
+## Chapter 12 — Producing and Issuing Electrical Drawings
+
+### Which drawing types apply to electrical work
+
+| Drawing type ID | Paper size | Scale | Purpose | When to produce |
+|-----------------|-----------|-------|---------|----------------|
+| `elec-power-A1-1to100` | A1 | 1:100 | Electrical power distribution plan | Shows panel locations, socket layout, circuit routes |
+| `elec-lighting-A1-1to100` | A1 | 1:100 | Lighting layout plan | Shows fitting positions, emergency designation, lux zones |
+| `elec-fire-alarm-A1-1to100` | A1 | 1:100 | Fire detection and alarm plan | Shows detector, call point, sounder, and panel locations |
+| `elec-riser-A2-1to100` | A2 | 1:100 | Electrical riser / schematic diagram | Shows supply hierarchy from incoming to final boards |
+| `elec-panel-schedule-A3` | A3 | n/a (schedule) | Panel schedule sheet | One sheet per distribution board |
+
+### Producing electrical drawings
+
+The complete drawing production workflow — including how to set up title blocks, apply
+drawing types, run the sheet batch command, and manage scale — is covered in the drawing
+production guide.
+
+> See **DRAWING_PRODUCTION_SYSTEM_GUIDE.md** for the complete drawing production workflow,
+> including how to assign drawing types, produce sheets in batch, and apply view style
+> packs to electrical views.
+
+### Issuing electrical drawings
+
+Once the drawings are produced and the panel schedules are on their sheets, issue the
+drawing package using the Document Manager.
+
+> See **DOCUMENT_MANAGER_GUIDE.md** for the complete document issue workflow, including
+> CDE status transitions, transmittal creation, and revision control.
+
+### The WORKFLOW_PanelScheduleProduction.json preset
+
+This workflow preset chains the five panel schedule production steps into a single
+automated run. It is the fastest way to bring a project's panel schedule package to
+issue-ready status.
+
+**To run it:**
+
+1. In the STING panel, go to the **BIM** tab.
+2. In the **Workflows** section, click **Workflow Preset**.
+3. In the workflow list, select **PanelScheduleProduction**.
+4. Click **Run**.
+
+**What happens at each step:**
+
+| Step | Command | What to expect |
+|------|---------|---------------|
+| 1 | Panel Schedule Audit | Result panel shows current state — panels with and without schedules, parameter gaps |
+| 2 | Batch Panel Schedules | Creates any missing schedules. A "N schedules created" message appears. If N = 0 and you were expecting new schedules, check that your panels are tagged correctly |
+| 3 | Fill All Spares (Project-Wide) | Fills empty slots with SPARE declarations. No interactive step — runs silently and reports the count |
+| 4 | Export Panel Schedules to Excel | A file-save dialog appears asking where to save the Excel workbook. Choose a location and click Save |
+| 5 | Panel Schedule Audit (re-run) | Final check. Every panel should now show green status |
+
+After Step 4, the workflow pauses and waits. Send the Excel file to the contractor or
+client for review. When it comes back filled in, run **Import Panel Schedules from Excel**
+separately, then run the workflow again from step 1 to re-audit and confirm convergence.
+
+---
+
+## Troubleshooting
+
+| Problem | Likely cause | Fix |
+|---------|-------------|-----|
+| Panel schedule not created after running Batch Panel Schedules | None of the five STING panel schedule templates are loaded in the project | Open **View → View Templates → Panel Schedule Templates** in the Revit ribbon and confirm the five templates are present. If missing, ask your BIM manager to load them from the office template file |
+| Circuit back-references not populating in the panel schedule | `ELC_PANEL_ID_TXT` is blank on the panel element itself | Select the panel element, open Properties, fill in `ELC_PANEL_ID_TXT` with the panel's identifier, then re-run Batch Panel Schedules |
+| Auto Tag gives the wrong DISC code (e.g. "M" on a lighting fitting) | The lighting family is in the `Mechanical Equipment` Revit category instead of `Lighting Fixtures` | Open the family in the Family Editor, check the family category (use **Manage → Settings → Object Styles** to see the category), and change it to the correct one. Reload the family |
+| LightingGrid places fittings at floor level instead of ceiling level | The family's origin point is at the bottom of the solid geometry | In the Family Editor, move the geometry so that the reference level plane is at the mounting surface (ceiling or slab underside). See **MEP_FOUNDATION_GUIDE.md, Chapter 2** |
+| Wire annotation shows "?" instead of the circuit number | `ELC_CIRCUIT_NUM_TXT` is not bound to the annotation family's label parameter | Open the annotation family in the Family Editor, check the label parameter, and bind it to `ELC_CIRCUIT_NUM_TXT`. See **MEP_FOUNDATION_GUIDE.md, Chapter 1, Section 1.4** |
+| Panel schedule template drift warning in audit | A panel was renamed after its schedule was created, so the template rule no longer matches | Delete the drifted schedule, rename the panel back (or update the template rules), and re-run Batch Panel Schedules |
+| Auto Drop produces conduits that go through walls | The wall's `STING_WALL_ROUTING_FLAG` parameter is set to `ALLOW` | Set the flag to `DENY` on walls that the routing pathfinder should not pass through. Select the wall, open Properties, find `STING_WALL_ROUTING_FLAG`, and change it to `DENY` |
+| Batch Assign Circuits puts all circuits on one panel | All panels except one are full (not enough free slots) | Add more panels or expand the `Number of Circuits` parameter on existing panels, then re-run the command |
+| The `ELC_PHOTO_LUMENS` parameter does not appear on the lighting family | The shared parameters were not loaded before the family was placed | Run **Load Shared Params** in the TEMP tab, which binds `LTG_*` and `ELC_PHOTO_*` parameters to the `Lighting Fixtures` category |
+| Penetration fire stops are not placed after Auto Drop | `STING_SEED_SpecialityEquipment` family is not loaded | Run **Build Seed Families** in the TEMP tab. The SpecialityEquipment seed includes the FR30/FR60/FR90/FR120 fire-stop types |
+| Phase balance command reports "0 circuits reassigned" | All circuits are multi-pole (2-pole or 3-pole) and cannot be moved to a different phase individually | Multi-pole circuits are deliberately excluded from phase balancing. Manually move them to the desired phase column in the panel schedule view |
+| Validation finds `ELEC.BENDS.EXCESS` on every conduit | The conduit routing produced too many bends because the panel and fixtures are on different floors with complex paths | Re-run Auto Drop with a larger ceiling offset to give the router more room, or route those conduits manually using a simpler path |
+
+---
+
+## Quick Reference
+
+### All electrical commands (complete table)
+
+| Button label | Panel tab | Sub-tab or section | What it does | When to use |
+|-------------|-----------|-------------------|-------------|-------------|
+| Load Shared Params | TEMP | Setup | Binds all electrical shared parameters to project | Once per project, before any electrical work |
+| Master Setup | TEMP | Setup | Runs all setup steps in sequence (params, filters, templates) | At project start |
+| Build Seed Families | TEMP | Templates | Creates 11 STING seed families and loads them | Once per project, after Master Setup |
+| View Templates | TEMP | Templates | Creates STING standard view templates including 4 electrical ones | Once per project |
+| Create Filters | TEMP | Templates | Creates VG filters for electrical element display | Once per project |
+| Auto Tag | CREATE | (main) | Tags all or selected electrical elements with DISC/SYS/PROD/SEQ | After placing elements; after any batch placement |
+| Validate Tags | CREATE | QA | Checks all tags are complete and correctly formatted | Before issuing drawings |
+| Repair Duplicate Seq | CREATE | QA | Fixes duplicate sequence numbers in a discipline/system/level group | When Validate Tags reports SEQ duplicates |
+| Batch Assign Circuits | BIM | Circuit Management | Automatically assigns all unassigned circuits to panels | After placing all fixtures and panels |
+| Phase Balance | BIM | Circuit Management | Redistributes 1-pole circuits to balance load across 3 phases | After circuit assignment |
+| Batch Panel Schedules | BIM | Panel Schedules | Creates one PanelScheduleView per panel | After panels are placed and tagged |
+| Panel Schedule Audit | BIM | Panel Schedules | Read-only check: missing schedules, template drift, param gaps | Before and after Batch Panel Schedules |
+| Export Panel Schedules to Excel | BIM | Panel Schedules | Exports all schedules to a multi-worksheet .xlsx file | Before sending to contractor for data fill-in |
+| Import Panel Schedules from Excel | BIM | Panel Schedules | Imports contractor-filled data back into Revit | After contractor returns filled workbook |
+| Fill Empty Slots (Spares) | BIM | Panel Schedules | Marks empty slots in active schedule as SPARE | Per-panel spare designation |
+| Fill Empty Slots (Spaces) | BIM | Panel Schedules | Marks empty slots in active schedule as SPACE | Per-panel space designation |
+| Fill All Spares (Project-Wide) | BIM | Panel Schedules | Fills all empty slots in every schedule as SPARE | Before export and issue |
+| Convert Spaces to Spares | BIM | Panel Schedules | Changes SPACE declarations to SPARE | When breakers have been retrofitted to previously empty slots |
+| Clear Spares and Spaces | BIM | Panel Schedules | Removes all spare/space declarations from active schedule | When resetting a schedule |
+| Workflow Preset | BIM | Workflows | Runs a named workflow chain | Run PanelScheduleProduction for panel schedule batch processing |
+| Auto Drop | TAGS | Routing | Routes conduits from panels to all connected devices | After circuit assignment |
+| Validate Fills | TAGS | Routing | Checks conduit fill percentages against BS EN 61386 | Before issuing drawings |
+| Consolidate Conduits | TAGS | Routing | Merges multiple per-cable conduits sharing a route into one | After initial routing to rationalise the model |
+| Run All Validators | TAGS | Routing | Runs full validation chain (BS 7671 + all STING validators) | Final QA before drawing issue |
+| Lighting Grid | TAGS | Fixtures | Places light fittings in a grid pattern based on lumen method | When designing a new lighting layout |
+| Bulk Parameter Write | CREATE | Tokens | Sets a parameter value on multiple selected elements | For manual circuit assignment and emergency lighting designation |
+| Smart Place Tags | CREATE | Smart Placement | Places annotation tags in bulk with collision avoidance | For batch wire annotation and tag placement |
+| Inspect Drawing Types | DOCS | Drawing Types | Shows all registered drawing types | To verify electrical drawing types exist |
+| Sync Styles | DOCS | Drawing Types | Applies the correct view style to stamped views | When a view looks wrong after template changes |
+| MEP Schedules — Lighting Fixture Schedule | BIM | MEP Schedules | Creates a lighting fixture schedule | After lighting design is complete |
+| MEP Schedules — Fire Alarm Schedule | BIM | MEP Schedules | Creates a fire alarm device schedule | After fire alarm layout is complete |
+| Load Summary | BIM | Calcs | Calculates and stamps connected load per panel | Before voltage drop calculation |
+| Voltage Drop | BIM | Calcs | Calculates voltage drop per circuit per BS 7671 Appendix 4 | After routing is complete |
+| Breaker Sizer | BIM | Calcs | Suggests breaker rating per circuit from load and cable size | During design development |
+| Apply Breakers | BIM | Calcs | Writes suggested breaker ratings to all circuits | After Breaker Sizer has been reviewed |
+
+---
+
+### Electrical parameter reference
+
+| Parameter name | What it stores | Which elements carry it |
+|----------------|---------------|------------------------|
+| `ELC_PANEL_ID_TXT` | The distribution board identifier (e.g. "DB-L01-A") | Electrical Equipment (panels), also written on connected fixtures |
+| `ELC_CIRCUIT_NUM_TXT` | The circuit number as it appears on the breaker (e.g. "L1.1") | All electrical fixtures, lighting fixtures, electrical equipment |
+| `ELC_BREAKER_SIZE_A` | Breaker rating in amps (e.g. 16, 32, 63) | Electrical Equipment (panels); written per circuit in the schedule |
+| `ELC_LOAD_KW` | Connected load in kilowatts | Electrical fixtures, panels (total) |
+| `ELC_WIRE_GAUGE_TXT` | Cable conductor cross-section (e.g. "2.5 mm²", "6 mm²") | Conduits, Electrical Systems |
+| `ELC_PNL_PHASE_TXT` | Phase configuration of the panel: "1Ph", "3Ph" | Electrical Equipment (panels) |
+| `ELC_PNL_TYPE_TXT` | Panel type: "Switchboard", "DB", "CU", "Data" | Electrical Equipment (panels) |
+| `ELC_PNL_LOCATION_TXT` | Physical location description (e.g. "Ground floor electrical cupboard") | Electrical Equipment (panels) |
+| `ELC_PNL_VOLTAGE_TXT` | Panel voltage (e.g. "230V", "400V/230V") | Electrical Equipment (panels) |
+| `ELC_PNL_RATING_A` | Main breaker/incoming rating in amps (e.g. 100, 200, 400) | Electrical Equipment (panels) |
+| `ELC_PNL_LOAD_KW` | Total connected load in kW | Electrical Equipment (panels) |
+| `ELC_PNL_FED_FROM_TXT` | Which upstream board feeds this panel | Electrical Equipment (panels) |
+| `ELC_PANEL_REF_TXT` | Back-reference to the assigned panel (written on the circuit) | Electrical Systems |
+| `ELC_CIRCUIT_GROUP_TXT` | Logical grouping: "kitchen", "emergency-lighting", "fire-alarm", "comms-room" | All fixtures (written by BatchAssignCircuits) |
+| `ELC_CDT_BEND_COUNT_NR` | Number of bends in a conduit between pull-in points | Conduits |
+| `ELC_CDT_RUN_LENGTH_M` | Length of conduit run in metres | Conduits |
+| `ELC_CDT_CABLE_COUNT_NR` | Number of cables inside the conduit | Conduits |
+| `ELC_CDT_CBL_FILL_PCT` | Cable fill percentage | Conduits |
+| `ELC_CDT_INSTALL_METHOD_TXT` | How the conduit is installed: "SURFACE", "FLUSH", "SOFFIT", "CHASED" | Conduits |
+| `ELC_JB_TYPE_TXT` | Junction box type: "PULL_BOX", "DRAW_IN_BOX", "ADAPTABLE_BOX" | Electrical Equipment (junction boxes) |
+| `ELC_JB_AUTO_PLACED_BOOL` | 1 if placed automatically by STING | Electrical Equipment (junction boxes) |
+| `ELC_JB_REASON_TXT` | Why the junction box was needed: "BENDS_EXCESS" or "RUN_TOO_LONG" | Electrical Equipment (junction boxes) |
+| `LTG_EMERG_BOOL` | 1 = emergency luminaire, 0 = normal | Lighting Fixtures |
+| `ELC_PHOTO_LUMENS` | Light output in lumens | Lighting Fixtures |
+| `ELC_LIGHTING_TARGET_LUX_TXT` | Target illuminance in lux (written by Lighting Grid) | Lighting Fixtures |
+| `STING_PENETRATION_REF_TXT` | Fire-rated slab penetration reference | Conduits, Pipes, Ducts |
+| `PEN_CONTROL_NUMBER_TXT` | Sequential fire-stop control number (e.g. FRP-0001) | Specialty Equipment (fire stops) |
+| `PEN_FIRE_RATING_TXT` | Fire resistance rating of the penetration (e.g. "FR60") | Specialty Equipment (fire stops) |
+| `STING_SEED_FAMILY_TXT` | Seed family identifier — written on seed families | All MEP elements placed from seeds |
+
+---
+
+### System codes for electrical (complete list)
+
+| Code | Full name | What goes on this system | Relevant standard |
+|------|-----------|------------------------|------------------|
+| `LV` | Low voltage | General building power distribution: sockets, switches, small power | BS 7671 |
+| `HV` | High voltage | HV switchgear, transformers (11 kV and above) | BS 7671 Part 2 |
+| `UPS` | Uninterruptible power supply | Critical circuits fed from UPS: servers, medical equipment, life safety | BS EN 62040 |
+| `GEN` | Standby generator | Generator-backed circuits: fire alarm, lifts, critical plant | BS 7671; BS 5839-1 |
+| `EMS` | Energy monitoring | Sub-metering, smart metering, BMS power monitoring | — |
+| `LTG` | Lighting | All lighting circuits: normal and emergency | BS EN 12464-1 |
+| `FLS` | Fire and life safety | Fire alarm, emergency voice alarm, automatic opening vents | BS 5839-1; BS 5839-8 |
+| `FP` | Fire protection | Sprinklers, dry risers, wet risers | BS EN 12845; BS 9990 |
+| `SEC` | Security | CCTV, access control, intruder alarm | — |
+| `ICT` | Information and communications technology | Structured cabling, Wi-Fi, servers | BS EN 50174-2 |
+| `COM` | Communications | Intercom, public address, nurse call | — |
+| `NCL` | Nurse call | Clinical nurse call, staff attack alarms (healthcare) | HTM 08-03 |
+
+---
+
+### Glossary
+
+**BS 7671:** The IET Wiring Regulations — the British Standard that governs all electrical
+installation work in the UK. Panel schedules, circuit protection, cable sizing, and conduit
+fill all have requirements in BS 7671.
+
+**Cable fill:** The percentage of a conduit's internal cross-section area that is occupied
+by the cables inside. A 20 mm conduit with 35% fill means 35% of its internal area is
+cable — the rest is air. BS EN 61386 sets maximum fill percentages to ensure cables can
+be drawn through and to prevent overheating.
+
+**Circuit:** A set of cables, a protection device (breaker), and the loads (sockets, lights)
+connected to that protection device. A circuit starts at the distribution board and ends
+at the last device on the run.
+
+**Distribution board (DB):** A metal enclosure containing circuit breakers. It receives
+incoming power from an upstream source (the main switchboard or another distribution
+board) and distributes it to individual circuits throughout a zone of the building.
+
+**Draw-in point:** A junction box or pull box along a conduit run where cables can be pulled
+in or out. BS 7671 §522.8 limits how far apart draw-in points must be (maximum 6 metres or
+3 bends, whichever comes first) to ensure cables can actually be installed.
+
+**Fire stop (FRP — Fire Rated Penetration):** A device that seals the gap around a conduit
+or pipe where it passes through a fire-rated floor or wall. The fire stop maintains the
+fire resistance of the structural element even though it has been pierced by the service.
+
+**Homerun:** The cable (or conduit containing cables) that runs from a group of devices back
+to the distribution board. On a drawing, a homerun arrow shows the point at which individual
+device drops are consolidated into a single homerun cable heading back to the panel.
+
+**Lux:** A unit of illuminance — how much light falls on a surface. 100 lux is a brightly
+lit corridor. 500 lux is an office at full working light. 1000 lux is a surgery table.
+
+**Lumen method:** A calculation method for lighting design that uses the luminaire's light
+output (in lumens) and the room's geometry to predict the average illuminance (in lux).
+The method accounts for how efficiently light is distributed (utilisation factor) and for
+ageing and dirt (maintenance factor).
+
+**Panel schedule:** A table that records the contents of a distribution board: each circuit
+breaker's number, the circuit it protects, the load it carries, and its physical slot
+position in the board. Required by BS 7671 to be attached to or provided with the board.
+
+**Phase balance:** The equal distribution of electrical load across the three phases (A, B,
+and C) of a three-phase supply. An unbalanced supply runs less efficiently and can cause
+problems for sensitive equipment. Good engineering practice aims for less than 10%
+imbalance between phases.
+
+**PanelScheduleView:** The Revit object type for a panel schedule. It is a special kind of
+view that is linked directly to the electrical systems connected to a specific panel. Unlike
+a general schedule, it can only be created for elements in the `Electrical Equipment`
+category that have circuits connected to them.
+
+**Seed family:** A generic placeholder family that STING creates automatically. It has the
+correct category, hosting type, and shared parameters, but simple placeholder geometry
+(a box or a circle). Seed families are used for design and BIM modelling before
+manufacturer-specific families are procured. They can be swapped for real manufacturer
+families using the **Swap to Manufacturer** command, and all parameter data survives the swap.
+
+**Shared parameter:** A parameter in Revit that has a stable, unique identifier (a GUID)
+shared across all projects that use the same shared parameter file. Unlike project
+parameters (which only exist in one project), shared parameters can appear in multiple
+projects with the same name, GUID, and schedule column alignment. STING uses shared
+parameters for all `ELC_*`, `LTG_*`, `FLS_*`, and other engineering data.
+
+**Voltage drop:** The reduction in voltage along a cable run due to the cable's resistance.
+BS 7671 Appendix 4 specifies maximum allowable voltage drop: 3% for lighting circuits,
+5% for other circuits. Excessively long cable runs or undersized conductors cause more
+voltage drop — equipment at the end of the circuit receives less voltage than the supply.
+
+---
+
+## Cross-references
+
+| Guide | Used for |
+|-------|---------|
+| **MEP_FOUNDATION_GUIDE.md** | Creating MEP symbols (Chapter 1), authoring families correctly (Chapter 2), using the Placement Centre for fixture placement (Chapter 3), wire annotation family creation (Chapter 1, Section 1.4) |
+| **DRAWING_PRODUCTION_SYSTEM_GUIDE.md** | Producing electrical floor plans, lighting plans, fire alarm plans, riser diagrams, and panel schedule sheets |
+| **DOCUMENT_MANAGER_GUIDE.md** | Issuing electrical drawing packages, transmittal creation, CDE status management, revision control |
+| **DRAWING_TYPE_MANAGER_GUIDE.md** | Understanding and customising the drawing type profiles that control electrical view appearance and sheet layout |
+| **HEALTHCARE_PACK_DESIGN.md** | Electrical systems in healthcare buildings: HTM 06-01 requirements, EES resilience, UPS zoning, medical gas power supplies |

--- a/docs/guides/HEALTHCARE_WORKFLOW_GUIDE.md
+++ b/docs/guides/HEALTHCARE_WORKFLOW_GUIDE.md
@@ -1,0 +1,1386 @@
+# STING Healthcare Workflow Guide
+
+A practical, step-by-step guide for designing and documenting healthcare facilities in Autodesk Revit using the STING Healthcare Pack. Written for healthcare building services engineers, architects, and project BIM managers who are new to STING.
+
+---
+
+## How to use this guide
+
+This guide is organised as a journey through a healthcare project — from initial setup through clinical zoning, service design, compliance validation, Room Data Sheet production, and commissioning. Each chapter builds on the one before it.
+
+- **Bold text** marks a named STING command, button, or field.
+- `Monospace text` marks a parameter name or code value.
+- Stuck-points are boxed and tell you what to do when something goes wrong.
+- Tables summarise reference material so you can quickly look up codes, parameters, and standards.
+
+You do not need to read every chapter. A mechanical engineer designing medical gas systems can jump straight to Chapter 2. A mental health architect can skip to Chapter 4. The Quick Reference at the end of this guide lists every command alphabetically.
+
+---
+
+## Who this guide is for
+
+This guide is written for professionals who know healthcare design but are new to STING. You do not need prior STING experience. You do need:
+
+- A basic understanding of Autodesk Revit (placing rooms, elements, and families).
+- Familiarity with the type of building you are working on (hospital, clinic, mental health unit, imaging centre, etc.).
+- Access to a Revit project with the STING plugin loaded.
+
+If you have never used STING before, read the standard STING Tagging Workflow Guide first to understand how the core tagging pipeline works. The Healthcare Pack layers clinical compliance on top of that foundation.
+
+---
+
+## The Big Picture
+
+The Healthcare Pack does not replace STING's core tools. It adds a clinical compliance layer on top of them. Think of it as a specialist overlay that activates when you tell STING you are working on a healthcare facility.
+
+Here is what the Healthcare Pack adds:
+
+- **5 new parameter groups** capturing clinical room attributes, medical gas systems, radiation protection, clinical equipment classification, and anti-ligature requirements.
+- **16 healthcare validators** that check your model against clinical standards before you issue drawings.
+- **22 healthcare-specific drawing types** for Room Data Sheets, medical gas schematics, pressure regime plans, radiation shielding plans, and more.
+- **8 commissioning workflow presets** that guide you through MGPS verification, pressure regime auditing, Room Data Sheet issue, and annual inspections.
+- **80 healthcare-specific filters** for viewing your model by pressure regime, medical gas type, essential power branch, infection control class, radiation zone, and more.
+
+All of STING's core tools — auto-tagging, sheet management, BIM coordination, COBie export, document issue — still apply. The healthcare layer activates on top.
+
+### Project journey at a glance
+
+```
+1. Project Setup
+   Set facility type (FULL / ACUTE / COMMUNITY / DENTAL / IMAGING-ONLY)
+   Load healthcare shared parameters
+        |
+        v
+2. Clinical Zoning
+   Place rooms in Revit
+   Set CLN_* parameters (room class, pressure regime, infection class)
+   Run RdsCompletenessValidator to check mandatory fields
+        |
+        v
+3. Discipline Design
+   Medical gas systems (Chapter 2 — MGS_* parameters, MGPS Network Builder)
+   Water safety (Chapter 4 — PLM_TMV_* parameters, HTM 04-01)
+   Essential electrical (Chapter 5 — ELC_EES_BRANCH_TXT, EES branch audit)
+   Anti-ligature (Chapter 6 — LIG_* parameters, mental health)
+   Radiation shielding (Chapter 7 — RAD_* parameters)
+   Clinical equipment (Chapter 8 — CEQ_* parameters)
+        |
+        v
+4. Healthcare Validation
+   Run RunAllHealthcareValidators
+   Fix red (error) findings first, then amber (warnings)
+   Get Authorising Engineer sign-offs
+        |
+        v
+5. Room Data Sheets
+   Fix any remaining RdsCompletenessValidator gaps
+   Run BatchIssueRoomDataSheetsCommand
+   Review generated .docx files
+        |
+        v
+6. Commissioning
+   Run WORKFLOW_HealthcareCommissioning
+   Complete manual steps (pressure tests, gas tests, sign-offs)
+   Export commissioning records to Planscape Server
+        |
+        v
+7. Issue
+   Export COBie healthcare package
+   Issue drawings via Document Manager
+   Archive commissioning records
+   (See DOCUMENT_MANAGER_GUIDE.md)
+```
+
+---
+
+## Prerequisites
+
+### What the Healthcare Pack requires
+
+Before you can use the Healthcare Pack, three things must be in place:
+
+1. **Standard STING shared parameters must already be loaded.** The Healthcare Pack extends the standard parameter set — it does not replace it. If you have not already run **Load Shared Params** (STING panel > Tags tab > **Load Params**), do that first.
+
+2. **Healthcare parameter groups must be loaded.** The five new healthcare groups (`CLN_CLINICAL`, `MGS_SYSTEMS`, `RAD_PROTECTION`, `CEQ_CLINICAL`, `LIG_BEHAVIOURAL`) are loaded in the same operation as the standard parameters. When you run **Load Shared Params** on a project with the Healthcare Pack installed, all five groups bind automatically.
+
+3. **The facility profile must be set.** STING needs to know what type of healthcare facility you are designing so it can activate the right validators and drawing types.
+
+> **Stuck?** If healthcare parameters do not appear in the Properties panel after loading, check that you are running a version of STING with the Healthcare Pack installed. The Healthcare Pack is identified by the presence of `CLN_ROOM_CLASS_TXT` in the STING shared parameter file. If it is missing, contact your STING administrator.
+
+### Setting the facility profile
+
+The facility profile is a project-level parameter stored in `PRJ_ORG_HEALTH_PACK_PROFILE_TXT`. It gates which validators, drawing types, and COBie presets are activated. A community clinic should not be required to pass LINAC vault shielding checks — the profile system prevents that.
+
+**To set the facility profile:**
+
+1. STING panel > BIM tab > **Project Setup** (or open Revit's Manage tab > Project Information).
+2. Find the parameter `PRJ_ORG_HEALTH_PACK_PROFILE_TXT`.
+3. Type one of the values from the table below.
+4. Click OK.
+
+| Profile value | Facility type | Plain English | Validators activated |
+|---|---|---|---|
+| `FULL` | Full acute hospital | A complete hospital including theatres, ICU, maternity, imaging, pharmacy, and mental health. Everything is activated. | All 16 healthcare validators |
+| `ACUTE` | Acute hospital (no mental health) | A general hospital without a dedicated mental health unit. Anti-ligature validator is suppressed. | 15 validators (excludes AntiLigature) |
+| `COMMUNITY` | Community health centre / GP surgery | A primary care facility. No theatres, no LINAC, no HBO. Simpler pressure regime and water safety checks only. | 6 validators (Pressure, Water, EES, RDS, Adjacency, Acoustic basics) |
+| `DENTAL` | Dental practice or hospital dental department | Activates the dental compressed air / vacuum MGPS sub-system and HTM 01-05 decontamination flow. | 8 validators |
+| `IMAGING-ONLY` | Standalone imaging centre (MRI, CT, X-ray, PET) | No wards, no theatres. Radiation, MRI zoning, structural loads, and RTLS validators. | 5 validators (Radiation, AdvancedRad, Structural, RDS, RTLS) |
+| `MENTAL-HEALTH` | Mental health unit or psychiatric hospital | Dedicated anti-ligature pack, observation line-of-sight validator, and behavioural-health room types. | 10 validators (includes AntiLigature, behavioural room classes) |
+
+> **Stuck?** If you set the profile but healthcare validators still do not run, the `PRJ_ORG_HEALTH_PACK_PROFILE_TXT` parameter may not be bound. Open Revit's **Manage** tab > **Project Information** and confirm the parameter appears there. If it does not, re-run **Load Shared Params**.
+
+### Healthcare parameter groups
+
+The five healthcare parameter groups carry the clinical information that drives validators, Room Data Sheets, and COBie exports.
+
+| Group prefix | Group name | What it covers | Number of parameters |
+|---|---|---|---|
+| `CLN_*` | CLN_CLINICAL | Clinical room attributes: room classification, pressure regime, infection control class, MRI zone, anti-ligature, acoustic requirements, waste class, BMS sensor references, FHIR location link | 44 parameters |
+| `MGS_*` | MGS_SYSTEMS | Medical gas pipeline systems: gas type, nominal pressure, design flow rate, zone valve box reference, area alarm panel reference, brazing compliance, verification records | 13 parameters |
+| `RAD_*` | RAD_PROTECTION | Radiation shielding: lead-equivalent thickness, barrier type, workload, use factor, occupancy factor, design goal, Qualified Expert sign-off | 8 parameters |
+| `CEQ_*` | CEQ_CLINICAL | Clinical equipment classification: GMDN code (global medical device nomenclature), Spaulding infection tier, decontamination method, SFG20 maintenance reference | 7 parameters |
+| `LIG_*` | LIG_BEHAVIOURAL | Anti-ligature and behavioural health: product rating, self-closing, pressure-release threshold, observation line-of-sight | 5 parameters |
+
+In addition, the Healthcare Pack extends several existing parameter groups:
+
+| Existing group | Healthcare extensions added |
+|---|---|
+| `ELC_*` (Electrical) | EES branch classification, ATS transfer time, IPS flag, cardiac-protected outlet, generator runtime target |
+| `PLM_*` (Plumbing) | TMV type, dead-leg distance, augmented care flag, point-of-use filter, sentinel flag, flushing log reference, dialysis RO loop |
+| `HVC_*` (HVAC) | HEPA filter requirement, HEPA grade, last DOP test date, outside air ACH component |
+| `PRJ_ORG_*` (Project Information) | Facility type, bed count, OR count, ICU bed count, Authorising Engineers for ventilation/medical gas/water/electrical, Qualified Expert for radiation, regional HTM variant |
+
+---
+
+## Chapter 1 — Clinical Zoning and Space Types
+
+### Why healthcare spaces are classified differently
+
+In an office building, every room is broadly similar — it needs heating, cooling, lighting, and power. In a hospital, every room is fundamentally different. An operating theatre, an isolation room, an ICU bay, and a ward corridor each have different ventilation regimes, different pressure relationships to adjacent spaces, different surface finish requirements, different services connections, and different access restrictions.
+
+STING captures this through the `CLN_ROOM_CLASS_TXT` parameter on Room elements. When you set the room class on a Revit Room, STING knows which validators to run, which default parameter values to suggest, and which standards to cross-check against.
+
+Think of it this way: the room class is the clinical contract for that space. Setting `OR-ULTRA` on a room tells STING (and everyone reading the model) that this space must deliver laminar flow at ≥ 300 ACH, maintain +25 Pa relative to the scrub corridor, and have HEPA H14 terminal filtration. Without the room class set, STING cannot validate any of that.
+
+### CLN_* parameters for rooms
+
+These are the most important clinical parameters on a Room element. Set them before running any validators.
+
+| Parameter | What it stores | Example values | Why it matters |
+|---|---|---|---|
+| `CLN_ROOM_CLASS_TXT` | The clinical room type classification (see the full list below) | `OR-ULTRA`, `AIIR`, `ICU`, `WARD-INPT` | Gates which validators apply and what default values are expected |
+| `CLN_PRESS_REGIME_TXT` | The ventilation pressure regime for this room | `POS` (positive), `NEG` (negative), `NEUTRAL` | The pressure regime validator checks that adjacent rooms form a valid cascade |
+| `CLN_PRESS_DELTA_DESIGN_PA_NR` | The design pressure difference in Pascals between this room and adjacent corridors | `25` for an OR, `15` for an AIIR anteroom | Validators flag rooms where the design delta is below the clinical minimum |
+| `CLN_INFECT_CLASS_TXT` | The infection control risk class for this room | `STD` (standard), `AIIR` (Airborne Infection Isolation), `PE` (Protective Environment), `CLASS-N`, `CLASS-P` | AIIR rooms need negative pressure; PE rooms need positive pressure |
+| `CLN_ANTERM_LINKED_ID_TXT` | The Revit Element ID of the anteroom that serves as an airlock for this room | The numeric element ID | Tells the pressure validator which anteroom to check |
+| `CLN_MRI_ZONE_INT` | The MRI zone (1 to 4) for rooms in or adjacent to an MRI suite | `3` for the scanner room itself | RTLS anchors inside Zone 3 and 4 raise blocking errors |
+| `CLN_RF_SHIELD_BOOL` | Whether this room has a radiofrequency Faraday cage (MRI) or lead shielding | `Yes` / `No` | Prevents RTLS anchors using BLE/Wi-Fi/UWB from being placed in shielded rooms |
+| `CLN_LIGATURE_RES_BOOL` | Whether anti-ligature design requirements apply in this room | `Yes` / `No` | Activates the anti-ligature validator for this room |
+| `CLN_LIG_RISK_LVL_TXT` | The ligature risk level | `LOW`, `MED`, `HIGH`, `VERY-HIGH` | Determines the minimum product rating required for fixtures |
+| `CLN_HANDWASH_COUNT_INT` | The number of clinical handwash basins required in this room | `2` for an ICU bay | The RDS completeness validator checks this against HBN minimum counts |
+| `CLN_WASTE_CLASS_TXT` | The dominant waste stream for this room | `CLINICAL`, `CYTOTOXIC`, `RADIOACTIVE`, `PHARMACEUTICAL`, `SHARPS`, `DOMESTIC` | Used by the waste flow validator to check segregation routes |
+
+### Setting up room classifications
+
+**Step 1.** Place rooms in the Revit model using the standard Revit Architecture tab > **Room** command. Give each room a meaningful name (for example "OR 1", "ICU Bay 4", "AIIR Room 12").
+
+**Step 2.** Select one or more rooms. In the Properties panel, scroll to the `CLN_CLINICAL` group. You will see the healthcare parameters listed there.
+
+**Step 3.** Fill in at minimum: `CLN_ROOM_CLASS_TXT`, `CLN_PRESS_REGIME_TXT`, and `CLN_INFECT_CLASS_TXT`. These three are mandatory for most validators.
+
+**Step 4.** For rooms in batches of the same type (for example, all general ward rooms), use **BulkParamWrite** to set the same values across multiple rooms at once:
+- STING panel > SELECT tab > **Bulk Param Write** button.
+- Select the rooms you want to update.
+- Choose the parameter name and value.
+- Click Apply.
+
+**Step 5.** Run **RDS Completeness Check** (STING panel > Healthcare > **RDS Completeness Check**) to see which mandatory fields are still missing.
+
+> **Stuck?** If the `CLN_CLINICAL` group does not appear in the Properties panel after loading parameters, the Room category may not be bound to those parameters. Re-run **Load Shared Params** and confirm that Rooms are included in the category bindings.
+
+### The clinical room type classification system
+
+STING defines a comprehensive set of room class codes. The most important ones are listed here. The full list is stored in the `CLN_ROOM_CLASS_TXT` parameter definition.
+
+| Room class code | Full name | Typical standards | Key design requirements |
+|---|---|---|---|
+| `OR-ULTRA` | Ultra-clean operating theatre | HTM 03-01, ASHRAE 170 | ≥ 300 ACH laminar flow, HEPA H14, +25 Pa, 19–24 °C, NR 40 |
+| `OR-CONV` | Conventional operating theatre | HTM 03-01 | ≥ 20 ACH, +25 Pa, NR 40 |
+| `OR-HYBRID` | Hybrid operating / imaging room | FGI Guidelines | ≥ 70 m², ceiling zone clearance for fluoroscopy, booms, and lights |
+| `CATHLAB` | Cardiac catheterisation laboratory | HBN 12, NEC 517 | Lead curtain at table, lead-lined walls, IPS mandatory |
+| `ICU` | Intensive care unit bay | HBN 09-02 | 6 ACH, neutral pressure, cardiac-protected outlets, bedhead pendant |
+| `HDU` | High dependency unit bay | HBN 09-02 | Similar to ICU with slightly relaxed standards |
+| `NICU` | Neonatal intensive care unit | HBN 09-03, FGI 2026 | ≥ 14 m² single room, 6 ACH, NR 30 |
+| `AIIR` | Airborne Infection Isolation Room | CDC, HBN 04-01 | 12 ACH (new build), HEPA H14, –15 Pa to anteroom, –30 Pa to corridor, exhaust to outside |
+| `PE-PROT` | Protective Environment room | CDC | 12 ACH, HEPA H14, +12 Pa to anteroom, monitored delta-P |
+| `ANTERM` | Anteroom / airlock | HTM 03-01, CDC | Pressure buffer between AIIR/PE and corridor |
+| `WARD-INPT` | In-patient ward room | HBN 04-01 | Standard ACH, natural or mechanical ventilation |
+| `IMG-MRI` | MRI scanner room | HBN 06, IEC 60601-2-33 | RF Faraday cage, 5-Gauss geometry, Z1–Z4 zoning, no ferrous within Zone 3 |
+| `IMG-CT` | CT scanner room | NCRP 147 | Primary and secondary shielding, QE sign-off mandatory |
+| `IMG-XRY` | Plain X-ray room | NCRP 147 | Lead-lined walls, controlled area designation, IRR17 |
+| `IMG-LIN` | Linear accelerator vault | NCRP 151 | Maze geometry, neutron shielding ≥ 10 MV, primary + secondary barriers |
+| `IMG-PET` | PET scanner room | NCRP 151 | 511 keV two-photon shielding — significantly more than diagnostic X-ray |
+| `PH-CSP-797` | Pharmacy compounding sterile area (USP 797) | USP <797> | ISO 5 primary engineering control in ISO 7 buffer, +5 Pa to anteroom |
+| `PH-CSP-800` | Pharmacy hazardous drug handling area (USP 800) | USP <800> | Negative pressure C-PEC, –2.5 Pa buffer to anteroom, isolated exhaust |
+| `PSY-BED` | Mental health in-patient bedroom | HBN 03-01 | Anti-ligature rated fittings, nurse call, minimum camera coverage |
+| `SECL` | Seclusion room | HBN 03-01, FGI Part 2 | Anti-ligature throughout, 100% observation line-of-sight, soft furnishings |
+| `HSDU-P` | HSDU packing/sterile storage room | HBN 13 | +10 Pa to corridor, separated from wash side |
+| `HSDU-W` | HSDU wash/decontamination room | HBN 13 | –10 Pa to corridor, separate exhaust |
+| `DECON-D` | Dirty decontamination utility | HBN 00-04 | Negative pressure, soiled linen / equipment entry point |
+| `DECON-C` | Clean decontamination utility | HBN 00-04 | Positive relative to dirty |
+| `MORT` | Mortuary | HBN 16 | 6 ACH, remote location, refrigeration capacity |
+| `DIAL` | Dialysis station | HBN 07-02 | RO-loop tap, 1.5 m clearance per chair, 24-hour RO water |
+| `ENDOSCOPY` | GI endoscopy suite | HTM 01-06, HBN 12 | Decon dirty-clean-sterile flow, RFID reader points, –10 Pa |
+| `BRACHYTHERAPY` | Brachytherapy vault (sealed source radiotherapy) | NCRP 151, IRR17 | Interlocked door, dose-rate monitor mandatory, afterloading source vault |
+| `TELEHEAL` | Telehealth consultation room | NHS Digital guidance | Camera mount, ≥ 500 lux face illuminance, ≥ 4 Mbps uplink, acoustic SENSITIVE class |
+
+---
+
+## Chapter 2 — Medical Gas Pipeline System (MGPS)
+
+### What MGPS is
+
+A Medical Gas Pipeline System (MGPS) is the network of copper pipework permanently installed in a hospital to deliver gases and vacuum to patient care areas. Unlike natural gas in an ordinary building — which is used for heating and cooking — medical gases are therapeutic agents delivered directly to patients. Oxygen is delivered to bedside pendants for ventilated patients. Medical vacuum removes secretions. Nitrous oxide and medical air support anaesthesia.
+
+MGPS failure can be fatal. For this reason, MGPS is governed by strict standards (HTM 02-01 in the UK, NFPA 99 in the US), must be designed to defined pressure and flow specifications, and must pass a documented 12-step verification before it can be used clinically.
+
+STING helps you design, document, and verify MGPS against these standards through three engines:
+
+- **MgasNetwork** — traces the pipe network and builds a zone graph showing how every outlet connects back to the plant room.
+- **MgasFlowSolver** — calculates the realistic simultaneous flow demand at each point in the network, applying diversity factors from NFPA 99.
+- **MgasVerificationLog** — records the 12-step NFPA 99 verification against the model.
+
+> **Cross-reference:** For MGPS piping modelling (placing pipes, sizing, routing), see **PLUMBING_WORKFLOW_GUIDE.md**. This chapter covers the healthcare-specific validation and documentation layer.
+
+### The gas types in STING MGPS
+
+| Gas code | Full name | Typical pressure | Pipe colour (BS EN 737) | Standards reference |
+|---|---|---|---|---|
+| `O2` | Medical oxygen | 400 kPa | White | HTM 02-01 Part A; NFPA 99 Ch.5 |
+| `MA4` | Medical compressed air (400 kPa) | 400 kPa | Black + white quadrant | HTM 02-01; ISO 7396-1 |
+| `MA7` | Surgical compressed air (700 kPa) | 700 kPa | Black + white quadrant | HTM 02-01 |
+| `N2O` | Nitrous oxide (laughing gas — anaesthetic) | 400 kPa | Blue | HTM 02-01 Part A |
+| `N2` | Surgical nitrogen (tool gas) | 700 kPa | Black | HTM 02-01 |
+| `CO2` | Carbon dioxide (laparoscopic insufflation) | 400–700 kPa | Grey | HTM 02-01 |
+| `HE` | Helium / heliox (respiratory therapy) | 400 kPa | Brown | Specialist — HTM 02-01 App |
+| `VAC` | Medical vacuum | –400 to –600 mbar | Yellow | HTM 02-01; NFPA 99 |
+| `AGS` | Anaesthetic gas scavenging (removes waste anaesthetic from theatres) | Passive or active sub-atmospheric | Lilac | HTM 02-01; ISO 7396-2 |
+| `DENT` | Dental compressed air / dental vacuum | Varies | Black / Yellow | HTM 01-05 (UK dental) |
+
+### MGS_* parameters for pipes and terminal units
+
+Set these parameters on every MGPS pipe, terminal unit (the outlet at the bedside), zone valve box, and alarm panel in your model.
+
+| Parameter | What it stores | Example value | Why it matters |
+|---|---|---|---|
+| `MGS_GAS_TYPE_TXT` | The gas type for this element | `O2`, `VAC`, `MA4` | STING uses this to colour-code elements and trace the network |
+| `MGS_NOM_PRESS_KPA_NR` | Nominal operating pressure in kilopascals | `400` for oxygen | Flow solver uses this to check pressure drop |
+| `MGS_DESIGN_FLOW_LPM_NR` | Design flow rate in litres per minute (free air) | `10` for a standard oxygen outlet | Flow solver sums these at each zone valve box |
+| `MGS_DIVERSITY_PCT_NR` | The diversity factor for this outlet | `70` (meaning only 70% of outlets are expected to run simultaneously) | NFPA 99 diversity factors reduce the total calculated demand |
+| `MGS_TU_BS5682_BOOL` | Does this terminal unit comply with BS 5682 (indexed probe pattern)? | `Yes` / `No` | The MGPS validator checks for BS 5682 compliance on all UK terminal units |
+| `MGS_TU_INDEXED_BOOL` | Does this terminal unit have gas-specific NIST indexing (US standard)? | `Yes` / `No` | Cross-connection prevention — indexed probes can only accept the correct gas |
+| `MGS_ZVB_REF_TXT` | The identifier of the zone valve box that controls this outlet | `ZVB-OR-1-O2` | Allows STING to group outlets by zone for flow calculations |
+| `MGS_AAP_REF_TXT` | The identifier of the area alarm panel for this zone | `AAP-OR-1` | Allows STING to check that every zone valve box has a corresponding alarm |
+| `MGS_PIPE_BRAZED_BOOL` | Was this pipe joint brazed under inert-gas purge (required by HTM 02-01)? | `Yes` / `No` | The MGPS validator checks brazing compliance on all copper pipe joints |
+| `MGS_VERIFY_DT` | Date of NFPA 99 §5.1.12 verification | `2026-09-15` | Records when the system was formally verified |
+| `MGS_VERIFY_BY_TXT` | Name of the ASSE 6030 certified verifier | `John Smith ASSE 6030` | Mandatory — STING will not mark verification as passed without a name |
+| `MGS_VERIFY_PASS_BOOL` | Did the latest verification pass? | `Yes` / `No` | The commissioning workflow reads this to determine if the MGPS is ready for clinical use |
+| `MGS_VERIFY_CERT_REF_TXT` | Reference number of the verification certificate | `CERT-2026-OR1-O2` | Document management link for the certificate |
+
+### The MGPS Network Builder (MgasNetwork)
+
+The MgasNetwork engine is STING's way of understanding how your MGPS is connected. Think of it as building a family tree: the plant room (compressors and cylinders) is the ancestor, and every bedside outlet is a descendant. STING traces the pipe connections to build this tree automatically — but only if the pipes are properly connected in Revit.
+
+**Step 1.** Ensure all MGPS pipes and fittings are placed and connected in Revit. Every pipe must be joined to the next (no gaps), and every terminal unit must be connected to a pipe. Use Revit's **Pipe** tool under Systems > Plumbing & Piping, and set the system type to the correct MGPS system (`MGAS-O2`, `MGAS-VAC`, etc.).
+
+**Step 2.** Set `MGS_GAS_TYPE_TXT` on all terminal units, zone valve boxes, and alarm panels.
+
+**Step 3.** In the STING panel, go to the **BIM** tab and click **MGPS Network Audit** (or run `MgasNetworkAuditCommand`). STING will trace all `MGAS-*` systems and report:
+- How many terminal units were found per gas type.
+- Which terminal units could not be connected back to a plant room (orphaned outlets — these must be fixed before commissioning).
+- Which zone valve boxes serve more than one alarm panel (this is not permitted under HTM 02-01).
+
+**Step 4.** Review the network report. Fix any orphaned outlets by checking pipe connections in Revit. Re-run the audit until it reports zero orphaned outlets.
+
+> **Stuck?** If STING reports "No MGAS systems found", check that the Revit pipe system types are named with the `MGAS-` prefix (e.g. `MGAS-O2`, `MGAS-MA4`). STING recognises systems only with that prefix. Open Revit's Manage > MEP Settings > Mechanical Settings > Pipe Settings to check system names.
+
+### MGPS Flow Verification (MgasFlowSolver)
+
+NFPA 99 §5.1.13 requires that medical gas systems be designed to deliver adequate flow with diversity. Diversity means that not every outlet in a hospital runs at full flow simultaneously — an ICU at 3 a.m. with 8 occupied beds does not draw the same demand as that same ICU with all 20 beds occupied and running maximum ventilation support.
+
+The MgasFlowSolver applies published diversity factors to calculate the realistic simultaneous demand at every node in the network. A node is any junction, zone valve box, or major branch point.
+
+**Step 1.** With the MGPS network graph built (see above), click **MGPS Flow Solver** in the STING panel BIM tab.
+
+**Step 2.** The solver reads `MGS_DESIGN_FLOW_LPM_NR` from every terminal unit and `MGS_DIVERSITY_PCT_NR` where set. Where diversity is not set, STING applies the NFPA 99 Table 5.1.13 defaults.
+
+**Step 3.** The solver calculates the diversified flow at each zone valve box, sums through to the branch header, and reports:
+- **Green nodes**: flow capacity adequate, pressure drop within the 10% limit.
+- **Red nodes**: undersized — the calculated flow exceeds the pipe capacity or the pressure drop is too high. The pipe needs to be upsized.
+- **Amber nodes**: marginal — within specification but close to the limit. Flag for the Authorising Engineer to review.
+
+**Step 4.** Resize any red-flagged pipes in Revit and re-run the solver.
+
+> **Stuck?** If the flow solver gives negative flow values at some nodes, the network graph was not built before running the solver. Run **MGPS Network Audit** first, confirm zero orphaned outlets, then run the flow solver again.
+
+### The 12-step NFPA 99 verification log
+
+NFPA 99 §5.1.12 requires that every medical gas pipeline system be formally verified before first clinical use. The verification covers 12 specific tests, each of which must be witnessed, recorded, and signed by an ASSE 6030 certified verifier.
+
+STING's `MgasVerificationLog` creates a structured record for each zone, persisted to `<project>/_BIM_COORD/healthcare/mgas_verifications/` as a JSON file per zone per date.
+
+The 12 verification steps, in order, are:
+
+| Step | What is tested | Pass criterion |
+|---|---|---|
+| 1 | Cross-connection test | No gas is present at any outlet of another gas species on the same system |
+| 2 | Concentration test | Gas purity meets pharmacopoeial standard (e.g. oxygen ≥ 99.5%) |
+| 3 | Particulate contamination | Particulate count at outlets meets ISO 8573-1 requirements |
+| 4 | Pressure test (operational) | System maintains nominal pressure under full diversified load |
+| 5 | Indexing / probe fit test | Terminal units accept only the correct indexed probe |
+| 6 | Flow test | Each outlet delivers at least the minimum flow at nominal pressure |
+| 7 | Labelling verification | All outlets, zone valve boxes, and alarm panels correctly labelled and colour-coded |
+| 8 | Zone valve box test | Closing each ZVB isolates only the correct zone and no other |
+| 9 | Area alarm panel test | Each alarm panel alerts correctly when pressure falls or rises outside limits |
+| 10 | Master alarm panel test | Master alarm receives and displays all area alarm signals |
+| 11 | Patient room alarm test | Visual and audible alarms at nurse call panels trigger correctly on pressure loss |
+| 12 | Final documentation review | All test records, certificates, and as-built drawings are present and consistent |
+
+**To record a verification step:**
+
+1. STING panel > BIM tab > **MGPS Verify** (or run `MgasVerifyCommand`).
+2. Select the zone to be verified from the dropdown.
+3. For each step, click the step row and mark it Pass, Fail, or N/A.
+4. Enter the verifier's name in `MGS_VERIFY_BY_TXT` and their ASSE 6030 certificate number.
+5. Click **Save Log**. STING writes the verification record to `_BIM_COORD/healthcare/mgas_verifications/`.
+
+**Where the log is saved:** `<project>/_BIM_COORD/healthcare/mgas_verifications/YYYYMMDD_zone-N.json` (one file per zone per verification date).
+
+> **Important:** STING cannot mark a zone as verified without a named verifier (`MGS_VERIFY_BY_TXT` must be populated). This is by design — the standard requires a human signature.
+
+### MGPS Workflow Preset: WORKFLOW_MgasVerification
+
+The `WORKFLOW_MgasVerification.json` preset chains all MGPS verification steps into a managed sequence.
+
+**To run the workflow:**
+1. STING panel > BIM tab > **Workflow Presets** dropdown > select **MgasVerification**.
+2. Review the step list in the dialog. Each step is shown with its automation level (Automated / Manual).
+3. Click **Run**.
+
+| Workflow step | What STING does | What you do |
+|---|---|---|
+| Pre-purge check | Verifies `MGS_PIPE_BRAZED_BOOL` is set on all joints | Confirm on-site purge records |
+| Cross-connection test | Opens verification log, records Step 1 | Test each outlet with probe tools; mark Pass/Fail |
+| Particulate test | Opens log, records Step 3 | Submit sample to laboratory; enter result when available |
+| Purity test | Opens log, records Step 2 | Submit gas sample; enter purity percentage |
+| Flow test | Runs MgasFlowSolver; records Step 6 | Confirm on-site flow measurements match model |
+| Flow verification | Checks solver results against 10% pressure-drop limit | Review and sign |
+| Write verification log | Saves complete log to _BIM_COORD; sets `MGS_VERIFY_PASS_BOOL` | Sign the log in the STING dialog |
+
+**Sign-off:** The workflow pauses at the final step for the Authorising Engineer (Medical Gas) to enter their name and confirm. STING will not write `MGS_VERIFY_PASS_BOOL = Yes` without this confirmation.
+
+---
+
+## Chapter 3 — Pressure Regimes and Ventilation
+
+### What pressure regimes mean in a hospital
+
+Imagine air pressure as water in a plumbing system. Positive pressure pushes water out through every opening — it creates a bubble that keeps contaminants outside. Negative pressure creates a vacuum that pulls air in through every opening — it acts as a trap that keeps infectious material from escaping.
+
+In a hospital, these principles protect patients and staff:
+
+- **Positive pressure** (a "clean bubble"): used in operating theatres, HEPA-filtered rooms, and protective environment rooms. Air flows outward through every gap, preventing corridor dust, spores, and bacteria from entering. An immunocompromised bone-marrow transplant patient needs this protection.
+
+- **Negative pressure** (a "containment zone"): used in airborne infection isolation rooms (AIIRs), mortuary post-mortem suites, and decontamination dirty utilities. Air flows inward through every gap, preventing infectious aerosols from escaping to the corridor. A patient with active tuberculosis or measles must be nursed in a negative pressure room.
+
+- **Neutral pressure**: the corridor itself is typically neutral. It acts as a buffer between positive and negative spaces. A scrub corridor outside an operating theatre is neutral relative to the theatre (positive) and the wider hospital corridor.
+
+The sequence of pressures from one side of a department to the other is called the **pressure cascade**. The cascade must be monotonic (always going in one direction). A positive operating theatre flowing to a neutral scrub corridor flowing to a neutral clean corridor is a valid cascade. An AIIR flowing from negative directly to a positive PE room without an anteroom in between is a dangerous design that STING's pressure validator will flag.
+
+### The pressure regime values in STING
+
+Set `CLN_PRESS_REGIME_TXT` on every Room element with one of these values:
+
+| Value | Direction | Typical rooms | Why |
+|---|---|---|---|
+| `POS` | Positive (clean bubble) | Operating theatres, HEPA PE rooms, pharmacy clean rooms (USP 797), HSDU sterile pack room | Keeps contaminants out |
+| `NEG` | Negative (containment) | AIIRs, mortuary post-mortem rooms, dirty decon utilities, PET hot labs | Keeps infectious material in |
+| `NEUTRAL` | Neutral (buffer) | Wards, corridors, clean utilities, scrub corridors | Pressure buffer |
+| `POS-ISO` | Positive isolation (enhanced positive) | Bone marrow transplant rooms, NICU single rooms | Enhanced protection for very immunocompromised patients |
+| `NEG-ISO` | Negative isolation (enhanced negative) | Biosafety level 3 labs, BSL4 labs | Enhanced containment for dangerous pathogens |
+
+### Running the Pressure Regime Audit
+
+The Pressure Regime Audit checks that adjacent rooms form valid pressure cascades. It reads `CLN_PRESS_REGIME_TXT` on all rooms and uses the model's room boundaries (walls and doors) to identify which rooms are adjacent.
+
+**Step 1.** Ensure `CLN_PRESS_REGIME_TXT` is set on all clinical rooms. Use **BulkParamWrite** for efficiency on large ward layouts.
+
+**Step 2.** STING panel > Healthcare > **Pressure Regime Audit** (or run `PressureRegimeValidator` via `RunAllHealthcareValidators`).
+
+**Step 3.** The validator produces a report showing:
+- **Red findings (Errors)**: adjacent rooms with incompatible pressure regimes (for example, a positive AIIR anteroom adjacent directly to a negative AIIR — the anteroom should be negative relative to the corridor but positive relative to the AIIR, creating a cascade).
+- **Amber findings (Warnings)**: pressure cascade arrows that are internally inconsistent, or AIIR rooms whose exhaust does not discharge to outside (it must not recirculate).
+- **Green**: valid cascade.
+
+**Step 4.** Fix pressure regime conflicts by:
+- Adding an anteroom between incompatible spaces (most common fix).
+- Correcting `CLN_PRESS_REGIME_TXT` values where the design intent was entered incorrectly.
+- Setting `CLN_ANTERM_LINKED_ID_TXT` on AIIR and PE rooms to point to their paired anteroom element ID.
+
+**Step 5.** Re-run the validator until zero red findings remain.
+
+### WORKFLOW_PressureRegimeAudit
+
+The `WORKFLOW_PressureRegimeAudit.json` preset chains the full pressure audit sequence:
+
+| Step | STING action | Your action |
+|---|---|---|
+| Build room graph | STING traces room adjacencies via doors and corridors | Confirm room connections are correct in the model |
+| Resolve cascades | STING checks monotonic cascade logic | Review report for cascade inversions |
+| HVAC verification | STING cross-checks `CLN_PRESS_REGIME_TXT` against `HVC_AIR_CHANGES_PER_HR` for minimum ACH | Confirm ACH values are correctly entered |
+| Produce drift report | STING generates a findings report | Sign off and issue via Document Manager |
+| Push to mobile | STING pushes live pressure data to the Planscape mobile app (if IoT bridge configured) | On-site team can read live delta-P on the mobile app |
+
+---
+
+## Chapter 4 — Water Safety (HTM 04-01 and Legionella Control)
+
+### Why water safety is a clinical governance issue in hospitals
+
+Legionnaires' disease — a severe form of pneumonia caused by the bacterium Legionella pneumophila — kills approximately 10% of those infected. Legionella thrives in water systems where water is stored between 25 °C and 45 °C, where stagnant water creates "warm corners", and where pipe systems accumulate scale, rust, or biofilm that the bacteria can feed on.
+
+For immunocompromised hospital patients — transplant recipients, ICU patients, cancer patients undergoing chemotherapy, NICU neonates — the risk is far higher than for healthy adults. A Legionella outbreak in an ICU can be catastrophic.
+
+HTM 04-01 (Safe Water in Healthcare Premises, Parts A, B, and C) is the UK standard governing hospital water systems. It sets out the design limits, maintenance requirements, and monitoring regime. The key requirement you will interact with as a designer is the **dead-leg limit**: no part of a hot or cold water pipe serving a high-risk outlet should be more than 1 metre from the nearest flowing point.
+
+Think of a dead leg as a cul-de-sac in a road network. Water sits in a cul-de-sac, goes stale, and harbours bacteria. The solution is to eliminate dead ends by extending the circuit or removing redundant pipe runs.
+
+### HTM 04-01 water safety: key concepts in STING
+
+STING tracks water safety through extensions to the existing `PLM_*` (Plumbing) parameter group. These parameters bind to plumbing fixtures (sinks, basins, showers, TMV units, outlets) and to pipe elements.
+
+| Parameter | Where it is set | What it records |
+|---|---|---|
+| `PLM_TMV_TYPE_TXT` | On TMV fitting families | The type of thermostatic mixing valve: `TMV2` (domestic standard), `TMV3` (healthcare standard), `NONE` (no TMV) |
+| `PLM_DEAD_LEG_M_NR` | On outlet fixtures | The estimated dead-leg distance in metres from the outlet back to the nearest flowing supply main |
+| `PLM_AUGMENTED_CARE_BOOL` | On outlet fixtures | Is this outlet in an augmented-care area (ICU, NICU, transplant, haematology, burns)? `Yes` / `No` |
+| `PLM_SENTINEL_BOOL` | On specific outlet fixtures | Is this a designated sentinel sampling point for monthly Legionella temperature measurement? `Yes` / `No` |
+| `PLM_POU_FILTER_BOOL` | On outlet fixtures in augmented care | Is a point-of-use sterile water filter fitted? `Yes` / `No` |
+| `PLM_POU_FILTER_CHANGED_DT` | On outlet fixtures with POU filter | Date the point-of-use filter was last replaced (POU filters must be changed every 3–6 months) |
+| `PLM_FLUSH_LOG_REF_TXT` | On sentinel outlets | Reference to the flush log record (weekly flushing of low-use outlets prevents stagnation) |
+| `PLM_DIALYSIS_RO_LOOP_BOOL` | On outlets in dialysis areas | Is this outlet connected to a reverse-osmosis loop (required for dialysis)? `Yes` / `No` |
+| `PLM_DHW_TEMP_SET_C_NR` | On hot-water storage and calorifier elements | The set-point temperature of the DHW system in this zone. Must be ≥ 60 °C in storage and ≥ 50 °C at sentinel outlets |
+| `PLM_CW_TEMP_MAX_C_NR` | On cold-water storage and pipe runs | The maximum cold-water temperature in this zone. Must be ≤ 20 °C at outlet |
+
+### Setting up water safety parameters
+
+**Step 1.** Identify your augmented care areas. These are the rooms where patients are most vulnerable:
+
+| Room type | Augmented care status |
+|---|---|
+| ICU bay (`ICU`) | Always augmented care |
+| HDU bay (`HDU`) | Always augmented care |
+| NICU room (`NICU`) | Always augmented care |
+| Burns unit (`BURNS`) | Always augmented care |
+| Haematology / bone marrow transplant room | Always augmented care |
+| General ward room (`WARD-INPT`) | Not augmented care unless specified by clinician |
+| Day surgery recovery | Not augmented care |
+
+**Step 2.** Select all plumbing fixtures in augmented care rooms. Use STING panel > SELECT tab > **Select by Discipline** (set to `P` for plumbing). Then filter further by room using **Select by Level** if needed.
+
+**Step 3.** Use **BulkParamWrite** to set `PLM_AUGMENTED_CARE_BOOL = Yes` on all selected fixtures.
+
+**Step 4.** Set `PLM_TMV_TYPE_TXT = TMV3` on all fixtures in augmented care areas. TMV3 is the higher-performance standard — it holds outlet temperature more tightly (±2 °C vs ±5 °C for TMV2) and has an anti-scald fail-safe that stops hot water flow if cold water fails.
+
+**Step 5.** Designate sentinel points. Sentinel points are specific outlets used for regular Legionella temperature monitoring. HTM 04-01 Part C requires at minimum:
+- One sentinel on the first outlet on each rising main.
+- One sentinel on the last outlet on each branch (the "end of line" outlet — the most vulnerable to stagnation).
+
+Select these outlet families and set `PLM_SENTINEL_BOOL = Yes`.
+
+**Step 6.** For dialysis areas, set `PLM_DIALYSIS_RO_LOOP_BOOL = Yes` on all outlets in `DIAL` rooms.
+
+> **Stuck?** If `PLM_TMV_TYPE_TXT` does not appear in the Properties panel for a plumbing fixture, the Healthcare Pack extension to the PLM group may not be loaded. Re-run **Load Shared Params**.
+
+### Running the Water Safety Audit
+
+**Step 1.** STING panel > Healthcare > **Water Safety Audit** (or `WaterSafetyAuditCommand`).
+
+**Step 2.** The validator checks:
+
+| Check | Pass criterion | Fail action |
+|---|---|---|
+| Augmented care outlets have TMV3 | `PLM_TMV_TYPE_TXT = TMV3` on all `PLM_AUGMENTED_CARE_BOOL = Yes` fixtures | Error: update TMV specification on the fixture. Replace TMV2 with TMV3. |
+| Dead legs ≤ 1 m in augmented care | `PLM_DEAD_LEG_M_NR ≤ 1.0` on all augmented care sentinel outlets | Error: redesign the pipework to eliminate dead ends longer than 1 m. |
+| DHW temperature at storage ≥ 60 °C | `PLM_DHW_TEMP_SET_C_NR ≥ 60` on calorifiers and storage vessels | Warning: set calorifier temperatures to at least 60 °C. |
+| DHW temperature at sentinel outlet ≥ 50 °C | Temperature measurement ≥ 50 °C (entered during annual audit workflow) | Warning: this indicates heat loss in the distribution system. Check pipe insulation and calorifier set-point. |
+| Cold water temperature ≤ 20 °C | `PLM_CW_TEMP_MAX_C_NR ≤ 20` on cold water pipe runs in warm plant spaces | Warning: check pipe routes near heat sources. Add cold pipe insulation. |
+| Dialysis outlets on RO loop | `PLM_DIALYSIS_RO_LOOP_BOOL = Yes` on all outlets in DIAL rooms | Error: non-RO water cannot be used for dialysis. |
+| Point-of-use filters present | `PLM_POU_FILTER_BOOL = Yes` on augmented care outlets in highest-risk rooms (NICU, transplant, burns) | Warning: POU filters reduce infection risk significantly in the highest-risk areas. |
+| Sentinel points designated | At least one `PLM_SENTINEL_BOOL = Yes` outlet per floor per branch | Warning: without sentinel points, annual monitoring cannot be structured correctly. |
+
+**Step 3.** Review the report. Fix all errors first, then review warnings with the Authorising Engineer (Water).
+
+**Step 4.** Document findings. The Water Safety Audit produces a structured report that feeds into the Water Safety Group meeting minutes and the Legionella risk assessment.
+
+### The annual HTM 04-01 water safety workflow
+
+Run this annually as part of the estates maintenance programme. See the full walkthrough in **Chapter 8** under `WORKFLOW_HTM-04-01-Annual`.
+
+> **Cross-reference:** For the underlying plumbing pipe modelling, system types, and routing design, see **PLUMBING_WORKFLOW_GUIDE.md**. This chapter covers the healthcare-specific compliance layer only.
+
+---
+
+## Chapter 5 — Essential Electrical Services (EES)
+
+### What the Essential Electrical System is
+
+A hospital cannot tolerate a power failure. Patients on ventilators, in the middle of surgery, or receiving intravenous infusions will die if power is lost for more than a few seconds. To ensure continuity of power, hospitals maintain a **Essential Electrical System (EES)** — a category of circuits that:
+
+1. Are connected through an **Automatic Transfer Switch (ATS)** that switches from mains to generator power within 10 seconds of a mains failure.
+2. Are physically separate from ordinary mains circuits, so a fault on the ordinary side does not affect the EES.
+3. Are powered by **on-site generators** sized to supply all essential loads for at least 24 hours without refuelling.
+
+The Essential Electrical System is divided into three branches:
+
+| Branch code | Full name | What it powers | Transfer time |
+|---|---|---|---|
+| `LIFE-SAFETY` (LS) | Life Safety Branch | Exit lighting, emergency lighting, fire alarm, nurse call, public address, alarm systems | ≤ 10 seconds |
+| `CRITICAL` (CR) | Critical Branch | Patient-care areas, OR luminaires, ICU monitoring equipment, patient-care receptacles | ≤ 10 seconds |
+| `EQUIPMENT` (EQ) | Equipment Branch | HVAC for isolation rooms, sterilisers, water heaters, fixed equipment | ≤ 10–30 seconds (varies) |
+
+In the UK, the equivalent framework is the Essential Services classification under HTM 06-01, with similar branch divisions.
+
+In addition, two specialist circuits apply in surgical and critical care areas:
+
+| Circuit code | Full name | Where required |
+|---|---|---|
+| `IPS-OR` | Isolated Power System — Operating Room | Every anaesthetising location (OR, catheter lab, certain imaging rooms) |
+| `IT-CARD` | IT-type isolated system for cardiac-protected areas | ICU, CCU, NICU — any room where cardiac microshock risk must be eliminated |
+
+### ELC_* parameters for EES classification
+
+These parameters are set on electrical outlet families, circuit panels, and ATS units.
+
+| Parameter | Where it is set | What it records |
+|---|---|---|
+| `ELC_EES_BRANCH_TXT` | On electrical outlets, circuit panels, ATS units | The EES branch classification: `LIFE-SAFETY`, `CRITICAL`, `EQUIPMENT`, `NORMAL` (not essential) |
+| `ELC_ATS_TRANSFER_TIME_S_NR` | On ATS units | The measured or design transfer time in seconds. Must be ≤ 10 s for LS and CR branches |
+| `ELC_IPS_BOOL` | On distribution panels and outlets in ORs and wet procedure rooms | Is this circuit on an Isolated Power System? `Yes` / `No` |
+| `ELC_CARDIAC_PROT_BOOL` | On receptacles in ICU and NICU | Is this outlet in a cardiac-protected (IT-CARD) circuit? `Yes` / `No` |
+| `ELC_GENERATOR_RUNTIME_HRS_NR` | On generator sets | Declared runtime on full tank of fuel in hours. Must be ≥ 24 h under NFPA 110 |
+| `ELC_UPS_BATTERY_REPLACE_DT` | On UPS units | The date when the UPS battery was last replaced |
+
+### Setting up EES classification
+
+**Step 1.** Select all patient-care receptacles (duplex outlets, socket outlets) in patient rooms, ICU bays, operating theatres, catheter labs, and treatment rooms. Use STING panel > SELECT > **Select by Category** > Electrical Equipment.
+
+**Step 2.** Use **BulkParamWrite** to set `ELC_EES_BRANCH_TXT` on these outlets:
+- OR outlets: `CRITICAL`
+- ICU outlets: `CRITICAL`
+- AIIR outlets: `CRITICAL`
+- General ward outlets: `CRITICAL` (patient-care area)
+- Corridor exit lighting: `LIFE-SAFETY`
+- Nurse call panels: `LIFE-SAFETY`
+- Fire alarm devices: `LIFE-SAFETY`
+
+**Step 3.** Set `ELC_IPS_BOOL = Yes` on all panels and outlets in `OR-ULTRA`, `OR-CONV`, `CATHLAB`, and other anaesthetising locations.
+
+**Step 4.** Set `ELC_CARDIAC_PROT_BOOL = Yes` on all receptacles in `ICU`, `CCU`, and `NICU` rooms.
+
+**Step 5.** Set `ELC_ATS_TRANSFER_TIME_S_NR` on all ATS units. Design value: ≤ 10 s (measured during commissioning).
+
+### Running the EES Branch Audit
+
+**Step 1.** STING panel > Healthcare > **EES Branch Audit** (or `EesBranchAuditCommand`).
+
+**Step 2.** The validator checks:
+
+| Check | Pass criterion | Fail action |
+|---|---|---|
+| All patient-care receptacles classified | `ELC_EES_BRANCH_TXT` set (not empty) on all outlets in clinical rooms | Error: classify all unclassified outlets. Use BulkParamWrite by room type. |
+| OR circuits on CRITICAL branch | All outlets in `OR-*` rooms: `ELC_EES_BRANCH_TXT = CRITICAL` | Error: update OR circuit classification. |
+| IPS declared in ORs | `ELC_IPS_BOOL = Yes` on at least one panel in each `OR-*` room | Error: add IPS panel family to OR. Set `ELC_IPS_BOOL = Yes`. |
+| ATS transfer time ≤ 10 s | `ELC_ATS_TRANSFER_TIME_S_NR ≤ 10` on all LIFE-SAFETY and CRITICAL branch ATSs | Warning (pre-commissioning) / Error (after commissioning): replace slow ATS or adjust settings. |
+| Cardiac-protected circuits in ICU | `ELC_CARDIAC_PROT_BOOL = Yes` on ICU and NICU outlets | Error: update ICU outlet classification. |
+| Generator runtime ≥ 24 h | `ELC_GENERATOR_RUNTIME_HRS_NR ≥ 24` on all standby generators | Warning: size or fuel tank is insufficient for NFPA 110 compliance. |
+
+**Step 3.** Fix all errors. Submit warnings for Authorising Engineer (Electrical) review.
+
+> **Cross-reference:** For the full electrical system design workflow including circuit modelling, riser diagrams, and panel schedules, see **ELECTRICAL_WORKFLOW_GUIDE.md**. This chapter covers only the healthcare EES compliance layer.
+
+---
+
+## Chapter 6 — Anti-Ligature Design (Mental Health)
+
+### What anti-ligature means
+
+A ligature point is any object that a person could attach a rope, cord, or other material to for the purpose of self-harm. In mental health facilities, every item in patient areas must be designed, selected, and installed to eliminate ligature risks. This includes:
+
+- Door handles (rounded, no projections above 25 mm when forced downward).
+- Coat hooks (designed to fold under load below a set threshold).
+- Curtain rails (continuous tension rail that releases along its full length; no end brackets).
+- Shower heads (anti-ligature shower rose flush-mounted; no riser bar).
+- Light fittings (enclosed, flush-mounted, no exposed brackets).
+- Towel rails (anti-ligature type that collapses under load).
+- Exposed pipework (lagged and boxing where possible; anti-ligature boxing).
+- Bedsteads (specific anti-ligature bed designs only).
+- Observation panels (flush-mounted, no frame projections).
+
+This is not about aesthetics — it is a life-safety requirement governed by HBN 03-01 (UK) and FGI Guidelines Part 2 (US).
+
+### When this applies
+
+The anti-ligature validator is activated when:
+- `PRJ_ORG_HEALTH_PACK_PROFILE_TXT` is set to `MENTAL-HEALTH`, `FULL`, or `ACUTE` (where the project includes a mental health unit).
+- `CLN_LIGATURE_RES_BOOL = Yes` is set on one or more rooms.
+
+The parameters that record anti-ligature compliance are on the **fitting or fixture element**, not on the room. For example, the anti-ligature rating is set on the door handle family, the coat hook family, or the shower unit family — not on the room itself.
+
+| Parameter | Location | What it records |
+|---|---|---|
+| `LIG_PRODUCT_RATING_TXT` | On the fixture/fitting element | The anti-ligature product rating (e.g. `BS 9263 LR1`, `LR2`, `LR3`, `LR4`) |
+| `LIG_SELF_CLOSE_BOOL` | On door and closure elements | Whether the fitting self-closes |
+| `LIG_PRESSURE_REL_BOOL` | On hooks, rails, and handles | Whether the fitting releases under load |
+| `LIG_FORCE_LIMIT_KG_NR` | On hooks, rails, and handles | The load in kilograms at which the fitting releases |
+| `LIG_AREA_OBS_LOS_TXT` | On room or zone elements | The observation line-of-sight code for the area |
+
+### Running the Anti-Ligature Audit
+
+**Step 1.** Ensure all rooms requiring anti-ligature design have `CLN_LIGATURE_RES_BOOL = Yes` and `CLN_LIG_RISK_LVL_TXT` set.
+
+**Step 2.** Ensure all fittings in those rooms have `LIG_PRODUCT_RATING_TXT` set. Use **AutoTag** and **BulkParamWrite** to populate these from family type parameters where the family is already rated.
+
+**Step 3.** STING panel > Healthcare > **Anti-Ligature Audit** (or run `AntiLigatureValidator` via `RunAllHealthcareValidators`).
+
+**Step 4.** The validator reports:
+- **Red (Errors)**: fittings in anti-ligature rooms with no `LIG_PRODUCT_RATING_TXT` — these must be rated before handover.
+- **Amber (Warnings)**: fittings where `LIG_PRODUCT_RATING_TXT` is present but `LIG_PRESSURE_REL_BOOL` is not set.
+- **Observation gaps**: rooms where the observation line-of-sight does not provide full room coverage.
+
+**Step 5.** For each non-compliant fitting:
+- Select the element in Revit.
+- Set `LIG_PRODUCT_RATING_TXT` to the product's rated value (from the manufacturer's certificate).
+- Set `LIG_PRESSURE_REL_BOOL = Yes` and `LIG_FORCE_LIMIT_KG_NR` if the fitting is load-release type.
+
+**Step 6.** Re-run the audit until zero red findings remain.
+
+> **Stuck?** If the validator reports "No anti-ligature rooms found" but you have set `CLN_LIGATURE_RES_BOOL = Yes` on rooms, check that the `LIG_BEHAVIOURAL` parameter group has been loaded. Re-run **Load Shared Params** and confirm the group appears in the parameter browser.
+
+### WORKFLOW_AntiLigatureAudit
+
+The `WORKFLOW_AntiLigatureAudit.json` preset:
+
+| Step | STING action | Your action |
+|---|---|---|
+| Build psy-room set | STING identifies all rooms with `CLN_LIGATURE_RES_BOOL = Yes` | Confirm room list is complete |
+| Load fittings | STING collects all family instances in those rooms | Confirm family placement is complete |
+| Check product rating | Validator checks `LIG_PRODUCT_RATING_TXT` on every fitting | Review red findings; update missing ratings |
+| Check observation LOS | Validator checks sightline coverage | Architect confirms sightlines with room layout |
+| Produce risk register | STING generates an anti-ligature risk register document | Sign and issue as part of commissioning pack |
+
+---
+
+## Chapter 7 — Radiation Protection (Imaging and Nuclear Medicine)
+
+### When radiation shielding applies
+
+Ionising radiation is used for diagnosis (X-rays, CT, PET, nuclear medicine scans) and treatment (radiotherapy). The biological hazard from ionising radiation requires that rooms housing radiation sources be shielded so that the dose to staff and members of the public in adjacent spaces remains within regulatory limits.
+
+In the UK, the Ionising Radiations Regulations 2017 (IRR17) designates spaces near radiation sources as **Controlled Areas** (where occupational workers may receive doses up to 6 mSv/year) or **Supervised Areas** (lower dose, general precautions). In the US, 10 CFR 20 governs.
+
+STING implements the NCRP 147 calculation method for diagnostic radiology shielding. This is the most widely used method internationally, covering X-ray rooms, CT suites, fluoroscopy rooms, and cath labs.
+
+**Important caveat before you use the calculator:** STING's radiation calculator is a planning tool. It provides a draft shielding design for review by a Qualified Expert (QE) — a medical or health physicist with formal qualifications in radiation protection. Under IRR17 (UK) and 10 CFR 20 (US), the final shielding design must be reviewed and approved by a QE. STING flags any radiation room where `RAD_QE_NAME_TXT` is empty and will not mark shielding as adequate until a QE has signed off.
+
+### RAD_* parameters
+
+Set these parameters on the **walls, doors, and windows** that form the boundary of a radiation-controlled room. These are element-level parameters, not room-level.
+
+| Parameter | What it records | Example value |
+|---|---|---|
+| `RAD_LEAD_MM_NR` | The lead-equivalent thickness in this element (mm Pb) | `2.0` for 2 mm lead |
+| `RAD_BARRIER_TYPE_TXT` | Whether this barrier is primary, secondary, or scatter | `PRIMARY`, `SECONDARY`, `SCATTER`, `LEAKAGE` |
+| `RAD_WORKLOAD_MAWK_NR` | Workload in milliampere-minutes per week (the total X-ray exposure for this room per week) | `600` for a moderate-use chest room |
+| `RAD_USE_FACTOR_NR` | The fraction of time the X-ray beam points at this wall (U factor) | `0.25` for a side wall, `1.0` for the primary wall behind the table |
+| `RAD_OCC_FACTOR_NR` | The fraction of time the adjacent space is occupied (T factor) | `1.0` for an office, `0.05` for a car park |
+| `RAD_DOSE_DESIGN_GOAL_TXT` | Whether the adjacent space is in a controlled or uncontrolled area | `CONTROLLED` (6 mSv/year) or `UNCONTROLLED` (0.3 mSv/year) |
+| `RAD_QE_NAME_TXT` | The name of the Qualified Expert who reviewed and approved this shielding design | `Dr Jane Smith, MIPEM` |
+| `RAD_QE_DT` | The date of the Qualified Expert's sign-off | `2026-09-20` |
+
+Also set on the Room element:
+
+| Parameter | What it records |
+|---|---|
+| `CLN_RAD_CONTROLLED_BOOL` | Is this room designated as an IRR17 Controlled Area? |
+| `CLN_MRI_ZONE_INT` | For MRI suites: which zone (1 to 4) is this room in? |
+| `CLN_RF_SHIELD_BOOL` | Does this room have RF shielding (MRI Faraday cage)? |
+
+### The NCRP 147 shielding calculator
+
+**How NCRP 147 works (in plain English):**
+
+The NCRP 147 method calculates the thickness of shielding material needed to reduce radiation to the design dose limit in the adjacent space. It uses four inputs:
+
+1. **Workload (W)**: how much X-ray exposure happens per week, measured in milliampere-minutes per week. A busy chest X-ray room might have W = 1,000 mA·min/week. A CT scanner runs much higher workloads than plain film.
+
+2. **Use factor (U)**: what fraction of the time does the beam point at this particular wall? For the wall directly behind the table (the primary wall), U = 1.0. For a side wall, U = 0.25. For the floor, U = 1.0 for rooms with an X-ray table pointing downward.
+
+3. **Occupancy factor (T)**: what fraction of the time is the adjacent space occupied? An office is T = 1.0 (occupied all day). A toilet is T = 0.05. An unoccupied storage room is T = 0.025.
+
+4. **Design dose goal**: the maximum acceptable annual dose in the adjacent space. For uncontrolled areas (corridors, offices, public spaces) this is typically 0.3 mSv/year (the "1 mSv/year public dose limit" divided by the occupancy-adjusted fraction).
+
+The calculator takes these four inputs and outputs the required thickness in mm of lead (Pb-equivalent). Other materials (concrete, barium plaster, gypsum board) are then converted using published transmission data.
+
+**Running the calculation:**
+
+**Step 1.** Select the wall, door, or window element you want to calculate shielding for.
+
+**Step 2.** STING panel > Healthcare > **Rad Calc** (or run `RadCalcChestRoomCommand` for a plain X-ray room, `RadCalcCtRoomCommand` for a CT suite).
+
+**Step 3.** The calculator dialog opens. Fill in the fields:
+- **Source type**: select the X-ray tube energy (70 kVp, 100 kVp, 125 kVp, 150 kVp, or 200 kVp for CT).
+- **Workload W (mA·min/week)**: enter the weekly workload. Your radiologist or equipment manufacturer can provide this. Typical values: chest room 1,000; fluoroscopy room 3,000; CT 40,000.
+- **Use factor U**: enter the fraction appropriate for this wall. Side wall = 0.25; primary wall = 1.0; floor = 1.0; ceiling = 0.05.
+- **Occupancy factor T**: enter the fraction for the adjacent space. Office, consultation room = 1.0; corridor = 0.2; outside area = 0.05.
+- **Design dose goal**: select Controlled (6 mSv/year) or Uncontrolled (0.3 mSv/year).
+
+**Step 4.** Click **Calculate**. STING outputs:
+- Required mm Pb (lead-equivalent).
+- Approximate concrete thickness equivalent.
+- A note about barium plaster (specialist — refer to manufacturer data).
+
+**Step 5.** STING writes the required mm Pb to `RAD_LEAD_MM_NR` on the selected element as a design note. The actual construction detail must be confirmed by the QE.
+
+**Step 6.** Send the calculations to your Qualified Expert for review. They will confirm or revise the values and complete `RAD_QE_NAME_TXT` and `RAD_QE_DT`.
+
+> **Stuck?** If the calculator gives no output, check that `RAD_BARRIER_TYPE_TXT` is set on the element and that a source type is selected. The calculator requires both.
+
+### The mandatory QE sign-off
+
+STING's `RadShieldValidator` will flag any radiation room where:
+- `RAD_QE_NAME_TXT` is empty on any barrier element around the room.
+- `RAD_LEAD_MM_NR` on any barrier is less than the calculated required value (i.e. the provided shielding is insufficient for the declared W·U·T inputs).
+
+**These are blocking errors** — the commissioning workflow will not complete until the QE has signed off all radiation rooms. This is deliberate and mirrors the legal requirement under IRR17 and 10 CFR 20.
+
+### Advanced radiation shielding (PET, nuclear medicine, brachytherapy)
+
+For PET scanners, nuclear medicine (SPECT/gamma camera), and brachytherapy (sealed source radiotherapy), the shielding requirements are significantly different from diagnostic X-ray. PET uses 511 keV photons from positron annihilation — much higher energy than diagnostic X-ray, requiring far more concrete per equivalent Pb value. NCRP 151 governs these advanced modalities.
+
+STING's `AdvancedRadShieldValidator` checks rooms of class `PET-HOT-LAB`, `NM-SCAN`, and `BRACHYTHERAPY`. It warns any `RAD_LEAD_MM_NR` value on a PET room that appears to have been calculated using NCRP 147 (diagnostic X-ray curves) rather than NCRP 151 (511 keV curves).
+
+All advanced radiation shielding outputs require QE sign-off regardless of source type.
+
+---
+
+## Chapter 8 — Clinical Equipment (CEQ)
+
+### What clinical equipment management covers
+
+A large acute hospital can contain 15,000 to 40,000 pieces of clinical equipment — from MRI scanners weighing 15 tonnes to individual ECG electrodes. Each item needs to be tracked through its lifecycle: procured, installed, commissioned, maintained, calibrated, decontaminated, and eventually replaced. In the BIM model, every piece of clinical equipment should be placed as a Revit family with its services connections (power, water, gas) modelled.
+
+STING tracks clinical equipment through a combination of the standard `ASS_*` (asset) parameters and the new `CEQ_*` (clinical equipment) parameters added by the Healthcare Pack.
+
+### CEQ_* parameters for clinical equipment
+
+| Parameter | What it records | Example value |
+|---|---|---|
+| `CEQ_CATEGORY_TXT` | High-level equipment category | `IMAGING`, `PENDANT`, `BEDHEAD`, `PHARMACY`, `DIAL`, `MORT`, `MOBIL` |
+| `CEQ_GMDN_CODE_TXT` | Global Medical Device Nomenclature code — a worldwide standard identifier for medical device types | `35977` for an anaesthetic machine |
+| `CEQ_UMDNS_CODE_TXT` | ECRI UMDNS code — alternative international identifier for medical devices | `11-977` |
+| `CEQ_SFG20_REF_TXT` | SFG20 healthcare maintenance schedule identifier — links this equipment to its PPM schedule | `SFG20-HC-ANA-01` |
+| `CEQ_CLINICAL_BOOL` | Does this item count as a clinical asset for the asset register? | `Yes` / `No` |
+| `CEQ_INFECT_TIER_TXT` | Spaulding infection risk tier — determines the level of decontamination required | `CRITICAL` (must be sterilised), `SEMI-CRITICAL` (high-level disinfection), `NON-CRITICAL` (low-level disinfection) |
+| `CEQ_DECON_METHOD_TXT` | The required decontamination method for this equipment | `AUTOCLAVE`, `AER-ENDO`, `WIPE-DOWN`, `SINGLE-USE` |
+
+In addition, the standard `ASS_*` parameters are used for:
+- `ASS_MANUFACTURER_TXT` — equipment manufacturer name.
+- `ASS_MODEL_NR_TXT` — model number.
+- `ASS_SERIAL_NR_TXT` — serial number (after commissioning).
+- `ASS_BARCODE_TXT` — asset barcode or QR code reference.
+- `ASS_MAINTENANCE_FREQUENCY_MONTHS` — PPM interval in months.
+
+> **Cross-reference:** For placing clinical equipment families, see **MEP_FOUNDATION_GUIDE.md, Chapter 3 (Placement Centre)**. This chapter covers the healthcare-specific parameter layer.
+
+### The Spaulding classification
+
+The Spaulding classification is a system used in hospitals worldwide to determine how intensively a piece of equipment must be decontaminated between patient uses. It was developed by Dr Earle Spaulding in 1968 and remains the foundation of healthcare decontamination policy globally.
+
+| Spaulding tier | Set as `CEQ_INFECT_TIER_TXT` | What it means | Decontamination required |
+|---|---|---|---|
+| Critical | `CRITICAL` | Enters sterile tissue or the vascular system (surgical instruments, catheters) | Sterilisation (autoclave or EO gas) |
+| Semi-critical | `SEMI-CRITICAL` | Contacts mucous membranes or non-intact skin (endoscopes, laryngoscopes, respiratory equipment) | High-level disinfection (AER or chemical soak) |
+| Non-critical | `NON-CRITICAL` | Contacts intact skin only (blood pressure cuffs, ECG leads, stethoscopes) | Low-level disinfection (wipe down) |
+
+### The 50 COBie clinical equipment types
+
+The Healthcare Pack adds 50 clinical equipment types to STING's COBie export (`COBIE_TYPE_MAP.csv`). These types link each equipment category to its COBie classification, Uniclass 2015 code, and SFG20 maintenance schedule reference. The COBie export includes these in the TYPE worksheet for FM handover.
+
+Examples:
+
+| COBie type | Equipment | Uniclass 2015 | SFG20 ref |
+|---|---|---|---|
+| `Medical Gas Terminal Unit` | Bedside gas outlet | Pr_40_50_16 | SFG20-HC-MG-TU |
+| `Anaesthetic Machine` | Anaesthesia workstation | Pr_70_65_97 | SFG20-HC-ANA-01 |
+| `MRI System` | MRI scanner | Pr_70_65_61_18 | SFG20-HC-RAD-MRI |
+| `Autoclave` | Steriliser | Pr_70_50_02 | SFG20-HC-SSD-AUTO |
+| `Dialysis Machine` | Haemodialysis unit | Pr_70_65_26 | SFG20-HC-DIA-01 |
+| `Ceiling Pendant — ICU` | Patient monitoring pendant | Pr_40_50_16 | SFG20-HC-PEN-ICU |
+
+---
+
+## Chapter 9 — Room Data Sheets (RDS)
+
+### What an RDS is
+
+A Room Data Sheet is a single document — typically one to four pages — that records everything about one clinical room type. It is the primary coordination document between architect, engineer, specialist designer, and clinical client. The RDS records:
+
+- Room dimensions and orientation.
+- Required ventilation regime, air changes, and temperatures.
+- Services connections (medical gases, specialist electrical outlets, water points).
+- Equipment list (all items that must be provided in the room).
+- Finish specifications (floor, walls, ceiling, coving, doors).
+- Environmental requirements (noise rating, lighting levels, colour rendering).
+- Access and safety requirements (access restriction, anti-ligature, observation).
+- Sign-off fields for architect, engineer, and clinician.
+
+A large acute hospital might have 150 distinct room types, each with its own RDS. Managing these manually in Word documents is error-prone and slow. STING generates them automatically from the BIM model parameters.
+
+### What STING's RDS engine produces
+
+STING's `RdsRenderer` reads the clinical parameters from every Room element in the model and renders a populated `.docx` file for each room type using the `health_rds.docx` template. The generated files are placed in `<project>/_BIM_COORD/generated/` with names like `YYYYMMDD_RDS_OR-ULTRA_1.docx`.
+
+The template uses the MiniWord token system. Tokens look like `{{room.number}}` in the template and are replaced with the actual values from the model. The key tokens include:
+
+| Token | Parameter source |
+|---|---|
+| `{{room.number}}` | Revit room number |
+| `{{room.name}}` | Revit room name |
+| `{{room.area}}` | `ASS_ROOM_AREA_SQ_M` |
+| `{{room.health_class}}` | `CLN_ROOM_CLASS_TXT` |
+| `{{room.hbn_ref}}` | `CLN_HBN_REF_TXT` |
+| `{{room.press.regime}}` | `CLN_PRESS_REGIME_TXT` |
+| `{{room.press.delta_pa}}` | `CLN_PRESS_DELTA_DESIGN_PA_NR` |
+| `{{room.ach.req}}` | `HVC_AIR_CHANGES_PER_HR` |
+| `{{room.temp.design_c}}` | `PER_ENVIRONMENTAL_TEMP_DESIGN_C` |
+| `{{room.noise.nr}}` | `CLN_NOISE_NR_NR` |
+| `{{room.lighting.lux}}` | `LTG_DESIGN_ILLUMINANCE_LUX` |
+| `{{room.fire_comp}}` | `FLS_COMPARTMENT_ID_TXT` |
+| `{{room.lig.risk}}` | `CLN_LIG_RISK_LVL_TXT` |
+| Equipment list | Loop over `CEQ_*` elements in the room |
+| Services connections | Loop over `MGS_*` and `ELC_*` elements in the room |
+| Finishes | `BLE_ROOM_FINISH_FLOOR_TXT`, `BLE_ROOM_FINISH_WALL_TXT`, `BLE_ROOM_FINISH_CEILING_TXT` |
+| Sign-offs | `signoff.architect`, `signoff.clinician`, `signoff.date` |
+
+> **Note:** The `health_rds.docx` template must be authored separately — STING provides an authoring guide showing how to build the Word template with the correct token syntax. Once the template exists in `<project>/_BIM_COORD/templates/`, STING renders it automatically.
+
+### The mandatory RDS parameters
+
+The `RdsCompletenessValidator` checks that every Room classified as clinical has all mandatory fields filled before RDS generation is attempted. A room with missing mandatory fields will block its own RDS generation.
+
+| Parameter | Why mandatory | What to fill in |
+|---|---|---|
+| `CLN_ROOM_CLASS_TXT` | Cannot generate RDS without knowing the room type | Set the appropriate class code (e.g. `OR-CONV`, `AIIR`, `WARD-INPT`) |
+| `CLN_HBN_REF_TXT` | Clinical client needs the standards reference | Enter the HBN room reference (e.g. `HBN 04-01 Section 3.2`) |
+| `CLN_PRESS_REGIME_TXT` | Ventilation engineer needs the pressure regime | `POS`, `NEG`, or `NEUTRAL` |
+| `HVC_AIR_CHANGES_PER_HR` | Mechanical engineer needs the ACH requirement | Enter the required ACH (e.g. `20` for an OR, `12` for an AIIR) |
+| `PER_ENVIRONMENTAL_TEMP_DESIGN_C` | Mechanical engineer needs the design temperature | Enter the design temperature in Celsius |
+| `ASS_ROOM_AREA_SQ_M` | Area is fundamental to all clinical standards | Populated automatically from the Revit Room area if Room is placed; or enter manually |
+| `BLE_ROOM_FINISH_FLOOR_TXT` | Infection control requires a defined floor finish specification | Enter the finish specification (e.g. `Vinyl sheet — welded seam — coved`) |
+
+### Generating Room Data Sheets step by step
+
+**Step 1.** Ensure all rooms have `CLN_*` parameters filled. The fastest way is to use **BulkParamWrite** by room type.
+
+**Step 2.** Run **RDS Completeness Check**:
+- STING panel > Healthcare > **RDS Completeness Check** button.
+- The validator lists every mandatory field that is missing, grouped by room.
+- Red rows are blocking errors. Amber rows are warnings that will generate incomplete RDS documents.
+
+**Step 3.** Fix all red findings. Re-run the completeness check until it shows zero red rows.
+
+**Step 4.** Run **Batch Issue RDS**:
+- STING panel > Healthcare > **Batch Issue Room Data Sheets** button (or run `BatchIssueRoomDataSheetsCommand`).
+- A dialog appears showing how many rooms will be processed and how many room types are represented.
+- Click **Generate**.
+- STING renders one `.docx` per room type and saves them to `_BIM_COORD/generated/`.
+
+**Step 5.** Open the generated documents and review. Check that all token values have populated correctly. Empty fields indicate missing parameters — return to Step 2.
+
+**Step 6.** Issue the RDS documents via the Document Manager. See **DOCUMENT_MANAGER_GUIDE.md** for the full document issue workflow. Use document type `Room Data Sheet (E17)` and suitability code `S2` (suitable for information) for initial issue, advancing to `S4` (suitable for construction) after clinical sign-off.
+
+> **Stuck?** If RDS generation fails with a "template not found" error, the `health_rds.docx` template has not been placed in the `_BIM_COORD/templates/` folder. Either author the template (see the authoring guide) or contact your BIM manager who should have placed it as part of project setup.
+
+### WORKFLOW_RdsIssue
+
+The `WORKFLOW_RdsIssue.json` preset automates the RDS generation and issue sequence:
+
+| Step | STING action | Your action |
+|---|---|---|
+| Refresh tag tokens | AutoTag updates `CLN_*` tokens from current model | Review any changed values |
+| Recompute room areas | STING recalculates `ASS_ROOM_AREA_SQ_M` from Room boundaries | Confirm room boundaries are correct |
+| Fetch ADB cross-refs | STING populates `CLN_ADB_CODE_TXT` from the ADB room-type table | Review ADB codes for accuracy |
+| Render RDS docs | `BatchIssueRoomDataSheetsCommand` runs | Review generated .docx files |
+| Audit and sign-off | Pauses for clinical review | Clinician reviews each RDS and approves |
+| Issue | Documents issued via Document Manager | Issue to suitability code S2 or S4 |
+
+---
+
+## Chapter 10 — Healthcare Commissioning Workflows
+
+### The 8 built-in healthcare workflow presets
+
+STING ships eight workflow presets for healthcare commissioning. Each one chains a sequence of validation, documentation, and sign-off steps. They are run from the STING panel > BIM tab > **Workflow Presets** dropdown.
+
+| Workflow name | What it covers | Who runs it | Standards reference |
+|---|---|---|---|
+| `WORKFLOW_HealthcareCommissioning` | The full commissioning sequence: RDS → adjacency → pressure → MGPS → EES → water safety → anti-ligature → COBie → handover | BIM Manager or Project Engineer | HBN 00, HTM series |
+| `WORKFLOW_MgasVerification` | MGPS 12-step verification record per zone | Authorising Engineer (Medical Gas) with ASSE 6030 verifier | NFPA 99 §5.1.12, HTM 02-01 Part A |
+| `WORKFLOW_PressureRegimeAudit` | Ventilation pressure regime cascade audit | Authorising Engineer (Ventilation) | HTM 03-01, ASHRAE 170 |
+| `WORKFLOW_RdsIssue` | Room Data Sheet generation and issue | BIM Manager + Clinical Sign-off | HBN 00-01, ADB |
+| `WORKFLOW_HTM-04-01-Annual` | Annual water safety inspection (sentinel flush logs, TMV3 checks, augmented care review) | Authorising Engineer (Water) | HTM 04-01 Parts A/B/C |
+| `WORKFLOW_AntiLigatureAudit` | Mental health anti-ligature assessment and risk register | Mental Health Architect + Clinician | HBN 03-01, FGI Part 2 |
+| `WORKFLOW_NFPA110-GeneratorTest` | Emergency power generator weekly exercise test log | Facilities / Estates | NFPA 110, NFPA 99 §6.4.2 |
+| `WORKFLOW_HTM-01-06-EndoReprocess` | Endoscope decontamination traceability chain audit | Decontamination Lead + SHTM variant if Scotland | HTM 01-06 Parts A/B/C |
+
+### Running a commissioning workflow step by step
+
+**Step 1.** In the STING panel, navigate to the **BIM** tab. Click the **Workflow Presets** dropdown.
+
+**Step 2.** Select the workflow you want to run. A dialog opens showing:
+- The name and purpose of the workflow.
+- A numbered list of every step, with each step's automation level (Automated, Semi-automated, Manual).
+- The estimated time to complete (where STING can calculate it from previous runs).
+
+**Step 3.** Review the step list. If a step is marked Manual, you must complete it on-site or with physical test equipment — STING cannot automate a pressure gauge reading.
+
+**Step 4.** Click **Run**. STING executes the automated steps immediately. When it reaches a manual step, it pauses and shows you:
+- What you need to do (for example: "Measure the differential pressure at the AIIR sensor and enter the reading below").
+- Where to find the relevant element in the model (STING can zoom to it).
+- The expected value range (from the design parameters).
+
+**Step 5.** Complete each manual step and enter the result. Click **Continue** to proceed to the next step.
+
+**Step 6.** When the workflow completes, STING saves a `WorkflowRunRecord` to `_BIM_COORD/workflow_state.json` with the date, step results, operator names, and pass/fail status. This is your commissioning audit trail.
+
+### The WORKFLOW_HealthcareCommissioning preset — full walkthrough
+
+This is the master commissioning workflow that chains all other checks. It is typically run at RIBA Stage 5 (Construction) leading into Stage 6 (Handover).
+
+| Step | What STING does automatically | What you must do |
+|---|---|---|
+| 1. RDS completeness gate | Runs `RdsCompletenessValidator`. Blocks if any clinical room has missing mandatory parameters. | Fix any red findings from the completeness report before proceeding. |
+| 2. Adjacency audit | Runs `AdjacencyValidator`. Checks that OR is adjacent to HSDU, ED is adjacent to Imaging, Mortuary is remote, Pharmacy is central. | Review the adjacency report. Flag any non-compliant adjacencies to the clinical team and architect. |
+| 3. Pressure regime audit | Runs `PressureRegimeValidator`. Checks all pressure cascades. | Review the cascade report. Fix any inverted cascades or missing anterooms. |
+| 4. MGPS audit | Runs `MgasFlowValidator`. Checks flow adequacy, pressure drop, cross-connection protection. | Review flow solver results. Upsize any undersized pipes in Revit. |
+| 5. EES audit | Runs `EesBranchValidator`. Checks that all patient-care receptacles are on LIFE-SAFETY or CRITICAL branch, ATS time ≤ 10 s. | Review EES branch report. Update `ELC_EES_BRANCH_TXT` on any incorrectly classified circuits. |
+| 6. Water safety audit | Runs `WaterSafetyValidator`. Checks TMV types, dead-leg distances, augmented care status, sentinel designation. | Review water safety report. Flag any dead legs > 1 m for remediation. |
+| 7. Anti-ligature audit | Runs `AntiLigatureValidator` (only if facility profile includes mental health). | Review anti-ligature report. Update `LIG_PRODUCT_RATING_TXT` on any non-rated fittings. |
+| 8. RDS generation | Runs `BatchIssueRoomDataSheetsCommand`. Generates all RDS documents. | Review all generated RDS documents. Obtain clinical sign-off. |
+| 9. COBie export | Runs the Hospital-NHS COBie preset. Generates the full COBie handover spreadsheet. | Review the COBie output and pass to the FM client. |
+| 10. Handover manual | Runs `HandoverManualCommand`. Assembles the FM/O&M handover package. | Review and issue the handover package via Document Manager. |
+
+### WORKFLOW_HTM-04-01-Annual — full walkthrough
+
+The annual water safety workflow implements the HTM 04-01 Part C schedule of inspections. It is run once per year (and additionally whenever a high-risk Legionella finding is made). Who runs it: the Authorising Engineer (Water) or a trained Water Safety Group member.
+
+**Before running this workflow:** confirm that `PLM_SENTINEL_BOOL = Yes` is set on all sentinel sampling points. These are typically one outlet per floor on the rising main, and one on each branch. If they are not designated, the workflow will flag "No sentinel points found" and you will not be able to complete Step 3.
+
+| Step | Automation | What STING does | What you must do |
+|---|---|---|---|
+| 1. System map refresh | Automated | STING traces all `PLM_*` plumbing systems and rebuilds the pipe network graph | Confirm all new pipework added since last audit is modelled |
+| 2. Augmented care check | Automated | WaterSafetyValidator checks `PLM_AUGMENTED_CARE_BOOL = Yes` on all ICU, NICU, transplant, haematology rooms | Confirm augmented care rooms are correctly flagged |
+| 3. Sentinel flush logs | Semi-automated | STING opens a log dialog per sentinel point; reads last-logged flush date from `PLM_FLUSH_LOG_REF_TXT` | Confirm each sentinel point has been flushed this week (or that the flush is logged in the linked system). Enter pass/fail |
+| 4. TMV3 survey | Semi-automated | WaterSafetyValidator lists all `PLM_TMV_TYPE_TXT` values. Flags any augmented-care outlet without `TMV3` | Check each flagged outlet on-site. Replace TMV2 with TMV3 where required |
+| 5. Temperature checks | Manual | STING opens a temperature entry dialog per sentinel point | Measure hot-water temperature at each sentinel outlet. Enter readings. STING flags any outside 50–60 °C |
+| 6. Dead-leg survey | Automated | STING calculates estimated pipe length to each outlet from the network graph. Flags outlets where dead-leg > 1 m | Review flagged outlets. Arrange remediation of any dead legs > 1 m in augmented care |
+| 7. RO loop check (dialysis only) | Automated | STING checks that all `DIAL` rooms connect only to `PLM_DIALYSIS_RO_LOOP_BOOL = Yes` outlets | Confirm dialysis stations are on RO loop |
+| 8. Point-of-use filter check | Automated | STING checks `PLM_POU_FILTER_BOOL = Yes` on all augmented care outlets | Confirm filters are present on all flagged outlets. Enter last-changed date |
+| 9. Generate water safety log | Automated | STING generates the annual water safety report with all readings, pass/fail status, and outstanding actions | Sign the report (Authorising Engineer sign-off field) |
+| 10. Issue and archive | Automated | STING issues the report via Document Manager as a `D15 Progress Report` with suitability `S4` | Distribute to the Water Safety Group and maintain on the estates file |
+
+### WORKFLOW_PressureRegimeAudit — full walkthrough
+
+| Step | Automation | What STING does | What you must do |
+|---|---|---|---|
+| 1. Build room adjacency graph | Automated | STING identifies all adjacent room pairs by wall and door connections | Confirm room placements are complete and room boundaries close correctly |
+| 2. Cascade validation | Automated | PressureRegimeValidator checks monotonic pressure direction in each department | Review red findings. Add missing anterooms where pressure transitions are invalid |
+| 3. AIIR exhaust check | Automated | STING checks that all NEG rooms have exhaust connected to an `HVC_EXHAUST_TO_OUTSIDE_BOOL = Yes` duct | Confirm exhaust routes are modelled correctly. Do not recirculate AIIR exhaust |
+| 4. ACH cross-check | Automated | STING compares `HVC_AIR_CHANGES_PER_HR` against HTM 03-01 minimums for each room class | Review rooms below the minimum ACH. Update AHU schedules |
+| 5. HEPA certification | Semi-automated | STING checks `HVC_HEPA_GRADE_TXT` on terminal filter units in OR and PE rooms | Confirm HEPA grade is H13 or H14. Enter DOP test dates where available |
+| 6. Produce drift report | Automated | STING generates the pressure regime findings report as a PDF | Sign and issue via Document Manager as a `Pressure Regime Audit (E04)` |
+| 7. Live push (if IoT bridge) | Semi-automated | STING pushes current pressure cascade data to the Planscape mobile app | On-site team can verify live differential pressure readings against design values on mobile |
+
+### WORKFLOW_AntiLigatureAudit — full walkthrough
+
+| Step | Automation | What STING does | What you must do |
+|---|---|---|---|
+| 1. Identify anti-ligature rooms | Automated | STING collects all rooms with `CLN_LIGATURE_RES_BOOL = Yes` | Confirm all mental health bedrooms, en-suites, seclusion rooms, day lounges, and corridors are flagged |
+| 2. Load fittings | Automated | STING collects all family instances (doors, handles, hooks, rails, pendants, light fittings, pipes) in the flagged rooms | Confirm that families have been placed to represent all physical fixtures |
+| 3. Check product ratings | Automated | AntiLigatureValidator checks `LIG_PRODUCT_RATING_TXT` on every fixture | Review unrated fixtures. Contact manufacturers for certificate data. Enter ratings |
+| 4. Check load-release | Automated | STING checks `LIG_PRESSURE_REL_BOOL` and `LIG_FORCE_LIMIT_KG_NR` on hooks, rails, and towel bars | Confirm that load-release fittings are specified. Enter force limits from manufacturer data sheets |
+| 5. Observation line-of-sight | Semi-automated | STING checks `LIG_AREA_OBS_LOS_TXT` per room and models sightlines from nurse station positions | Architect confirms sightline geometry in model. Mark any observation-blind corners |
+| 6. Anti-barricade check | Automated | STING checks that en-suite doors in `PSY-BED` and `SECL` rooms are flagged `LIG_SELF_CLOSE_BOOL = Yes` and have inward/outward release hardware | Confirm door hardware specification. Update `LIG_PRODUCT_RATING_TXT` accordingly |
+| 7. Exposed services check | Automated | STING checks for any unboxed pipe runs, conduit runs, or cable routes in anti-ligature rooms | Engineer reviews flagged elements. Add boxing families or anti-ligature lagging |
+| 8. Risk register | Automated | STING generates the anti-ligature risk register document (one row per room, one column per ligature risk category) | Risk register reviewed and signed by mental health clinician and architect |
+| 9. Issue | Automated | Document issued via Document Manager as `Anti-Ligature Assessment (E18)` | Issue to clinical client for sign-off |
+
+### WORKFLOW_NFPA110-GeneratorTest — full walkthrough
+
+This workflow is used by estates and facilities teams to log the mandatory generator exercise tests required by NFPA 110 and NFPA 99 §6.4.2. It is run weekly (brief 30-minute load test) and monthly (full ATS transfer test under load).
+
+| Step | Automation | What STING does | What you must do |
+|---|---|---|---|
+| 1. Identify EES assets | Automated | STING collects all generators, ATS units, and UPS systems tagged with `ELC_EES_BRANCH_TXT = LIFE-SAFETY` | Confirm all EES plant is tagged |
+| 2. Weekly test log entry | Manual | STING opens the generator test log dialog | Run the generator under a test load. Enter start time, stop time, voltage, frequency, and load percentage. STING flags any test older than 35 days as overdue |
+| 3. ATS transfer test | Manual | STING opens the ATS test dialog | Simulate mains failure. Record transfer time. Enter measured transfer time in seconds. STING flags any ATS with transfer time > 10 s |
+| 4. UPS battery check | Automated | STING reads `ELC_UPS_BATTERY_REPLACE_DT` on all UPS units. Flags any overdue | Enter battery replacement dates. Raise purchase orders for overdue batteries |
+| 5. N+1 redundancy check | Automated | EesResilienceValidator checks that critical Level 1 equipment has N+1 redundancy | Review findings. Note any single-points-of-failure for the Authorising Engineer (Electrical) |
+| 6. Generate test log | Automated | STING generates the NFPA 110 test log record | Sign and file. Upload to estates management system |
+
+### WORKFLOW_HTM-01-06-EndoReprocess — full walkthrough
+
+This workflow is used in endoscopy decontamination units to verify RFID traceability compliance against HTM 01-06 Parts A, B, and C. In Scotland, SHTM 01-06 applies.
+
+| Step | Automation | What STING does | What you must do |
+|---|---|---|---|
+| 1. Identify endoscopy rooms | Automated | STING collects all rooms with `CLN_ROOM_CLASS_TXT = ENDOSCOPY` | Confirm all decontamination rooms (soak, AER, drying cabinet, sterile storage) are modelled |
+| 2. RFID reader position check | Automated | EndoscopeTraceValidator checks that each ENDOSCOPY room has four RFID reader families placed: soak position, AER position, drying position, and storage position | Place RFID reader families at all four positions in the decontamination flow sequence |
+| 3. Dirty-clean flow check | Automated | STING checks that the dirty-clean-sterile flow is non-crossing: soiled scopes enter from the dirty side; decontaminated scopes exit to the sterile side; no crossover | Review AdjacencyValidator findings for endoscopy rooms. Confirm dirty entry and clean exit are on separate sides of the decon room |
+| 4. Scope asset check | Automated | STING checks that all endoscope assets have `ASS_BARCODE_TXT`, `CEQ_GMDN_CODE_TXT`, and `CEQ_SFG20_REF_TXT` populated | Update missing GMDN codes and maintenance references on each scope asset |
+| 5. Cycle count check | Automated | STING reads `ASS_MAINTENANCE_FREQUENCY_MONTHS` and flags scopes with cycle count exceeding manufacturer limits | Replace scopes that have exceeded their operational cycle life |
+| 6. AER validation | Semi-automated | STING checks that AER units have `CEQ_DECON_METHOD_TXT = AER-ENDO` and last validation date is within 12 months | Confirm AER validation certificates are in the document register. Enter last validation date |
+| 7. Generate traceability audit | Automated | STING generates the HTM 01-06 traceability audit report | Decontamination Lead reviews and signs the report |
+| 8. Issue | Automated | Document issued via Document Manager | Issue to clinical team and infection control |
+
+> **Stuck?** If the workflow reports "No endoscopy rooms found" even though you have rooms named "Endoscopy", check that `CLN_ROOM_CLASS_TXT` is set to `ENDOSCOPY` on the rooms (not just a text name). STING looks at the parameter value, not the room name.
+
+### WORKFLOW_MgasVerification — detailed step reference
+
+For the full 12-step NFPA 99 verification, see **Chapter 2** of this guide. The workflow preset chains those steps in this order:
+
+| Step | Automation | Notes |
+|---|---|---|
+| Pre-purge check | Semi-automated | `MGS_PIPE_BRAZED_BOOL` must be set on all joints |
+| Cross-connection test | Manual | Probe every outlet with the opposite gas — must accept no gas |
+| Particulate test | Manual (lab result) | Submit gas samples; enter ISO 8573-1 particle count results |
+| Purity test | Manual (lab result) | Submit oxygen sample to pharmacopoeial standard; enter purity % |
+| Pressure test | Semi-automated | Enter on-site gauge readings; STING compares to design pressure |
+| Indexing check | Manual | Confirm indexed probes reject wrong gas type |
+| Flow test | Semi-automated | MgasFlowSolver runs; enter on-site measured flows |
+| Labelling check | Manual | Walk each zone; confirm all labels match BIM model |
+| ZVB isolation test | Manual | Close each ZVB; confirm correct zone isolates |
+| Area alarm test | Manual | Drop pressure below limit; confirm AAP alarm fires |
+| Master alarm test | Manual | Confirm master alarm panel receives all area alarms |
+| Final documentation | Semi-automated | STING assembles log; verifier signs; certificate reference entered |
+
+---
+
+## Chapter 11 — The 16 Healthcare Validators
+
+### What validators do
+
+A validator is a set of automated checks that STING runs against your model. It reads parameters, measures distances, checks connections, and compares values against standards. Think of it as a knowledgeable colleague who reads every element in your model and tells you what is missing or wrong before the drawings leave your office.
+
+Validators run on demand. They do not slow down your Revit session when you are working — they only check when you ask them to.
+
+**To run all healthcare validators at once:**
+- STING panel > Healthcare > **Run All Healthcare Validators** button (or `RunAllHealthcareValidatorsCommand`).
+- The combined report shows findings from all active validators, sorted by severity.
+- Alternatively, each validator has its own dedicated command for targeted checking (listed below).
+
+### Complete validator reference table
+
+| Validator | Dedicated command | What it checks | Standards | Profiles that activate it | Severity |
+|---|---|---|---|---|---|
+| **PressureRegimeValidator** | `PressureRegimeAuditCommand` | Adjacent room pressure cascades are monotonic; AIIR exhaust goes to outside; PE supply uses HEPA H14; OR meets minimum ACH; linked anterooms form valid pressure buffers | HTM 03-01, ASHRAE 170, CDC | All profiles with clinical rooms | Errors for invalid cascades; Warnings for marginal values |
+| **MgasFlowValidator** | `MgasNetworkAuditCommand` | Diversified flow adequate at each zone valve box; pressure drop ≤ 10% of source pressure; gas-type indexing present on all terminal units; each ZVB serves only one alarm panel; brazing flag set on all copper joints | HTM 02-01, NFPA 99 Ch.5, ISO 7396-1 | FULL, ACUTE, COMMUNITY (if MGPS present) | Errors for cross-connection risk; Warnings for undersized pipes |
+| **EesBranchValidator** | `EesBranchAuditCommand` | Every patient-care receptacle on LIFE-SAFETY or CRITICAL branch; ATS transfer time ≤ 10 s for LS/CR; OR and ICU circuits correctly classified; cardiac-protected outlets in IT-CARD circuit only | NFPA 99 Ch.6, NEC 517, HTM 06-01 | FULL, ACUTE | Errors for uncategorised patient-care circuits; Warnings for ATS time > 10 s |
+| **WaterSafetyValidator** | `WaterSafetyAuditCommand` | HTM 04-01 dead-leg ≤ 1 m for sentinel outlets; TMV3 on all augmented care outlets; DHW flush temperatures 50–60 °C; no blind branches; dialysis stations only on RO-loop | HTM 04-01 Parts A/B/C, ASHRAE 188, BS 8558 | FULL, ACUTE, COMMUNITY | Errors for dead legs > 1 m in augmented care; Warnings for missing TMV designation |
+| **RadShieldValidator** | `RadShieldAuditCommand` | NCRP 147 W·U·T → required mm Pb ≤ provided; QE sign-off present; doors interlocked with beam-on; controlled-area designation correct; MRI 5-Gauss fence geometry present | NCRP 147, IRR17, 10 CFR 20 | FULL, ACUTE, IMAGING-ONLY | Errors for insufficient shielding or missing QE; Warnings for marginal values |
+| **AdjacencyValidator** | `AdjacencyAuditCommand` | HBN-derived adjacency requirements: ED ≤ 3 doors from Imaging; OR ↔ HSDU in same compartment; Mortuary remote; Pharmacy central; clean/dirty flow non-crossing | HBN 00-01, HBN 04-01, HBN 13, FGI Guidelines | FULL, ACUTE | Warnings (not blocking) — adjacency non-conformance reported for clinical review |
+| **AntiLigatureValidator** | `AntiLigatureAuditCommand` | Every fitting in `PSY-*` rooms has `LIG_PRODUCT_RATING_TXT`; observation line-of-sight intact; en-suite door is anti-barricade type; no exposed pipes in bedrooms or seclusion rooms | HBN 03-01, FGI Part 2, BS 9263 | MENTAL-HEALTH, FULL (if mental health wing) | Errors for unrated fittings; Warnings for marginal observation coverage |
+| **RdsCompletenessValidator** | `RdsCompletenessCheckCommand` | All ADB/HBN-required parameters populated on clinical rooms; equipment groups accounted for; room finishes match clinical class; HBN reference present | HBN 00-01, ADB, HTM series | All profiles | Errors for missing mandatory fields; Warnings for incomplete optional fields |
+| **AcousticValidator** | `AcousticAuditCommand` | HTM 08-01 NR target by room class met; FGI/HIPAA STC threshold met; RT60 target vs `CLN_RT60_TARGET_S_NR`; NC curve vs `HVC_NC_CURVE_INT`; sound masking system present when STC < 45 | HTM 08-01, FGI Guidelines, HIPAA | FULL, ACUTE, COMMUNITY, MENTAL-HEALTH | Warnings — acoustic non-conformance reported for review |
+| **StructuralLoadValidator** | `StructuralLoadAuditCommand` | Declared floor load ≥ equipment weight from reference table; vibration criterion specified for imaging rooms; structural sign-off date present before handover | BS EN 1991, manufacturer specs, HTM series | FULL, ACUTE, IMAGING-ONLY | Errors for missing structural sign-off at handover; Warnings for under-declared loads |
+| **AdvancedRadShieldValidator** | `AdvancedRadCalcCommand` | PET 511 keV geometry; SPECT/gamma camera scatter shielding; brachytherapy afterloading vault dose-rate; all using energy-correct transmission factors (not NCRP 147 kV curves) | NCRP 151, IRR17 | FULL, ACUTE, IMAGING-ONLY (if PET/NM/brachytherapy present) | Errors for insufficient 511 keV shielding; Warnings if NCRP 147 curves used for PET room |
+| **IoTStalenessValidator** | `IoTStalenessAuditCommand` | BMS last-seen timestamp > 30 min triggers sensor-fault warning; TMV temperature outside 40–45 °C band triggers scald/Legionella warning; cleanroom cert overdue; radiation area monitor above alert threshold | HTM 04-01, USP <797>, ASHRAE 135 | All profiles (only when IoT bridge configured) | Warnings for stale sensors; Errors for safety-critical alerts |
+| **EndoscopeTraceValidator** | `EndoscopeTraceAuditCommand` | Each ENDOSCOPY room has 4 RFID reader positions modelled (soak, AER, drying, storage); each scope asset has ID, AER reference, and cycle count; decon dirty-clean-sterile flow non-crossing | HTM 01-06 Parts A/B/C, SHTM 01-06 (Scotland) | FULL, ACUTE, COMMUNITY (if endoscopy present) | Errors for missing RFID positions; Warnings for scope cycle count exceeding manufacturer limit |
+| **EesResilienceValidator** | `EesResilienceDashboardCommand` | NFPA 110 weekly generator test log not older than 35 days; monthly ATS transfer test logged; UPS battery replacement date not overdue; N+1 redundancy check on Level 1 EES equipment | NFPA 110, NFPA 99 §6.4.2 | FULL, ACUTE | Errors for overdue generator tests; Warnings for approaching UPS replace date |
+| **RtlsCoverageValidator** | Runs as part of MGPS/Healthcare suite | RTLS anchor coverage adequate per zone; no BLE/Wi-Fi/UWB anchors in RF-shielded rooms; no active wireless in MRI Zone ≥ 3 (blocking error); anchor technology matches room shielding type | Vendor RTLS design guides | FULL, ACUTE (if RTLS specified) | Blocking errors for wireless transmitters in MRI Zone 3/4; Warnings for coverage gaps |
+| **WasteFlowValidator** | `WasteFlowAuditCommand` | `CLN_WASTE_CLASS_TXT` populated per HBN; waste routing from clinical collection points to segregation store does not cross patient or clean supply flow; radioactive waste rooms have `CLN_RAD_CONTROLLED_BOOL = Yes` | HBN 07-01, HTM 07-01, IRR17 | FULL, ACUTE | Warnings for routing conflicts; Errors for radioactive waste in uncontrolled areas |
+
+### Running all validators and reading the combined report
+
+When you run **Run All Healthcare Validators**, STING presents a unified report with four sections:
+
+1. **Blocking Errors** (red): findings that must be resolved before commissioning can proceed. These map to mandatory sign-offs in the commissioning workflow.
+2. **Errors** (orange): findings that must be resolved before issue — they indicate non-compliant design.
+3. **Warnings** (amber): findings that should be reviewed but are not automatically blocking — they may represent design decisions that differ from the standard recommendation, which need a clinical or engineering justification.
+4. **Informational** (blue): notes that may affect downstream processes (for example, a missing ADB code that will cause an incomplete RDS).
+
+**Priority order for fixing findings:**
+1. Fix Blocking Errors first (RTLS in MRI Zone 3/4, radiation shielding below required, AIIR exhaust not to outside).
+2. Fix Errors second (uncategorised EES circuits, dead legs > 1 m, unrated anti-ligature fittings, missing QE sign-off).
+3. Review Warnings with the relevant Authorising Engineer (adjacency, acoustic shortfalls, structural margin).
+4. Action Informational items as part of completeness checking (missing ADB codes, missing HBN references).
+
+---
+
+## Chapter 12 — Healthcare Drawing Types
+
+### The 22 healthcare-specific drawing types
+
+These drawing types are defined in STING's drawing type registry (`STING_DRAWING_TYPES.json`) and are produced using the Drawing Production System. For the full workflow to produce these drawings, see **DRAWING_PRODUCTION_SYSTEM_GUIDE.md**.
+
+| Drawing type ID | Paper / scale | Purpose | When to produce |
+|---|---|---|---|
+| `health-rds-A2` | A2 / No scale | Room Data Sheet — one per clinical room type | RIBA Stage 3 onwards; updated at each stage |
+| `health-eqp-pln-A1-1to50` | A1 / 1:50 | Clinical equipment plan with furniture, fixtures, and equipment callouts | RIBA Stage 4 (Technical Design) |
+| `health-mep-coord-A1-1to50` | A1 / 1:50 | MEP coordination plan with shielding overlay | RIBA Stage 4; updated at Stage 5 |
+| `health-medgas-pln-A1-1to100` | A1 / 1:100 | MGPS layout plan showing pipe routes, ZVBs, alarm panels | RIBA Stage 4 |
+| `health-medgas-schem-A1` | A1 / Schematic | MGPS schematic: zone valves, manifolds, alarms, plant room | RIBA Stage 3 (for approval); updated at Stage 4 |
+| `health-pressure-pln-A1-1to100` | A1 / 1:100 | Pressure regime plan with pressure cascade arrows | RIBA Stage 3; updated at each revision |
+| `health-ess-power-riser-A1` | A1 / Schematic | Essential power single-line diagram (LS/CR/EQ branches, ATS, generator) | RIBA Stage 4 |
+| `health-ips-pln-A1-1to50` | A1 / 1:50 | Isolated power systems layout for OR/ICU | RIBA Stage 4 |
+| `health-decon-flow-A1-1to50` | A1 / 1:50 | Decontamination dirty-clean-sterile flow diagram | RIBA Stage 4; mandatory for HSDU, Endoscopy |
+| `health-mortuary-pln-A2-1to50` | A2 / 1:50 | Mortuary and post-mortem suite plan | RIBA Stage 4 |
+| `health-fire-comp-A1-1to100` | A1 / 1:100 | Fire compartmentation and PHE refuge plan | RIBA Stage 4; mandatory for fire strategy |
+| `health-rad-shield-A1-1to50` | A1 / 1:50 | Radiation shielding plan with mm Pb callouts per barrier element | RIBA Stage 4; updated after QE review |
+| `health-mri-zoning-A1-1to50` | A1 / 1:50 | MRI suite zone 1–4 zoning plan with 5-Gauss line | RIBA Stage 3 (for magnet purchase approval) |
+| `health-ligature-pln-A1-1to50` | A1 / 1:50 | Anti-ligature plan with risk levels by area | RIBA Stage 4; mandatory for mental health projects |
+| `health-bedhead-elev-A2-1to20` | A2 / 1:20 | Bedhead trunking elevations (services, pendants, call points) | RIBA Stage 4 |
+| `health-or-ceiling-A2-1to20` | A2 / 1:20 | Operating theatre ceiling reflected plan with pendant boom positions | RIBA Stage 4 |
+| `health-acoustic-pln-A1-1to100` | A1 / 1:100 | Acoustic zoning plan: NR targets per room, STC of separating walls | RIBA Stage 4 |
+| `health-struct-loads-A1-1to50` | A1 / 1:50 | Structural loading plan: floor live-load zones, point-load callouts, vibration isolation pads | RIBA Stage 4 |
+| `health-infection-ctrl-A1-1to100` | A1 / 1:100 | Infection control classification plan: rooms coloured by class, coving zones, pass-throughs | RIBA Stage 3 onwards |
+| `health-waste-flow-A1-1to100` | A1 / 1:100 | Waste flow diagram: segregation by waste class, chute and collection routes | RIBA Stage 4 |
+| `health-rtls-coverage-A1-1to100` | A1 / 1:100 | RTLS anchor coverage plan: beacon locations, technology type, coverage radii, RF dead zones | RIBA Stage 4 (if RTLS specified) |
+| `health-nm-schem-A1` | A1 / Schematic | Nuclear medicine/PET schematic: dose calibrator, hot lab, decay storage, exhaust routes | RIBA Stage 4 (nuclear medicine only) |
+
+### Healthcare ViewStylePacks
+
+Six ViewStylePacks are included in the Healthcare Pack. Each one applies a consistent set of graphic overrides to make the relevant clinical information immediately readable.
+
+| Pack ID | What it shows | Key visual settings |
+|---|---|---|
+| `corp-healthcare-clinical` | Standard clinical plan | Clinical equipment in saturated colour, non-clinical content lighter, wet-room floors hatched |
+| `corp-healthcare-shielding` | Radiation shielding | Lead-equivalent walls drawn thick; X-ray hazard hatch pattern; MRI 5-Gauss line as red dashed circle; controlled-area halo |
+| `corp-healthcare-pressure` | Pressure regime | Negative-pressure rooms blue tint, positive-pressure rooms red tint, neutral rooms grey; pressure cascade arrows as detail components |
+| `corp-healthcare-fire` | Fire compartmentation | Compartments in primary colours; PHE refuge zones halftoned; smoke-rated lines visually distinct from fire-rated |
+| `corp-healthcare-acoustic` | Acoustic zoning | Room boundaries tinted by acoustic class (sensitive / medium / not-sensitive); STC callout annotation visible at coarse detail |
+| `corp-healthcare-structural` | Structural loads | Floor-load zone polygons in graduated fill intensity; point-load symbols prominent; vibration isolation elements hatched |
+
+> **Cross-reference:** For the full drawing production workflow — creating views, applying drawing types, placing sheets, and issuing — see **DRAWING_PRODUCTION_SYSTEM_GUIDE.md**.
+
+> **Cross-reference:** For document issue and revision management — see **DOCUMENT_MANAGER_GUIDE.md**.
+
+---
+
+## Chapter 13 — Standards References
+
+Understanding which standard governs which aspect of healthcare design helps you respond correctly when a validator raises a finding. The table below lists every standard referenced by the Healthcare Pack.
+
+| Standard | Full title | What it governs | STING validators that reference it |
+|---|---|---|---|
+| **HTM 02-01 Parts A/B** | Medical Gas Pipeline Systems | Design, installation, testing, and maintenance of medical gas systems | MgasFlowValidator |
+| **HTM 03-01 Parts A/B** | Specialist Ventilation for Healthcare Premises | ACH, pressure regimes, HEPA filtration, temperature and humidity ranges | PressureRegimeValidator |
+| **HTM 04-01 Parts A/B/C** | Safe Water in Healthcare Premises | Legionella risk management, dead-leg limits, TMV requirements, augmented care | WaterSafetyValidator |
+| **HTM 05-01/05-02** | Fire Safety / Firecode Functional Provisions | Fire compartmentation, PHE refuges, smoke control strategy | AdjacencyValidator (partial) |
+| **HTM 06-01** | Electrical Services Supply and Distribution | Essential electrical services branches, IPS, isolated power systems | EesBranchValidator |
+| **HTM 01-06 Parts A/B/C** | Decontamination of Flexible Endoscopes | Endoscope reprocessing flow, RFID traceability, AER performance | EndoscopeTraceValidator |
+| **HTM 08-01** | Acoustics in Healthcare Buildings | NR targets by room type, sound insulation, speech privacy | AcousticValidator |
+| **HBN 00-01** | General Design Guidance for Healthcare Buildings | Departmental adjacency, circulation, room-size standards | AdjacencyValidator, RdsCompletenessValidator |
+| **HBN 03-01** | Adult Acute Mental Health and Psychiatric Intensive Care | Anti-ligature design, observation standards, seclusion room design | AntiLigatureValidator |
+| **HBN 04-01** | Adult In-Patient Facilities | Bed-head services, AIIR requirements, isolation room design | PressureRegimeValidator, RdsCompletenessValidator |
+| **HBN 09-02** | Critical Care | ICU bay design, monitoring services, pendant design | RdsCompletenessValidator |
+| **HBN 13** | Sterile Services / HSDU | Dirty-clean-sterile flow, washer-disinfector and autoclave clearances | AdjacencyValidator |
+| **HBN 16** | Mortuary and Post-mortem | Refrigeration capacity, downflow ventilation, remote location | AdjacencyValidator |
+| **NFPA 99 (Health Care Facilities Code)** | Medical gas systems, essential electrical services, isolated power systems, anaesthetising locations | MgasFlowValidator, EesBranchValidator |
+| **NFPA 110 (Emergency and Standby Power)** | Generator systems, ATS performance, weekly testing requirements | EesResilienceValidator |
+| **NCRP 147** | Structural Shielding Design for Medical X-Ray Imaging Facilities | Diagnostic X-ray shielding calculation (up to 200 kVp) | RadShieldValidator |
+| **NCRP 151** | Radiation Shielding Design for Megavoltage X-Ray and Gamma-Ray Radiotherapy Facilities | LINAC vault shielding, neutron shielding, PET/NM advanced shielding | AdvancedRadShieldValidator |
+| **ANSI/ASHRAE/ASHE 170** | Ventilation of Health Care Facilities | ACH requirements, pressure differentials, HEPA filter specifications for all clinical space types | PressureRegimeValidator |
+| **IRR17 (Ionising Radiations Regulations 2017, UK)** | Designation of controlled and supervised areas, dose limits, Qualified Expert requirements | RadShieldValidator |
+| **10 CFR 20 (US)** | Standards for Protection Against Radiation (NRC) | US dose limits, controlled area designation | RadShieldValidator (US projects) |
+| **USP <797>** | Pharmaceutical Compounding — Sterile Preparations | Pharmacy clean room pressure cascade, ISO classification, recertification cycle | PressureRegimeValidator (pharmacy rooms), IoTStalenessValidator |
+| **USP <800>** | Handling Hazardous Drugs in Healthcare Settings | Negative-pressure hazardous drug handling areas, isolated exhaust | PressureRegimeValidator (pharmacy rooms) |
+| **NEC 517 (National Electrical Code, Article 517, US)** | Health-care occupancies electrical requirements | EES branch classification, IPS, cardiac-protected circuits | EesBranchValidator (US projects) |
+| **ISO 7396-1** | Medical gas pipeline systems | Terminal unit specifications, alarm system design | MgasFlowValidator |
+| **ISO 14644-1/3/4** | Cleanrooms and associated controlled environments | Cleanroom classification, recovery testing, HEPA validation | IoTStalenessValidator (USP rooms) |
+| **BS 5682** | Terminal units for medical gas pipeline systems | Indexed probe design, cross-connection prevention | MgasFlowValidator |
+| **BS 8300** | Design of an Accessible and Inclusive Built Environment | Accessibility requirements in healthcare | AdjacencyValidator (partial) |
+| **BS 9263** | Specification for anti-ligature products | Product rating LR1–LR4 | AntiLigatureValidator |
+| **ASSE 6030/6040** | Medical gas pipeline system verifier and maintenance credentials | Verifier qualifications for NFPA 99 verification log | MgasFlowValidator (sign-off check) |
+| **IEC 60601-1** | Medical electrical equipment — General safety requirements | Electrical safety clearances, IT-cardiac protection | EesBranchValidator |
+| **HBN 21** | Maternity Facilities | LDR rooms, NICU design, midwife-led birth centre | RdsCompletenessValidator |
+
+---
+
+## Troubleshooting
+
+| Problem | Likely cause | Fix |
+|---|---|---|
+| Healthcare validators do not run when I click Run All Healthcare Validators | `PRJ_ORG_HEALTH_PACK_PROFILE_TXT` is empty | Open Manage > Project Information > set `PRJ_ORG_HEALTH_PACK_PROFILE_TXT` to one of: `FULL`, `ACUTE`, `COMMUNITY`, `DENTAL`, `IMAGING-ONLY`, `MENTAL-HEALTH` |
+| MGPS flow solver gives negative flow values at some nodes | Network graph was not built before running the flow solver | Run **MGPS Network Audit** first. Confirm zero orphaned outlets. Then run the flow solver. |
+| RDS generation fails with "template not found" error | `health_rds.docx` is not in `_BIM_COORD/templates/` | Author the RDS template using the provided authoring guide and place it in that folder, or ask your BIM manager. |
+| Radiation calculator gives no output | `RAD_BARRIER_TYPE_TXT` is missing on the selected element, or no source type is selected in the calculator dialog | Set `RAD_BARRIER_TYPE_TXT` (`PRIMARY`, `SECONDARY`, or `SCATTER`) on the wall, door, or window element. Select a source type in the calculator. |
+| Anti-ligature validator reports "No anti-ligature rooms found" | `CLN_LIGATURE_RES_BOOL` is not set on any rooms, or the `LIG_BEHAVIOURAL` parameter group has not been loaded | Run **Load Shared Params** to ensure the LIG_BEHAVIOURAL group is bound. Then set `CLN_LIGATURE_RES_BOOL = Yes` on the relevant rooms. |
+| Pressure regime audit finds no rooms | Rooms are not placed in the model, or `CLN_PRESS_REGIME_TXT` is not filled on any room | Confirm Room elements are placed (not just room bounding boxes). Fill `CLN_PRESS_REGIME_TXT` on each room. |
+| RDS Completeness Check shows red for every room | CLN_* parameters are not loaded as shared parameters | Re-run **Load Shared Params**. Confirm that the CLN_CLINICAL group (group 28) appears in the parameter browser. |
+| MGPS Network Audit reports orphaned terminal units | Pipes are not connected to the terminal units, or system types do not use the `MGAS-` prefix | Check pipe connections in Revit (select a pipe and verify its system connectivity in Properties). Check that system types are named `MGAS-O2`, `MGAS-VAC`, etc. |
+| EES branch validator flags all receptacles | `ELC_EES_BRANCH_TXT` is not loaded, or the Healthcare Pack is not installed | Run **Load Shared Params**. Check that `ELC_EES_BRANCH_TXT` appears in the Electrical group. |
+| Water safety validator cannot find sentinel outlets | `PLM_SENTINEL_BOOL` is not set on any plumbing fixtures | Select the sentinel temperature measurement points (typically one per floor, one per branch) and set `PLM_SENTINEL_BOOL = Yes`. |
+| MRI zone validator reports blocking error for RTLS anchor | A BLE, Wi-Fi, or UWB RTLS anchor is placed inside MRI Zone 3 or 4 | Move the anchor outside Zone 3, or change its technology to IR (infrared). Active wireless transmitters cannot be placed within the 5-Gauss line. This is a life-safety requirement. |
+| Commissioning workflow pauses and will not continue | A mandatory sign-off field is empty | Read the pause message. The workflow tells you which parameter is missing. Enter the required name or date. |
+| COBie export does not include clinical equipment | `CEQ_CLINICAL_BOOL` is not set to `Yes` on clinical equipment elements | Select all clinical equipment families. Set `CEQ_CLINICAL_BOOL = Yes` using **BulkParamWrite**. |
+| Acoustic validator flags all ward rooms | `CLN_NOISE_NR_NR` is not set, or the NR target CSV has not loaded | Ensure the `HEALTHCARE_ACOUSTIC_NR_TARGETS.csv` data file is in the STING data folder. Set `CLN_NOISE_NR_NR` on rooms where you want to override the default HTM 08-01 target. |
+
+---
+
+## Quick Reference
+
+### All healthcare commands
+
+| Button label | STING panel tab | Command class | What it does | When to use |
+|---|---|---|---|---|
+| Load Shared Params | Tags | `LoadSharedParamsCommand` | Binds all STING shared parameters including healthcare groups | First step on any new project |
+| MGPS Network Audit | BIM / Healthcare | `MgasNetworkAuditCommand` | Traces MGAS-* systems and reports network topology | Before running MGPS flow solver or verification |
+| MGPS Flow Solver | BIM / Healthcare | `MgasFlowSolver` (via Audit) | Calculates diversified flow and checks pressure drop | After network audit; before commissioning |
+| MGPS Generate Schematic | BIM / Healthcare | `MgasGenerateSchematicCommand` | Generates MGPS schematic drawing from model | RIBA Stage 4 |
+| MGPS Verify | BIM / Healthcare | `MgasVerifyCommand` | Records NFPA 99 §5.1.12 12-step verification | On-site commissioning |
+| Pressure Regime Audit | Healthcare | `PressureRegimeAuditCommand` | Checks pressure cascade validity | RIBA Stage 4; before commissioning |
+| EES Branch Audit | Healthcare | `EesBranchAuditCommand` | Checks essential power branch classification | Before commissioning |
+| Water Safety Audit | Healthcare | `WaterSafetyAuditCommand` | Checks dead legs, TMV, augmented care status | Before commissioning; annually (HTM 04-01) |
+| Rad Shield Audit | Healthcare | `RadShieldAuditCommand` | Checks shielding against NCRP 147 calculation | After QE review; before commissioning |
+| Rad Calc — Chest Room | Healthcare / Radiation | `RadCalcChestRoomCommand` | NCRP 147 calculator for plain X-ray rooms | Design stage |
+| Rad Calc — CT Room | Healthcare / Radiation | `RadCalcCtRoomCommand` | NCRP 147 calculator for CT suites | Design stage |
+| Rad Calc — Advanced | Healthcare / Radiation | `AdvancedRadCalcCommand` | NCRP 151 calculator for PET/NM/brachytherapy | Design stage (advanced imaging only) |
+| MRI Zone Audit | Healthcare / Radiation | `MriZoneAuditCommand` | Checks MRI zone geometry and 5-Gauss line | Design stage and before commissioning |
+| Adjacency Audit | Healthcare | `AdjacencyAuditCommand` | Checks HBN adjacency requirements | RIBA Stage 3 and 4 |
+| Anti-Ligature Audit | Healthcare | `AntiLigatureAuditCommand` | Checks anti-ligature product ratings in mental health rooms | Design and pre-commissioning |
+| RDS Completeness Check | Healthcare | `RdsCompletenessCheckCommand` | Lists missing mandatory parameters for Room Data Sheets | Before RDS generation |
+| Batch Issue RDS | Healthcare | `BatchIssueRoomDataSheetsCommand` | Generates .docx Room Data Sheets for all clinical rooms | RIBA Stage 4 onwards |
+| Acoustic Audit | Healthcare | `AcousticAuditCommand` | Checks NR, STC, and RT60 targets | RIBA Stage 4 |
+| Structural Load Audit | Healthcare | `StructuralLoadAuditCommand` | Checks floor loads for heavy medical equipment | RIBA Stage 4; before handover |
+| RTLS Coverage Audit | Healthcare | `RtlsCoverageValidator` (via Run All) | Checks RTLS anchor coverage and RF dead zones | Design and commissioning |
+| Endoscope Trace Audit | Healthcare | `EndoscopeTraceAuditCommand` | Checks HTM 01-06 RFID traceability chain | Design and commissioning |
+| EES Resilience Dashboard | Healthcare | `EesResilienceDashboardCommand` | Reports NFPA 110 generator test log age, UPS dates | Ongoing facilities management |
+| Run All Healthcare Validators | Healthcare | `RunAllHealthcareValidatorsCommand` | Runs all active healthcare validators in sequence | Before any significant drawing issue |
+| Workflow Presets | BIM | `WorkflowPresetCommand` | Opens workflow preset runner | Commissioning and annual audits |
+
+### Healthcare parameter groups — key parameters
+
+**CLN_CLINICAL (Group 28 — binds to Rooms)**
+
+| Parameter | Type | Key values |
+|---|---|---|
+| `CLN_ROOM_CLASS_TXT` | Text | `OR-ULTRA`, `AIIR`, `ICU`, `WARD-INPT`, `IMG-MRI`, `PSY-BED`, etc. |
+| `CLN_PRESS_REGIME_TXT` | Text | `POS`, `NEG`, `NEUTRAL`, `POS-ISO`, `NEG-ISO` |
+| `CLN_PRESS_DELTA_DESIGN_PA_NR` | Number | 8–25 Pa typical |
+| `CLN_INFECT_CLASS_TXT` | Text | `STD`, `AIIR`, `PE`, `CLASS-N`, `CLASS-P` |
+| `CLN_LIGATURE_RES_BOOL` | Yes/No | Activates anti-ligature validator |
+| `CLN_MRI_ZONE_INT` | Integer | 1, 2, 3, or 4 |
+| `CLN_HANDWASH_COUNT_INT` | Integer | HBN minimum |
+| `CLN_WASTE_CLASS_TXT` | Text | `CLINICAL`, `CYTOTOXIC`, `RADIOACTIVE`, etc. |
+
+**MGS_SYSTEMS (Group 29 — binds to Pipes, Mechanical Equipment)**
+
+| Parameter | Type | Key values |
+|---|---|---|
+| `MGS_GAS_TYPE_TXT` | Text | `O2`, `MA4`, `MA7`, `VAC`, `N2O`, `AGS`, `N2`, `CO2`, `HE`, `DENT` |
+| `MGS_NOM_PRESS_KPA_NR` | Number | 400 or 700 kPa typical |
+| `MGS_DESIGN_FLOW_LPM_NR` | Number | Litres per minute (free air) |
+| `MGS_VERIFY_PASS_BOOL` | Yes/No | Must be Yes before clinical use |
+| `MGS_VERIFY_BY_TXT` | Text | ASSE 6030 certified verifier name |
+
+**RAD_PROTECTION (Group 30 — binds to Walls, Doors, Windows)**
+
+| Parameter | Type | Key values |
+|---|---|---|
+| `RAD_LEAD_MM_NR` | Number | Required mm Pb |
+| `RAD_BARRIER_TYPE_TXT` | Text | `PRIMARY`, `SECONDARY`, `SCATTER`, `LEAKAGE` |
+| `RAD_QE_NAME_TXT` | Text | Qualified Expert name — mandatory |
+| `RAD_QE_DT` | Text (date) | QE sign-off date |
+
+**CEQ_CLINICAL (Group 31 — binds to Mechanical Equipment, Specialty Equipment)**
+
+| Parameter | Type | Key values |
+|---|---|---|
+| `CEQ_CATEGORY_TXT` | Text | `IMAGING`, `PENDANT`, `BEDHEAD`, `PHARMACY`, `DIAL` |
+| `CEQ_INFECT_TIER_TXT` | Text | `CRITICAL`, `SEMI-CRITICAL`, `NON-CRITICAL` |
+| `CEQ_CLINICAL_BOOL` | Yes/No | Must be Yes for COBie clinical asset register |
+
+**LIG_BEHAVIOURAL (Group 32 — binds to Fixtures and Fittings)**
+
+| Parameter | Type | Key values |
+|---|---|---|
+| `LIG_PRODUCT_RATING_TXT` | Text | `BS 9263 LR1`, `LR2`, `LR3`, `LR4` |
+| `LIG_PRESSURE_REL_BOOL` | Yes/No | Whether fitting releases under load |
+| `LIG_FORCE_LIMIT_KG_NR` | Number | Release load in kilograms |
+
+### Facility profile comparison
+
+| Validator | FULL | ACUTE | COMMUNITY | DENTAL | IMAGING-ONLY | MENTAL-HEALTH |
+|---|---|---|---|---|---|---|
+| PressureRegimeValidator | Yes | Yes | Yes | Partial | No | Yes |
+| MgasFlowValidator | Yes | Yes | Yes | Yes (dental gas) | No | Yes |
+| EesBranchValidator | Yes | Yes | No | No | Partial | Yes |
+| WaterSafetyValidator | Yes | Yes | Yes | Yes | No | Yes |
+| RadShieldValidator | Yes | Yes | No | No | Yes | No |
+| AdjacencyValidator | Yes | Yes | No | No | No | Yes |
+| AntiLigatureValidator | Yes | Partial | No | No | No | Yes |
+| RdsCompletenessValidator | Yes | Yes | Yes | Yes | Yes | Yes |
+| AcousticValidator | Yes | Yes | Partial | No | No | Yes |
+| StructuralLoadValidator | Yes | Yes | No | No | Yes | No |
+| AdvancedRadShieldValidator | Yes | Yes | No | No | Yes | No |
+| IoTStalenessValidator | Yes | Yes | Partial | No | Partial | Partial |
+| EndoscopeTraceValidator | Yes | Yes | Partial | No | No | No |
+| EesResilienceValidator | Yes | Yes | No | No | No | No |
+| RtlsCoverageValidator | Yes | Yes | No | No | Partial | Yes |
+| WasteFlowValidator | Yes | Yes | Partial | No | No | Yes |
+
+### Glossary of clinical and regulatory terms
+
+| Term | Plain English explanation |
+|---|---|
+| ACH | Air Changes per Hour — the number of times the entire air volume of a room is replaced in one hour. An operating theatre needs 20 or more; a ward needs 6 or more. |
+| AER | Automated Endoscope Reprocessor — the machine that washes and disinfects flexible endoscopes. |
+| AIIR | Airborne Infection Isolation Room — a room kept at negative pressure to prevent infectious aerosols (from tuberculosis, measles, chickenpox, COVID-19) from escaping to the corridor. |
+| ATS | Automatic Transfer Switch — the electrical device that switches from mains power to generator power when the mains fails. NFPA 99 requires this to happen within 10 seconds for life-safety circuits. |
+| Augmented care | A term from HTM 04-01 for wards where patients are immunocompromised or have open wounds (ICU, transplant, NICU). These areas require stricter water safety controls including TMV3 and point-of-use filters. |
+| ASSE 6030/6040 | American Society of Sanitary Engineers qualifications for medical gas pipeline system verifiers (6030) and maintenance personnel (6040). |
+| Dead leg | A section of water pipework that is sealed at one end, like a cul-de-sac. Water in a dead leg stagnates and can harbour Legionella bacteria. HTM 04-01 limits dead legs to 1 m maximum in sentinel circuits and augmented care areas. |
+| EES | Essential Electrical System — the category of electrical circuits in a hospital that must continue to function even when mains power fails. Divided into Life Safety (LS), Critical (CR), and Equipment (EQ) branches. |
+| HEPA | High Efficiency Particulate Air — a type of filter that removes at least 99.97% of particles ≥ 0.3 µm. Grade H13 or H14 is required in operating theatres and protective environment rooms. |
+| IPS | Isolated Power System — an electrical system where the supply conductors are isolated from earth, used in wet locations (OR, ICU, wet procedure rooms) to prevent dangerous earth-fault currents. |
+| IRR17 | Ionising Radiations Regulations 2017 (UK) — the primary legislation governing radiation protection in the UK. Requires Radiation Protection Advisers and Qualified Experts to oversee shielding design. |
+| Legionella | A bacterium (Legionella pneumophila) that grows in warm water (25–50 °C) and causes Legionnaires' disease, a serious form of pneumonia. Hospital water systems must be managed to prevent Legionella growth. |
+| Ligature point | Any fixture or fitting in a mental health ward to which a patient could attach a cord or rope. Anti-ligature design eliminates all such points. |
+| MGPS | Medical Gas Pipeline System — the permanent pipework system that delivers medical gases and vacuum to clinical areas. |
+| MRI Zone | MRI suites are divided into zones 1 to 4 based on proximity to the magnet. Zone 4 is the magnet room itself. No ferrous metal and no active wireless transmitters are permitted in Zones 3 or 4. |
+| NCRP 147/151 | National Council on Radiation Protection and Measurements reports 147 (diagnostic X-ray shielding) and 151 (radiotherapy and advanced imaging shielding). These are the most widely used shielding calculation methods internationally. |
+| NFPA 99 | National Fire Protection Association standard for health care facilities (US). Covers medical gas systems, essential electrical systems, isolated power systems, and emergency management. |
+| Pb | Chemical symbol for lead — the most common shielding material for X-ray rooms. Shielding is expressed in millimetres of lead equivalent (mm Pb). |
+| PE room | Protective Environment room — a room kept at positive pressure with HEPA filtration to protect immunocompromised patients (bone marrow transplant, haematology) from airborne organisms. |
+| PPM | Planned Preventive Maintenance — scheduled maintenance carried out at regular intervals to prevent equipment failure. SFG20 is the standard PPM schedule library used in the UK. |
+| Pressure cascade | The sequence of pressure relationships from one side of a department to the other. A valid cascade is one where pressures change monotonically (always in one direction). |
+| QE | Qualified Expert — in UK radiation protection, a medical or health physicist who has formal qualifications to advise on and approve radiation shielding designs. Required by IRR17. |
+| RDS | Room Data Sheet — a single document that captures all design requirements for one clinical room type. |
+| Spaulding classification | A system that classifies medical devices into Critical, Semi-critical, and Non-critical categories based on their infection risk, determining the required level of decontamination. |
+| SFG20 | Standard Form of Guidance for the Specification of Planned Preventive Maintenance for Building Engineering Services — the PPM schedule library used in UK healthcare facilities management. |
+| TMV | Thermostatic Mixing Valve — a valve that blends hot and cold water to produce tempered water at a safe temperature (typically 38–43 °C for handwash, 41–46 °C for showering). TMV2 is a domestic standard; TMV3 is the higher-performance healthcare standard required in augmented care areas. |
+| ZVB | Zone Valve Box — the assembly of shut-off valves that can isolate one zone of the medical gas pipeline system without affecting other zones. |
+
+---
+
+## Cross-references
+
+This guide covers the healthcare-specific layer of STING. For the underlying systems that healthcare design is built on, see:
+
+- **MEP_FOUNDATION_GUIDE.md** — for MEP symbol creation (Chapter 1), family authoring (Chapter 2), and the Placement Centre for placing clinical equipment families (Chapter 3).
+- **ELECTRICAL_WORKFLOW_GUIDE.md** — for electrical systems design including nurse call systems, fire alarm systems, emergency lighting, and security systems. This guide covers only the healthcare EES/IPS classification layer on top.
+- **PLUMBING_WORKFLOW_GUIDE.md** — for plumbing and piping systems including MGPS pipe routing, water systems, and drainage. This guide covers the healthcare-specific validation layer (MGPS verification, water safety audit).
+- **DRAWING_PRODUCTION_SYSTEM_GUIDE.md** — for the full drawing production workflow: creating views, applying drawing types, running ViewStylePacks, managing sheets, and producing the drawing register.
+- **DOCUMENT_MANAGER_GUIDE.md** — for document issue, revision management, transmittals, COBie export, and the ISO 19650 document lifecycle. Room Data Sheets and commissioning records are issued through this system.

--- a/docs/guides/INTEGRATION_INDEX.md
+++ b/docs/guides/INTEGRATION_INDEX.md
@@ -1,0 +1,199 @@
+# STING Documentation — Integration Index & Navigation Guide
+
+> **Start here.** This index shows every guide in `docs/guides/`, what it covers, what
+> it depends on, and what depends on it. Use it to find the right guide for your task
+> and to understand the reading order before starting a new workflow.
+
+---
+
+## Reading Order (for a new user)
+
+If you are new to STING, read the guides in this order:
+
+```
+1. MEP_FOUNDATION_GUIDE.md          ← Shared foundation. Read this first.
+        ↓
+2. DRAWING_PRODUCTION_SYSTEM_GUIDE.md  ← How drawings are produced.
+        ↓
+3. DOCUMENT_MANAGER_GUIDE.md           ← How documents are issued.
+        ↓
+Then pick your discipline:
+   ├── ELECTRICAL_WORKFLOW_GUIDE.md
+   ├── PLUMBING_WORKFLOW_GUIDE.md
+   └── HEALTHCARE_WORKFLOW_GUIDE.md    ← Also requires the two above.
+```
+
+---
+
+## Guide Inventory
+
+### 1. MEP_FOUNDATION_GUIDE.md
+**What it covers:** MEP symbol creation in the Revit Family Editor (step-by-step), wire annotation symbol creation and placement, placement family authoring rules, and the complete Placement Centre workflow including rehosting elements.
+
+**Depends on:** Nothing. This is the foundation.
+
+**Referenced by:**
+- ELECTRICAL_WORKFLOW_GUIDE.md (symbols, wire annotation, placement)
+- PLUMBING_WORKFLOW_GUIDE.md (symbols, family authoring, placement)
+- HEALTHCARE_WORKFLOW_GUIDE.md (clinical equipment placement)
+- DRAWING_PRODUCTION_SYSTEM_GUIDE.md (annotation during drawing production)
+
+**Consolidates:**
+- `docs/MEP_SYMBOL_GUIDE.md` ← redirect notice added
+- `docs/PLACEMENT_FAMILY_AUTHORING.md` ← redirect notice added
+- `docs/PLACEMENT_CENTRE_GUIDE.md` ← content incorporated
+
+---
+
+### 2. DRAWING_PRODUCTION_SYSTEM_GUIDE.md
+**What it covers:** The complete 4-stage drawing production system — Slot Taxonomy (what spaces exist on a title block), Title Block Creation (building the .rfa family), Drawing Type Manager (wiring the recipe), and Managed View Templates (STING auto-generates and maintains Revit view templates).
+
+**Depends on:** Nothing structural. Best read after MEP_FOUNDATION_GUIDE for annotation context.
+
+**Referenced by:**
+- ELECTRICAL_WORKFLOW_GUIDE.md (electrical drawing types)
+- PLUMBING_WORKFLOW_GUIDE.md (drainage drawing types)
+- HEALTHCARE_WORKFLOW_GUIDE.md (healthcare drawing types)
+- DOCUMENT_MANAGER_GUIDE.md (drawings become deliverables)
+
+**Consolidates:**
+- `docs/title_blocks/SLOT_TAXONOMY.md`
+- `docs/guides/TITLE_BLOCK_CREATION_GUIDE.md`
+- `docs/guides/DRAWING_TYPE_MANAGER_GUIDE.md`
+- `docs/STING_MANAGED_TEMPLATES_DESIGN.md` ← redirect notice added
+- `StingTools/Data/DRAWING_TEMPLATE_GUIDE.md` ← redirect notice added
+
+---
+
+### 3. DOCUMENT_MANAGER_GUIDE.md
+**What it covers:** Complete document management workflow — the `_BIM_COORD/` folder structure, first-time setup, all 16 document templates, CDE states (WIP/Shared/Published/Archive), every button in the Document Management Center, transmittal workflow, audit trail, distribution groups, and SLA-based workflow engine.
+
+**Depends on:** DRAWING_PRODUCTION_SYSTEM_GUIDE.md (drawings become deliverables that are issued here).
+
+**Referenced by:**
+- ELECTRICAL_WORKFLOW_GUIDE.md (issuing electrical drawings)
+- PLUMBING_WORKFLOW_GUIDE.md (issuing plumbing drawings)
+- HEALTHCARE_WORKFLOW_GUIDE.md (issuing healthcare documents and commissioning records)
+
+**Moves:**
+- `docs/DOCUMENT_MANAGER_GUIDE.md` ← redirect notice added; canonical version is now in `docs/guides/`
+
+---
+
+### 4. ELECTRICAL_WORKFLOW_GUIDE.md
+**What it covers:** Complete electrical workflow from blank floor plan to issued drawings — project setup, placing electrical equipment, panel schedules (the full BatchPanelSchedules system), circuit assignment, conduit/cable tray routing, lighting design with LightingGrid, wire annotation in electrical drawings, fire alarm and security, riser diagrams, and electrical QA/validation.
+
+**Depends on:**
+- MEP_FOUNDATION_GUIDE.md (symbols, family authoring, placement)
+- DRAWING_PRODUCTION_SYSTEM_GUIDE.md (drawing production)
+- DOCUMENT_MANAGER_GUIDE.md (document issue)
+
+**Referenced by:**
+- HEALTHCARE_WORKFLOW_GUIDE.md (EES, nurse call, fire alarm, operating theatre lighting)
+
+**Engine reference (not this guide):**
+- `docs/STING_ELECTRICAL_LAYMANS_GUIDE.md` — the technical engine/command reference; keep separate
+
+---
+
+### 5. PLUMBING_WORKFLOW_GUIDE.md
+**What it covers:** Complete plumbing and public health workflow — plumbing system codes (DCW, DHW, HWS, SAN, RWD, GAS), pipe system setup, fixture placement, AutoPipeDrop, manual routing, slope requirements for drainage, insulation parameters, plumbing schedules, and QA validation.
+
+**Depends on:**
+- MEP_FOUNDATION_GUIDE.md (symbol creation, family authoring, placement)
+- DRAWING_PRODUCTION_SYSTEM_GUIDE.md (drawing production)
+- DOCUMENT_MANAGER_GUIDE.md (document issue)
+
+**Referenced by:**
+- HEALTHCARE_WORKFLOW_GUIDE.md (MGPS piping, water safety piping infrastructure)
+
+---
+
+### 6. HEALTHCARE_WORKFLOW_GUIDE.md
+**What it covers:** Healthcare Pack layer on top of core STING — facility profiles, clinical zoning (CLN_* parameters), MGPS (medical gas network builder, flow solver, 12-step NFPA 99 verification), pressure regimes, anti-ligature design, radiation protection (NCRP 147 calculator), clinical equipment (CEQ_*), Room Data Sheets (RDS), the 16 healthcare validators, 8 commissioning workflow presets, 22 healthcare drawing types, and standards references (HTM, NFPA 99, NCRP 147, ASHRAE 170, IRR17, USP 797/800).
+
+**Depends on:**
+- MEP_FOUNDATION_GUIDE.md (placement, family authoring)
+- ELECTRICAL_WORKFLOW_GUIDE.md (EES, nurse call, fire alarm, theatre lighting)
+- PLUMBING_WORKFLOW_GUIDE.md (MGPS piping, water safety piping)
+- DRAWING_PRODUCTION_SYSTEM_GUIDE.md (healthcare drawing types)
+- DOCUMENT_MANAGER_GUIDE.md (commissioning records, document issue)
+
+**Depends on nothing from this guide.**
+
+---
+
+## Cross-Reference Map
+
+| I am doing this… | Read this guide | Jump to section |
+|---|---|---|
+| Creating an MEP symbol from scratch | MEP_FOUNDATION_GUIDE | Ch.1 — MEP Symbol Creation |
+| Setting up the Revit Family Editor | MEP_FOUNDATION_GUIDE | §1.2 — Family Editor Walkthrough |
+| Creating a wire annotation family | MEP_FOUNDATION_GUIDE | §1.4 — Wire Annotation Workflow |
+| Preparing a family for auto-placement | MEP_FOUNDATION_GUIDE | Ch.2 — Placement Family Authoring |
+| Using the Placement Centre | MEP_FOUNDATION_GUIDE | Ch.3 — The Placement Centre |
+| Rehosting elements to a new host | MEP_FOUNDATION_GUIDE | §3.8 — Rehosting Elements |
+| Understanding what slot types exist | DRAWING_PRODUCTION_SYSTEM_GUIDE | Stage 1 — Slot Taxonomy |
+| Building a title block .rfa family | DRAWING_PRODUCTION_SYSTEM_GUIDE | Stage 2 — Title Block Creation |
+| Configuring a Drawing Type | DRAWING_PRODUCTION_SYSTEM_GUIDE | Stage 3 — Drawing Type Manager |
+| Setting up Managed View Templates | DRAWING_PRODUCTION_SYSTEM_GUIDE | Stage 4 — Managed View Templates |
+| Understanding the _BIM_COORD/ folder | DOCUMENT_MANAGER_GUIDE | Part 1 — Setup |
+| Issuing a deliverable | DOCUMENT_MANAGER_GUIDE | Part 3 — Daily Workflows |
+| Creating a transmittal | DOCUMENT_MANAGER_GUIDE | §3.3 — Transmittal Workflow |
+| Setting up panel schedules | ELECTRICAL_WORKFLOW_GUIDE | Ch.4 — Panel Schedules |
+| Assigning circuits to devices | ELECTRICAL_WORKFLOW_GUIDE | Ch.5 — Circuit Assignment |
+| Designing a lighting layout | ELECTRICAL_WORKFLOW_GUIDE | Ch.7 — Lighting Design |
+| Routing conduit automatically | ELECTRICAL_WORKFLOW_GUIDE | Ch.6 — Conduit Routing |
+| Setting up plumbing pipe systems | PLUMBING_WORKFLOW_GUIDE | Ch.4 — Pipe Systems |
+| Running AutoPipeDrop | PLUMBING_WORKFLOW_GUIDE | §5.2 — AutoPipeDrop |
+| Setting drainage pipe slopes | PLUMBING_WORKFLOW_GUIDE | §5.3 — Slope Requirements |
+| Setting the healthcare facility profile | HEALTHCARE_WORKFLOW_GUIDE | Prerequisites |
+| Configuring MGPS (medical gas) | HEALTHCARE_WORKFLOW_GUIDE | Ch.2 — MGPS |
+| Running pressure regime audit | HEALTHCARE_WORKFLOW_GUIDE | Ch.3 — Pressure Regimes |
+| Anti-ligature assessment | HEALTHCARE_WORKFLOW_GUIDE | Ch.4 — Anti-Ligature |
+| Radiation shielding calculation | HEALTHCARE_WORKFLOW_GUIDE | Ch.5 — Radiation Protection |
+| Generating Room Data Sheets | HEALTHCARE_WORKFLOW_GUIDE | Ch.7 — Room Data Sheets |
+| Running healthcare commissioning | HEALTHCARE_WORKFLOW_GUIDE | Ch.8 — Commissioning |
+
+---
+
+## Integration Gaps Tracker
+
+Items marked ⚠ are cross-references that point to content not yet fully written or that
+needs expansion. Update this table when gaps are closed.
+
+| Gap ID | Guide | Section | Gap description | Status |
+|---|---|---|---|---|
+| GAP-01 | MEP_FOUNDATION_GUIDE | §1.4 Wire Annotation | Wire annotation for lighting control wiring (DALI, KNX) not yet covered | ⚠ Open |
+| GAP-02 | ELECTRICAL_WORKFLOW_GUIDE | Ch.6 Conduit | Two-phase conduiting workflow referenced in PLACEMENT_FAMILY_AUTHORING not fully developed | ⚠ Open |
+| GAP-03 | PLUMBING_WORKFLOW_GUIDE | Ch.5 AutoPipeDrop | AutoDuctDrop covered in MEP Foundation but AutoPipeDrop integration with duct system not documented | ⚠ Open |
+| GAP-04 | HEALTHCARE_WORKFLOW_GUIDE | Ch.6 CEQ | COBie integration for clinical equipment (50 types) not covered in workflow guide | ⚠ Open |
+| GAP-05 | DRAWING_PRODUCTION_SYSTEM_GUIDE | Stage 3 | Phase III SheetManager integration with Drawing Types needs a worked example | ⚠ Open |
+| GAP-06 | All guides | Quick Ref | Keyboard shortcuts for STING panel not documented in any guide | ⚠ Open |
+| GAP-07 | ELECTRICAL_WORKFLOW_GUIDE | Ch.9 Fire Alarm | Fire alarm zoning and cause-and-effect matrix not covered | ⚠ Open |
+| GAP-08 | HEALTHCARE_WORKFLOW_GUIDE | Ch.2 MGPS | HTM 02-01 zone valve panel commissioning workflow not yet detailed | ⚠ Open |
+| GAP-09 | All guides | — | Mobile app (Planscape) workflow integration not cross-referenced in any discipline guide | ⚠ Open |
+| GAP-10 | DOCUMENT_MANAGER_GUIDE | Part 6 | Planscape Server sync workflow (what happens when you push to cloud) needs a dedicated section | ⚠ Open |
+
+To close a gap: write the missing content in the appropriate guide, update the Status
+column to ✅ Closed with the date, and add a note to `docs/CHANGELOG.md`.
+
+---
+
+## Files Moved or Consolidated
+
+| Original file | New location / status |
+|---|---|
+| `docs/MEP_SYMBOL_GUIDE.md` | Consolidated → `docs/guides/MEP_FOUNDATION_GUIDE.md` Ch.1 |
+| `docs/PLACEMENT_FAMILY_AUTHORING.md` | Consolidated → `docs/guides/MEP_FOUNDATION_GUIDE.md` Ch.2 |
+| `docs/PLACEMENT_CENTRE_GUIDE.md` | Consolidated → `docs/guides/MEP_FOUNDATION_GUIDE.md` Ch.3 |
+| `docs/title_blocks/SLOT_TAXONOMY.md` | Consolidated → `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md` Stage 1 |
+| `docs/guides/TITLE_BLOCK_CREATION_GUIDE.md` | Consolidated → `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md` Stage 2 |
+| `docs/guides/DRAWING_TYPE_MANAGER_GUIDE.md` | Consolidated → `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md` Stage 3 |
+| `docs/STING_MANAGED_TEMPLATES_DESIGN.md` | Consolidated → `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md` Stage 4 |
+| `StingTools/Data/DRAWING_TEMPLATE_GUIDE.md` | Consolidated → `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md` (short embed kept as quick-start) |
+| `docs/DOCUMENT_MANAGER_GUIDE.md` | Moved → `docs/guides/DOCUMENT_MANAGER_GUIDE.md` (redirect notice at original) |
+
+---
+
+*Last updated: 2026-05-14 — Phase 174 documentation consolidation*

--- a/docs/guides/MEP_FOUNDATION_GUIDE.md
+++ b/docs/guides/MEP_FOUNDATION_GUIDE.md
@@ -1,0 +1,1550 @@
+# MEP Foundation Guide — Symbols, Family Authoring & Placement
+
+---
+
+## How to use this guide
+
+This guide is a single, self-contained reference for three topics that always go together: making MEP symbols, authoring families correctly so that automated placement tools can use them, and using the STING Placement Centre to deploy those families across a building model.
+
+Read it from beginning to end the first time. After that, use the chapter headings and quick-reference tables at the back to find specific information fast.
+
+Code blocks, table references, and button labels are written exactly as they appear on screen — what you see in Revit and in STING is exactly what is written here.
+
+> **How to use the blockquotes:** anywhere you see a `> **Stuck?**` blockquote, stop and read it before moving on. It explains what a confusing screen means and what to do about it.
+
+---
+
+## Who this guide is for
+
+You have opened Revit. You have placed a door or a desk family by clicking `Insert → Load Family` and then clicking in the model. You have not spent much time in the Family Editor — the window that opens when you edit or create a family from scratch.
+
+This guide assumes:
+
+- You know what a Revit project is (a `.rvt` file that contains a building model).
+- You know what a family is in loose terms (a reusable component — a light fitting, a socket outlet, a basin).
+- You have not yet built a family from scratch in the Family Editor.
+- You have not used STING's automated placement tools before.
+
+You do not need to be a programmer. All instructions are written for someone using the mouse and the keyboard, clicking menus and typing values into fields.
+
+---
+
+## The Big Picture — Read This Before Anything Else
+
+MEP (Mechanical, Electrical, Plumbing) drawings show two kinds of things: real equipment that will be installed in a building, and the symbols that represent that equipment on a drawing. A socket outlet on a wall is the real thing. The small circle with two slots drawn on a floor plan is the symbol.
+
+In Revit, the work happens in three stages that always go in this order:
+
+**Stage 1 — Build symbols.** You draw the 2D shapes that represent each piece of equipment: the circle for a smoke detector, the oval for a basin, the rectangle for a distribution board. These shapes live inside Revit family files (`.rfa` files).
+
+**Stage 2 — Author families.** You make sure each family file is set up correctly so that automated tools can place it in the right location, at the right height, on the right wall or ceiling. A family that hasn't been set up correctly will either fail to place automatically, or land in the wrong position.
+
+**Stage 3 — Use the Placement Centre.** With correct families loaded, you write rules — plain-language instructions like "put one socket every 3 metres along office walls at 1100 mm above the floor" — and STING executes those rules across every room in the building, placing the right family in the right place automatically.
+
+An analogy: imagine you are baking 600 identical muffins for a conference. Stage 1 is writing the recipe. Stage 2 is making sure your mixing bowl, tins, and oven are the right sizes. Stage 3 is running the production line. Skipping Stage 1 means you have no recipe. Skipping Stage 2 means the recipe calls for a 12-inch tin but you only have 9-inch tins — nothing comes out right. Stage 3 doesn't work without the first two.
+
+---
+
+# Chapter 1 — MEP Symbol Creation
+
+---
+
+## 1.1 What is an MEP Symbol?
+
+A symbol is a small 2D drawing that represents a real piece of equipment on a plan or section drawing.
+
+Think of a map legend. On a road map, a small red cross means hospital. On an MEP drawing, a small circle with the letter "S" inside means smoke detector. A small oval shape means basin or hand basin. A small rectangle with the letters "DB" means distribution board.
+
+Symbols matter for two reasons:
+
+1. **Communication.** An electrician on site reads the symbol to know what goes where. A commissioning engineer reads it to know what to test. An architect reads it to know whether the services fit in the ceiling void.
+
+2. **Standards.** Different countries use different symbol conventions. A UK project follows BS EN 60617. A US project follows NFPA 170 and IEEE 315. An international project may need all three. Symbols must follow the correct standard for the jurisdiction so that the drawing is legally and professionally valid.
+
+STING's MEP symbol library covers nine disciplines: Gas, Controls/BMS, Lighting, Public Health/Drainage, Communications/Low Voltage, Fire Protection, Plumbing, Electrical, and HVAC. Each discipline follows one or more published standards, and the library carries three standard variants (IEC/ISO, BS/EN, and ANSI/NFPA) inside a single family file so one file can serve any jurisdiction.
+
+---
+
+## 1.2 Revit Family Editor Setup — A Step-by-Step Walkthrough
+
+The Family Editor is a separate application mode inside Revit. When you open a `.rfa` file, Revit switches into Family Editor mode. You can tell you're in Family Editor mode because the ribbon changes completely — instead of the Architecture / Structure / Systems tabs you see in a project, you see `Create`, `Insert`, `Annotate`, `View`, and `Manage` tabs.
+
+Think of a Revit family like a rubber stamp. The family is the stamp — a fixed shape. When you place the family in a project, each placement is an impression of that stamp. You make the stamp once (Family Editor), then use it as many times as you need (project).
+
+### Opening the Family Editor
+
+There are two ways to open the Family Editor, depending on whether you are creating a brand new family or editing an existing one.
+
+**To create a brand new family:**
+
+1. In the main Revit window, click `File` in the top-left corner (the large R menu on older versions, or the File tab on newer ones).
+2. Hover over `New`.
+3. A flyout menu appears. Click `Family`.
+4. A file browser dialog opens titled "New Family — Select Template File". This is where you choose which kind of family you are creating.
+
+**To edit an existing family:**
+
+1. In the Revit project, find the family in the Project Browser (the panel usually docked on the left of the screen). It is under `Families → [Category] → [Family Name]`.
+2. Right-click the family name.
+3. Click `Edit...`. The Family Editor opens with that family loaded.
+
+Alternatively: Insert tab → Load Family → navigate to the `.rfa` file → open it directly in Revit which will open the Family Editor.
+
+> **Stuck?** If you do not see a `File → New → Family` option, you may be looking at a view of the project rather than the main application menu. Click the large `R` (or the File tab) in the very top-left of the Revit window, not the tabs in the middle of the ribbon.
+
+### Choosing the Right Template
+
+When you create a new family, the first decision is the template. A template is a blank starting point with the right settings already configured for a particular type of family.
+
+Think of a template like a form with fields already labelled. A medical intake form has spaces for name, date of birth, blood type. A tax form has spaces for income, deductions, tax code. Choosing the wrong template is like filling in a tax form when you needed a medical form — the spaces don't match what you need to record.
+
+The "New Family — Select Template File" dialog shows a list of `.rft` files. You need to navigate to the right folder. On most Revit installations:
+
+- Revit 2025: `C:\ProgramData\Autodesk\RVT 2025\Family Templates\English\`
+- Revit 2026: `C:\ProgramData\Autodesk\RVT 2026\Family Templates\English\`
+- Revit 2027: `C:\ProgramData\Autodesk\RVT 2027\Family Templates\English\`
+
+The folder contains many subfolders. The ones most relevant to MEP symbols are:
+
+| Template file | Where to find it | When to use it | What it enables |
+|---|---|---|---|
+| `Generic Annotation.rft` | Root of the English folder | Standalone symbols not attached to a wall, ceiling, or floor | The default for 80% of MEP symbols. The family scales with the view and can be placed anywhere. |
+| `Lighting Fixture Ceiling Based.rft` | `English\` root | Ceiling-mounted luminaires | The family automatically attaches to a ceiling when placed. |
+| `Lighting Fixture Wall Based.rft` | `English\` root | Wall-mounted luminaires and switches | Attaches to a wall. |
+| `Plumbing Fixture Floor Based.rft` | `English\` root | Floor-mounted sanitary fixtures (shower trays, floor drains) | Attaches to the floor slab. |
+| `Plumbing Fixture Wall Based.rft` | `English\` root | Wall-hung sanitary fixtures (basins, WCs) | Attaches to the wall. |
+| `Plumbing Fixture Ceiling Based.rft` | `English\` root | Ceiling-mounted plumbing (overhead showers) | Attaches to the ceiling. |
+| `Mechanical Equipment.rft` | `English\` root | Large HVAC plant (AHUs, boilers) | For equipment, not annotation symbols. |
+
+**The critical rule:** use `Generic Annotation.rft` for any symbol that is a 2D annotation only. Use a hosted template only when the physical family genuinely attaches to a host element (a wall, ceiling, or floor) in the real building.
+
+**Do not use** `Generic Model.rft` for MEP symbols. Generic Model families are three-dimensional and appear in 3D views and rendered images. Annotation symbols should only appear on 2D drawings; Generic Annotation families are hidden in 3D views automatically.
+
+After selecting the template, click `Open`. The Family Editor opens.
+
+> **Stuck?** If the `English` folder is empty or missing, your Revit installation may be in a language other than English, or the Family Templates component may not have been installed. Go to `Control Panel → Programs → Autodesk Revit [version] → Modify` and make sure Family Templates is ticked.
+
+### The Family Editor Canvas — What You Are Looking At
+
+The Family Editor window looks similar to a Revit project, but simpler. Here is what you see:
+
+**The canvas (large centre area):** This is where you draw. It shows either a plan view, an elevation view, or a 3D view of the family. When you first open a Generic Annotation template, you are looking at a plan view.
+
+**The ribbon (top):** The Family Editor ribbon has these tabs:
+- `Create` — the main tab for drawing geometry, adding parameters, and adding labels.
+- `Insert` — for loading other families to nest inside this one.
+- `Annotate` — for adding dimensions and text to the canvas (mostly used for documentation, not for symbol geometry).
+- `View` — for changing which view of the family you are looking at.
+- `Manage` — for managing shared parameters, project units, and other settings.
+
+**The pink/green reference planes:** When you open a Generic Annotation template, you immediately see two lines crossing at the centre of the canvas — one horizontal and one vertical. These are called reference planes. They are shown in pink or green depending on which is selected.
+
+Reference planes are like the crosshairs on a gunsight. They mark the family's origin — the point that Revit will snap to the exact location where you click when you place the family in a project. Everything you draw must be aligned to these planes.
+
+An analogy: the reference planes are the pin you push through a paper map to stick it to a board. Revit places the family pin-first — exactly at the point you click. If you draw your symbol 20 mm to the right of the pin, the symbol will appear 20 mm to the right of wherever you click in the project.
+
+**The Properties palette (usually docked on the left):** Shows properties of whatever is selected. When nothing is selected, it shows the view properties.
+
+**The Project Browser (also usually on the left):** In the Family Editor, this shows the views available inside the family — typically `Floor Plans: Ref. Level`, `Elevations`, and possibly a 3D view.
+
+### Configuring the Reference Planes — The Critical First Step
+
+Before drawing any geometry, check and configure the reference planes.
+
+1. Click on the horizontal reference plane (the horizontal line crossing the canvas). The line turns blue to show it is selected.
+
+2. Look at the Properties palette on the left. You should see:
+   - `Is Reference:` with a dropdown. Change this to `Strong Reference` if it is not already set.
+   - `Defines Origin:` tick this box if it is not already ticked.
+
+3. Click somewhere empty to deselect. Then click the vertical reference plane and repeat: set `Is Reference: Strong Reference` and tick `Defines Origin`.
+
+4. The intersection of these two planes is now the family origin — the pin point. All symbol geometry must be drawn centred on this intersection.
+
+> **Stuck?** If you cannot see the Properties palette, go to `View → User Interface → Properties`. If you cannot find the reference planes (they may be very faint), go to `View → Visibility/Graphics`, find "Reference Planes" in the list, and make sure they are ticked visible.
+
+**Why Strong Reference matters:** Strong Reference makes the reference plane selectable as a dimension anchor when this family is placed in a project. This allows the placement engine to precisely position the family relative to walls, doors, and other elements.
+
+### Adding Symbolic Lines — Drawing the Symbol
+
+Now you can draw the actual symbol geometry. In the Family Editor, 2D shapes drawn for plan-view symbols are called "Symbolic Lines." They are called this because they represent what the element looks like symbolically — not a 3D geometry of the object itself.
+
+Step by step:
+
+1. Make sure you are looking at the plan view (`Floor Plans: Ref. Level` in the Project Browser on the left).
+
+2. Click the `Create` tab in the ribbon.
+
+3. In the `Detail` panel (one of the groups of buttons in the Create tab ribbon), click `Symbolic Lines`. A small toolbar appears at the top of the canvas with line drawing tools.
+
+4. Before drawing, set the subcategory. In the `Properties` palette on the left, find `Subcategory` and click the dropdown. If the subcategory you need does not exist yet, you need to create it first (see Section 2.5 on subcategories below). For now, if you just want to draw and test, you can leave it as `<None>` and change it later.
+
+5. Also in the small toolbar that appeared, check the line style. There is a dropdown showing the current line style (usually `Solid`). Leave it as `Solid` for most symbols.
+
+6. Click `Line` in the toolbar (the straight line tool). Your cursor changes to a crosshair with a pencil icon.
+
+7. Click once to start the line, click again to end it. The line appears on the canvas.
+
+8. To draw a circle: in the same toolbar, click `Circle`. Click once to place the centre, then drag to set the radius and click again.
+
+9. To draw a rectangle: in the same toolbar, click `Rectangle`. Click two opposite corners.
+
+10. When you have finished drawing, press `Escape` or click the green tick button (Finish) in the toolbar. You return to the regular selection mode.
+
+> **Stuck?** If you cannot find the `Symbolic Lines` button, look carefully at the `Create` tab ribbon. The `Detail` panel group is towards the right side of the ribbon, after the `Datum`, `Forms`, and `Work Plane` groups. The buttons in the Detail panel are `Component`, `Symbol`, `Masking Region`, `Filled Region`, `Detail Line`, and `Symbolic Lines` — in roughly that order.
+
+**Setting line weights:** After drawing, select the line. In the Properties palette, look for `Subcategory`. Line weights in Revit families are set on the subcategory, not on individual lines. If your subcategory has line weight 2 (approximately 0.18 mm at printed scale), all lines on that subcategory will print at that weight.
+
+To change the line weight for a subcategory: `Manage` tab → `Object Styles` → find the subcategory in the list → change the `Line Weight: Projection` number.
+
+**The "Visible in 3D Views" checkbox:** When a line is selected, the Properties palette shows `Visible: [checkbox]`. By default, Symbolic Lines are NOT visible in 3D views — only in plan, section, and elevation views. This is the correct behaviour for annotation symbols. Leave the checkbox alone.
+
+### Adding Filled Regions — Solid Shapes
+
+Some symbols need a solid filled shape rather than just outline lines. For example, a fire alarm manual call point may have a solid red square. A gas cylinder symbol may have a grey filled circle.
+
+A Filled Region is a closed 2D boundary with a fill pattern applied inside it.
+
+1. `Create` tab → in the `Detail` panel → click `Filled Region`.
+
+2. A new toolbar appears. In the `Properties` palette, you will see `Filled Region Type` — click the dropdown to choose the fill pattern. `Solid Fill` is the most common for symbols.
+
+3. Draw the boundary of the filled region using the line tools in the toolbar. The boundary must be a fully closed loop — every line must connect to another at both ends with no gaps.
+
+4. When the boundary is closed, click the green tick button to finish. The filled region appears on the canvas.
+
+5. To change the fill pattern colour, you need to do it through the subcategory (same as line colour — set it on the subcategory, not on individual elements).
+
+> **Stuck?** If Revit says "The boundary is not closed" when you click Finish, you have at least one gap between your lines. Click Cancel, then zoom in very close to where you think the lines meet. Use Trim/Extend (in the Modify tab, Geometry panel) to force the lines to meet exactly.
+
+### Setting Up Parameters — The Fields on the Form
+
+Parameters are the information stored inside a family. Think of them as the fields on a form. A family for a socket outlet might have parameters for: mounting height, gang count, IP rating, circuit number, STING tag.
+
+There are two kinds of parameters and the distinction is critical:
+
+**Family Parameters** exist only inside the family file. They cannot be scheduled in a Revit project, cannot be read by external tools, and cannot be shared across multiple families. Think of them as a private note on a sticky label — only visible if you open the specific family to look.
+
+**Shared Parameters** are defined in an external text file (the "shared parameter file") and can be used across many different families and across projects. They can be scheduled, exported to COBie, read by STING's tagging pipeline, and exported to Excel. Think of them as a column in a shared spreadsheet — the same column appears in many different tables.
+
+For MEP symbols that will be used with STING, always use Shared Parameters for any data that STING needs to read. Family Parameters are only for internal family behaviour (like "is the IEC variant visible").
+
+**To add a Family Parameter:**
+
+1. `Create` tab → in the `Properties` panel → click `Family Types`. A dialog opens showing all the types and parameters in the family.
+
+2. Click `Add Parameter...` at the bottom.
+
+3. The "Parameter Properties" dialog opens. In the top section, choose `Family parameter` (not `Shared parameter`).
+
+4. Give it a Name, choose a Discipline (Common, Electrical, HVAC, etc.), choose a Type of Parameter (Yes/No, Text, Length, etc.), and choose whether it is a Type parameter or Instance parameter.
+
+5. Click `OK`. The parameter appears in the Family Types dialog.
+
+**To add a Shared Parameter (the right way for STING):**
+
+1. First, make sure the STING shared parameter file is set as the current shared parameter file:
+   - `Manage` tab → `Settings` panel → `Shared Parameters`.
+   - In the dialog that opens, click `Browse...` and navigate to `StingTools/Data/MR_PARAMETERS.txt`.
+   - Click `Open`, then `OK`.
+
+2. Now go to `Create` tab → `Family Types` → `Add Parameter...`.
+
+3. In the Parameter Properties dialog, choose `Shared parameter`.
+
+4. Click `Select...`. The "Shared Parameters" dialog opens. It shows the groups and parameters from `MR_PARAMETERS.txt`.
+
+5. Click on the group that matches your discipline (e.g. `ELC_` for electrical, `HVC_` for HVAC).
+
+6. Find and select the parameter you need (e.g. `ELC_CIRCUIT_NUM_TXT`).
+
+7. Click `OK`. Click `OK` again to close Parameter Properties. The parameter now appears in the family and can be read by STING.
+
+**Linking a parameter to a label on the symbol:**
+
+Some symbols need to display a value from a parameter directly on the drawing — for example, a controls sensor displays the letter "T" for temperature. In a family, this is done with a Label.
+
+1. `Create` tab → in the `Text` panel → click `Label`.
+
+2. Click on the canvas where you want the label to appear.
+
+3. The "Edit Label" dialog opens. On the left is a list of all available parameters. On the right is the label content.
+
+4. Find the parameter you want to display (e.g. `DEVICE_TYPE_TXT`), click it, then click the arrow in the middle to move it to the right side.
+
+5. You can also add a prefix or suffix text in the columns on the right.
+
+6. Click `OK`. The label appears on the canvas showing the parameter value (or a placeholder if no value is set).
+
+7. You can change the text size, font, and style by selecting the label and editing its Properties.
+
+### Saving and Loading the Family
+
+**To save the family:**
+
+1. `File → Save As → Family`.
+2. Navigate to the correct folder. For STING symbol families:
+   - Gas symbols: `CompiledPlugin/Data/SymbolLibrary/Gas/`
+   - Controls symbols: `CompiledPlugin/Data/SymbolLibrary/Controls/`
+   - Lighting symbols: `CompiledPlugin/Data/SymbolLibrary/Lighting/`
+   - Public Health: `CompiledPlugin/Data/SymbolLibrary/PublicHealth/`
+   - Comms/LV: `CompiledPlugin/Data/SymbolLibrary/Comms/`
+   - Fire Protection: `CompiledPlugin/Data/SymbolLibrary/FireProtection/`
+   - Plumbing: `CompiledPlugin/Data/SymbolLibrary/Plumbing/`
+   - Electrical: `CompiledPlugin/Data/SymbolLibrary/Electrical/`
+   - HVAC: `CompiledPlugin/Data/SymbolLibrary/HVAC/`
+3. Name the file following the STING convention: `STING_[DISC]_[symbol_id].rfa`. For example: `STING_E_E_SKT_13A_1.rfa` for a UK 13A socket outlet electrical symbol.
+4. Click `Save`.
+
+**To load the family into a Revit project:**
+
+1. In the Revit project (not the Family Editor), go to the `Insert` tab.
+2. In the `Load from Library` panel, click `Load Family`.
+3. Navigate to the `.rfa` file you saved.
+4. Click `Open`. The family is now available in the project.
+
+Alternatively, with the family open in the Family Editor:
+
+1. `Create` tab → in the `Family Editor` panel → click `Load into Project`.
+2. If multiple projects are open, a dialog asks which project to load into.
+3. The family loads into the selected project.
+
+> **Stuck?** After loading, if you cannot find the family in the Project Browser, look under `Families → [Category name]`. If the category name is unexpected, you may have used the wrong family template. For annotation families (Generic Annotation), they appear under `Families → Annotation Symbols`.
+
+---
+
+## 1.3 Standard MEP Symbol Morphology by Discipline
+
+STING's library covers 516 symbols across 9 disciplines. Each discipline follows specific published standards and has established visual conventions (called "morphology" — the shape and form of the symbols).
+
+### Gas (21 symbols)
+
+**Standards:** ISO 14617-2/8 (international P&ID), BS 1553-1 (UK gas), ASME B31.8 (US distribution).
+
+**When to use which standard:** UK domestic and commercial projects follow BS 1553-1. International and oil/gas projects use ISO 14617. US projects use ASME B31.8.
+
+**Visual conventions:** Gas symbols carry a yellow highlight per BS 1710 colour coding. Small text labels ('G', 'NG', 'LPG') identify the gas type. Valves use the international P&ID two-triangle body with valve-specific markers:
+- Spring line = pressure relief valve
+- Fusible link = emergency shutoff valve (ESV)
+- 'E' = ESV for gas
+- Solid disc = ball valve
+
+| Symbol group | Count | Shape |
+|---|---|---|
+| Pipes | 3 | Line types only — not families |
+| Meters | 2 | 6-8 mm rectangles, centred origin |
+| Regulators/valves | 7 | Two-triangle P&ID body + identifier |
+| Gas train assembly | 1 | 20 × 8 mm compound symbol |
+| Equipment connections | 3 | Wall-hosted stubs |
+| Manifold/riser/drain/cylinder | 5 | Individual shapes |
+
+**Tip for UK projects:** Note that medical gases (oxygen, nitrous oxide, medical air, vacuum) are NOT in the Gas discipline — they live in the Plumbing discipline under HTM 02-01 references, to prevent confusion between fuel gas and medical gas on drawings.
+
+### Controls / BMS (32 symbols)
+
+**Standards:** ISO 14617-6 / BS EN ISO 14617-6 (P&ID instrumentation), ASHRAE Guideline 4 (US HVAC controls). Fieldbus protocols: BACnet (ISO 16484-5), Modbus (IEC 61158), KNX (ISO 22510).
+
+**Visual conventions:** Controls symbols use a consistent letter-in-shape language used worldwide:
+- Sensors: small circle Ø4-5 mm with one identifying letter (T=temperature, H=humidity, P=pressure, F=flow, L=level, CO2=carbon dioxide)
+- Actuators: the host valve or damper symbol with a small 'M' box above it indicating a motorised actuator
+- Controllers: labelled rectangles (DDC for Direct Digital Control, PLC, HMI)
+- Fieldbus cables: dashed lines labelled with the protocol name
+
+**Tip:** Controls symbols are largely standard-agnostic in practice. The same circle-with-letter convention works across all three jurisdictions. What changes is the sensor letter codes (ISA-style PIC-100 vs. simple 'P') and the fieldbus labelling.
+
+### Lighting (31 symbols)
+
+**Standards:** IEC 60617-11-02 / BS EN 60617-11 (luminaire symbols), NFPA 170 (US life-safety), ISO 7010 E001 (running-man exit sign — identical across all standards).
+
+**Emergency lighting:** BS EN 60598-2-22 and BS 5266 (UK/EU), UL 924 (US).
+
+**Visual conventions:**
+- Luminaires: circles or rectangles with a cross or dot indicating the light source position
+- Emergency variant: same shape with shaded half-circle or 'M' (maintained) / 'NM' (non-maintained) label
+- Switches: angled line meeting a circle, with dots indicating the number of ways (1-way, 2-way, intermediate), with added dimmer arrow for dimmer switches
+- Exit signs: ISO 7010 running-man pictogram — the same across all standards
+
+**Important note:** Revit already ships many lighting fixture families with built-in geometry. The STING library adds the IEC/BS/ANSI plan-view annotation overlay on top of Revit's existing families, rather than replacing them.
+
+### Public Health / Drainage (40 symbols)
+
+**Standards:** ISO 4067-1 (international piping), BS EN 752 (drainage outside buildings), BS 5572 (sanitary pipework), BS 8301 (building drainage), ASPE 45 (US), BS 8582 (SuDS).
+
+**Visual conventions:** Drainage symbols emphasise flow direction, trap types, and access points:
+- Gullies: small square or rectangular footprints with grate markings
+- Traps: shown as P-trap, S-trap, bottle trap, or running trap with the correct bend
+- Access points: rodding eye (small circle with diagonal line), inspection chamber, manhole (larger rectangle with cover lines)
+- Rainwater: circles for rainwater outlets, rectangles for hoppers
+- SuDS (Sustainable Drainage): stippled fills indicate permeable surfaces; dashed outlines for below-ground attenuation
+
+Note on SuDS symbols: these operate at larger scales (1:100 to 1:500) and use a separate subcategory `ISO_Symbols_PH_SuDS_*` to allow them to be shown or hidden independently of drainage symbols.
+
+### Communications / Low Voltage (39 symbols)
+
+**Standards:** IEC 60617-11 / BS EN 60617-11 (comms outlets), TIA-606 (US cabling labelling), TIA-568 (US cabling performance), BS EN 50173 (structured cabling UK/EU), BS 5839-9 (fire telephones), HTM 08-03 (nurse call).
+
+**Visual conventions:**
+- Data outlets: triangles with numbers inside (1 = single RJ45, 2 = double, 4 = quad)
+- Comms rooms: rectangles labelled RACK or WR
+- CCTV: dome (circle with dome shape), bullet (rectangle), PTZ (rectangle with rotation arc)
+- PA speakers: traditional speaker horn icon
+- Nurse call: cross icon with call button
+
+### Fire Protection (52 symbols)
+
+**Standards:** ISO 6790 (detection/suppression symbols), BS EN 54 series (detection devices), BS EN 12845 (sprinklers), BS 5839 (detection and warning), NFPA 170/13/14/15/2001 (US). Gaseous agents: ISO 14520-9 (FM-200), ISO 6183 (CO2).
+
+**This discipline has the highest life-safety stakes — invest time in getting the symbols right.**
+
+**Visual conventions:**
+- Detection: square or circle Ø5-6 mm with a single letter (S=smoke, H=heat, M=multi-sensor, CO=carbon monoxide, V=video smoke)
+- Manual call points: squares with 'MCP' text or break-glass icon
+- Sounders: bell symbol; beacons: triangle (VAD per BS EN 54-23, with category C/W/O)
+- Sprinklers: Ø4 mm circles with a small triangle indicating orientation — pointing down for pendant, up for upright, sideways for sidewall
+- Extinguishers: vertical ovals with colour-coded letters per BS EN 3-7 (red body, agent-specific colour strip)
+- Gaseous suppression nozzles: Ø5 mm circles on ceiling
+
+### Plumbing (81 symbols)
+
+**Standards:** ISO 4067-1/6 (piping P&IDs, fluid colour-coding), BS 5572, BS 8558, BS 6700 (UK), ASME A112.19.2, ASPE 45 (US). Medical gases: ISO 7396-1 / BS EN ISO 7396-1 / NFPA 99.
+
+**The three half-days of build work (by complexity):**
+
+*Sanitaryware (23 rows):* WC, urinal, basin, bath, shower, bidet, sink. Most use plan-view "footprint" shapes — the shape you would see if you looked straight down at the fixture. The insertion point (origin) sits at the trap or at the fixture's geometric centre.
+
+*Service pipes (13 rows + 2 fittings):* These are mostly line types and labels in the project, not individual families. CWS (cold water supply), HWS (hot water supply), LTHW (low temperature hot water) and others are identified by colour-coded lines per BS 1710.
+
+*Valves, pumps, tanks, accessories (41 rows):* All valves use the international two-triangle P&ID body. Six base valve shapes cover all variants:
+- Gate valve: lines through the body
+- Globe valve: filled body
+- Ball valve: solid circle in the body
+- Butterfly valve: disc line through the body
+- Check/non-return valve: triangle pointing in flow direction
+- Pressure relief valve: spring symbol above body
+
+### Electrical (101 symbols)
+
+**Standards:** IEC 60617 series / BS EN 60617 (UK/EU), IEEE 315 / ANSI Y32.9 / NEMA (US), AS/NZS 3000 (AU/NZ).
+
+**The most jurisdiction-sensitive discipline.** Socket outlet morphology differs between standards:
+- UK (BS 1363): circle with two slots and earth, usually with safety shutters shown
+- EU Schuko (CEE 7/4): circle with two round pins and earth clips
+- US NEMA 5-15R: circle with two vertical slots and earth
+- AU/NZ: circle with angled slots
+
+| Symbol group | Rows | Typical geometry |
+|---|---|---|
+| Sockets/outlets | 15 | Circles with jurisdiction-specific pin/slot arrangement |
+| FCUs, isolators, spurs | 5 | Small wall-hosted rectangles |
+| Control devices | 5 | Emergency stop, push-start, key switch, pull cord |
+| Floor boxes / wall management | 10 | Rectangles, often with port count label |
+| Distribution boards / switchgear | 6 | Larger rectangles with 'DB', 'MSB', 'CU' labels |
+| Transformers, UPS, generators | 8 | Visually distinct labelled shapes |
+| Protection devices | 12 | MCB, RCD, RCBO — IEC thermal+magnetic symbol |
+| Motors and starters | 6 | Circle with 'M' or 'G' inside |
+| Cabling and containment | 12 | Mostly line styles: trunking, tray, conduit |
+| Lightning and renewables | 10 | Air rod, PV module, EV charger — unique shapes |
+
+### HVAC / Mechanical (120 symbols)
+
+**Standards:** ISO 14617-8 (fluid-power and HVAC P&IDs), BS 1553-1 / BS EN 1505 (ductwork), ASHRAE Fundamentals, SMACNA (US). Fire and smoke dampers: BS EN 15650, UL 555/555S.
+
+**The largest discipline — plan three working days for a complete build.**
+
+**Visual conventions:**
+- Air terminals: squares with arrows radiating outward (supply, 4-way diffuser), or double lines (extract/return grille), or slot line (linear slot diffuser)
+- Dampers: rectangle with a blade line inside, labelled VCD (volume control), FD (fire), FSD (fire/smoke), SD (smoke)
+- AHU/FCU: labelled rectangles with schematic icons — fan wheel, heating coil (parallel lines), cooling coil (zigzag), filter (dotted lines)
+- Radiators: rectangle with wavy heat lines; TRV (thermostatic radiator valve): radiator with a valve cap symbol
+
+---
+
+## 1.4 Wire Annotation — Complete Workflow
+
+### 1.4.1 What is Wire Annotation?
+
+Wire annotation is the layer of text and graphical marks on an electrical floor plan drawing that tells an electrician how to wire up the circuits they see.
+
+Imagine you are looking at an electrical drawing of an office floor. You can see symbols for socket outlets, light switches, distribution boards, and luminaires. But how does the electrician know:
+
+- Which sockets are on the same circuit?
+- What size cable (2.5 mm² twin and earth? 4 mm² SWA?) connects them?
+- Which circuit number in the distribution board does this group connect to?
+- Where does the circuit enter the floor (a "homerun" back to the board)?
+
+Wire annotation answers all of those questions. It consists of:
+
+1. **Wire lines** drawn on the drawing to show circuit routes (not physical cables, but schematic routes).
+2. **Slash marks** crossing wire lines to show the number of conductors in a cable (one diagonal slash per conductor — so a 2.5 mm² twin and earth cable gets two slashes, a three-core gets three).
+3. **Circuit reference labels** showing which circuit number from the distribution board feeds each group.
+4. **Cable size labels** showing the conductor cross-sectional area (e.g. "2.5mm²", "4mm²", "10mm²").
+5. **Homerun arrows** — a special arrowhead on the wire line pointing toward the distribution board, indicating "this is where the circuit goes up or away to the panel".
+
+Wire annotation is used on:
+- Domestic electrical drawings
+- Commercial lighting and power layouts
+- Industrial electrical distribution layouts
+- Any drawing where individual circuit routing matters
+
+### 1.4.2 Revit's Wire Tool vs STING Wire Annotation
+
+Revit has a built-in wire tool under the `Systems → Electrical → Wire` command. It draws schematic wire connections between electrical elements. However, it has limitations:
+
+- Revit's native wires are part of the electrical system connectivity — they drive calculations like voltage drop and circuit load. This is useful but means they require proper electrical system connections to work.
+- Native wires are difficult to control for precise graphical annotation (line weight, slash marks, circuit labels all need separate work).
+- Native wires appear in 3D views in a way that can clutter coordination models.
+
+STING's wire annotation approach uses annotation families — the same Generic Annotation family type used for MEP symbols — to create a clean, drafting-quality wire annotation layer that sits on the drawing independently of the electrical system model. This gives precise graphical control while keeping the coordination model clean.
+
+You can use both approaches on the same project: Revit's native wires for system connectivity and load calculations, and STING annotation families for the polished, contractor-readable drawing deliverable.
+
+### 1.4.3 Creating a Wire Annotation Family in the Family Editor
+
+This section walks through building a wire annotation family from scratch, step by step.
+
+**Before you start:** make sure STING's shared parameter file is set. See Section 1.2 above for how to do this (Manage → Settings → Shared Parameters → Browse to `StingTools/Data/MR_PARAMETERS.txt`).
+
+**Step 1: Open the Family Editor with the correct template**
+
+1. `File → New → Family`.
+2. In the template browser, navigate to the `English` folder.
+3. Find and select `Generic Annotation.rft`.
+4. Click `Open`.
+
+The Family Editor opens. You see a plain canvas with two reference planes crossing at the centre. This template is specifically designed for annotation families — things that appear on drawings but are not 3D objects.
+
+**Step 2: Plan what your annotation will show**
+
+Before drawing anything, decide which type of wire annotation you are making. Common types:
+
+- **STING_WIRE_ANN_HOMERUN.rfa** — for circuit homeruns (the arrow that indicates the circuit exits the plan to the distribution board)
+- **STING_WIRE_ANN_BRANCH.rfa** — for branch circuit runs (the wire line with slash marks for conductor count)
+- **STING_WIRE_ANN_3WIRE.rfa** — for 3-wire circuits specifically (three slashes)
+- **STING_WIRE_ANN_LABEL.rfa** — for circuit number labels only (no wire line, just text)
+
+This walkthrough builds `STING_WIRE_ANN_HOMERUN.rfa`.
+
+**Step 3: Save immediately with the correct name**
+
+Before drawing anything, save the file with the correct name. This avoids saving over the template accidentally.
+
+1. `File → Save As → Family`.
+2. Navigate to `Families/Annotations/Wire/` (create this folder if it doesn't exist).
+3. In the File name box, type `STING_WIRE_ANN_HOMERUN`.
+4. Click `Save`.
+
+**Step 4: Create the subcategories**
+
+Wire annotation families use subcategories to allow project-wide visibility control. You will create one subcategory called `STING_Wire_Annotation`.
+
+1. `Manage` tab → in the `Settings` panel → click `Object Styles`.
+2. The Object Styles dialog opens. Make sure you are on the `Annotation Objects` tab (not Model Objects).
+3. Click `New...` at the bottom of the list.
+4. In the "New Subcategory" dialog, type `STING_Wire_Annotation` in the Name box.
+5. The Parent Category should be `Generic Annotations`. Click `OK`.
+6. The new subcategory appears in the list. Set `Line Weight: Projection = 2`, `Line Color = Black`, `Line Pattern = Solid`.
+7. Click `OK` to close Object Styles.
+
+**Step 5: Draw the wire line**
+
+The wire line represents the cable route on the drawing.
+
+1. `Create` tab → `Detail` panel → `Symbolic Lines`.
+2. In the Properties palette, set `Subcategory: STING_Wire_Annotation`.
+3. Choose `Line` in the drawing toolbar.
+4. Click at a point to the LEFT of the origin (the cross in the centre of the canvas). Click at a point to the RIGHT of the origin. You have drawn a horizontal wire line passing through the origin.
+
+The line should extend about 15-20 mm on each side of the origin at typical annotation size (the exact length matters less than the origin being on the line).
+
+5. Press `Escape` to finish drawing.
+
+> **Stuck?** The origin is at the intersection of the two reference planes (the pink cross). If your line does not pass through the origin, the annotation will not align correctly to the circuit element when placed. Undo, zoom in, and redraw more carefully — snap to the reference plane intersection.
+
+**Step 6: Add the homerun arrowhead**
+
+A homerun arrowhead is a filled arrow at one end of the wire line, pointing toward the distribution board. In practice, you place the annotation at the point where the circuit exits the drawing, and the arrow points in the direction the circuit travels to reach the board.
+
+1. Still in the Symbolic Lines drawing mode (or click `Symbolic Lines` again in the Create tab).
+2. In the Properties palette: `Subcategory: STING_Wire_Annotation`.
+3. Look at the drawing toolbar at the top. There is a `Line Style` dropdown and a row of buttons for different line and endpoint types. Find the endpoint style controls — these are small dropdowns showing arrows and dots for line ends.
+4. Set the endpoint style to `Filled Arrow` for the left endpoint (the end pointing toward the board).
+5. Draw a short arrow line (about 3-4 mm) pointing left from the start of the wire line. This is the homerun indicator.
+
+Alternatively, draw the arrowhead as a separate filled region:
+
+1. `Create` → `Filled Region`.
+2. In the Properties palette, choose `Solid Fill` as the filled region type.
+3. Draw a small filled triangle (3-4 mm high, 2 mm wide) at the left end of the wire line.
+4. Click the green tick to finish.
+
+**Step 7: Add conductor slash marks**
+
+Slash marks are short diagonal lines crossing the wire line. Convention: one slash per conductor. For a standard twin-and-earth cable (live, neutral, earth): three slashes. For a twin cable (live and neutral, no earth): two slashes.
+
+1. `Create` tab → `Symbolic Lines`.
+2. `Subcategory: STING_Wire_Annotation`.
+3. Draw a short diagonal line (about 5 mm long at 45 degrees) crossing the wire line. Position it 5-7 mm to the right of the origin.
+4. For a homerun family representing a standard 3-core circuit, draw two more slash marks alongside the first, spaced 1.5 mm apart.
+
+> **Note on count:** If you want the slash count to be variable (1, 2, 3, or 4 conductors), you need to build four separate families (one per count), or use a more advanced approach with visibility parameters that show/hide individual slash marks per count. For most projects, building three standard families (2-wire, 3-wire, 4-wire) is sufficient.
+
+**Step 8: Add the circuit number label**
+
+The circuit number label shows which circuit in the distribution board feeds this wire run.
+
+1. `Create` tab → `Text` panel → `Label`.
+2. Click on the canvas just ABOVE the wire line, near the centre. A label cursor appears.
+3. The "Edit Label" dialog opens. On the left, you see a list of available parameters — if you have not yet added `ELC_CIRCUIT_NUM_TXT` to the family, the list will be empty or show only built-in parameters.
+
+**First, add the shared parameter to the family:**
+
+Close the Edit Label dialog by clicking Cancel. Then:
+
+1. `Create` tab → `Properties` panel → `Family Types`.
+2. In the Family Types dialog, click `Add Parameter...`.
+3. In Parameter Properties, choose `Shared parameter`.
+4. Click `Select...`.
+5. In the Shared Parameters dialog, navigate to the `ELC_` group (Electrical parameters).
+6. Find `ELC_CIRCUIT_NUM_TXT` and click `OK`.
+7. Back in Parameter Properties: set Group = `Identity Data`, and choose `Instance` (so each placed annotation can have its own circuit number).
+8. Click `OK`. The parameter now appears in Family Types.
+
+Now add the label:
+
+1. `Create` tab → `Text` panel → `Label`.
+2. Click above the wire line.
+3. The Edit Label dialog now shows `ELC_CIRCUIT_NUM_TXT` in the left-side parameter list.
+4. Click on `ELC_CIRCUIT_NUM_TXT` in the left list.
+5. Click the middle arrow button (pointing right) to add it to the label content on the right.
+6. In the `Prefix` column, you can optionally type `L` (for luminaire circuits) or `P` (for power circuits) to prefix the circuit number automatically. Leave blank for no prefix.
+7. Click `OK`.
+
+The label appears on the canvas. When the annotation is placed in a project and the parameter is filled in (e.g. "1.1" for circuit 1, sub-circuit 1), the label will display `1.1` on the drawing.
+
+**Styling the label:** Select the label. In the Properties palette:
+- Set `Type` to a suitable text type (small annotation text, approximately 1.5-2.0 mm at the typical 1:50 scale).
+- Check that `Horizontal Align: Center` so it centres over the wire line.
+
+**Step 9: Add the cable gauge label**
+
+The cable gauge label shows the conductor size in mm².
+
+1. Repeat the parameter-adding process for `ELC_WIRE_GAUGE_TXT` (in the `ELC_` group of STING shared parameters). If this parameter does not exist in the shared parameter file, use a family parameter named `Wire_Gauge_TXT` instead for now.
+
+2. Add a second `Label` below the wire line (so the circuit number is above the wire, the gauge is below).
+
+3. In the Edit Label dialog, add `ELC_WIRE_GAUGE_TXT` with a suffix of `mm²` in the `Suffix` column.
+
+4. Click `OK`.
+
+The finished annotation should look like this on the canvas (schematically):
+
+```
+         L1.1
+ ←───── ////── ─────
+         2.5mm²
+```
+
+Where `///` represents the three conductor slash marks.
+
+**Step 10: Test in the Family Types dialog**
+
+Before saving, test that the labels work:
+
+1. `Create` tab → `Family Types`.
+2. In the Family Types dialog, find `ELC_CIRCUIT_NUM_TXT` and type a test value: `L1.1`.
+3. Find `ELC_WIRE_GAUGE_TXT` and type: `2.5`.
+4. Click `Apply`.
+5. Look at the canvas. The label above the wire line should now show `L1.1` and the label below should show `2.5mm²`.
+6. If they update correctly, click `OK`.
+
+> **Stuck?** If the labels do not update when you change the parameter value, make sure the label is linked to the parameter (not just displaying static text). Double-click the label on the canvas to open Edit Label and verify that `ELC_CIRCUIT_NUM_TXT` appears in the right-side content panel.
+
+**Step 11: Save the family**
+
+1. `File → Save` (or Ctrl+S).
+
+The file is saved to `Families/Annotations/Wire/STING_WIRE_ANN_HOMERUN.rfa`.
+
+### 1.4.4 Loading Wire Annotation Families into a Project
+
+1. Open the Revit project.
+2. `Insert` tab → `Load from Library` panel → `Load Family`.
+3. Navigate to `Families/Annotations/Wire/`.
+4. Select `STING_WIRE_ANN_HOMERUN.rfa` (and any other wire annotation families you have built).
+5. Click `Open`.
+
+The families are now loaded into the project. You can verify this in the Project Browser: expand `Families → Annotation Symbols → STING_WIRE_ANN_HOMERUN`.
+
+### 1.4.5 Placing Wire Annotations on a Drawing
+
+Wire annotation families are placed using the Symbol tool, not the Tag tool.
+
+1. Go to an electrical floor plan view (a floor plan with the Electrical discipline setting, showing socket outlets, luminaires, etc.).
+
+2. `Annotate` tab → `Detail` panel → `Symbol`.
+
+3. In the ribbon, a `Type Selector` dropdown appears (usually at the top left of the screen, showing the current family and type). Click the dropdown and find `STING_WIRE_ANN_HOMERUN`.
+
+4. Click on the drawing near the point where the circuit exits toward the panel (typically near the edge of the plan, or near the distribution board symbol).
+
+5. Press `Escape` to stop placing.
+
+6. The annotation appears. It shows placeholder text for the circuit number and gauge (`<ELC_CIRCUIT_NUM_TXT>` and `<ELC_WIRE_GAUGE_TXT>`) until the parameters are filled in.
+
+**Filling in the parameters:**
+
+1. Select the placed annotation.
+2. In the Properties palette on the left, find `ELC_CIRCUIT_NUM_TXT` and type the circuit reference (e.g. `L1.1`).
+3. Find `ELC_WIRE_GAUGE_TXT` and type the cable size (e.g. `2.5`).
+4. The labels on the canvas update immediately.
+
+> **Stuck?** If you cannot find `ELC_CIRCUIT_NUM_TXT` in the Properties palette, the shared parameter was not added correctly to the family, or the family was not loaded with the shared parameter bound. Go back to the Family Editor, check that the parameter is a Shared Parameter (not a Family Parameter), re-save the family, and reload it into the project.
+
+### 1.4.6 Editing Wire Annotations After Placement
+
+**To change the circuit number:** Select the annotation in the drawing. In the Properties palette, edit `ELC_CIRCUIT_NUM_TXT` directly.
+
+**To change the cable gauge:** Same process — edit `ELC_WIRE_GAUGE_TXT` in the Properties palette.
+
+**To move the annotation:** Click and drag it. The annotation is a free-standing element (not linked to a specific host element), so it moves wherever you drag it.
+
+**To rotate the annotation:** Select it, then use the rotation handle (blue circle with rotation arrow) that appears at the top of the selection box when it is selected. Drag the rotation handle to orient the wire line in the correct direction for the circuit route.
+
+**To delete the annotation:** Select it and press `Delete`. This only removes the annotation symbol from the drawing — it does not affect any electrical elements in the model.
+
+### 1.4.7 STING's Wire Annotation in the Electrical Workflow
+
+Wire annotations link to the broader STING electrical workflow in several ways:
+
+**Panel schedules:** When you run the `Panel_BatchSchedules` command (STING → BIM tab → Panels), STING creates panel schedule views and fills in circuit data including back-references to the circuit numbers. The circuit numbers in your wire annotation families (stored in `ELC_CIRCUIT_NUM_TXT`) should match the circuit IDs in the panel schedule.
+
+**Automatic circuit assignment:** If your electrical fixtures already have `ELC_CIRCUIT_NUM_TXT` filled in through STING's auto-tagging pipeline (the `RunFullPipeline` command that writes all STING parameters), wire annotations placed near those fixtures can be manually updated to match, or — if you author the wire annotation to read from the host element rather than storing its own value — they update automatically.
+
+**Validation:** Running `ValidateTagsCommand` (STING → Tags → Validate) flags any electrical elements where `ELC_CIRCUIT_NUM_TXT` is empty. This report helps you identify where wire annotations are needed and where circuit assignment is incomplete.
+
+**COBie export:** When STING exports a COBie handover spreadsheet, it reads `ELC_CIRCUIT_NUM_TXT` from electrical elements to populate the Component sheet's circuit reference column.
+
+### 1.4.8 Common Wire Annotation Mistakes
+
+**Placing the annotation on a non-electrical element:** If you click on a generic model family (a table, a partition) instead of an empty space in the drawing, the annotation may attach to that element. If the element is deleted later, the annotation may disappear or move unexpectedly. Always place wire annotations in open space, not on top of model elements.
+
+**Not loading the shared parameter file first:** If `ELC_CIRCUIT_NUM_TXT` does not appear in the Family Types parameter list when you are building the family, the STING shared parameter file is not set. Go to `Manage → Settings → Shared Parameters → Browse` and point it to `StingTools/Data/MR_PARAMETERS.txt` before adding any parameters.
+
+**Placing in a 3D view:** Generic Annotation families are not visible in 3D views. If you switch to a 3D or perspective view and your wire annotations disappear, this is normal and expected. They will reappear when you switch back to a plan or elevation view.
+
+**Drawing the wire line not passing through the origin:** If the annotation rotates and jumps to a wrong position when you rotate it in the project, the wire line probably does not pass through the origin. Return to the Family Editor, check that the wire line intersects the reference plane crosshairs, and re-save.
+
+**Using a Family Parameter instead of a Shared Parameter for the circuit number:** Family parameters cannot be seen in the project's Properties palette and cannot be scheduled. Always use Shared Parameters from `MR_PARAMETERS.txt` for any data that needs to be visible, schedulable, or readable by STING.
+
+---
+
+# Chapter 2 — Placement Family Authoring
+
+---
+
+## 2.1 What Does "Placement-Ready" Mean?
+
+STING's Placement Centre can automatically place hundreds of families across a building in seconds. But it can only do this if each family "speaks STING's language" — that is, each family is set up correctly so the engine knows:
+
+- Exactly where to grab the family (the origin / insertion point)
+- Which direction is "front" (orientation)
+- What parameters to fill in after placing (STING shared parameters)
+- Which variant of the family to use for each rule
+
+A family that is NOT placement-ready will either be skipped by the engine with a warning ("no FamilySymbol found") or placed in the wrong position (origin in the wrong place means the fixture sits inside the wall, or floats above the ceiling).
+
+Think of the Placement Centre as a robotic chef following a recipe. The recipe says "take one socket outlet, place it 300 mm from the door, 1100 mm above the floor, facing into the room." The robot knows the dimensions, but it needs to know which end of the socket outlet is the "front face" and which end goes into the wall. If the family isn't oriented correctly, the robot places it facing backward. That is what "placement-ready" means — the family is set up so the robot can orient it correctly.
+
+---
+
+## 2.2 The Three Universal Rules Every Family Must Follow
+
+These three rules apply to every single family that will be used with STING's automated placement. There are no exceptions.
+
+### Rule 1: The Insertion Point (Origin) Must Be at the Correct Location
+
+Every family has an origin — the point that Revit snaps to the exact location where you click when placing the family. The Placement Centre uses the origin as its placement point.
+
+For different types of equipment, the origin goes in different places:
+
+- **Wall-mounted fixtures (sockets, switches, data outlets):** The origin sits at the fixing-centre midpoint of the front face (the faceplate plane). NOT at the back of the back box. NOT at the geometric centre of the complete assembly.
+
+- **Ceiling-mounted fixtures (downlights, smoke detectors, sprinklers):** The origin sits at the point where the fixture meets the ceiling — the visible face of the fitting.
+
+- **Floor-mounted fixtures (shower trays, floor drains):** The origin sits at the geometric centre of the footprint at floor level.
+
+- **Wall-hung sanitary fixtures (basins, WCs):** The origin sits at the centre of the fixture footprint, not the bowl or the basin centre.
+
+An analogy: think of the origin as a drawing pin you push through a map to stick it to a board. Revit places the family pin-first. If the pin is at the back of the box (25 mm behind the wall face), the socket will sit 25 mm inside the wall — invisible and wrong. If the pin is at the correct face position, the socket sits flush with the wall surface.
+
+**Common mistake:** Many families downloaded from manufacturer websites or generic libraries have the origin at the geometric centre of the 3D solid — the middle of the box, not the faceplate. You MUST check and correct this before using the family with STING's Placement Centre.
+
+**How to fix a wrong origin:** Open the family in the Family Editor. Switch to a front elevation view. Move the model geometry so that the faceplate plane aligns exactly with the vertical reference plane. The vertical reference plane is the origin line.
+
+### Rule 2: Reference Planes Must Be Named Correctly
+
+Reference planes in the Family Editor are used by the Placement Centre to understand the family's orientation. Specifically, the plane that represents the wall face (for wall-mounted fixtures) must be named correctly and configured correctly.
+
+The required reference plane name is `Center (Front/Back)`.
+
+Why this name? The Placement Centre's auto-orientation code (`OrientPlacedInstance` in the engine) looks for a reference plane with this name to determine which direction is "outward into the room" — so it can flip the family to face the correct direction.
+
+**To check and fix the reference plane configuration:**
+
+1. Open the family in the Family Editor.
+2. Switch to a plan view.
+3. You should see two reference planes: one horizontal (the `Center (Left/Right)` plane) and one vertical (the `Center (Front/Back)` plane).
+4. Click on the vertical reference plane (the one running from top to bottom in plan view — this represents the wall face for a wall-mounted fixture).
+5. In the Properties palette:
+   - `Name:` should read `Center (Front/Back)`. If it reads anything else, click in the Name field and type the correct name.
+   - `Is Reference:` set to `Strong Reference`.
+   - `Defines Origin:` ticked.
+6. Save the family.
+
+> **Stuck?** If you cannot see the reference plane names, look in the Properties palette while the reference plane is selected. The name appears near the top of the properties list. If the name field shows `<unnamed>`, you need to type a name in.
+
+### Rule 3: STING Shared Parameters Must Be Bound
+
+Without STING's shared parameters, the Placement Centre cannot write tag data to the family after placing it, cannot track the provenance of the placement, and cannot run the COBie export correctly.
+
+The minimum required shared parameters for every family are:
+
+| Parameter name | Type | Purpose |
+|---|---|---|
+| `STING_BOX_LOCATION_ID` | Text | Two-phase matching — links the second-fix fitting to the first-fix back box |
+| `STING_NOGGIN_REQUIRED` | Yes/No | Flags that a structural noggin is needed for pendants and heavy fittings |
+| `STING_AUTO_PLACED_BOOL` | Yes/No | The Placement Centre sets this to Yes after placing; identifies auto-placed elements |
+| `STING_FIXTURE_VARIANT_TXT` | Text | The variant hint the placement rule matches against (e.g. "FLUSH", "IP65", "BASIN") |
+
+Additionally, the catalogue parameters (`MK_BOX_DEPTH_MM`, `MK_FIXING_CENTRES_MM`, `MK_GANG_COUNT`, `MK_CATALOGUE_REF`) are needed for the manufacturer catalogue matching system.
+
+Section 2.4 below walks through adding these parameters step by step.
+
+---
+
+## 2.3 Per-Category Authoring Rules
+
+Each Revit category has its own specific requirements. Use this table to find the rules for the category you are working on:
+
+| Category | Origin location | Required reference planes | Key STING parameters | Special notes |
+|---|---|---|---|---|
+| Electrical Fixtures (sockets, FCUs, cooker points) | Fixing-centre midpoint of the FRONT face (faceplate plane) | `Center (Front/Back)` = wall face; `Center (Left/Right)` for symmetry | `MK_BOX_DEPTH_MM`, `MK_FIXING_CENTRES_MM`, `MK_GANG_COUNT`, `MK_CATALOGUE_REF`, `STING_FIXTURE_VARIANT_TXT` | Set `Family Placement Type = One Level Based Hosted`. Engine auto-flips to face the room. |
+| Lighting Devices (switches, dimmers, 2-way, DALI) | Faceplate midpoint | `Center (Front/Back)` = wall face | `MK_BOX_DEPTH_MM`, `STING_FIXTURE_VARIANT_TXT` ("DIMMER" / "DALI" / "2-WAY") | Set `Always Vertical = Yes` or switch lands flat on door head. Engine auto-rotates so the rocker faces into the room. |
+| Lighting Fixtures (pendants, downlights, LED panels) | Visible drop centre (for pendants), flush face (for downlights) | `Ceiling` plane, `Defines Origin = Yes` | `MK_CATALOGUE_REF`, `STING_PHOTOMETRIC_LM` (lumens), `IS_INDIVIDUAL_LUMINAIRE = Yes` | Must be Ceiling-Hosted (not OneLevelBased-Unhosted) or the engine cannot find a ceiling to attach to. |
+| Plumbing Fixtures (WC, basin, shower, urinal) | Centre of the FIXTURE FOOTPRINT (not the bowl centre) | `Center (Left/Right)`, `Center (Front/Back)`, both `Reference = Strong` | `IS_FIXTURE_BACK_TO_WALL = Yes`, `STING_FIXTURE_VARIANT_TXT` ("WC" / "BASIN" / "SHOWER") | Engine does NOT rotate plumbing fixtures — "facing away from wall" must be correct in the family. Room name regex filters (word-boundary matched) prevent WCs in wardrobes. |
+| Mechanical Equipment (AHUs, boilers, chillers) | Equipment footprint centre at floor level | `Center (Front/Back)` for access door side | `PLACE_WEIGHT_KG`, `MNT_ENV_W_MM`, `MNT_ENV_D_MM`, `MNT_ENV_H_MM`, `STING_CLEARANCE_MM` | Large equipment uses structural pre-flight check (`PLACE_WEIGHT_KG` vs floor loading). |
+| Fire Protection (MCP, sounder, beacon) | Faceplate centre | `Center (Front/Back)` = wall face | `BS5839_DEVICE_KIND` ("MCP" / "SOUNDER" / "BEACON"), `STING_FIXTURE_VARIANT_TXT` | Must be Wall-Hosted. Ceiling-hosted smoke/heat detectors use separate rules. |
+| Fire Protection (smoke, heat detectors) | Sensor head face (bottom of detector) | Ceiling plane | `BS5839_DEVICE_KIND` ("SMOKE" / "HEAT"), `Coverage Radius` | Must be Ceiling-Hosted. The LightingGridCalculator checks structural fixing suitability for ceiling hosts. |
+| Sprinklers | Deflector centre | Face of ceiling or soffit | `BS_5306_K_FACTOR`, `Coverage Radius`, `STING_FIXTURE_VARIANT_TXT` ("UPRIGHT" / "PENDANT" / "CONCEALED") | Ceiling-Hosted or Face-Based. Engine enforces 600 mm minimum BS 5306 separation from other sprinklers. |
+| Data/Comms Devices (RJ45, HDMI outlets) | Faceplate midpoint | `Center (Front/Back)` = wall face | `STING_FIXTURE_VARIANT_TXT` ("HDMI" / "USB-C" / "RJ45"), `MK_MODULE_PITCH_MM = 25.4` | Must be the correct Revit category (Communications Devices, not Generic Model). |
+| Generic Models (grab rails, miscellaneous) | Geometric centre | Standard reference planes | `STING_FIXTURE_VARIANT_TXT`, `STING_AUTO_PLACED_BOOL` | Used for accessibility items. Engine places using standard anchor types. |
+
+---
+
+## 2.4 Binding STING Shared Parameters to a Family
+
+Shared parameters must be explicitly added to each family file. This is a manual process but a fast one once you know the steps.
+
+**Step 1: Set the STING shared parameter file as the current file**
+
+1. Open the family `.rfa` file in the Family Editor.
+2. `Manage` tab → `Settings` panel → click `Shared Parameters`.
+3. The "Edit Shared Parameters" dialog opens.
+4. Click `Browse...` and navigate to `StingTools/Data/MR_PARAMETERS.txt`.
+5. Click `Open`. The dialog now shows the parameter groups from the STING shared parameter file.
+6. Click `OK` to close the dialog.
+
+**Step 2: Add the required parameters**
+
+1. `Create` tab → `Properties` panel → `Family Types`.
+2. The Family Types dialog opens.
+3. Click `Add Parameter...` at the bottom-left.
+4. The "Parameter Properties" dialog opens. Choose `Shared parameter` (not `Family parameter`).
+5. Click `Select...`.
+6. The shared parameters dialog opens. Find the correct group for your family's category:
+   - `MK_` group = MK Electric manufacturer catalogue parameters (sockets, switches, etc.)
+   - `STING_` group = STING automation parameters (auto-placed bool, box location ID, etc.)
+   - `ELC_` group = Electrical parameters (circuit number, wire gauge, etc.)
+   - `HVC_` group = HVAC parameters
+   - `PLM_` group = Plumbing parameters
+   - `FLS_` group = Fire and life safety parameters
+7. Click on the group, then click the specific parameter you want to add.
+8. Click `OK`.
+9. Back in Parameter Properties: choose whether it should be a `Type` or `Instance` parameter.
+   - Most STING automation parameters (`STING_AUTO_PLACED_BOOL`, `STING_BOX_LOCATION_ID`) should be **Instance** parameters — each placed copy has its own value.
+   - Catalogue parameters like `MK_BOX_DEPTH_MM` and `MK_GANG_COUNT` are typically **Type** parameters — all instances of the same type share the same depth and gang count.
+10. Click `OK`. The parameter appears in the Family Types list.
+11. Repeat for each required parameter.
+12. Click `OK` to close the Family Types dialog.
+13. `File → Save`.
+
+**Step 3: Verify the parameters in a test project**
+
+1. `Create` tab → `Family Editor` panel → `Load into Project`.
+2. In the project, place a test instance of the family.
+3. Select the placed instance.
+4. In the Properties palette, look for your newly added parameters. They should appear under the relevant group heading.
+5. Try typing a value into one of the parameters. It should save without error.
+
+> **Stuck?** If a parameter you added does not appear in the project's Properties palette for the placed instance, it may have been added as a Type parameter when it should be an Instance parameter (or vice versa). Go back to the Family Editor, open Family Types, find the parameter, and check/change its Type vs Instance setting. Re-save and reload.
+
+---
+
+## 2.5 Testing a Family Before Production Use
+
+Run this checklist every time you author or modify a family for use with STING:
+
+- [ ] **Origin placement:** Place the family in a test project at multiple levels. Does it sit at the correct height and position? A socket at 300 mm AFF with a 1100 mm rule should sit with its face flush with the wall at 300 mm, not 25 mm inside the wall or floating 25 mm in front.
+
+- [ ] **Orientation:** After placing, does the family face the correct direction? For wall-mounted fixtures, the faceplate should face into the room. If it faces the wall, the origin or the `Center (Front/Back)` reference plane is wrong.
+
+- [ ] **Auto-tag:** Select the placed family and run the STING Auto Tag command (STING panel → SELECT tab → Auto Tag, or from the dock panel Tags/Tokens section). Does STING successfully write the DISC, LOC, ZONE, LVL, SYS, FUNC, PROD, and SEQ tokens?
+
+- [ ] **Validate Tags:** Run `ValidateTagsCommand` (STING panel → Tags → Validate). Are there any errors reported for this family's placed instances?
+
+- [ ] **Shared parameters visible:** In the Properties palette for a placed instance, can you see `STING_AUTO_PLACED_BOOL`, `STING_BOX_LOCATION_ID`, `STING_FIXTURE_VARIANT_TXT`, and `MK_CATALOGUE_REF`?
+
+- [ ] **Ceiling/wall attachment:** For hosted families (Ceiling-Based, Wall-Based), can you place the family on the correct host? Try placing a ceiling-hosted fixture and then moving the ceiling — does the fixture move with it?
+
+- [ ] **Placement Centre test:** Open the Placement Centre, find or create a rule for this family's category, run Preview. Do the preview dots appear at the correct locations?
+
+- [ ] **STING Placement Audit:** Run `Placement_AuditSetup` from the STING dock panel. This command cross-checks all placement requirements against the live model and writes a CSV report identifying missing parameters, wrong reference planes, and other issues.
+
+---
+
+# Chapter 3 — The Placement Centre
+
+---
+
+## 3.1 What the Placement Centre Does
+
+The 30-second version: you write rules ("put one smoke detector every 7.5 metres in corridors per BS 5839-1"). The Placement Centre executes those rules automatically across every room in the building.
+
+In an average UK office building, one floor needs approximately:
+- 200 wall sockets
+- 80 light switches
+- 120 luminaires
+- 40 emergency luminaires
+- 30 smoke detectors
+- 20 sprinklers
+- 40 air diffusers
+
+That is roughly 600 placements per floor. On a six-storey building, 3,600 placements. Doing this by hand takes weeks per revision. The Placement Centre does it in minutes — and every placement carries a provenance stamp recording which rule placed it, when, and with which standard reference.
+
+When an inspector asks "why is this socket here?" the answer is one click away: the provenance stamp says `Rule: elec-perimeter-socket-01, Standard: Approved Doc M / BS 7671, Placed: 2026-04-25 14:30 UTC`.
+
+---
+
+## 3.2 Before You Start — Prerequisites
+
+Before running the Placement Centre for the first time on a project, confirm all four prerequisites:
+
+**1. Families must be placement-ready (Chapter 2)**
+
+Every family you want the Centre to place must have the correct origin, correct reference planes, and STING shared parameters bound. Run `Placement_AuditSetup` to check this automatically.
+
+**2. STING shared parameters must be loaded into the project**
+
+The shared parameters must be bound to the Revit project, not just to individual families.
+
+To do this: STING dock panel → SELECT tab → scroll to find `Load Shared Parameters` button → click it. STING runs through a two-pass binding process that loads all STING shared parameters from `MR_PARAMETERS.txt` into the project.
+
+Alternatively: `Tags.LoadSharedParamsCommand` from the Tags dropdown.
+
+> **Stuck?** If the Load Shared Parameters button asks you to confirm overwriting existing parameters, say Yes — this is safe and just ensures all parameters are bound to the current project.
+
+**3. A placement rules file must exist or be loaded**
+
+STING ships with a baseline rule set of approximately 43 rules (`StingTools/Data/Placement/STING_PLACEMENT_RULES.json`), plus seven additional discipline packs covering electrical, mechanical, lighting, accessibility, commissioning, and more.
+
+On first use, the Placement Centre automatically loads the baseline rules. You do not need to do anything.
+
+**4. The project must have Phases set up correctly**
+
+The Placement Centre uses Revit Phases to separate first-fix work (the back boxes and conduit installed before plastering) from second-fix work (the fittings installed after plastering). You need at least two phases named `Construction` and `Handover` in the project.
+
+To check: `Manage` tab → `Phases`. Make sure at least two phases exist with names the Centre can recognise.
+
+---
+
+## 3.3 The STING_PLACEMENT_RULES.json File
+
+Placement rules are stored in JSON files — text files in a format that both humans and computers can read. You do not need to edit JSON directly; the Placement Centre has a visual editor for all rule fields. But understanding the file structure helps when you need to share rules between projects or troubleshoot unexpected behaviour.
+
+**Where the files live:**
+
+```
+StingTools/Data/Placement/
+├── STING_PLACEMENT_RULES.json                      (baseline ~43 rules)
+├── STING_PLACEMENT_RULES.electrical.json           (electrical discipline pack)
+├── STING_PLACEMENT_RULES.mechanical.json           (mechanical discipline pack)
+├── STING_PLACEMENT_RULES.architecture.json         (architectural services pack)
+├── STING_PLACEMENT_RULES.healthcare-education.json (healthcare and school rules)
+├── STING_PLACEMENT_RULES.accessibility.json        (BS 8300-2 / Approved Doc M)
+├── STING_PLACEMENT_RULES.commissioning.json        (T&C test points and gauges)
+├── STING_PLACEMENT_RULES.medical-gases.json        (HTM 02-01 bedhead trunking)
+└── STING_PLACEMENT_RULES.routing.json              (cable tray, conduit, duct riser routes)
+
+[project folder]/
+├── STING_PLACEMENT_RULES.project.json              (your project-specific overrides)
+└── STING_PLACEMENT_RULES.learned.json              (output from LearnPlacementV4Command)
+```
+
+**The layering system (four layers, highest wins):**
+
+When the Centre loads, it reads all layers in order. Rules with the same ID in a higher layer override rules in a lower layer:
+
+1. Baseline (`STING_PLACEMENT_RULES.json`) — lowest priority
+2. Discipline packs (the seven pack files above)
+3. Learned rules (`STING_PLACEMENT_RULES.learned.json`) — Priority 90
+4. Project overrides (`STING_PLACEMENT_RULES.project.json`) — highest priority
+
+This means: if you save a modified version of the emergency lighting rule to the project file, YOUR version runs instead of the shipped version, on your project only.
+
+**Anatomy of a single rule:**
+
+Every rule answers the questions: what, where, in which rooms, how many, per which standard. Here is a simplified example of what a rule looks like in JSON:
+
+```json
+{
+  "RuleId": "elec-light-emergency-route",
+  "CategoryFilter": "Lighting Fixtures",
+  "VariantHint": "EM",
+  "RoomFilter": "(?i)\\b(corridor|lobby|stair|escape|exit)\\b",
+  "AnchorType": "ESCAPE_ROUTE_CENTRELINE",
+  "MountingHeightMm": 0,
+  "MountingReference": "CEILING",
+  "MinSpacingMm": 8000,
+  "RuleKind": "Linear",
+  "PerLinearMetre": 8.0,
+  "MaxPerRoom": 0,
+  "StandardRef": "BS 5266-1 / BS EN 1838",
+  "Priority": 70
+}
+```
+
+Reading this plain-English: "In rooms whose name contains corridor, lobby, stair, escape, or exit, place Lighting Fixtures with the EM (emergency) variant at ceiling height, spaced no closer than 8 metres, one every 8 linear metres of escape route centreline, per BS 5266-1."
+
+**The 43 built-in rules cover:**
+
+Perimeter sockets at 600 mm centres, door-hinge switches per Approved Doc M, smoke detectors per BS 5839-1, sprinklers per BS EN 12845, emergency lighting per BS 5266-1, air diffusers per BS EN 12464-1, thermostats, data outlets at desks, MCP travel distance per BS 5839-1, accessible WC grab rails per BS 8300-2, and more.
+
+---
+
+## 3.4 Every Button in the Placement Centre Explained
+
+The Placement Centre opens as a floating dialog or a docked panel. It has a toolbar at the top, a rule list on the left, a rule editor on the right, and a status bar at the very bottom.
+
+| Button label | Keyboard shortcut | What it does | When to use it |
+|---|---|---|---|
+| `Reload Defaults` | (none) | Discards all in-memory edits and reloads the shipped baseline rules | "I've made a mess — give me back factory settings." Will prompt before discarding unsaved edits. |
+| `Import…` | (none) | Opens a file picker and merges rules from a `.json` file | Importing discipline packs from a colleague or from a project library. Rules with the same ID are skipped (not overwritten). |
+| `Export…` | (none) | Writes all valid rules to a `.json` file | Sharing your rule set or backing it up. Invalid rules are skipped. |
+| `Save Project` | Ctrl+S | Writes the current rule set to `[project]/STING_PLACEMENT_RULES.project.json` | Every time you edit or create a rule. Orange dot in the rule list column means unsaved. |
+| `Run Placement` | Alt+R | Runs the engine — reads every rule, walks every room in scope, places real Revit family instances | When you are ready to commit placements to the model. Wraps in a single TransactionGroup (one Ctrl+Z undoes the whole batch). |
+| `Preview` | Alt+P | Dry-run — shows a 3D coloured overlay of where fixtures would land, without touching the model | Before committing. Each rule gets its own colour. Press Escape to clear the overlay. |
+| `Validate` | Alt+V | Runs validators against the placed elements or project-wide | After a placement run, or for a standalone audit. Eight validators available (see Section 3.10). |
+| `Undo last run` | (none) | Deletes every element placed by the most recent run (reads provenance stamps to find them) | "I placed 600 fixtures but something's wrong — take them all back." Prompts with the count before deleting. |
+| `Push to Families` | (none) | Writes the selected rule's values (clearances, weights, mounting height) onto every family Type in that category | Keeping family parameters in sync with rules so COBie export and schedules read the right numbers. |
+| `Heat-map` | (none) | Paints an Analysis Visualization Framework (AVF) compliance overlay — green where rules are satisfied, red where not | Management reviews, deliverable QA, showing completion status to a reviewer. |
+| `Save view preset` | (none) | Stamps the current view scope and settings so a run is reproducible | At the end of a successful placement run you want to be able to repeat. |
+| `GD Study` | (none) | Explains how to launch the Generative Design study (`.dyn` file in `Data/GenerativeDesign/`) | Optimising rule weights when you don't yet know the right values. |
+| `Close` | (none) | Closes the Centre | Unsaved edits are kept in memory but lost when Revit closes. Always Save Project first. |
+
+**The rule list grid (left side):**
+
+| Column | What it means |
+|---|---|
+| `●` | Orange dot = unsaved edits |
+| `Category` | Revit category name (e.g. "Lighting Devices") |
+| `Variant` | The variant hint (or blank) |
+| `Room` | Room filter regex (or blank = all rooms) |
+| `Anchor` | The anchor type |
+| `Pri` | Priority 0-100. Higher priority wins when rooms compete for slots. |
+
+The search box above the grid filters by any column. Type "door" to see only door-related rules. Clear it to see everything.
+
+The `● Dirty` and `✗ Invalid` toggle buttons show only unsaved or only invalid rules. Useful for focused editing.
+
+---
+
+## 3.5 Placing Fixtures — Step by Step
+
+This worked example places socket outlets along the perimeter of office rooms.
+
+**Scenario:** You have an office floor plan. Office rooms need perimeter socket outlets at 1100 mm above the floor, one every 600 mm along every wall.
+
+**Step 1: Verify families are loaded**
+
+1. In the project, go to the Project Browser.
+2. Expand `Families → Electrical Fixtures`.
+3. Look for a socket outlet family with a `FLUSH` type (the `STING_FIXTURE_VARIANT_TXT` value). If it is not there, load it: `Insert → Load Family → navigate to your socket outlet family → Open`.
+
+**Step 2: Open the Placement Centre**
+
+From the STING dock panel:
+- `TAGS` tab → `Fixtures` sub-tab → click `Place Fixtures`.
+
+Or from the ribbon (if using the STING ribbon tab):
+- `STING Tools` tab → Placement group → `PlaceFixtures`.
+
+The Placement Centre dialog opens.
+
+**Step 3: Find the perimeter socket rule**
+
+In the rule list on the left, look for a rule named approximately `elec-perimeter-socket` or similar. You can type "socket" or "perimeter" in the search box to filter.
+
+Click the rule to select it. The right side shows all the rule's settings.
+
+**Step 4: Verify the rule settings**
+
+In the `Rule Core` group on the right:
+- `Category Filter:` should read `Electrical Fixtures`
+- `Variant Hint:` should read `FLUSH` (or `FLUSH,SURFACE` as a fallback chain)
+- `Room Filter (regex):` should read something like `(?i)\b(office|workspace|open plan)\b`
+- `Anchor:` should read `PERIMETER_OFFSET`
+
+In the `Geometry` group:
+- `Mount Height (mm):` `1100`
+- `Mount Reference:` `FFL` (above finished floor)
+- `Min Spacing (mm):` `600`
+
+In the `Rule Kind` group:
+- `Kind:` `Linear`
+- `Per linear m:` `0.6` (one per 600 mm = one per 0.6 metres)
+
+In `Standards & Classification`:
+- `Standard ref:` should read `Approved Doc M / BS 7671`
+
+If any of these don't match what you need, edit the fields directly. Remember to click Save Project (Ctrl+S) after editing.
+
+**Step 5: Set the scope**
+
+In the `Run Options` group (bottom of the right panel):
+- `Scope:` choose `Active view` for just the current floor plan, or `Project` for all floors.
+
+**Step 6: Preview first**
+
+Click `Preview` (or press Alt+P) in the toolbar.
+
+The canvas shows coloured dots/crosses at every location where a socket would be placed. Each rule has its own colour, so you can identify socket placements vs other fixture placements.
+
+Check:
+- Are the dots along the walls of office rooms? (Yes = correct anchor type)
+- Are there dots in the corridor? (If yes, your Room Filter may be too broad — it is matching corridor rooms)
+- Are the dots at roughly 600 mm spacing? (If they look closer or further, check the Per linear m value)
+
+Press `Escape` to clear the preview.
+
+**Step 7: Run Placement**
+
+When the preview looks correct, click `Run Placement` (or press Alt+R).
+
+A progress indicator appears. For a large floor with many rooms, this may take 10-60 seconds.
+
+When complete, a result panel appears showing:
+- Rooms visited: N
+- Candidates evaluated: M
+- Placed: P
+- Skipped (rule conditions not met): Q
+- Warnings: W (if any)
+
+The placed elements are automatically selected in Revit — you can immediately see them highlighted in the canvas.
+
+**Step 8: Review the result**
+
+Click somewhere empty to deselect, then look at the model. Socket outlets should appear along the walls of office rooms.
+
+If something looks wrong:
+- Click `Undo last run` in the Centre toolbar (not Ctrl+Z — use the Centre's own undo button for batch placements).
+- Adjust the rule as needed.
+- Preview again.
+- Re-run.
+
+**Step 9: Run Validate**
+
+After any successful placement run, click `Validate` (Alt+V) in the toolbar.
+
+The validator checks clearances, maintenance access, and any other validators you have selected in the `Validators` checkbox panel. Any issues appear in a result panel.
+
+Common validation findings after socket placement:
+- "Clearance violation: M-ELC-01-0003 is 180 mm from M-ELC-01-0004" — two sockets are too close (probably because the room corner forced them together). Click the element reference to select and inspect.
+- "Spec mismatch: STING_FIXTURE_VARIANT_TXT expected FLUSH, found SURFACE" — the family resolved to a SURFACE type instead of FLUSH (the preferred variant was not loaded). Load the FLUSH type family and re-run.
+
+> **Stuck?** If Run Placement reports "No FamilySymbol found for category Electrical Fixtures," there is no family of that category loaded in the project. Load one first (Insert → Load Family), then re-run. See Section 3.10 for more troubleshooting.
+
+---
+
+## 3.6 The Lighting Grid
+
+The lighting grid is a specific placement pattern for luminaires — a regular rectangular grid of light fittings calculated to meet a target illuminance level per BS EN 12464-1.
+
+Think of ceiling tiles in an office. They are arranged in a perfect grid, usually 600 × 600 mm or 1200 × 600 mm. Luminaires in an office follow a similar grid, sized so that the spacing between luminaires provides the required light level (measured in lux) at the working plane (typically 0.85 m above the floor for a desk, or 0.0 m for a car park).
+
+**What the LightingGridCommand does:**
+
+1. For each room in scope, reads the room's dimensions and the target lux level from the rule.
+2. Calculates the required luminaire spacing using the Light Loss Factor, luminaire lumens, and utilisation factor.
+3. Generates a grid of candidate points snapped to the nearest ceiling tile centre (if `SnapToCeilingTile = Yes` in the rule) or at regular spacing.
+4. Checks each point against clearance rules (minimum distance from walls, from sprinklers per BS 5306).
+5. Places luminaires at the accepted points.
+6. Reports uniformity ratio (minimum lux / average lux) and flags rooms that cannot achieve the target uniformity.
+
+**Step-by-step for a standard office lighting grid:**
+
+1. Open the Placement Centre.
+2. Find the rule `lux-grid-office-500` (or similar) in the rule list. If it does not exist, click `+` and create one:
+   - `Category Filter:` `Lighting Fixtures`
+   - `Variant Hint:` `RECESSED` (or whatever your office luminaire type is)
+   - `Room Filter:` `(?i)\b(office|workspace|open plan)\b`
+   - `Anchor:` `LIGHTING_GRID`
+   - `Mount Reference:` `CEILING`
+   - `Mount Height (mm):` `100` (100 mm below the ceiling — adjust for your ceiling type)
+
+3. In the `Geometry` group, set `Min Spacing (mm):` `1200` (minimum 1.2 m between luminaires — prevents the grid from placing luminaires too close together in small rooms).
+
+4. In `Run Options`, make sure `Scope:` is set correctly (`Active view` for a single floor plan).
+
+5. Click `Preview`. You should see a regular grid of dots on the ceiling of office rooms.
+
+**Boundary options:**
+
+The grid can be bounded in three ways, selected in the rule's `Geometry` group:
+
+- **Room boundary (default):** The grid is calculated to fit inside the room boundary with a margin (typically 600 mm from the wall, editable). This is the most common option.
+- **Crop region:** The grid fills the active view's crop region. Useful for open-plan layouts that span multiple rooms.
+- **Manual:** You draw a boundary in the project before running. Not currently supported through the Centre's UI — use Room boundary or Crop region.
+
+**Adjusting after placement:**
+
+Luminaires placed by the lighting grid can be moved manually after placement. When you move a luminaire, you break its "auto-placed" provenance link — but the luminaire remains tagged and parametric. Moving a small number of luminaires to avoid ceiling features (beams, HVAC grilles) is normal practice.
+
+If you need to re-run the grid after moving luminaires (for example, after a room layout change), click `Undo last run` in the Centre, make your changes to the rules or room boundaries, and re-run.
+
+---
+
+## 3.7 Learning from Existing Placements (LearnPlacementV4Command)
+
+Imagine you receive a project where someone has already manually placed a representative sample of fixtures in a few rooms — a careful drafter has placed sockets, switches, and lights correctly in the ground floor. Now you need to place the same pattern across the remaining five floors.
+
+The `LearnPlacementV4Command` analyses the existing placements in the model and reverse-engineers the placement rules that would produce them. It then saves those rules to a `STING_PLACEMENT_RULES.learned.json` file next to the `.rvt`.
+
+**When to use this command:**
+
+- When you inherit a partially modelled project and want to continue with consistent placement rules.
+- When a client provides a sample layout for one floor that should be replicated across all others.
+- When you want to verify that STING's built-in rules match what was already in the model.
+
+**Step by step:**
+
+1. Make sure the source model contains at least one well-placed example of each fixture type you want to learn. The more examples (more rooms), the more reliable the learned rules.
+
+2. From the STING dock panel: `TAGS` tab → `Fixtures` sub-tab → click `Learn Placement V4`.
+
+Or from the Revit search (press the `/` key or use the search box in the ribbon): type `Placement_Learn` and press Enter.
+
+3. The command runs. It walks the model, groups placed fixtures by category and room type (using the room name), and calculates the statistical centre, spacing, and mounting height for each group.
+
+4. A result dialog appears showing how many rule "prototypes" were found:
+   ```
+   Learned 12 rule prototypes:
+   - Lighting Fixtures / office: 1200 mm spacing, 2400 mm AFF, 47 instances
+   - Electrical Fixtures / FLUSH / office: 600 mm linear, 1100 mm AFF, 83 instances
+   - Plumbing Fixtures / BASIN / bathroom: 1 per room, 850 mm AFF, 8 instances
+   ...
+   ```
+
+5. Click `Save` in the result dialog. The rules are written to `STING_PLACEMENT_RULES.learned.json`.
+
+6. Open the Placement Centre. In the toolbar, click `Reload Defaults`. The Centre now loads the learned rules (at Priority 90) alongside the baseline rules.
+
+7. In the rule list, the learned rules appear with a `SourcePack: learned` tag. Review them — the engine is making educated guesses from statistical analysis, so some rules may need tweaking.
+
+8. Edit any rules that don't look right. Save Project.
+
+9. Run Placement for the remaining floors.
+
+**What the output looks like:**
+
+The `STING_PLACEMENT_RULES.learned.json` file contains rules in exactly the same JSON format as the shipped baseline. The rules are tagged with Priority 90 so they override the baseline (Priority ~50-70) but can be overridden by project-specific rules (Layer 4, any priority).
+
+---
+
+## 3.8 Rehosting Elements — Moving Equipment Between Hosts
+
+### What is Rehosting?
+
+In Revit, some families are "hosted" — they physically attach to a host element. A ceiling-mounted downlight is hosted by the ceiling. A wall socket is hosted by the wall. A wall-hung basin is hosted by the wall.
+
+This hosting relationship means the family moves when the host moves. If you move the ceiling 50 mm lower, all the downlights hosted by that ceiling move down 50 mm with it. This is a useful behaviour — services follow the structural decisions automatically.
+
+But hosting can cause problems:
+
+- If you delete the ceiling and recreate it (common during design changes), the downlights lose their host and become "unhosted" — they float in space at their original position.
+- If you change a wall's location significantly, the hosted socket may end up in a void or inside another wall.
+- If a level changes height, elements hosted to the slab may shift unexpectedly.
+
+Rehosting means assigning a new host element to a family instance that has lost its original host, or deliberately moving a family from one host to another.
+
+### When Rehosting is Needed
+
+- **Ceiling deleted and recreated:** The most common cause. Any design coordination change that requires deleting and recreating a ceiling will orphan its hosted luminaires.
+- **Wall demolished and rebuilt:** Moving a wall to a new location and back may require rehosting wall-mounted fixtures.
+- **Level height changed:** If a level is shifted in the Levels view, elements may not re-host correctly to the revised level.
+- **Phase change:** Elements placed in Phase 1 on a temporary ceiling may need rehosting to the permanent ceiling in Phase 2.
+- **Linked model changes:** If a structural engineer updates their linked model and ceiling soffits change, MEP fixtures may lose their hosts.
+
+### How to Rehost in Revit — The Native Way
+
+Revit's built-in rehosting tool is called "Pick New Host." Here is how to use it:
+
+1. Select the element that needs rehosting (the orphaned luminaire, the socket on the deleted wall, etc.).
+
+2. In the ribbon, go to the `Modify` tab (this tab appears whenever an element is selected).
+
+3. Look in the `Host` panel (usually on the right side of the Modify tab). Click `Pick New Host`.
+
+4. The cursor changes to indicate it is waiting for you to select a host. Move over the element you want to use as the new host (the new ceiling, the replacement wall). When the correct element is highlighted, click.
+
+5. The family instance reattaches to the new host. It moves to the host's surface — which may change its position if the new host is at a different location.
+
+6. Check the family's position. You may need to adjust the offset to maintain the correct location.
+
+> **Stuck?** If the "Pick New Host" button is greyed out or not visible, the selected family is not a hosted family — it is either face-based or unhosted. Face-based families can be rehosted; unhosted families cannot.
+
+### How STING Helps with Rehosting
+
+STING provides two tools that automate rehosting tasks:
+
+**ValidateFillsCommand:** Identifies elements that have lost their host (or have other connectivity issues). Run it from the STING dock panel (Routing tab or BIM tab depending on your version). The report shows elements that are "orphaned" (no valid host found).
+
+**AutoDropCommand:** The AutoDropCommand is primarily for routing MEP services, but it also re-establishes host connections when MEP elements have been orphaned. Run it after any significant model change that may have broken hosting.
+
+### Rehosting Workflow — Step by Step
+
+When you receive a message like "1 warning: Lighting Fixtures lost host" (shown in Revit's warnings) or the ValidateFills report shows orphaned elements, follow this workflow:
+
+1. **Identify orphaned elements:**
+   - Run `ValidateFillsCommand` (STING dock panel → Routing tab → Validate Fills).
+   - In the result panel, note which elements are flagged as "No valid host" or "Orphaned."
+   - Alternatively: use Revit's native "Review Warnings" (Manage → Review Warnings) to find "Hosted element lost its host."
+
+2. **Find the replacement hosts:**
+   - Go to the area in the model where the orphaned elements are.
+   - Identify the new ceiling, wall, or floor that should host each orphaned element.
+
+3. **Rehost each element:**
+   - Select the orphaned element.
+   - Modify tab → Pick New Host → click the replacement host.
+   - Verify position.
+
+4. **For large batches:** If dozens of luminaires have lost their host due to a ceiling redesign:
+   - Consider deleting the orphaned elements and re-running the Placement Centre for that area.
+   - The Placement Centre's "Undo last run" + "Re-run" workflow is faster than manually rehosting large numbers of elements.
+
+5. **Re-validate:**
+   - Run `ValidateFillsCommand` again.
+   - All previously-orphaned elements should now show as hosted.
+
+### Common Rehosting Errors and Fixes
+
+| Error | Cause | Fix |
+|---|---|---|
+| "Hosted element lost its host" (Revit warning) | The host element was deleted or significantly modified | Use Pick New Host, or delete and re-place using Placement Centre |
+| Family appears at wrong height after rehosting | New host is at a different elevation than the old host | Adjust the vertical offset in the family's Properties after rehosting |
+| "Cannot pick host: invalid host" | Trying to host a wall-based family on a ceiling (wrong host category) | Delete and re-place using the correct family template (wall-based vs ceiling-based) |
+| Family disappears after rehosting | New host is in a different Design Option or Phase | Check that you are viewing the correct Design Option and Phase |
+| Rehosted family faces wrong direction | The new wall has a different normal direction (inside/outside swapped) | After rehosting, select the family → click the blue flip arrow that appears near the family to mirror it |
+
+---
+
+## 3.9 Auto Drop — Letting STING Place Elements at the Correct Level
+
+### What Does "Drop" Mean?
+
+In MEP engineering, "dropping" means routing a service from where it travels (at ceiling level, above the suspended ceiling) down to where it is used (at the wall face or at a piece of equipment). 
+
+Think of water in a building. The main cold water supply pipe runs at ceiling level in a plant room, then drops down the risers, then branches horizontally at each floor level, then drops again down to the basins and WCs. Each "drop" is a short vertical section that connects the horizontal service run to the point of use.
+
+The same principle applies to:
+- Electrical conduit: drops from the containment system (cable tray above the ceiling) down to socket outlet back boxes, switch boxes, and luminaire terminals.
+- Pipe: drops from horizontal branch mains down to plumbing fixtures.
+- Duct: drops from main horizontal duct runs down to diffusers.
+
+### The Three Auto Drop Engines
+
+STING has three separate auto-drop engines, one for each service type:
+
+**AutoConduitDrop:** Routes conduit from the cable tray or conduit system above the ceiling down to every electrical fixture (socket outlets, switches, luminaires, fire alarm devices) placed by the Placement Centre. Uses the conduit routing preferences set in the project's MEP settings.
+
+**AutoPipeDrop:** Routes pipe from the horizontal branch main down to every plumbing fixture. Calculates the correct pipe size, drop angle, and the correct fitting type at the branch connection.
+
+**AutoDuctDrop:** Routes duct from the horizontal supply or extract duct down to every air terminal (diffuser, grille, VAV box). Sizes the drop duct based on the terminal's airflow requirement.
+
+### Running AutoDropCommand
+
+1. After running Placement (so fixtures are in position), open the STING dock panel.
+2. Go to the `TAGS` tab → `Routing` sub-tab (or find the Routing section in the appropriate tab for your version).
+3. Click `Auto Drop`.
+
+The AutoDrop dialog opens. Options:
+- **Drop type:** `Electrical`, `Pipe`, or `Duct` — choose which service to route.
+- **Scope:** `Selected elements`, `Active view`, or `Project`.
+- **Drop route preference:** `Shortest`, `Via tray` (routes to the nearest cable tray first, then drops), `Vertical only` (straight down).
+
+4. Click `Run Drop`.
+
+The engine calculates routes for each fixture and creates the conduit/pipe/duct geometry. A result panel reports:
+- Routes created: N
+- Routes failed (no path found): M
+- Warnings (e.g. pipe size too small for calculated flow): W
+
+5. Review any failed routes manually. Failed routes are usually where there is a structural obstruction or where the horizontal service run has not been modelled yet.
+
+### Reading the Result
+
+After AutoDropCommand runs:
+- In the 3D view, you should see short vertical sections of conduit/pipe/duct connecting from the ceiling-level service runs down to each fixture.
+- In the clash detection view (BIM Coordination Center → Clash tab), any clashes between the drops and structural elements appear as red spheres.
+- Validation results appear automatically if "Run validators after placement" is set to On.
+
+---
+
+## 3.10 Troubleshooting the Placement Centre
+
+| Problem | Likely cause | Fix |
+|---|---|---|
+| Rule shows `✗ Invalid` chip | A required field is empty, the category name is misspelled, or the regex is malformed | Click the rule and look at the orange error message at the bottom of the right panel. Fix the field it names. |
+| Run Placement says "No FamilySymbol found for category X" | No family of that Revit category is loaded in the project | Load a family of the correct category (Insert → Load Family), then re-run. |
+| Preview shows no candidates for a rule | Room filter too strict; room area below Min Area; another rule has filled room's Max-per-room slots | Try clearing the Room Filter box temporarily and re-previewing. Check Priority and Max-per-room. |
+| Fixtures placed at wrong height | Mount Height set wrong; family origin in wrong location | Check rule Geometry group Mount Height; check family origin (see Chapter 2). |
+| Fixtures facing wrong direction (e.g. socket facing wall) | Family `Center (Front/Back)` reference plane not set; `Always Vertical` not set | Fix reference planes in Family Editor (Chapter 2, Rule 2). |
+| Fixtures stack on top of each other | Min Spacing too small; multiple rules running in same room at same anchor | Increase Min Spacing in the rule. Check Conflicts with field to suppress conflicting rules. |
+| WC fixtures appear in walk-in closets or wardrobes | Room Filter regex too broad (old `(?i)wc` matches "walk-in closet") | Use word-boundary regex: `(?i)\b(wc|toilet|bathroom)\b` — the `\b` prevents partial word matches. |
+| Emergency lights appear in plant rooms | Room Filter not excluding non-public areas | Add Exclude room regex: `(?i)\b(plant|riser|cupboard|store)\b` |
+| Placement Centre is very slow | Large project + Project scope + all validators enabled | Switch to Active view scope. Disable validators during placement (turn off "Run validators after placement"), then validate separately. |
+| "Undo last run" doesn't find the elements | Provenance stamping was disabled during the run, or elements were placed before the Centre was opened | Use Revit Ctrl+Z instead. In future runs, make sure "Stamp provenance on each placement" is On. |
+| Import shows "0 rules imported, N skipped" | All rules in the imported file already exist (same RuleId) | Use a text editor to check the RuleIds in the imported file. If you want to overwrite existing rules, you must first delete them from the Centre (left-rail `-` button), then import. |
+| Electrical fixtures land inside the wall | Family origin at back of back box, not at faceplate | Open the family in the Family Editor, move the geometry forward so the faceplate aligns with the origin reference plane. Re-save. Reload into project. Re-run. |
+| Ceiling-hosted luminaire says "no ceiling found" | Family is OneLevelBased (not Ceiling-Hosted); or ceiling not modelled yet | Check the family's hosting type in the Family Editor (the `Family Placement Type` setting in `Create → Properties → Family Category and Parameters`). Change to Ceiling Hosted. |
+
+---
+
+# Quick Reference
+
+---
+
+## Placement Centre Commands — Complete Table
+
+| Command | Where to find it | What it does |
+|---|---|---|
+| `PlaceFixturesCommand` | TAGS tab → Fixtures sub-tab → Place Fixtures | Opens the Placement Centre and runs rule-based placement for all fixture categories |
+| `LightingGridCommand` | TAGS tab → Fixtures sub-tab → Lighting Grid | Runs the lighting grid algorithm for luminaires (BS EN 12464-1 lux calculation) |
+| `LearnPlacementV4Command` | TAGS tab → Fixtures sub-tab → Learn Placement | Analyses existing placements and writes STING_PLACEMENT_RULES.learned.json |
+| `AutoDropCommand` | TAGS tab → Routing sub-tab → Auto Drop | Routes conduit/pipe/duct drops from ceiling-level services to placed fixtures |
+| `GenerateLayoutCommand` | TAGS tab → Routing sub-tab → Generate Layout | Generates the containment layout (cable tray routes, duct mains) for a floor |
+| `ValidateFillsCommand` | TAGS tab → Routing sub-tab → Validate Fills | Checks conduit/cable tray fill against rated capacity; flags over-filled and orphaned elements |
+| `RunAllValidatorsCommand` | TAGS tab → Routing sub-tab → Validate All | Runs all eight validators (clearance, maintenance, connectivity, fill, spec, termination, slope, separation) |
+| `Placement_AuditSetup` | BIM tab or TEMP tab → Audit Setup | Cross-checks all family authoring requirements against the live model; writes a CSV report |
+
+---
+
+## MEP Symbol Authoring Checklist
+
+Use this checklist before committing any new MEP symbol family to the library:
+
+- [ ] Family template: `Generic Annotation.rft` (for most symbols) or a hosted template for fixed-host fixtures
+- [ ] Two reference planes at origin: both have `Defines Origin = Yes` and `Is Reference = Strong Reference`
+- [ ] Three subcategories created under `Manage → Object Styles → Annotation Objects`: `ISO_Symbols_[DISC]_IEC`, `ISO_Symbols_[DISC]_BS`, `ISO_Symbols_[DISC]_ANSI`
+- [ ] Three Yes/No type parameters added: `SYMBOL_SHOW_IEC`, `SYMBOL_SHOW_BS`, `SYMBOL_SHOW_ANSI`
+- [ ] All drawn geometry assigned to one of the three subcategories (not `<None>`)
+- [ ] Visibility of each subcategory's geometry bound to its `SYMBOL_SHOW_*` parameter using the formula field in Properties → Visible
+- [ ] `EMERGENCY_MODE` Yes/No parameter present for fire, emergency, or life-safety symbols
+- [ ] At least one type created with `SYMBOL_SHOW_IEC = Yes` (the default IEC/ISO standard)
+- [ ] File named per convention: `STING_[DISC]_[symbol_id].rfa` (e.g. `STING_E_E_SKT_13A_1.rfa`)
+- [ ] File saved to `CompiledPlugin/Data/SymbolLibrary/[Discipline]/`
+- [ ] Test load into a blank project: place one instance, switch through the three types, verify only the correct standard's geometry renders each time
+- [ ] Origin position matches the `insertion_point` column in `mep_symbols.csv`
+- [ ] Line weights set correctly: weight 1 for construction lines, weight 2 for standard symbols, weight 3 for fire/emergency/critical symbols
+
+---
+
+## Placement Family Authoring Checklist
+
+Use this checklist before using any family with STING's Placement Centre:
+
+- [ ] Family origin at the correct insertion point (see per-category table in Section 2.3)
+- [ ] Reference plane `Center (Front/Back)` named correctly, `Is Reference = Strong Reference`, `Defines Origin = Yes`
+- [ ] Reference plane `Center (Left/Right)` named correctly, `Is Reference = Strong Reference`, `Defines Origin = Yes`
+- [ ] `Always Vertical = Yes` for vertical wall fittings (switches, sockets, sensors)
+- [ ] `Cuts with Voids When Loaded = Yes` for sleeves and chase-through elements
+- [ ] Family Placement Type set correctly (`One Level Based Hosted` for wall fixtures, `Ceiling Based` for ceiling fixtures, etc.)
+- [ ] STING shared parameter file set to `StingTools/Data/MR_PARAMETERS.txt` before adding parameters
+- [ ] `STING_BOX_LOCATION_ID` (Text, Instance) bound
+- [ ] `STING_NOGGIN_REQUIRED` (Yes/No, Type) bound — for pendants and heavy ceiling fixtures
+- [ ] `STING_AUTO_PLACED_BOOL` (Yes/No, Instance) bound
+- [ ] `STING_FIXTURE_VARIANT_TXT` (Text, Type) bound and populated with the correct variant name (e.g. "FLUSH", "BASIN", "PENDANT")
+- [ ] `MK_CATALOGUE_REF` (Text, Type) bound (manufacturer part number)
+- [ ] Category-specific parameters bound (see per-category matrix in Section 2.3)
+- [ ] `Placement_AuditSetup` run and no critical errors reported
+- [ ] Test Auto Tag run: STING writes all 8 tag tokens successfully
+- [ ] Test Placement Centre run: fixture places at the correct position and orientation
+
+---
+
+## Glossary
+
+| Term | Plain English explanation |
+|---|---|
+| AFF | Above Finished Floor. The standard height datum for mounting heights. "1100 mm AFF" means 1.1 metres above the top of the floor finish. |
+| Anchor | In the Placement Centre, the reference point from which offsets are measured. "DOOR_HINGE" means measure from the hinge side of the door. |
+| Annotation family | A Revit family that is 2D only. Annotation families are visible in plan, section, and elevation views, but hidden in 3D views. Used for MEP symbols and wire annotations. |
+| AVF | Analysis Visualization Framework. Revit's built-in heat-map system. The Placement Centre uses it to show a compliance heat-map (green = rules met, red = rules not met). |
+| BMS | Building Management System. The computerised control system that monitors and controls HVAC, lighting, and other building services. |
+| COBie | Construction-Operations Building Information Exchange. A spreadsheet format (BS 1192-4) for handing over building data to the FM team at project completion. |
+| Defines Origin | A reference plane setting. A reference plane with `Defines Origin = Yes` contributes to the family's insertion point. |
+| Family | A reusable Revit component stored as a `.rfa` file. Examples: a socket outlet, a basin, a smoke detector, a downlight. |
+| Family Editor | The separate Revit mode (opened by clicking Edit on a family) where you create and modify the geometry, parameters, and properties of a family. |
+| FamilyInstance | A copy of a family that has been placed in a Revit project model. Each placed copy is one instance. |
+| FamilySymbol | A type variant within a family. One socket outlet `.rfa` might have types "1G FLUSH", "2G FLUSH", "1G SURFACE". Each is a FamilySymbol. |
+| FFL | Finished Floor Level. The top of the floor finish. The reference datum for most mounting heights. |
+| Filled Region | A closed 2D boundary with a fill pattern inside it. Used in families for solid-coloured shapes in symbols. |
+| Homerun | In electrical drawings, the homerun is where a circuit exits the floor plan to return to the distribution board. Shown with an arrowhead annotation. |
+| Hosting | The relationship between a hosted family and its host element. A ceiling-mounted downlight is "hosted by" the ceiling it sits in. |
+| IEC | International Electrotechnical Commission. Publisher of IEC 60617, the international electrical symbol standard. |
+| Insert point / Origin | The single point in a family that Revit snaps to the exact location you click when placing the family in a project. |
+| ISO | International Organization for Standardization. Publisher of ISO 14617 (piping symbols), ISO 7010 (safety signs), and many others. |
+| Label | In the Family Editor, a text element that displays the value of a linked parameter. When the parameter value changes, the label updates. |
+| Lux | The unit of illuminance (light level on a surface). BS EN 12464-1 specifies minimum lux levels for different workplaces: 500 lux for office tasks, 300 lux for storage areas. |
+| MCP | Manual Call Point. The red break-glass fire alarm device mounted on walls. Also called a "break glass unit" or "call point". |
+| MEP | Mechanical, Electrical, Plumbing. The collective term for building services engineering. |
+| Morphology | The shape and form of a symbol — how it looks. The morphology of a socket outlet symbol is two circles with a line. |
+| P&ID | Piping and Instrumentation Diagram. A schematic drawing showing all pipes, valves, and instruments in a system. The symbols in P&IDs follow ISO 14617 and ANSI conventions. |
+| Placement Centre | The STING tool that automatically places families in a Revit project based on written rules. |
+| Provenance stamp | An invisible record written onto every element placed by the Placement Centre, recording which rule placed it, when, and by whom. |
+| Reference plane | A construction aid in the Family Editor — an infinite plane (shown as a line in any view) used to define the family's origin, symmetry, and dimensional anchors. |
+| Regex | Regular expression. A compact notation for matching text patterns. `(?i)office|workspace` matches any text containing "office" or "workspace", case-insensitively. |
+| Rehosting | Assigning a new host element to a hosted family instance whose original host has been deleted or moved. |
+| Rule | In the Placement Centre, a description of what to place, where to place it, in which rooms, per which standard. Each rule produces zero or more placed family instances. |
+| Shared parameter | A parameter defined in a `.txt` file (the shared parameter file) that can be used across multiple families and projects. Shared parameters can be scheduled, exported, and read by STING. |
+| Subcategory | A named sub-division of a Revit category (e.g. "ISO_Symbols_E_IEC" is a subcategory of "Generic Annotations"). Subcategories control line weights, colours, and visibility independently. |
+| Symbolic lines | Lines drawn in the Family Editor's 2D annotation layer. They represent the symbol's visible shape on plan and elevation views. |
+| Variant hint | A text value stored in `STING_FIXTURE_VARIANT_TXT` that tells the Placement Centre which type of a family to prefer (e.g. "FLUSH" prefers flush-plate types over surface-mount types). |
+
+---
+
+## Cross-references
+
+> **This is the foundation guide. It references no other guides.**
+
+> **Used by:** The following discipline-specific guides all assume you have read this guide first. When those guides say "make the family placement-ready" or "add the STING shared parameters" or "open the wire annotation family", they are referring to the steps described here.
+>
+> - `ELECTRICAL_WORKFLOW_GUIDE` — electrical fixture placement, panel schedules, wire annotation in context
+> - `PLUMBING_WORKFLOW_GUIDE` — sanitary fixture placement, drainage routing
+> - `HEALTHCARE_WORKFLOW_GUIDE` — medical gas outlets, bedhead trunking, HTM compliance rules
+> - `DRAWING_PRODUCTION_SYSTEM_GUIDE` — how annotation families (including MEP symbols and wire annotations) appear on finished drawing deliverables, view template configuration, and the Drawing Template Manager
+
+---
+
+*Guide version 1.0. Covers: MEP symbol authoring for 516 symbols across 9 disciplines; wire annotation family creation and placement; placement-ready family authoring requirements; STING Placement Centre — all rules, buttons, and dialogs. For the phase history of the Placement Centre codebase, see `docs/CHANGELOG.md`. For open gaps and planned enhancements, see `docs/ROADMAP.md`.*

--- a/docs/guides/PLUMBING_WORKFLOW_GUIDE.md
+++ b/docs/guides/PLUMBING_WORKFLOW_GUIDE.md
@@ -1,0 +1,1125 @@
+# STING Plumbing & Public Health Workflow Guide
+
+---
+
+## How to use this guide
+
+Read the first three sections (this one, "Who this guide is for", and "The Big Picture") before touching any buttons. They explain the overall plan so that every individual step makes sense in context.
+
+After that, work through the chapters in order the first time. The chapters follow the natural sequence of a plumbing project: set up the project, place fixtures, create pipe systems, route pipes, validate, schedule, produce drawings, issue.
+
+Code blocks, table references, and button labels are written exactly as they appear on screen. What you see in Revit and in STING is exactly what is written here.
+
+> **How to use the blockquotes:** anywhere you see a `> **Stuck?**` blockquote, stop and read it before moving on. It explains what a confusing screen means and what to do about it.
+
+---
+
+## Who this guide is for
+
+You are a qualified plumber, public health engineer, or building services designer. You know what a domestic cold water system is. You know why drainage pipes must slope. You know the difference between a soil stack and a vent stack. You have opened Revit before and placed a family or drawn a wall.
+
+What you have not done before is use STING — the plugin that sits inside Revit and adds ISO 19650-compliant tagging, automated pipe routing, validation, scheduling, and drawing production to your Revit workflow.
+
+This guide assumes:
+
+- You know what a Revit project file (`.rvt`) is.
+- You know how to open the STING panel (click the **STING Panel** button on the Revit ribbon, or look for the docked panel on the right side of the screen).
+- You have not used STING's plumbing tools before.
+- You do not need to be a programmer. Every instruction involves clicking buttons and typing values into fields.
+
+If you have never created an MEP symbol family or never used the Placement Centre, read `MEP_FOUNDATION_GUIDE.md` first. This guide will tell you exactly where to go there when you need it.
+
+---
+
+## The Big Picture
+
+A STING plumbing project follows eight stages in sequence. Think of it like installing an actual plumbing system: you do not start soldering joints before you have a schematic, and you do not commission before you have tested.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  PLUMBING PROJECT WORKFLOW — ALL EIGHT STAGES                   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  STAGE 1 ── Set up the project                                  │
+│  Load shared parameters, create pipe types, verify              │
+│  plumbing drawing types are available.                          │
+│            │                                                    │
+│            ▼                                                    │
+│  STAGE 2 ── Place plumbing fixtures                             │
+│  Basins, WCs, taps, floor drains, riser valves — every          │
+│  physical piece of equipment that connects to a pipe.            │
+│            │                                                    │
+│            ▼                                                    │
+│  STAGE 3 ── Create Revit pipe systems                           │
+│  Tell Revit which pipes carry DCW, which carry SAN,             │
+│  which carry GAS. STING reads these to assign system codes.     │
+│            │                                                    │
+│            ▼                                                    │
+│  STAGE 4 ── Route pipes                                         │
+│  AutoPipeDrop draws pipe runs from distribution points          │
+│  to fixtures automatically. Manual routing fills gaps.          │
+│            │                                                    │
+│            ▼                                                    │
+│  STAGE 5 ── Apply tagging and push system data                  │
+│  AutoTagCommand stamps every element with its ISO 19650         │
+│  eight-segment tag. SystemParamPushCommand fills pipe           │
+│  parameters from the connected Revit system.                    │
+│            │                                                    │
+│            ▼                                                    │
+│  STAGE 6 ── Validate                                            │
+│  RunAllValidatorsCommand checks slope, fill, connectivity,      │
+│  and termination. Fix every error before proceeding.            │
+│            │                                                    │
+│            ▼                                                    │
+│  STAGE 7 ── Produce schedules and drawings                      │
+│  Fixture schedules, pipe schedules, insulation schedules.       │
+│  Drawing sheets using the plumb-drainage-A1-1to100 type.        │
+│            │                                                    │
+│            ▼                                                    │
+│  STAGE 8 ── Issue                                               │
+│  See DOCUMENT_MANAGER_GUIDE.md                                  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+You cannot skip stages. If you try to run AutoPipeDrop (Stage 4) before creating pipe systems (Stage 3), the engine will not know which system to assign to the pipes it creates. If you try to validate (Stage 6) before tagging (Stage 5), the validators will report every element as untagged.
+
+---
+
+## Prerequisites
+
+### Shared parameters
+
+STING stores plumbing data in Revit "shared parameters" — named fields that exist in a central text file and can be attached to any element in any project. Before STING can write pipe sizes, flow rates, or slope data to your model, these parameters must be bound to the right Revit categories.
+
+The relevant parameter group is **PLM_DRN** (Plumbing and Drainage). This group contains all PLM_* parameters for pipes, fittings, fixtures, valves, and accessories.
+
+**How to load shared parameters:**
+
+1. Open the STING panel.
+2. Click the **CREATE** tab.
+3. In the Setup section, click **Load Params**. This runs `LoadSharedParamsCommand`.
+4. STING will show a progress dialog and a results summary. You should see "PLM_DRN" listed in the bound groups.
+5. To verify: select any pipe in your model → open the Properties palette → scroll down. You should see parameters beginning with `PLM_`.
+
+> **Stuck?** If you do not see the **Load Params** button, make sure you are on the **CREATE** tab of the STING panel (not the SELECT or BIM tab). If the button is greyed out, you may not have a Revit document open.
+
+### Key plumbing parameters
+
+The parameters you will encounter most often are:
+
+| Parameter name | What it records | Which elements carry it | Example value |
+|---|---|---|---|
+| `PLM_PPE_SZ_MM` | Pipe nominal diameter in millimetres | Pipes, pipe fittings | `22`, `28`, `100` |
+| `PLM_FLOW_RATE_LPS` | Design flow rate through the pipe in litres per second | Pipes | `0.15` |
+| `PLM_PPE_FLW_LPS` | Flow rate on a pipe accessory (valve, strainer) | Pipe accessories | `0.30` |
+| `PLM_SYSTEM_TXT` | The system code this element belongs to | Pipes, fixtures, valves | `DCW`, `SAN`, `GAS` |
+| `PLM_SLOPE_PCT` | Drainage pipe slope as a percentage | Drainage pipes | `1.25` |
+| `PLM_INSULATION_TXT` | Insulation material name | Pipes | `Armaflex`, `Rockwool` |
+| `PLM_PPE_INSULATION_THK_MM` | Insulation thickness in millimetres | Pipes | `25`, `38` |
+| `PLM_PPE_MAT_TXT` | Pipe material | Pipes | `Copper`, `HDPE` |
+| `PLM_PPE_JOINT_TYPE_TXT` | Joint type | Pipes, fittings | `Soldered`, `Compression` |
+| `PLM_PPE_PSR_RATING_BAR` | Pressure rating of the pipe | Pipes | `10`, `16` |
+| `PLM_EQP_PRESSURE_KPA` | Design pressure at a fixture or equipment item | Plumbing fixtures | `150`, `300` |
+| `PLM_HED_M` | Static head in metres (used in pump and gravity drain calculations) | Equipment | `12.5` |
+| `PLM_VEL_MPS` | Water velocity in the pipe in metres per second | Pipes | `1.5` |
+
+> **Note on naming:** STING's parameter names follow a prefix pattern. `PLM_` means Plumbing. `PLM_PPE_` means Plumbing Pipe. `PLM_EQP_` means Plumbing Equipment. `PLM_VLV_` means Plumbing Valve. `PLM_DRN_` means Plumbing Drainage. Once you know the prefixes, the names become self-explanatory.
+
+### Plumbing view templates
+
+STING ships a built-in drawing type called `plumb-drainage-A1-1to100`. This drawing type controls sheet size (A1), scale (1:100), the view template applied, the title block used, sheet numbering, and the graphic style pack. Think of it as a saved recipe for how every plumbing drainage drawing should look.
+
+**How to verify the drawing type exists:**
+
+1. Click the **DOCS** tab in the STING panel.
+2. In the Drawing Types section, click **Inspect Drawing Types**. This runs `DrawingTypesInspectCommand`.
+3. In the results window that appears, look for `plumb-drainage-A1-1to100` in the list.
+4. If it is listed without any warnings, you are ready. If it shows a warning about a missing view template, follow the instructions in `DRAWING_PRODUCTION_SYSTEM_GUIDE.md` to create the template before continuing.
+
+---
+
+# Chapter 1 — Understanding Plumbing Systems in STING
+
+---
+
+## 1.1 The plumbing discipline code
+
+Every element in STING carries an eight-segment ISO 19650 tag. The first segment is the discipline code — a single letter or short code that tells you which trade the element belongs to.
+
+For plumbing and public health, the discipline code is **P**.
+
+This means every domestic cold water pipe, sanitary drain, gas supply pipe, and hot water cylinder in your model will carry tags beginning with `P-`. When you run reports, schedules, or validation, you can filter to discipline `P` to see only plumbing elements.
+
+---
+
+## 1.2 System codes for plumbing work
+
+Within discipline P, each element also carries a system code (the fifth segment of the tag, `SYS`). The system code tells you what the element is carrying — cold water, hot water, drainage, and so on.
+
+A pipe system in STING is like a named pipeline in a factory: everything connected to it shares the same label. A DCW system groups all the cold water pipes and fittings feeding domestic outlets. A SAN system groups all the soil and waste pipes leading to the drainage stack.
+
+The full set of plumbing system codes:
+
+| Code | Full name | What it carries | Typical operating conditions | Standards reference | Typical connected elements |
+|---|---|---|---|---|---|
+| **DCW** | Domestic Cold Water | Cold mains-pressure drinking water | 1–10 bar, 5–20°C | BS EN 806-2, WRAS | Taps, WC cisterns, shower mixers, cold water storage tanks, pressure reducing valves |
+| **DHW** | Domestic Hot Water | Hot water from a central heat source (boiler, cylinder, heat pump) | 0.5–4 bar, 60–65°C storage, 55°C distribution | BS EN 806-2, L8 ACOP | Hot taps, shower mixers, thermostatic mixing valves, calorifiers |
+| **HWS** | Hot Water Services Circulation | The return leg of a hot water circuit — water circulating back from the distribution pipework to be reheated | Very low flow, 55°C | BS EN 806-2, L8 ACOP | Circulation pump, calorifier return, secondary circuit |
+| **SAN** | Sanitary Drainage | Foul water from toilets, basins, baths, showers, kitchen sinks, floor gullies, laboratory sinks | Gravity, 0 bar pressure, typically ≤18 m/s maximum velocity | BS EN 12056-2, Building Regs Part H | WC pan connectors, basin wastes, bath traps, floor drains, gullies, soil stacks, underground drainage |
+| **RWD** | Rainwater Drainage | Surface water from roofs, paved areas, car parks | Gravity, 0 bar pressure | BS EN 12056-3, Building Regs Part H | Roof drains, gutters, rainwater downpipes, underground surface water drains |
+| **GAS** | Gas Supply | Natural gas, liquefied petroleum gas (LPG), or biogas to boilers, cookers, laboratory equipment | Low pressure: ≤21 mbar; medium pressure: 21 mbar–2 bar | IGEM UP/2, Gas Safety (Installation and Use) Regs, IGE/UP/1B | Gas meters, boilers, cookers, laboratory gas cocks, isolation valves |
+
+### Explaining each system in plain English
+
+**DCW — Domestic Cold Water.** This is mains water coming into the building and being distributed to every cold tap, WC cistern, shower, washing machine, and dishwasher. In most UK buildings it arrives at roughly 3–6 bar. You either use it directly at mains pressure, or you break it to a lower pressure using a pressure reducing valve (PRV). Pipes are typically copper (15mm, 22mm, 28mm for small buildings), CPVC, or stainless steel. Insulation is needed in warm spaces to prevent Legionella.
+
+**DHW — Domestic Hot Water.** This is the hot water system: a boiler or heat pump heats water in a cylinder, and that hot water is pumped out to every hot tap. The cylinder stores water at 60–65°C (hot enough to kill Legionella bacteria), and a thermostatic mixing valve (TMV) blends it with cold at the point of use to a safe 38–45°C. DHW pipes are typically the same size as DCW pipes but insulated throughout.
+
+**HWS — Hot Water Services Circulation.** In any building larger than a house, if hot water simply sat in long pipe runs, it would cool down between uses. HWS is the circulation return: a small pump continuously recirculates hot water around a loop so that hot water is always available immediately at the tap. HWS pipes carry the return leg of this circulation circuit. Without HWS, users would waste water waiting for hot water to arrive.
+
+**SAN — Sanitary Drainage.** This is the foul drainage system: every WC, basin, bath, shower, kitchen sink, and floor gully discharges to a soil or waste pipe that drains by gravity to the sewer. SAN pipes are always gravity pipes — they must slope downwards towards the point of discharge. Horizontal SAN pipes must slope at 1:80 (1.25%) for soil branches and 1:50 (2%) for most wastes, per BS EN 12056-2. A soil stack is the vertical riser that collects branches from multiple floors. An open vent above the stack (and sometimes air admittance valves on branches) prevents the trap seals from being siphoned.
+
+**RWD — Rainwater Drainage.** Surface water from the roof and paved areas must be collected and discharged to a storm sewer or soakaway. Roof drains collect water at the lowest points of flat roofs; gutters collect it from pitched roofs. RWD pipes must also slope to drain. The sizing is governed by BS EN 12056-3 using the rainfall intensity for the location (litres per second per square metre of roof area). Critical detail: in the UK, surface water (RWD) must be discharged separately from foul water (SAN) — it is illegal to connect them together in most new construction.
+
+**GAS — Gas Supply.** Natural gas or LPG arrives at the building via a meter and is distributed to boilers, cookers, gas fires, and laboratory equipment. Gas pipes are run in steel (black steel or stainless) or copper, with joints typically threaded, brazed, or press-fit depending on the application. Gas pipes must be properly supported, bonded to earth, and run in accessible locations. They cannot be run through a void without being sleeved. Gas system design involves pressure drop calculations to ensure adequate pressure at every appliance — STING records gas system data but does not perform these calculations itself (see Chapter 7).
+
+---
+
+## 1.3 How Revit pipe systems map to STING codes
+
+In Revit, a "Pipe System" (accessed through the Systems panel) is a logical grouping: you create a system, name it, and then connect pipes and fittings to it. Revit tracks which elements belong to which system for its own flow and pressure calculations.
+
+STING reads the Revit system name to assign the `SYS` token to every element. The rule is simple: **name your Revit pipe system with the STING system code, and STING will automatically assign the correct system code to all connected elements.**
+
+For example:
+- Create a Revit Pipe System named `DCW` → all connected pipes get tagged with `SYS=DCW`
+- Create a Revit Pipe System named `SAN` → all connected drainage pipes get tagged with `SYS=SAN`
+- Create a Revit Pipe System named `GAS` → all gas pipes get tagged with `SYS=GAS`
+
+If you name the system something like "Cold Water" or "Drainage" instead of the STING code, the tagging engine will not recognise it and will leave the `SYS` token blank. That then appears as a compliance failure when you run `ValidateTagsCommand`.
+
+---
+
+## 1.4 The PLM_* parameter family
+
+| Parameter | What it records | Which elements | Example value |
+|---|---|---|---|
+| `PLM_PPE_SZ_MM` | Nominal pipe bore in mm | Pipes | `22` |
+| `PLM_PPE_MAT_TXT` | Pipe material | Pipes | `Copper` |
+| `PLM_PPE_JOINT_TYPE_TXT` | Joint type | Pipes, fittings | `Soldered` |
+| `PLM_PPE_LENGTH_M` | Pipe run length in metres | Pipes | `3.65` |
+| `PLM_PPE_FLW_LPS` | Flow rate on an accessory (l/s) | Valves, strainers | `0.30` |
+| `PLM_PPE_PSR_RATING_BAR` | Pressure rating (bar) | Pipes | `10` |
+| `PLM_PPE_INS_TYPE_TXT` | Insulation material | Pipes | `Armaflex` |
+| `PLM_PPE_INS_THK_MM` | Insulation thickness (mm) | Pipes | `25` |
+| `PLM_PPE_INSULATION_THK_MM` | Insulation thickness — v4 constant | Pipes | `38` |
+| `PLM_INSULATION_TXT` | Insulation material — v4 constant | Pipes | `Rockwool` |
+| `PLM_SLOPE_PCT` | Drainage slope as a percentage | Drainage pipes | `1.25` |
+| `PLM_SYSTEM_TXT` | System code this element belongs to | Pipes, fixtures | `DCW` |
+| `PLM_FLOW_RATE_LPS` | Design flow rate (l/s) | Pipes | `0.15` |
+| `PLM_VEL_MPS` | Water velocity (m/s) | Pipes | `1.5` |
+| `PLM_PSR_KPA` | Pressure at this element (kPa) | Pipes, equipment | `150` |
+| `PLM_HED_M` | Static head (m) | Equipment, pumps | `12.5` |
+| `PLM_EQP_CAPACITY_L` | Storage volume of equipment (litres) | Hot water cylinders, tanks | `200` |
+| `PLM_EQP_PRESSURE_KPA` | Design pressure at equipment (kPa) | All plumbing equipment | `300` |
+| `PLM_HOTWTR_TEMP_C` | Hot water storage temperature (°C) | Calorifiers, cylinders | `65` |
+| `PLM_HOTWTR_FUEL_TYPE_TXT` | Fuel type for water heater | Boilers, water heaters | `Gas`, `Heat Pump` |
+| `PLM_HOTWTR_INPUT_PWR_KW` | Heat input to water heater (kW) | Boilers, immersion heaters | `24` |
+| `PLM_VLV_BODY_MAT_TXT` | Valve body material | Valves | `Brass`, `Bronze` |
+| `PLM_VLV_END_CONNECTION_TXT` | Valve end connection type | Valves | `Compression`, `Threaded` |
+| `PLM_DRN_PPE_SLOPE_PCT` | Slope on a drainage pipe (%) | Drainage pipes | `1.25` |
+| `PLM_DRN_FLW_RATE_LPS` | Flow rate in drainage pipe (l/s) | Drainage pipes | `0.08` |
+| `PLM_DRN_TRAP_TYPE_TXT` | Trap type | Drainage fittings | `P-trap`, `Bottle trap` |
+| `PLM_DRN_TRAP_SEAL_DEPTH_MM` | Trap seal depth (mm) | Drainage fittings | `75` |
+| `PLM_EQP_TAG` | Plumbing equipment tag container | Fixtures, equipment | `P-BLD1-Z01-L02-DCW-SUP-BSN-0003` |
+
+---
+
+# Chapter 2 — Setting Up Your Plumbing Project
+
+---
+
+## Step 1: Load shared parameters
+
+Loading shared parameters is the equivalent of wiring up the data fields before you start entering data. Without this step, STING has nowhere to put the pipe sizes, flow rates, and system codes it calculates.
+
+**Step by step:**
+
+1. Open the STING panel. It should be docked on the right side of Revit. If you cannot see it, click **STING Panel** on the STING ribbon tab.
+2. Click the **CREATE** tab at the top of the STING panel.
+3. In the **Setup** section (near the top of the tab), click **Load Params**. A progress dialog will appear.
+4. STING runs two passes: Pass 1 binds all instance parameters; Pass 2 binds type parameters. Both passes should complete successfully.
+5. When the dialog says "Done", click OK.
+6. To verify: in your Revit project, draw a short test pipe (Systems tab → Pipe). Select it. In the Properties palette on the left, scroll down. You should see parameters like `PLM_PPE_SZ_MM`, `PLM_SYSTEM_TXT`, and others beginning with `PLM_`.
+
+> **Stuck?** If you see "Pass 2: 0 parameters bound" in the results, it usually means the shared parameter file is not at the expected path. Check that your project has a shared parameter file loaded: `Manage → Shared Parameters`. If none is loaded, contact your BIM coordinator to point Revit to the STING shared parameter file (`MR_PARAMETERS.txt`) from the STING data folder.
+
+---
+
+## Step 2: Create plumbing pipe types
+
+STING ships a set of standard pipe types defined in its data CSV file. These are the standard pipe materials and sizes used in UK building services work.
+
+**Step by step:**
+
+1. In the STING panel, click the **TEMP** tab.
+2. In the **Families** section, click **Pipes**. This runs `CreatePipesCommand`.
+3. STING reads its pipe type definitions and creates the following pipe types in the project:
+
+| Type name | Material | Typical use | Sizes created |
+|---|---|---|---|
+| Copper — Half Hard | Copper | DCW, DHW, HWS | 15, 22, 28, 35, 42, 54 mm |
+| CPVC Pressure | Chlorinated PVC | DCW in commercial buildings | 15, 22, 28, 35 mm |
+| HDPE Drainage | High-density polyethylene | SAN underground | 100, 150, 225 mm |
+| Cast Iron Soil | Cast iron | SAN above-ground stacks | 100, 150 mm |
+| Stainless Steel Pressed | Stainless steel 316 | DHW in food-prep and healthcare | 15, 22, 28, 35, 42, 54 mm |
+| Black Steel | Carbon steel | GAS distribution | 15, 20, 25, 32, 40, 50 mm |
+
+4. To verify: in the Project Browser on the left of the screen, expand `Families → Pipes`. You should see the new type families listed under `Pipe Types`.
+
+> **Stuck?** If the **Pipes** button is not visible in the TEMP tab, scroll down within the Families section — there are several family creation buttons and they may be scrolled out of view.
+
+---
+
+## Step 3: Verify plumbing drawing types
+
+STING ships a drawing type profile called `plumb-drainage-A1-1to100` which defines how every plumbing drawing is produced: A1 paper at 1:100 scale, using the `corp-standard-plan` style pack, with a STING corporate title block.
+
+**Step by step:**
+
+1. In the STING panel, click the **DOCS** tab.
+2. Click **Inspect Drawing Types**. This runs `DrawingTypesInspectCommand`.
+3. In the results dialog, find `plumb-drainage-A1-1to100`. Check for any warnings.
+4. Common warnings and what they mean:
+
+| Warning text | What it means | Fix |
+|---|---|---|
+| "View template 'STING - Drainage Plan' not found" | The Revit view template hasn't been created yet | Follow `DRAWING_PRODUCTION_SYSTEM_GUIDE.md` to create the template |
+| "Title block family not loaded" | The STING title block family isn't in the project | Load it from `Insert → Load Family → navigate to STING Families` |
+| No warnings | You are ready | Continue to Chapter 3 |
+
+---
+
+# Chapter 3 — Placing Plumbing Fixtures
+
+---
+
+## 3.1 Fixture families must be placement-ready
+
+Before STING can place a basin, WC, shower tray, or floor drain automatically, the family file (`.rfa`) for that fixture must be set up correctly. This is called being "placement-ready."
+
+A placement-ready plumbing fixture family has:
+- Its insertion point at the correct connection point (the pipe connector, not the geometric centre of the object)
+- Reference planes correctly named
+- STING shared parameters bound to it
+
+For the full authoring process, see **MEP_FOUNDATION_GUIDE.md, Chapter 2** — "Placement Family Authoring." The rules described there for MEP families apply equally to plumbing fixtures.
+
+---
+
+## 3.2 Using the Placement Centre for automatic fixture placement
+
+If you need to place dozens of basins, WCs, or floor drains across a building using rules (for example, "one basin per WC cubicle on every floor"), use STING's Placement Centre.
+
+See **MEP_FOUNDATION_GUIDE.md, Chapter 3** — "The Placement Centre." Everything described there applies directly to plumbing fixtures.
+
+---
+
+## 3.3 Manual fixture placement
+
+For small projects or when placing individual fixtures by hand:
+
+**Step by step:**
+
+1. In the STING panel, click the **MODEL** tab.
+2. Click **Place Fixture**. This runs `ModelPlaceFixtureCommand`.
+3. A list picker dialog appears showing all plumbing fixture families loaded in the project. If you cannot see the family you need, load it first via `Insert → Load Family`.
+4. Click the family name you want to place.
+5. Click the placement point in the view. For a wall-hung basin, click the wall face at the correct height. For a floor drain, click the floor at the drain location.
+6. STING places the family and immediately runs an auto-tag on the new element.
+
+> **Stuck?** If STING places the fixture but the tag shows `P-???-???-??-DCW-???-???-0001` with question marks, it means the spatial auto-detection could not find a room or zone at that location. Make sure your floor plan has rooms placed (Architecture → Room) before placing plumbing fixtures.
+
+---
+
+## 3.4 After placement: tagging
+
+After placing fixtures (whether via the Placement Centre or manually), run the tagger:
+
+1. In the STING panel, click the **CREATE** tab.
+2. Click **Auto Tag**. This runs `AutoTagCommand`.
+3. STING will tag all untagged plumbing elements in the active view:
+   - `DISC` is set to `P` (Plumbing)
+   - `SYS` is auto-detected from the connected Revit pipe system name
+   - `PROD` is derived from the family name (a basin family named `BSN - Wall Hung` gets PROD code `BSN`)
+   - `LOC`, `ZONE`, and `LVL` are detected from the room and level the fixture is in
+   - `SEQ` is automatically incremented
+
+4. The `PLM_EQP_TAG` parameter on each fixture receives its full ISO 19650 tag.
+
+**Tip:** If you have placed fixtures across multiple floors, switch to a 3D view or use **Batch Tag** (also on the CREATE tab) to tag all plumbing elements in the entire project at once.
+
+---
+
+# Chapter 4 — Creating Pipe Systems
+
+---
+
+## 4.1 What is a Revit Pipe System?
+
+A pipe system in Revit is a logical container — it groups connected pipes, fittings, and equipment under one name. Think of it as a colour-coded team: every member of the DCW team wears blue, every member of the SAN team wears orange. The system is what Revit uses for its internal calculations (flow balance, pressure drop), and it is what STING reads to assign the SYS token to each element.
+
+When you create a pipe run in Revit, you must assign it to a system. If you do not, the pipe floats unassigned and STING cannot determine what it is carrying.
+
+---
+
+## 4.2 Creating pipe systems in Revit
+
+**Step by step:**
+
+1. Open the **Systems** tab in the Revit ribbon (this is a standard Revit tab, not a STING panel).
+2. Click **Piping → Pipe System**. A "Create Pipe System" dialog appears.
+3. In the **Name** field, type the STING system code exactly as listed in the table in Chapter 1.2 — for example, `DCW` for domestic cold water.
+4. In the **System Classification** dropdown, choose the Revit classification that best matches:
+   - DCW, DHW, HWS → `Domestic Cold Water`, `Domestic Hot Water` (or `Other` if those aren't listed)
+   - SAN, RWD → `Sanitary`, `Storm` (or `Other`)
+   - GAS → `Other`
+5. Click OK.
+
+> **Critical rule:** The system name in the **Name** field must exactly match the STING system code (e.g., `DCW`, `SAN`, `GAS`). Capitalisation matters. `dcw` will not be recognised. `Cold Water` will not be recognised. Only `DCW` will produce `SYS=DCW` in the tag.
+
+Repeat this process for every system you need: DCW, DHW, HWS, SAN, RWD, GAS.
+
+---
+
+## 4.3 Assigning elements to systems
+
+When you draw pipes in Revit using the Pipe tool (Systems tab → Pipe), Revit prompts you to select a system. Choose the system you created above.
+
+When you place fixtures, connect them to pipes by using the pipe connector on the fixture family. Once physically connected, Revit automatically includes the fixture in the connected system.
+
+If you have placed fixtures and pipes but they are not connected, use Revit's native connect tool: select a pipe end → right-click → "Draw Pipe" to connect to the next element.
+
+**After connecting elements to systems, push the system data into the STING parameters:**
+
+1. Select all plumbing elements you want to update (or press `Ctrl+A` to select all).
+2. In the STING panel CREATE tab, in the Tag Operations section, click **System Push**. This runs `SystemParamPushCommand`.
+3. STING traverses the Revit pipe system graph and writes the system code, flow data, and pressure data from the Revit system down into the PLM_* parameters on each element.
+
+> **Stuck?** If **System Push** shows "0 elements updated", the pipes may not be connected to a named system. Select a pipe → look at Properties palette → find the "System Name" field. If it is blank, the pipe is not in any system. Connect it using Revit's pipe drawing tool.
+
+---
+
+# Chapter 5 — Pipe Routing
+
+---
+
+## 5.1 The two routing approaches
+
+STING offers two ways to create pipe runs:
+
+1. **AutoPipeDrop** — STING does the routing for you. You tell it the source point and the destination fixtures, and it calculates and places the pipe route, complete with elbows and fittings. Use this for any regular pressure or gravity system where the route follows a logical path.
+
+2. **Manual routing** — You draw pipes one run at a time using the `ModelCreatePipeCommand` or Revit's native pipe tool. Use this for complex routing around obstructions, or for small point-to-point connections that do not follow a pattern.
+
+Most plumbing projects use AutoPipeDrop for the main distribution runs and manual routing for the final connections to individual fixtures.
+
+---
+
+## 5.2 AutoPipeDrop — automatic pipe drops from distribution points
+
+AutoPipeDrop is STING's pipe routing engine. It is found in the TAGS tab of the STING panel under the **Routing** sub-tab.
+
+### 5.2.1 What AutoPipeDrop does
+
+Imagine you are fitting out a floor of a hospital. The DCW riser comes up through a plant room and you need to branch from it to 14 wash basins spread across four rooms. Normally you would have to trace each individual run, work out where bends go, and place each pipe segment by hand.
+
+AutoPipeDrop automates this: you select the 14 basins, tell STING where the riser connection point is, and STING calculates the most direct route for each drop, places the pipe segments, inserts elbows and tees, and assigns everything to the DCW system.
+
+The engine works for all pipe systems: DCW, DHW, HWS, SAN, RWD, and GAS. For drainage systems (SAN, RWD), it also applies the correct slope to horizontal runs.
+
+Think of AutoPipeDrop as a skilled pipe-fitter working from a schematic. You give it the start point (where the water comes from) and the end points (each fixture). It works out the most efficient route connecting them all.
+
+### 5.2.2 Before you run AutoPipeDrop
+
+Check all of these before clicking the button:
+
+| Prerequisite | How to check | What to do if missing |
+|---|---|---|
+| Destination fixtures are placed | Select one in the model | Place fixtures (Chapter 3) |
+| Destination fixtures are tagged | Properties show a tag in `PLM_EQP_TAG` | Run Auto Tag (Chapter 3.4) |
+| Pipe systems exist and are named correctly | Systems tab shows named systems | Create systems (Chapter 4.2) |
+| Pipe types exist in the project | Project Browser → Families → Pipe Types | Run Create Pipes (Chapter 2, Step 2) |
+| A distribution/riser point is defined | An element exists at the branch-off point | Place a pipe cap or valve at the riser tee position |
+
+### 5.2.3 Step by step: running AutoPipeDrop
+
+1. **Select your destination fixtures.** In the Revit view, click one fixture, then hold `Ctrl` and click the others you want to connect. To select all basins on a floor at once, use the STING panel → SELECT tab → click **Plumbing** under the Category selectors. This selects all plumbing category elements in the active view.
+
+2. **Open the Routing sub-tab.** In the STING panel, click the **TAGS** tab. Then click the **Routing** sub-tab (one of the sub-tabs along the top of the TAGS content area).
+
+3. **Click Auto-drop.** The button is labelled **Auto-drop** and runs `AutoDropCommand` (which internally uses the `AutoPipeDrop` engine for pipe categories).
+
+4. **The Auto Drop dialog appears.** Fill in these fields:
+
+   | Field | What to enter | Example |
+   |---|---|---|
+   | **System** | The STING system code for this run | `DCW` |
+   | **Pipe type** | Select from the dropdown list of pipe types in the project | `Copper — Half Hard` |
+   | **Nominal diameter** | The pipe size in mm | `22` |
+   | **Source point** | Click "Pick Source Point" then click the riser tee or distribution valve in the model | (you click a point) |
+   | **Slope** | For pressure systems: leave as 0. For drainage (SAN, RWD): enter the required slope percentage | `0` for DCW; `1.25` for SAN |
+   | **Max horizontal run** | Maximum distance a horizontal branch can travel before STING routes it down a vertical drop | `6000` (6 metres) |
+   | **Route preference** | Choose "Ceiling void" to route above ceiling, or "Exposed" to route at fixture level | Depends on project |
+
+5. **Click Generate.** STING calculates the routes and places the pipes. You will see pipes appearing in the view as the engine works.
+
+6. **Review the result report.** A results dialog shows:
+   - Number of fixtures connected
+   - Total pipe length placed
+   - Any fixtures that could not be connected (with reasons)
+   - Any fittings that could not be placed (these need manual attention)
+
+### 5.2.4 After AutoPipeDrop: immediate checks
+
+After the engine completes, do these checks before moving on:
+
+1. **Visual check:** Scroll through the view. Look for any pipe segments that appear to be floating, going in the wrong direction, or not connected to the fixture.
+
+2. **Tag the new pipes:** The pipes placed by AutoPipeDrop are not yet tagged. Run **Auto Tag** again from the CREATE tab. The new pipes will be tagged with the correct SYS code from the system you specified.
+
+3. **Validate fills:** Click **Validate fills** on the Routing sub-tab. This runs `ValidateFillsCommand` and checks that the pipe sizes are consistent with the design flow rates. Any oversized or undersized pipes are flagged.
+
+> **Stuck?** If the engine says "No source point found", it means you clicked "Pick Source Point" but did not click on a connectable element. A "source point" must be an element with a pipe connector facing outward — a pipe cap, a valve, or an open pipe end. If you placed a piece of solid geometry (a wall, a room), nothing will connect to it.
+
+> **Stuck?** If some fixtures show as "not connected" in the report, the most common cause is that the fixture's pipe connector is not at the expected height. Open the fixture in the Family Editor, check that the connector is at the correct Z-height for the system type (DCW connectors for a wall-hung basin should be at the centre of the supply pipework, typically 750–900 mm above finished floor level).
+
+---
+
+## 5.3 Manual pipe routing
+
+For single pipe runs, short connections, or any section that AutoPipeDrop cannot handle:
+
+**Using ModelCreatePipeCommand:**
+
+1. In the STING panel, click the **MODEL** tab.
+2. Click **Create Pipe**. This runs `ModelCreatePipeCommand`.
+3. A dialog appears with fields for:
+   - Pipe type (choose from the list)
+   - System (choose the STING system code from the dropdown — e.g., `DCW`)
+   - Nominal diameter (type the size in mm)
+4. Click **Pick Start Point** → click the start point in the model.
+5. Click **Pick End Point** → click the end point.
+6. STING places the pipe segment and assigns it to the specified system.
+7. Run **Auto Tag** to tag the new pipe.
+
+**Using Revit's native pipe tool:**
+
+You can also use Revit's built-in pipe drawing tool (Systems tab → Pipe). When using the native tool, make sure to select the correct pipe system from the Type Selector and the Properties palette. After placing pipes natively, run **System Push** (`SystemParamPushCommand`) to populate the PLM_* parameters from the system data.
+
+---
+
+## 5.4 Slope requirements for drainage pipes
+
+### Why drainage pipes must slope
+
+A sanitary or rainwater drainage pipe carries water mixed with waste solids. For the flow to self-cleanse (carry solids along without blockages), the water must move fast enough — but not so fast that the water runs away and leaves the solids behind.
+
+The British Standard BS EN 12056-2 (for foul water drainage) and BS EN 12056-3 (for rainwater drainage) define the required slopes. Think of it like a playground slide: too gentle and you barely move; too steep and you fly off the end.
+
+For a 100mm soil branch:
+- **Minimum slope:** 1:80 (1.25%) — at this slope the flow velocity is approximately 0.7 m/s, just enough to carry solids.
+- **Maximum slope:** 1:20 (5%) for branches (steeper and water separates from solids).
+- **Ideal slope:** 1:40 to 1:50 (2.0–2.5%).
+
+### The PLM_SLOPE_PCT parameter
+
+STING stores the pipe slope as a percentage in the parameter `PLM_SLOPE_PCT`. A slope of 1:80 is 1.25%. A slope of 1:50 is 2.0%. A slope of 1:40 is 2.5%.
+
+**How to set pipe slope in STING:**
+
+1. Select the drainage pipe in the model.
+2. In the Properties palette on the left, find the **PLM_SLOPE_PCT** parameter.
+3. Type the required slope percentage (e.g., `1.25`).
+4. This records the design slope for STING's validator. You must also set the geometric slope in Revit's pipe properties: in the Properties palette, find the **Slope** field (this is Revit's native field) and set it to match.
+
+> **Important:** STING's `PLM_SLOPE_PCT` is a data parameter — it records the slope value for tagging, scheduling, and validation purposes. The actual geometric slope of the pipe in the 3D model is controlled by Revit's native **Slope** field in pipe properties. Both must be set to the same value for the model to be accurate.
+
+**Recommended slope values by system:**
+
+| System | Pipe type | Recommended slope | Minimum slope | Maximum slope | BS EN reference |
+|---|---|---|---|---|---|
+| SAN | Branch waste pipe (soil) | 2.0–2.5% | 1.25% | 5.0% | BS EN 12056-2, Table 4 |
+| SAN | Long branch (>3 m) | 1.25% | 1.25% | 2.5% | BS EN 12056-2, Table 4 |
+| SAN | Stack (vertical) | Vertical — no slope | N/A | N/A | N/A |
+| SAN | Underground drain | 1.0–2.5% | 0.6% | 5.0% | BS EN 752, BS EN 1671 |
+| RWD | Flat roof drainage branch | 0.5–1.0% | 0.3% | 2.0% | BS EN 12056-3 |
+| RWD | Above-ground rainwater pipe | Vertical | N/A | N/A | N/A |
+| RWD | Underground surface water | 1.0–1.5% | 0.5% | 5.0% | BS EN 752 |
+| DCW / DHW / HWS / GAS | All (pressure pipes) | Not applicable | N/A | N/A | Pressure pipes do not slope to drain |
+
+### STING slope validation
+
+When you run `RunAllValidatorsCommand` (Chapter 9), the slope validator checks:
+
+1. That every drainage pipe (SAN, RWD) has a `PLM_SLOPE_PCT` value set.
+2. That the value is within the permitted range for the pipe size and system code.
+3. That the geometric slope in Revit matches the declared `PLM_SLOPE_PCT` value (within a small tolerance).
+
+If the validator flags a slope error, it will tell you:
+- Which pipe failed
+- What slope value was found
+- What range is acceptable
+- Whether the error is a gradient-too-shallow (risk of blockage) or gradient-too-steep (risk of surcharging)
+
+**How to correct a slope validation failure:**
+
+1. Select the pipe that failed.
+2. Open Properties palette.
+3. Set the Revit **Slope** field to the correct value (e.g., `2.00 %` or `1:50`).
+4. Set `PLM_SLOPE_PCT` to the same numeric percentage (e.g., `2.0`).
+5. Run the validator again to confirm the fix.
+
+---
+
+## 5.5 Pipe insulation
+
+### Why pipes get insulated
+
+Different systems need insulation for different reasons:
+
+| System | Why insulate | Target thickness (typical) | Standard |
+|---|---|---|---|
+| DCW (in warm areas) | Prevent water temperature rising above 20°C — above this, Legionella bacteria can multiply | 25–38 mm | L8 ACOP, HSG274 Part 2 |
+| DHW and HWS | Reduce heat loss from distribution pipework — saves energy and maintains temperature at point of use | 25–38 mm | BS 5422 Table 2 |
+| SAN and RWD (in cold areas) | Prevent freezing in unheated spaces (roof voids, external walls, car parks) | 25 mm minimum | BS 6700 |
+| GAS | Not typically insulated above ground (gas pipework is metal and rusts if moisture is trapped under insulation) | Not insulated | IGEM UP/2 |
+
+### STING insulation parameters
+
+STING records insulation data in two parameters on each pipe:
+
+- `PLM_INSULATION_TXT` — the insulation material name (e.g., "Armaflex", "Rockwool", "PIB")
+- `PLM_PPE_INSULATION_THK_MM` — the insulation thickness in millimetres
+
+### Applying insulation data in bulk
+
+Rather than setting these parameters one pipe at a time, use Bulk Parameter Write:
+
+1. Select all the DCW pipes you want to insulate. (Use SELECT tab → Category → **Pipes** to select all pipes in the active view, then filter by system using Properties palette if needed.)
+2. In the STING panel SELECT tab, click **Bulk Param Write**. This runs `BulkParamWriteCommand`.
+3. In the dialog, choose parameter `PLM_INSULATION_TXT`, set value to `Armaflex` (or your specified material).
+4. Click Apply. All selected pipes receive the insulation type.
+5. Repeat for `PLM_PPE_INSULATION_THK_MM`, setting the appropriate thickness value.
+
+---
+
+# Chapter 6 — Drainage Design
+
+---
+
+## 6.1 Sanitary drainage vs rainwater drainage
+
+These two drainage systems are separate and must never be connected to each other on new construction in the UK.
+
+**Sanitary drainage (SAN)** carries foul water — the contaminated water from WCs, sinks, basins, baths, and kitchen drains. It discharges to the foul sewer, which takes it to a sewage treatment works.
+
+**Rainwater drainage (RWD)** carries clean surface water — rain falling on the roof and paved areas. It discharges to the storm sewer, which takes it to a watercourse or soakaway. Because it is relatively clean, it must not be contaminated by foul water.
+
+Connecting RWD to SAN (or vice versa) creates a "combined drain" — illegal on new construction under Building Regulations Part H and the Water Industry Act 1991. Always keep them separate from the point of collection all the way to the point of discharge.
+
+---
+
+## 6.2 The SAN system
+
+The sanitary drainage system collects waste from:
+- WCs and urinals (soil connection — 100 mm minimum pipe)
+- Wash basins (waste connection — typically 32–40 mm branch, running into 50 mm or 100 mm stack)
+- Baths and showers (waste connection — 40 mm branch)
+- Kitchen sinks (40 mm branch)
+- Floor gullies and cleaners' sinks (40 mm or 100 mm branch)
+
+**Creating a sanitary drainage layout in STING:**
+
+1. **Place sanitary fixtures** (Chapter 3) — WCs, basins, baths.
+2. **Create a SAN pipe system** (Chapter 4.2) — name it exactly `SAN`.
+3. **Route waste branches to the stack:**
+   - Use AutoPipeDrop: select the fixtures, choose system `SAN`, set pipe type `HDPE Drainage` or `Cast Iron Soil`, set nominal diameter (40 mm for wastes, 100 mm for soil), set slope to `2.0`%, set source point at the stack connection point.
+   - AutoPipeDrop will route each branch from the fixture to the stack, sloped correctly.
+4. **Route the stack** — the vertical soil stack is a vertical pipe with no slope. Place it manually using `ModelCreatePipeCommand` or Revit's pipe tool, with a vertical orientation.
+5. **Connect branches to the stack** — STING's AutoPipeDrop will have placed the branches at the correct level; use Revit's connection tools to connect each branch to the stack with a swept tee fitting.
+6. **Validate** — Run `RunAllValidatorsCommand`. The slope, connectivity, and termination validators will check the entire SAN system.
+7. **Create a sanitary drainage schedule** — Chapter 8.3.
+
+**Vent pipes:** BS EN 12056-2 requires that every sanitary system has a vent to atmosphere to prevent trap siphonage. The soil stack itself typically extends above the roof line as a vent. Individual branch pipes longer than 3 m (for 32mm pipes) need additional venting — either by extending them to a vent stack, or by fitting air admittance valves (AAVs). Record vent connection locations in `PLM_DRN_VNT_TERMINAL_LOC_TXT` and `PLM_VENT_CONNECTED_TO_TXT`.
+
+---
+
+## 6.3 The RWD system
+
+Rainwater drainage collects surface water from:
+- Flat roof drainage outlets (typically 100 mm or 150 mm)
+- Gutters and hoppers on pitched roofs (typically 100 mm diameter, 112 mm half-round gutters)
+- Rainwater downpipes (typically 68 mm circular, 65×65 mm square)
+
+**Pipe sizing for RWD** uses the "rational method": multiply the catchment area (m²) by the design rainfall intensity (l/s per m²) to get the design flow rate, then size the pipe to carry that flow at the chosen slope.
+
+In the UK, design rainfall intensities are taken from CIBSE Guide G or BS EN 12056-3: typically 0.014 l/s/m² for 2-minute storms in most of England, up to 0.025 l/s/m² in Scotland.
+
+STING does not calculate pipe sizes automatically — it records the sizes you specify in `PLM_PPE_SZ_MM`. The sizing calculation is done by the engineer using BS EN 12056-3 methods.
+
+---
+
+## 6.4 Trap requirements
+
+Every sanitary appliance must have a trap — a water seal that prevents sewer gases from entering the building. BS EN 274 and the Building Regulations Part H require:
+
+| Appliance | Minimum trap seal depth | Trap type |
+|---|---|---|
+| WC | 50 mm | Integral (built into pan) |
+| Basin | 75 mm | P-trap or bottle trap |
+| Bath / shower | 50 mm | P-trap |
+| Kitchen sink | 75 mm | P-trap |
+| Floor gully | 50 mm | Gully trap |
+
+Record these in `PLM_DRN_TRAP_TYPE_TXT` and `PLM_DRN_TRAP_SEAL_DEPTH_MM`.
+
+---
+
+# Chapter 7 — Gas Systems
+
+---
+
+## 7.1 The GAS system code in STING
+
+STING treats gas supply as system code `GAS`. This covers:
+- Natural gas (NG) from the national grid
+- Liquefied petroleum gas (LPG) from a bulk storage tank
+- Biogas from a site digester
+
+All three share the same STING system code because they follow the same general routing and tagging approach within the building. The specific gas type is recorded in the `PLM_PPE_MAT_TXT` or the equipment parameter field.
+
+---
+
+## 7.2 Key considerations for gas piping
+
+| Consideration | Rule | Where recorded in STING |
+|---|---|---|
+| Pipe material | Steel (black or galvanised) for above-ground; polyethylene for below-ground | `PLM_PPE_MAT_TXT` |
+| Plastic prohibition | No plastic pipe inside a building above ground | N/A — flag in validation if plastic material is selected |
+| Pressure tier | Low pressure ≤21 mbar; medium pressure 21 mbar–2 bar | `PLM_PPE_PSR_RATING_BAR` |
+| Sleeve through walls | Gas pipe must be sleeved where it passes through a wall or floor | `PLM_DRN_BODY_MAT_TXT` or notes |
+| No enclosed ducts | Above-ground gas pipe must not be run in an enclosed duct unless ventilated | Notes only |
+| Bonding | All metallic gas pipework must be cross-bonded to earth | Recorded in electrical BIM |
+| Emergency control valve | An Emergency Control Valve (ECV) must be accessible near each appliance | Placed as a valve family; tagged with system `GAS` |
+| Isolation valve | A gas isolation valve must be fitted to each branch serving an appliance | Same as above |
+
+---
+
+## 7.3 Creating gas pipe layouts
+
+The workflow for gas piping follows the same sequence as DCW:
+
+1. **Place gas appliances** (boilers, cookers, laboratory benches) — Chapter 3.3.
+2. **Create the GAS pipe system** — Chapter 4.2. Name it exactly `GAS`.
+3. **Route pipes from the meter to each appliance:**
+   - AutoPipeDrop works for gas: select appliances → click Auto-drop → choose system `GAS` → choose pipe type `Black Steel` → choose nominal diameter → set source point at the meter outlet.
+   - Set slope to `0` (gas pipes do not slope unless serving a condensate trap).
+4. **Tag** — Run Auto Tag. All gas pipes get `DISC=P`, `SYS=GAS`.
+5. **Validate** — Run `RunAllValidatorsCommand`. The connectivity validator checks every gas appliance is connected to the GAS system.
+
+---
+
+## 7.4 STING does NOT design gas pressure calculations
+
+STING records gas system data and produces drawings, schedules, and tags — but it does not calculate pressure drop through gas pipe networks. Gas pressure design requires:
+
+1. Knowing the appliance gas rates (kW input / calorific value = m³/h)
+2. Summing demands with a diversity factor
+3. Calculating pressure drop through each run using the Weymouth or Spitzglass formula
+4. Ensuring the pressure available at each appliance (after all losses) is above the minimum required
+
+These calculations are performed using specialist gas design software (e.g., CIBSE TM20, or the gas network design calculators in IGEM UP/2) or manually per IGEM/UP/1B. The results — pipe sizes, operating pressures, gas rates — are then entered into STING's parameters for record purposes.
+
+Record gas design results in:
+- `PLM_PPE_SZ_MM` — pipe nominal diameter selected from the calculation
+- `PLM_PPE_PSR_RATING_BAR` — rated pressure of the pipework
+- `PLM_PSR_KPA` — operating pressure at this point in kPa
+- `PLM_EQP_CAPACITY_L` — for storage vessels (propane tanks, LPG cylinders)
+
+---
+
+# Chapter 8 — Plumbing Schedules
+
+---
+
+## 8.1 What plumbing schedules are produced
+
+A complete plumbing package typically includes three types of schedules:
+
+| Schedule type | What it lists | Used by |
+|---|---|---|
+| **Plumbing fixture schedule** | Every sanitary and plumbing fixture: WCs, basins, baths, showers, floor drains — with their tag, flow rates, connection sizes, location, and room | Contractor for ordering and installation |
+| **Pipe schedule (by system)** | Every pipe run: system, pipe type, nominal diameter, length, slope (for drainage), insulation — for each of DCW, DHW, HWS, SAN, RWD, GAS | Contractor for material take-off; engineer for checking |
+| **Insulation schedule** | All insulated pipes: pipe tag, system, size, insulation material, thickness, area of insulation | Insulation contractor; QS for pricing |
+
+---
+
+## 8.2 Creating a plumbing fixture schedule
+
+1. In the STING panel, click the **TEMP** tab.
+2. Scroll to the **Schedules** section.
+3. Click **MEP Plumbing Fixtures**. This runs `PlumbingFixtureScheduleCommand` (also accessible via command tag `MEPSchedulePlumb`).
+4. STING creates a schedule called "STING - Plumbing Fixture Schedule" with these columns:
+
+   | Column | Parameter | Notes |
+   |---|---|---|
+   | Tag | `PLM_EQP_TAG` | Full ISO 19650 tag |
+   | Family | Family name | The fixture type |
+   | Level | `ASS_LVL_COD_TXT` | Level code |
+   | Room | Room name | From spatial data |
+   | System | `PLM_SYSTEM_TXT` | DCW, DHW, SAN etc. |
+   | Hot connection | `PLM_PPE_SZ_MM` | Hot supply pipe size |
+   | Cold connection | `PLM_PPE_SZ_MM` | Cold supply pipe size |
+   | Waste connection | `PLM_PPE_SZ_MM` | Waste pipe size |
+   | Flow rate (l/s) | `PLM_FLOW_RATE_LPS` | Design flow rate |
+   | Status | `ASS_STATUS_TXT` | NEW / EXISTING |
+
+5. The schedule opens automatically. You can filter it by system, sort by level, or group by room.
+
+**Exporting to Excel:**
+
+1. Select the schedule in the Project Browser (Views → Schedules → STING - Plumbing Fixture Schedule).
+2. In the STING panel BIM tab, click **Export Schedules to Excel**. This runs `ExportSchedulesToExcelCommand`.
+3. Choose the schedule name and click Export. The schedule is written to an `.xlsx` file in your project output folder.
+
+---
+
+## 8.3 Creating a pipe schedule by system
+
+1. In the STING panel, click the **TEMP** tab.
+2. In the Schedules section, click **Batch Create**. This runs `BatchSchedulesCommand`.
+3. STING creates one schedule per system present in the project. You will get:
+   - "STING - Pipe Schedule - DCW"
+   - "STING - Pipe Schedule - DHW"
+   - "STING - Pipe Schedule - SAN"
+   - (and so on for every system found)
+4. Each schedule lists all pipes in that system with: pipe tag, nominal diameter, material, length, slope (for drainage), insulation type, insulation thickness.
+
+**Filtering by system:** Each schedule is automatically filtered to its system code via `PLM_SYSTEM_TXT`. You do not need to set this up manually.
+
+---
+
+## 8.4 Creating an insulation schedule
+
+The insulation schedule is generated as part of the pipe schedule. It uses the same `BatchSchedulesCommand` output but focuses on the insulation parameter columns. To produce a dedicated insulation schedule:
+
+1. In the Revit Project Browser, right-click one of the pipe schedules.
+2. Click Duplicate → Duplicate with Detailing.
+3. In the new schedule, open Schedule Properties (View tab → Properties → Edit Fields).
+4. Remove all columns except: Tag, System, Nominal Size, Insulation Material, Insulation Thickness, Pipe Length.
+5. Add a calculated column for Insulation Area (in m²) = `PLM_PPE_LENGTH_M` × (pipe circumference + insulation thickness).
+6. Rename the schedule to "STING - Insulation Schedule".
+
+---
+
+# Chapter 9 — Validation and QA
+
+---
+
+## 9.1 RunAllValidatorsCommand for plumbing projects
+
+STING's validation engine runs five checks on plumbing elements. Think of it as a digital commissioning checklist: the same checks a commissioning engineer would make before signing off the installation.
+
+**How to run:**
+
+1. In the STING panel, click the **TAGS** tab.
+2. Click the **Routing** sub-tab.
+3. Click **Validate fills**. This runs `ValidateFillsCommand`, which in turn triggers the full `RunAllValidatorsCommand` suite.
+
+Alternatively, the full validator suite can be accessed directly via the command tag `Validation_RunAll`.
+
+**The five validators and what they check:**
+
+| Validator | What it checks for plumbing | Standard reference |
+|---|---|---|
+| **Slope validator** | Checks `PLM_SLOPE_PCT` on every SAN and RWD pipe. Compares against permitted range for pipe size. | BS EN 12056-2, BS EN 752 |
+| **Fill validator** | For drainage pipes: checks fill ratio (calculated flow / maximum flow capacity) is ≤ 0.7 per Maguire's formula. For pressure pipes: checks velocity is ≤ 3.0 m/s (DCW) or ≤ 1.5 m/s (DHW circulation). | BS EN 12056-2, CIBSE Guide G |
+| **Connectivity validator** | Checks that every plumbing fixture is connected to an appropriate pipe system (e.g., a WC is connected to SAN, a basin is connected to both DCW and SAN). | ISO 19650-2, BS EN 806-2 |
+| **Termination validator** | Checks that every pipe system has a defined termination point (a discharge to sewer, a storage tank, a meter connection). Systems without a termination point are flagged. | Building Regs Part H, BS EN 806-2 |
+| **Spec validator** | Checks that key parameters are populated on every pipe: `PLM_PPE_SZ_MM`, `PLM_PPE_MAT_TXT`, and `PLM_SYSTEM_TXT`. Unfilled parameters flag as incomplete. | ISO 19650-1, project BEP |
+
+---
+
+## 9.2 Reading the validation report
+
+When `RunAllValidatorsCommand` completes, a results panel appears. This is what you will see:
+
+```
+STING Validation Report — Plumbing (Discipline: P)
+═══════════════════════════════════════════════════
+
+[PASS] Connectivity validator: 47 fixtures connected, 0 unconnected
+[PASS] Termination validator: 6 systems, all terminated
+
+[FAIL] Slope validator: 3 failures
+  ► P-BLD1-Z01-L01-SAN-DRN-PPC-0004: slope 0.80% is below minimum 1.25% for 100mm SAN
+  ► P-BLD1-Z01-L01-SAN-DRN-PPC-0007: slope 0.80% is below minimum 1.25% for 100mm SAN
+  ► P-BLD1-Z01-L02-RWD-DRN-PPC-0003: no slope set (PLM_SLOPE_PCT is blank)
+
+[WARN] Fill validator: 1 warning
+  ► P-BLD1-Z01-L01-SAN-DRN-PPC-0012: fill ratio 0.82 (design flow 4.8 l/s, capacity 5.9 l/s)
+    Recommendation: increase pipe from 100mm to 150mm
+
+[FAIL] Spec validator: 5 failures
+  ► PLM_PPE_MAT_TXT is blank on 5 DCW pipes on Level 02
+
+═══════════════════════════════════════════════════
+SUMMARY: 2 categories failed, 1 warning, 1 category passed
+```
+
+**How to read each section:**
+
+- `[PASS]` — No action needed.
+- `[FAIL]` — These must be fixed before the drawing can be issued. The tag number tells you exactly which pipe to select.
+- `[WARN]` — These do not block issue but should be reviewed by the engineer. The fill ratio warning above is telling you a pipe is oversized (0.82 > 0.7) — it is carrying more flow than it should.
+
+**How to fix failures:**
+
+1. Note the tag numbers of all failing pipes (e.g., `P-BLD1-Z01-L01-SAN-DRN-PPC-0004`).
+2. In Revit, use the ORGANISE tab → Analysis → **Highlight Invalid** (`HighlightInvalidCommand`). This colours failing elements in red so you can find them quickly on the drawing.
+3. Select the failing pipe → fix the issue (set slope, set material, etc.) → re-run the validator.
+4. Repeat until all `[FAIL]` items are cleared.
+
+---
+
+## 9.3 ValidateTagsCommand for plumbing elements
+
+After fixing validator failures, run the tag validator to confirm every plumbing element has a complete, ISO 19650-compliant tag.
+
+1. In the STING panel, click the **CREATE** tab.
+2. In the QA section, click **Validate**. This runs `ValidateTagsCommand`.
+3. For plumbing elements, the validator checks:
+   - `DISC` = `P` (flag if any plumbing element has DISC set to something else)
+   - `SYS` is one of the valid plumbing system codes (DCW, DHW, HWS, SAN, RWD, GAS)
+   - `PROD` code matches the element category (e.g., a pipe should have a valid pipe product code)
+   - All eight segments are populated (no blanks)
+
+**Common tag errors and fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `SYS` is blank | Pipe is not connected to a named system | Run System Push (`SystemParamPushCommand`) |
+| `SYS` shows "Cold Water" | Revit system was not named using the STING code | Rename the Revit pipe system to `DCW` then re-tag |
+| `DISC` shows `M` on a gas pipe | Gas pipe was categorised under Mechanical | Manually set `ASS_DISCIPLINE_COD_TXT` = `P` on affected elements |
+| `PROD` is blank | Family name does not match any STING PROD code | Open `ConfigEditorCommand` → check PROD code mappings for your family names |
+
+---
+
+# Chapter 10 — Producing and Issuing Plumbing Drawings
+
+---
+
+## 10.1 Applicable drawing types
+
+STING ships two drawing type profiles relevant to plumbing work:
+
+| ID | Purpose | Scale | Paper | When to use |
+|---|---|---|---|---|
+| `plumb-drainage-A1-1to100` | Dedicated drainage and plumbing service drawing | 1:100 | A1 landscape | Drainage plans, cold water plans, hot water plans — each shown on a separate sheet |
+| `mep-plan-A1-1to100` | Combined MEP services drawing showing all disciplines | 1:100 | A1 landscape | Coordination drawings where plumbing is shown alongside HVAC and electrical |
+
+For most plumbing packages, use `plumb-drainage-A1-1to100`. Use `mep-plan-A1-1to100` for coordination reviews.
+
+---
+
+## 10.2 Producing drawings
+
+For full step-by-step drawing production instructions — creating views, placing them on sheets, applying the drawing type profile, setting crops, numbering sheets — see:
+
+> See **DRAWING_PRODUCTION_SYSTEM_GUIDE.md** for the complete drawing production process.
+
+The drawing type `plumb-drainage-A1-1to100` is already configured in STING with the correct scale, view template, and title block. When you use it via the Sheet Manager or the Drawing Types workflow, these settings are applied automatically.
+
+---
+
+## 10.3 Issuing drawings
+
+For the complete document issue workflow — creating a transmittal, setting the suitability code (for construction, for approval, etc.), distributing to recipients, and maintaining the ISO 19650 document register — see:
+
+> See **DOCUMENT_MANAGER_GUIDE.md** for the complete document issue process.
+
+---
+
+# Troubleshooting
+
+| Problem | Likely cause | Fix |
+|---|---|---|
+| **Pipe not connecting to fixture** | The fixture's pipe connector is not at the right location, or the pipe type does not match the connector type | Open the fixture family in the Family Editor; check connector location and type. Also check pipe system types match (cannot connect a Hydronic Supply system to a Domestic Cold Water pipe) |
+| **AutoPipeDrop places pipe in wrong location** | Source point was not defined correctly — STING routed to the wrong origin | Re-run Auto-drop → click "Pick Source Point" more carefully, clicking directly on the pipe connector of the riser/distribution valve |
+| **AutoPipeDrop says "no source point found"** | You clicked on a non-connectable element (a room, a wall, a column) | The source point must be an element with an exposed pipe connector — a pipe cap, a valve with an unconnected port, or an open pipe end |
+| **Slope validation fails even though slope is set** | Slope was set on the wrong axis — Revit pipe slope must be on the Z axis (vertical) not X or Y | Select the pipe → Properties palette → check the **Slope** field (not just `PLM_SLOPE_PCT`). If the pipe is running vertically and shows a slope value, delete the slope |
+| **Slope validation fails: "PLM_SLOPE_PCT is blank"** | The STING parameter was never set on this pipe | Select the pipe → Properties palette → find `PLM_SLOPE_PCT` → type the slope percentage |
+| **PLM_* parameters not appearing in Properties** | Shared parameters were not loaded, or not bound to the Pipe category | Run `LoadSharedParamsCommand` again. Check the results show "PLM_DRN" group bound successfully |
+| **System code wrong in tag — shows blank or wrong code** | Revit pipe system was not named with the STING code | In the Revit Systems panel, rename the pipe system to the exact STING code (e.g., `DCW`), then run `SystemParamPushCommand` |
+| **Drainage schedule missing fittings** | Fittings were placed but not connected to the SAN system | Select the fittings → check Properties palette for "System Name" field. If blank, drag-connect the fittings to a connected pipe |
+| **Gas pipes tagged as P with wrong SYS code** | Gas system was created after pipes were placed and pipes were not assigned to it | Select all gas pipes → in Revit Systems tab, use "Edit System" to add them to the GAS system → run `SystemParamPushCommand` → re-run Auto Tag |
+| **Auto Tag assigns wrong PROD code** | The plumbing fixture family name does not contain a recognisable abbreviation | Open `ConfigEditorCommand` (STING panel → CREATE tab → Setup → Configure) → in the PROD code mapping section, add a mapping for your family name |
+| **Fill validator shows warning for drainage pipe** | Design flow exceeds 70% of pipe capacity at the specified slope | Either increase the pipe diameter, or increase the slope (if geometry allows) — re-run validator to confirm |
+| **Connectivity validator fails for isolated pipe section** | Pipe section is not connected to the rest of the system | Zoom into the failing pipe tag → look for a gap between the pipe end and the connected element → use Revit's connect tool to close the gap |
+| **RunAllValidatorsCommand completes instantly with no results** | No plumbing elements are in the active selection or view | Make sure you are in a view that contains plumbing elements, or change to a 3D view showing all levels |
+
+---
+
+# Quick Reference
+
+---
+
+## All plumbing commands
+
+| Button label | Panel tab | Sub-tab | What it does | When to use it |
+|---|---|---|---|---|
+| **Load Params** | CREATE | Setup | Binds PLM_DRN shared parameters to Revit categories | Once per project, at project setup |
+| **Pipes** | TEMP | Families | Creates standard pipe type families from STING CSV | Once per project, at project setup |
+| **Inspect Drawing Types** | DOCS | Drawing Types | Lists all drawing types and flags missing assets | At setup and before drawing production |
+| **Place Fixture** | MODEL | (main) | Places a single plumbing fixture at a picked point | One-off fixture placement |
+| **Auto Tag** | CREATE | (main) | Tags all untagged plumbing elements in active view | After placing fixtures or pipes |
+| **Batch Tag** | CREATE | (main) | Tags all plumbing elements in entire project | After any bulk placement operation |
+| **System Push** | CREATE | Tag Operations | Writes Revit system data into PLM_* parameters | After connecting pipes to systems |
+| **Auto-drop** | TAGS | Routing | Routes pipes automatically from source to fixtures | Main pipe routing operation |
+| **Validate fills** | TAGS | Routing | Runs fill, slope, connectivity, and termination validators | After all pipe routing is complete |
+| **Bulk Param Write** | SELECT | (main) | Sets any parameter on all selected elements at once | Setting insulation material, slope |
+| **MEP Plumbing Fixtures** | TEMP | Schedules | Creates plumbing fixture schedule | After tagging all fixtures |
+| **Batch Create** (schedules) | TEMP | Schedules | Creates pipe schedules for every system present | After all pipe routing and tagging |
+| **Export Schedules to Excel** | BIM | Excel | Exports any Revit schedule to .xlsx | Preparing handover data |
+| **Validate** | CREATE | QA | Validates ISO 19650 tag completeness | Before drawing production |
+| **Highlight Invalid** | ORGANISE | Analysis | Colours elements with incomplete tags red/orange | While fixing tag errors |
+| **Completeness Dashboard** | CREATE | QA | Shows per-discipline compliance percentages | Progress monitoring |
+
+---
+
+## Plumbing system codes — complete reference
+
+| Code | Full name | Revit system classification to use | Standards | Typical pipe materials | Pressure / gravity |
+|---|---|---|---|---|---|
+| `DCW` | Domestic Cold Water | Domestic Cold Water | BS EN 806-2, WRAS | Copper, CPVC, stainless | Pressure (1–10 bar) |
+| `DHW` | Domestic Hot Water | Domestic Hot Water | BS EN 806-2, L8 ACOP | Copper, stainless | Pressure (0.5–4 bar) |
+| `HWS` | Hot Water Services Circulation | Domestic Hot Water (return) | BS EN 806-2, L8 ACOP | Copper, stainless | Pumped low-pressure |
+| `SAN` | Sanitary Drainage | Sanitary | BS EN 12056-2, Building Regs Part H | HDPE, cast iron, uPVC | Gravity |
+| `RWD` | Rainwater Drainage | Storm | BS EN 12056-3, Building Regs Part H | uPVC, HDPE, cast iron | Gravity |
+| `GAS` | Gas Supply | Other | IGEM UP/2, Gas Safety Regs | Black steel, copper | Low/medium pressure |
+
+---
+
+## PLM_* parameter reference
+
+| Parameter name | What it stores | Example value | Which elements |
+|---|---|---|---|
+| `PLM_PPE_SZ_MM` | Pipe nominal diameter (mm) | `22`, `100` | Pipes |
+| `PLM_PPE_MAT_TXT` | Pipe material | `Copper`, `HDPE` | Pipes |
+| `PLM_PPE_JOINT_TYPE_TXT` | Joint type | `Soldered`, `Compression` | Pipes, fittings |
+| `PLM_PPE_LENGTH_M` | Pipe length (m) | `3.65` | Pipes |
+| `PLM_FLOW_RATE_LPS` | Design flow rate (l/s) | `0.15` | Pipes |
+| `PLM_VEL_MPS` | Water velocity (m/s) | `1.5` | Pipes |
+| `PLM_PSR_KPA` | Pressure at this point (kPa) | `150` | Pipes, equipment |
+| `PLM_PPE_PSR_RATING_BAR` | Pressure rating of pipe (bar) | `10` | Pipes |
+| `PLM_SYSTEM_TXT` | System code | `DCW`, `SAN` | Pipes, fixtures |
+| `PLM_SLOPE_PCT` | Slope percentage for drainage | `1.25`, `2.0` | Drainage pipes |
+| `PLM_INSULATION_TXT` | Insulation material | `Armaflex` | Pipes |
+| `PLM_PPE_INSULATION_THK_MM` | Insulation thickness (mm) | `25`, `38` | Pipes |
+| `PLM_EQP_CAPACITY_L` | Equipment storage volume (L) | `200` | Tanks, cylinders |
+| `PLM_EQP_PRESSURE_KPA` | Equipment design pressure (kPa) | `300` | All plumbing equipment |
+| `PLM_HOTWTR_TEMP_C` | Hot water storage temperature (°C) | `65` | Calorifiers, cylinders |
+| `PLM_HOTWTR_INPUT_PWR_KW` | Water heater heat input (kW) | `24` | Boilers, heaters |
+| `PLM_HOTWTR_FUEL_TYPE_TXT` | Fuel type | `Gas`, `Heat Pump` | Boilers, heaters |
+| `PLM_HED_M` | Static head (m) | `12.5` | Pumps, tanks |
+| `PLM_DRN_TRAP_TYPE_TXT` | Trap type | `P-trap`, `Bottle trap` | Drainage fittings |
+| `PLM_DRN_TRAP_SEAL_DEPTH_MM` | Trap seal depth (mm) | `75` | Drainage fittings |
+| `PLM_DRN_FLW_RATE_LPS` | Drainage flow rate (l/s) | `0.08` | Drainage pipes |
+| `PLM_DRN_PPE_SLOPE_PCT` | Slope on drainage pipe (%) | `1.25` | Drainage pipes |
+| `PLM_VLV_BODY_MAT_TXT` | Valve material | `Brass`, `Bronze` | Valves |
+| `PLM_VLV_END_CONNECTION_TXT` | Valve connection type | `Compression`, `Flanged` | Valves |
+| `PLM_VLV_ACTUATION_TYPE_TXT` | How the valve is operated | `Manual`, `Motorised` | Valves |
+| `PLM_EQP_TAG` | Plumbing equipment tag container | `P-BLD1-Z01-L02-DCW-SUP-BSN-0001` | Fixtures, equipment |
+
+---
+
+## Slope requirements by system
+
+| System | Application | Min slope | Recommended | Max slope | BS EN reference |
+|---|---|---|---|---|---|
+| SAN | WC branch (100 mm) | 1.25% | 2.0% | 5.0% | BS EN 12056-2, Table 4 |
+| SAN | Wash basin waste (32–40 mm) | 2.0% | 2.5% | 5.0% | BS EN 12056-2 |
+| SAN | Long branch >3 m (any size) | 1.25% | 1.5% | 2.5% | BS EN 12056-2 |
+| SAN | Soil stack (vertical) | Vertical | Vertical | Vertical | N/A |
+| SAN | Underground foul drain | 0.6% | 1.25% | 5.0% | BS EN 752 |
+| RWD | Flat roof drainage branch | 0.3% | 0.5–1.0% | 2.0% | BS EN 12056-3 |
+| RWD | Rainwater downpipe (vertical) | Vertical | Vertical | Vertical | N/A |
+| RWD | Underground surface water drain | 0.5% | 1.0% | 5.0% | BS EN 752 |
+| DCW / DHW / HWS | All (pressure system) | Not applicable | Not applicable | Not applicable | Pressure pipes drain back to lowest point if needed — not a routing constraint |
+| GAS | All (pressure system) | Not applicable (condensate traps are special cases) | Not applicable | Not applicable | IGEM UP/2 |
+
+---
+
+## Glossary
+
+**AutoPipeDrop:** STING's automated pipe routing engine. Given a source point (where water comes from) and a set of destination fixtures, it calculates and places the pipe route, fittings, and elbows automatically.
+
+**BS EN 12056:** The British/European Standard for gravity drainage systems inside buildings. Part 2 covers sanitary pipework; Part 3 covers roof drainage.
+
+**CIBSE:** The Chartered Institution of Building Services Engineers. Publishes guides on HVAC, plumbing, and building services design. CIBSE Guide G covers public health engineering.
+
+**DCW:** Domestic Cold Water. Mains cold water supply distributed throughout a building to taps, WCs, and appliances.
+
+**DHW:** Domestic Hot Water. Hot water produced by a boiler or heat pump and distributed to hot taps.
+
+**Discipline code P:** STING's code for plumbing and public health. All elements tagged with `P` as the first segment of their ISO 19650 tag.
+
+**Fill ratio:** The ratio of actual flow in a pipe to the maximum flow capacity of that pipe at the design slope and size. For drainage pipes the maximum recommended fill ratio is 0.7 (70% full) per BS EN 12056-2.
+
+**HDPE:** High-density polyethylene. A plastic pipe material used for underground drainage and sometimes above-ground waste pipework.
+
+**HWS:** Hot Water Services. The circulation return leg of a hot water system — water returning from distribution pipes back to the calorifier to be reheated.
+
+**ISO 19650:** The international standard for managing information over the whole life cycle of a built asset using Building Information Modelling (BIM). The eight-segment tag format used by STING is based on ISO 19650-2.
+
+**L8 ACOP:** The Approved Code of Practice for Legionella control, published by the Health and Safety Executive. Governs hot and cold water system design and maintenance to prevent Legionella bacteria growth.
+
+**Legionella:** A bacterium that grows in water systems where temperatures are between 20–45°C. Can cause Legionnaires' disease (a severe form of pneumonia). DCW must be kept cold (below 20°C) and DHW must be stored hot (above 60°C) to prevent growth.
+
+**Maguire's formula:** The standard formula used in BS EN 12056-2 for calculating the flow capacity of drainage pipes at a given slope. STING's fill validator uses this formula.
+
+**PLM_DRN:** The STING shared parameter group containing all plumbing and drainage parameters.
+
+**PLM_EQP_TAG:** The tag container parameter on plumbing fixtures and equipment. Holds the full ISO 19650 eight-segment tag.
+
+**PRV:** Pressure Reducing Valve. A valve that reduces mains water pressure to a lower design pressure. Used where mains pressure exceeds the safe pressure for the building's plumbing system.
+
+**RWD:** Rainwater Drainage. The system that collects and discharges surface water from roofs and paved areas.
+
+**SAN:** Sanitary Drainage. The foul water drainage system collecting from WCs, sinks, baths, and floor drains.
+
+**Slope validator:** One of STING's five validation checks. It verifies that all drainage pipes (SAN, RWD) have a slope value set, and that the slope is within the permitted range for the pipe size and system type.
+
+**Soil stack:** A vertical pipe collecting soil and waste branches from multiple floors and discharging to the underground drain below ground level.
+
+**System code:** The five-letter (or three-letter) code assigned to a pipe system: DCW, DHW, HWS, SAN, RWD, GAS. STING reads this from the Revit pipe system name.
+
+**TMV:** Thermostatic Mixing Valve. A valve that blends hot and cold water to deliver water at a safe temperature (typically 38–43°C at the outlet) regardless of variations in hot or cold supply temperatures.
+
+**Trap seal:** The water held in the bend of a drainage trap (P-trap, S-trap, bottle trap) that forms a barrier against sewer gases entering the building. The minimum seal depth is 75 mm for most sanitary appliances.
+
+**uPVC:** Unplasticised polyvinyl chloride. The most common above-ground drainage pipe material (white or grey).
+
+---
+
+# Cross-references
+
+> **This guide uses information from:**
+> - `MEP_FOUNDATION_GUIDE.md` — MEP symbol creation (Chapter 1), family authoring to make families placement-ready (Chapter 2), and the Placement Centre for automated fixture placement (Chapter 3). Read this guide first if you are creating new plumbing fixture families.
+> - `DRAWING_PRODUCTION_SYSTEM_GUIDE.md` — Complete drawing production workflow: creating views, placing them on sheets, applying drawing type profiles, numbering sheets.
+> - `DOCUMENT_MANAGER_GUIDE.md` — Document issue workflow: transmittals, suitability codes, the ISO 19650 document register, revision management.
+
+> **This guide is used by:**
+> - `HEALTHCARE_WORKFLOW_GUIDE.md` — Medical gas systems (MGPS: oxygen, nitrogen, vacuum) extend the GAS system code. Water safety for Legionella control in healthcare buildings extends the DCW/DHW workflow. This plumbing guide covers the foundations that the healthcare guide builds on.


### PR DESCRIPTION
## Summary

Reorganize and consolidate STING documentation into a unified `docs/guides/` directory structure with a new integration index. This improves discoverability, establishes a clear reading order for new users, and consolidates five overlapping guides into single authoritative sources.

## Key Changes

- **New consolidated guides** in `docs/guides/`:
  - `MEP_FOUNDATION_GUIDE.md` — unified MEP symbol creation, placement families, and wire annotation (consolidates `docs/MEP_SYMBOL_GUIDE.md`, `docs/PLACEMENT_FAMILY_AUTHORING.md`)
  - `DRAWING_PRODUCTION_SYSTEM_GUIDE.md` — unified drawing production workflow (consolidates `SLOT_TAXONOMY.md`, `TITLE_BLOCK_CREATION_GUIDE.md`, `DRAWING_TYPE_MANAGER_GUIDE.md`, `STING_MANAGED_TEMPLATES_DESIGN.md`, `DRAWING_TEMPLATE_GUIDE.md`)
  - `DOCUMENT_MANAGER_GUIDE.md` — document lifecycle and CDE state management (moved from `docs/`)
  - `ELECTRICAL_WORKFLOW_GUIDE.md` — complete electrical design workflow (1,711 lines; new)
  - `PLUMBING_WORKFLOW_GUIDE.md` — complete plumbing & drainage workflow (1,125 lines; new)
  - `HEALTHCARE_WORKFLOW_GUIDE.md` — healthcare-specific workflows (1,386 lines; new)

- **New navigation guide**:
  - `INTEGRATION_INDEX.md` — reading order for new users, guide inventory, cross-references, and dependency map

- **Deprecation notices** added to original locations:
  - `docs/DOCUMENT_MANAGER_GUIDE.md` — redirects to `docs/guides/DOCUMENT_MANAGER_GUIDE.md`
  - `docs/MEP_SYMBOL_GUIDE.md` — redirects to `docs/guides/MEP_FOUNDATION_GUIDE.md`
  - `docs/PLACEMENT_FAMILY_AUTHORING.md` — redirects to `docs/guides/MEP_FOUNDATION_GUIDE.md`
  - `docs/STING_MANAGED_TEMPLATES_DESIGN.md` — redirects to `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md`
  - `StingTools/Data/DRAWING_TEMPLATE_GUIDE.md` — redirects to `docs/guides/DRAWING_PRODUCTION_SYSTEM_GUIDE.md`

## Implementation Details

- All new guides follow the established STING documentation style: plain-English explanations, step-by-step procedures with exact button names, `> **Stuck?**` troubleshooting blockquotes, and ASCII workflow diagrams
- Guides are discipline-specific (electrical, plumbing, healthcare) and build on the shared MEP foundation
- Integration index provides a dependency graph so users can identify prerequisites before starting a workflow
- Original documents retained for historical reference with deprecation headers; no content deletion

## Documentation Stats

- **New content**: ~7,500 lines across 6 guides
- **Total guides in `docs/guides/`**: 6 consolidated + 1 integration index
- **Disciplines covered**: Electrical, Plumbing, Healthcare, MEP Foundation, Drawing Production, Document Management

https://claude.ai/code/session_01UP79LZjmQ7dw5UCGF7MYxM