### PR TITLE
Add ArchiCAD plugin scaffold and update pricing model

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/BcfController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/BcfController.cs
@@ -13,18 +13,24 @@ namespace Planscape.API.Controllers;
 /// <summary>
 /// T3 — BCF 2.1 bidirectional round-trip.
 ///
-///   GET  /api/projects/{projectId}/bcf/export  → returns a .bcfzip with all
-///        open issues serialised as BCF topics + viewpoints.
+///   GET  /api/projects/{projectId}/bcf/export  → .bcfzip consumable by
+///        ArchiCAD BCF Manager, Revit StingTools plugin, Solibri, BIM Collab.
 ///   POST /api/projects/{projectId}/bcf/import  → accepts a .bcfzip, upserts
 ///        matching issues by BcfGuid.
 ///
 /// BCF 2.1 (buildingSMART) structure:
 ///   bcf.version (XML)
-///   {topic-guid}/markup.bcf (XML: Topic + Comment nodes)
-///   {topic-guid}/viewpoint.bcfv (XML: camera + visibility)
+///   {topic-guid}/markup.bcf   (XML: Topic + Comment nodes)
+///   {topic-guid}/viewpoint.bcfv (XML: camera + Components[IfcGuid])
 ///
-/// Scaffold stores the essentials; camera serialisation matches the existing
-/// BCF writer in the plugin so exports round-trip cleanly.
+/// ArchiCAD compatibility notes:
+///   - Each viewpoint includes &lt;Components&gt;&lt;Component IfcGuid="..."/&gt; when
+///     ModelElementGuid is set. ArchiCAD BCF Manager uses this to locate and
+///     highlight the element automatically on import (ArchiCAD 22+).
+///   - ?source=archicad query param restricts export to issues originating
+///     from ArchiCAD IFC uploads (Source field on BimIssue).
+///   - Export filename encodes the source hint so clients know which IFC
+///     model's GUIDs are referenced.
 /// </summary>
 [ApiController]
 [Route("api/projects/{projectId:guid}/bcf")]
@@ -39,13 +45,21 @@ public class BcfController : ControllerBase
     public BcfController(PlanscapeDbContext db) => _db = db;
 
     [HttpGet("export")]
-    public async Task<IActionResult> Export(Guid projectId, [FromQuery] string? status, CancellationToken ct)
+    public async Task<IActionResult> Export(
+        Guid projectId,
+        [FromQuery] string? status,
+        [FromQuery] string? source,
+        CancellationToken ct)
     {
         if (!await ProjectInTenant(projectId, ct)) return Forbid();
 
         var q = _db.Issues.AsNoTracking().Where(i => i.ProjectId == projectId);
         if (!string.IsNullOrEmpty(status)) q = q.Where(i => i.Status == status);
+        // ?source=archicad → only issues raised against ArchiCAD IFC uploads
+        if (!string.IsNullOrEmpty(source)) q = q.Where(i => i.Source == source);
         var issues = await q.ToListAsync(ct);
+
+        var sourceHint = string.IsNullOrEmpty(source) ? "all" : source;
 
         using var ms = new MemoryStream();
         using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
@@ -65,7 +79,7 @@ public class BcfController : ControllerBase
             }
         }
         ms.Position = 0;
-        return File(ms.ToArray(), "application/zip", $"planscape-{projectId:N}.bcfzip");
+        return File(ms.ToArray(), "application/zip", $"planscape-{projectId:N}-{sourceHint}.bcfzip");
     }
 
     [HttpPost("import")]
@@ -168,13 +182,26 @@ public class BcfController : ControllerBase
 
     private static string BuildViewpoint(BimIssue i)
     {
-        // Minimal orthogonal camera anchored on the issue's model XYZ when set.
+        // Orthogonal camera anchored on the issue's model XYZ when set.
         var hasXyz = i.ModelX.HasValue && i.ModelY.HasValue && i.ModelZ.HasValue;
         var px = hasXyz ? i.ModelX!.Value : 0;
         var py = hasXyz ? i.ModelY!.Value : 0;
         var pz = hasXyz ? i.ModelZ!.Value : 10;
+
+        // BCF 2.1 §4.4 Components — IfcGuid lets ArchiCAD (and Revit, Solibri,
+        // BIM Collab) locate and highlight the flagged element on BCF import.
+        // ModelElementGuid is set when an issue is raised from the 3D viewer.
+        var components = !string.IsNullOrEmpty(i.ModelElementGuid)
+            ? $"<Components>" +
+              $"<ViewSetupHints SpacesVisible=\"false\" SpaceBoundariesVisible=\"false\" OpeningsVisible=\"false\"/>" +
+              $"<Selection><Component IfcGuid=\"{X(i.ModelElementGuid)}\"/></Selection>" +
+              $"<Visibility DefaultVisibility=\"true\"/>" +
+              $"</Components>"
+            : "";
+
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<VisualizationInfo xmlns=\"" + BcfXmlns + "\">" +
+              components +
               "<OrthogonalCamera>" +
                 $"<CameraViewPoint><X>{px:0.###}</X><Y>{py:0.###}</Y><Z>{pz:0.###}</Z></CameraViewPoint>" +
                 "<CameraDirection><X>0</X><Y>0</Y><Z>-1</Z></CameraDirection>" +

--- a/Planscape.Server/src/Planscape.API/Controllers/PricingController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PricingController.cs
@@ -23,22 +23,27 @@ public class PricingController : ControllerBase
         {
             plans = new[]
             {
-                Render(BillingPlan.Studio,   "Studio",   "Solo studio · 1 author + 10 coordinators · 3 projects",  highlight: false),
-                Render(BillingPlan.Practice, "Practice", "Small practice · 1 author + 25 coordinators · 10 projects", highlight: false),
-                Render(BillingPlan.Network,  "Network",  "Mid-size firm · 3 authors + 35 coordinators · 10 projects", highlight: true),
-                Render(BillingPlan.Enterprise, "Enterprise", "≥100 seats · SSO · SLA · on-prem option", highlight: false, custom: true),
+                Render(BillingPlan.Studio,    "Small",      "Small firm · up to 6 users · 5 projects",                 highlight: false),
+                Render(BillingPlan.Practice,  "Medium",     "Growing practice · up to 12 users · 10 projects",         highlight: true),
+                Render(BillingPlan.Network,   "Large",      "Established firm · up to 20 users · unlimited projects",  highlight: false),
+                Render(BillingPlan.Enterprise,"Enterprise", "≥20 seats · SSO · SLA · on-prem option",                  highlight: false, custom: true),
             },
             mim = new
             {
                 name = "MIM Add-on",
                 description = "Asset lifecycle + handover module for FM phase",
-                priceUsd = 12,
+                priceUsd = 10,
                 cycle = "monthly",
             },
             annualDiscount = new
             {
-                description = "Pay yearly, get 2 months free",
-                multiplierMonthsPerYear = 10,
+                description = "Pay annually — get 1 month free (pay 11, use 12)",
+                multiplierMonthsPerYear = 11,
+            },
+            ngoDiscount = new
+            {
+                description = "NGO and government organisations",
+                discountPct = 15,
             },
             currencies = new
             {
@@ -47,11 +52,11 @@ public class PricingController : ControllerBase
             },
             comparison = new[]
             {
-                new { vs = "Autodesk Construction Cloud", price = "$40-80/seat/mo", planscape = "$4.50/seat at Network" },
-                new { vs = "Procore",                     price = "$375-549+/mo",   planscape = "$80-150/firm" },
-                new { vs = "Trimble Connect",             price = "$20-40/seat",    planscape = "$4.50/seat" },
-                new { vs = "BIM Track",                   price = "$40-55/seat",    planscape = "issue-tracking + viewer + plugin" },
-                new { vs = "Dalux",                       price = "$30-50/seat",    planscape = "offline-first parity" },
+                new { vs = "Autodesk Construction Cloud", price = "$40-80/seat/mo",    planscape = "$35-90/firm (not per seat)" },
+                new { vs = "Procore",                     price = "$375-549+/mo",      planscape = "$35-90/firm" },
+                new { vs = "Trimble Connect",             price = "$20-40/seat",       planscape = "flat firm pricing" },
+                new { vs = "BIM Track",                   price = "$40-55/seat",       planscape = "issue-tracking + viewer + plugin included" },
+                new { vs = "Dalux",                       price = "$30-50/seat",       planscape = "offline-first + local currency billing" },
             },
         });
     }
@@ -90,12 +95,12 @@ public class PricingController : ControllerBase
 <body>
 <header>
   <h1>Pricing built for East African firms</h1>
-  <p class=""lead"">Per-firm, per-month, USD. Pay annually and get two months free. Invoiced in your local currency via Flutterwave (UGX/KES/TZS/RWF/NGN/ZAR/ZMW) or in USD/EUR/GBP via Stripe.</p>
+  <p class=""lead"">Per-firm, per-month, USD. Pay annually and get 1 month free. NGO &amp; government: 15% discount. Invoiced in your local currency via Flutterwave (UGX/KES/TZS/RWF/NGN/ZAR/ZMW) or in USD/EUR/GBP via Stripe.</p>
 </header>
 <section class=""grid"">
-  {Card("Studio",   s, "For solo studios just getting started.",         featured: false, plan: "Studio")}
-  {Card("Practice", p, "Small practice with one author and a field team.", featured: false, plan: "Practice")}
-  {Card("Network",  n, "Mid-size firm. The default we recommend.",      featured: true,  plan: "Network", pill: "Most popular")}
+  {Card("Small",   s, "Up to 6 users · 5 projects. Start here.",                featured: false, plan: "Studio")}
+  {Card("Medium",  p, "Up to 12 users · 10 projects. Most popular.",           featured: true,  plan: "Practice", pill: "Most popular")}
+  {Card("Large",   n, "Up to 20 users · unlimited projects.",                  featured: false, plan: "Network")}
   {EnterpriseCard()}
 </section>
 <footer>
@@ -166,7 +171,7 @@ public class PricingController : ControllerBase
   {pillHtml}
   <div class=""name"">{name}</div>
   <div class=""price"">${l.MonthlyUsd:0}<span class=""cycle""> / firm / mo</span></div>
-  <div class=""cycle"">Pay annually = ${l.MonthlyUsd * 10:0} / year</div>
+  <div class=""cycle"">Pay annually = ${l.MonthlyUsd * 11:0} / year (1 month free)</div>
   <ul class=""feat"">{feats}</ul>
   <a class=""{ctaClass}"" href=""/signup?plan={plan}"">Start 30-day trial</a>
 </article>";

--- a/Planscape.Server/src/Planscape.API/Controllers/PricingController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PricingController.cs
@@ -21,12 +21,13 @@ public class PricingController : ControllerBase
     {
         return Ok(new
         {
+            pluginOnly = Render(BillingPlan.PluginOnly, "StingTools Plugin", "Revit plugin only · local workflow · no cloud needed", highlight: false),
             plans = new[]
             {
-                Render(BillingPlan.Studio,    "Small",      "Small firm · up to 6 users · 5 projects",                 highlight: false),
-                Render(BillingPlan.Practice,  "Medium",     "Growing practice · up to 12 users · 10 projects",         highlight: true),
-                Render(BillingPlan.Network,   "Large",      "Established firm · up to 20 users · unlimited projects",  highlight: false),
-                Render(BillingPlan.Enterprise,"Enterprise", "≥20 seats · SSO · SLA · on-prem option",                  highlight: false, custom: true),
+                Render(BillingPlan.Studio,    "Small",      "Plugin + cloud · up to 6 users · 5 projects",            highlight: false),
+                Render(BillingPlan.Practice,  "Medium",     "Plugin + cloud · up to 12 users · 10 projects",          highlight: true),
+                Render(BillingPlan.Network,   "Large",      "Plugin + cloud · up to 20 users · unlimited projects",   highlight: false),
+                Render(BillingPlan.Enterprise,"Enterprise", "≥20 seats · SSO · SLA · on-prem option",                 highlight: false, custom: true),
             },
             mim = new
             {
@@ -66,6 +67,7 @@ public class PricingController : ControllerBase
     [Produces("text/html")]
     public ContentResult HtmlPage()
     {
+        var plugin = BillingPlanLimits.For(BillingPlan.PluginOnly);
         var s = BillingPlanLimits.For(BillingPlan.Studio);
         var p = BillingPlanLimits.For(BillingPlan.Practice);
         var n = BillingPlanLimits.For(BillingPlan.Network);
@@ -98,9 +100,10 @@ public class PricingController : ControllerBase
   <p class=""lead"">Per-firm, per-month, USD. Pay annually and get 1 month free. NGO &amp; government: 15% discount. Invoiced in your local currency via Flutterwave (UGX/KES/TZS/RWF/NGN/ZAR/ZMW) or in USD/EUR/GBP via Stripe.</p>
 </header>
 <section class=""grid"">
-  {Card("Small",   s, "Up to 6 users · 5 projects. Start here.",                featured: false, plan: "Studio")}
-  {Card("Medium",  p, "Up to 12 users · 10 projects. Most popular.",           featured: true,  plan: "Practice", pill: "Most popular")}
-  {Card("Large",   n, "Up to 20 users · unlimited projects.",                  featured: false, plan: "Network")}
+  {PluginOnlyCard(plugin)}
+  {Card("Small",   s, "Plugin + cloud · up to 6 users · 5 projects.",          featured: false, plan: "Studio")}
+  {Card("Medium",  p, "Plugin + cloud · up to 12 users · 10 projects.",        featured: true,  plan: "Practice", pill: "Most popular")}
+  {Card("Large",   n, "Plugin + cloud · up to 20 users · unlimited projects.", featured: false, plan: "Network")}
   {EnterpriseCard()}
 </section>
 <footer>
@@ -134,28 +137,48 @@ public class PricingController : ControllerBase
 
     private static string[] FeaturesFor(BillingPlan plan) => plan switch
     {
+        BillingPlan.PluginOnly => new[]
+        {
+            "Full Revit 2025/2026/2027 plugin", "ISO 19650 tagging suite",
+            "IFC 4 export + property sets", "Local file storage only",
+            "Unlimited Revit users on one machine", "No internet required",
+        },
         BillingPlan.Studio => new[]
         {
-            "Revit plugin (1 seat)", "Mobile + web viewer (10 seats)",
-            "Issue tracking", "ISO 19650 tag templates", "Offline-first mobile",
+            "Everything in StingTools Plugin", "Up to 6 users (cloud)",
+            "Cloud sync + real-time dashboard", "5 active projects · 10 GB storage",
+            "Issue tracker (BCF 2.1)", "Offline-first mobile app",
         },
         BillingPlan.Practice => new[]
         {
-            "Everything in Studio", "25 coordinator seats", "10 active projects",
-            "25 GB model storage", "Document control + CDE", "Meeting minutes + transmittals",
+            "Everything in Small", "Up to 12 users", "10 active projects · 25 GB storage",
+            "Document control + CDE", "Meeting minutes + transmittals",
         },
         BillingPlan.Network => new[]
         {
-            "Everything in Practice", "3 author seats", "35 coordinator seats",
-            "50 GB model storage", "4D/5D scheduling", "Federation across disciplines", "Priority support",
+            "Everything in Medium", "Up to 20 users", "Unlimited projects · 50 GB storage",
+            "4D/5D scheduling", "Federation across disciplines", "Priority support",
         },
         BillingPlan.Enterprise => new[]
         {
-            "Everything in Network", "Unlimited seats + projects", "SSO (SAML/OIDC)",
-            "Dedicated tenant + on-prem option", "99.9% SLA", "Audit replay + ISO 27001-light evidence pack",
+            "Everything in Large", "Unlimited seats + projects", "SSO (SAML/OIDC)",
+            "On-prem or dedicated tenant", "99.9% SLA", "ISO 27001-light evidence pack",
         },
         _ => Array.Empty<string>(),
     };
+
+    private static string PluginOnlyCard(BillingPlanLimits.Limits l)
+    {
+        var feats = string.Join("", FeaturesFor(BillingPlan.PluginOnly).Select(f => $"<li>{f}</li>"));
+        return $@"<article class=""card plugin-card"">
+  <div class=""pill"" style=""background:rgba(28,31,38,.08);color:#1c1f26"">Plugin only</div>
+  <div class=""name"">StingTools</div>
+  <div class=""price"">${l.MonthlyUsd:0}<span class=""cycle""> / firm / mo</span></div>
+  <div class=""cycle"">or ${l.MonthlyUsd * 11:0} / year · no cloud needed</div>
+  <ul class=""feat"">{feats}</ul>
+  <a class=""cta"" href=""/signup?plan=PluginOnly"">Start 30-day trial</a>
+</article>";
+    }
 
     private static string Card(string name, BillingPlanLimits.Limits l, string blurb, bool featured, string plan, string? pill = null)
     {
@@ -180,8 +203,9 @@ public class PricingController : ControllerBase
     private static string EnterpriseCard() => @"<article class=""card"">
   <div class=""name"">Enterprise</div>
   <div class=""price"">Custom</div>
-  <div class=""cycle"">From $3,500 / mo</div>
+  <div class=""cycle"">Unlimited users, on-prem option</div>
   <ul class=""feat"">
+    <li>Everything in Large</li>
     <li>Unlimited seats + projects</li>
     <li>SSO (SAML/OIDC)</li>
     <li>On-prem deployment option</li>

--- a/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
@@ -113,15 +113,15 @@ public enum MimTier
 /// </summary>
 public enum BillingPlan
 {
-    /// <summary>Free 30-day trial; converts to Studio on expiry unless cancelled.</summary>
+    /// <summary>Free 30-day trial; converts to Small on expiry unless cancelled.</summary>
     Trial = 0,
-    /// <summary>$30/mo — 1 author + 10 coordinators · 3 projects · 5 GB</summary>
+    /// <summary>$35/mo — up to 6 users (1 author + 5 coordinators) · 5 projects · 10 GB</summary>
     Studio = 1,
-    /// <summary>$80/mo — 1 author + 25 coordinators · 10 projects · 25 GB</summary>
+    /// <summary>$55/mo — up to 12 users (1 author + 11 coordinators) · 10 projects · 25 GB</summary>
     Practice = 2,
-    /// <summary>$150/mo — 3 authors + 35 coordinators · 10 projects · 50 GB</summary>
+    /// <summary>$90/mo — up to 20 users (1 author + 19 coordinators) · unlimited projects · 50 GB</summary>
     Network = 3,
-    /// <summary>≥$3,500/mo — custom; SLA + dedicated support + on-prem option</summary>
+    /// <summary>Custom — unlimited seats + projects; SSO · SLA · on-prem option</summary>
     Enterprise = 4,
 }
 
@@ -142,11 +142,11 @@ public static class BillingPlanLimits
 
     public static Limits For(BillingPlan plan) => plan switch
     {
-        BillingPlan.Trial      => new Limits(1, 25, 3,  5_000, 0m),
-        BillingPlan.Studio     => new Limits(1, 10, 3,  5_000, 30m),
-        BillingPlan.Practice   => new Limits(1, 25, 10, 25_000, 80m),
-        BillingPlan.Network    => new Limits(3, 35, 10, 50_000, 150m),
-        BillingPlan.Enterprise => new Limits(int.MaxValue, int.MaxValue, int.MaxValue, long.MaxValue, 3_500m),
+        BillingPlan.Trial      => new Limits(1,  5,           3,          10_000,      0m),
+        BillingPlan.Studio     => new Limits(1,  5,           5,          10_000,      35m),
+        BillingPlan.Practice   => new Limits(1, 11,          10,          25_000,      55m),
+        BillingPlan.Network    => new Limits(1, 19, int.MaxValue,          50_000,      90m),
+        BillingPlan.Enterprise => new Limits(int.MaxValue, int.MaxValue, int.MaxValue, long.MaxValue, 0m),
         _ => new Limits(1, 5, 1, 500, 0m),
     };
 

--- a/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
@@ -113,16 +113,18 @@ public enum MimTier
 /// </summary>
 public enum BillingPlan
 {
-    /// <summary>Free 30-day trial; converts to Small on expiry unless cancelled.</summary>
+    /// <summary>Free 30-day trial; converts to PluginOnly on expiry unless cancelled.</summary>
     Trial = 0,
-    /// <summary>$35/mo — up to 6 users (1 author + 5 coordinators) · 5 projects · 10 GB</summary>
-    Studio = 1,
-    /// <summary>$55/mo — up to 12 users (1 author + 11 coordinators) · 10 projects · 25 GB</summary>
-    Practice = 2,
-    /// <summary>$90/mo — up to 20 users (1 author + 19 coordinators) · unlimited projects · 50 GB</summary>
-    Network = 3,
+    /// <summary>$15/mo — Revit plugin only, local storage, no cloud sync.</summary>
+    PluginOnly = 1,
+    /// <summary>$35/mo — plugin + cloud · up to 6 users · 5 projects · 10 GB</summary>
+    Studio = 2,
+    /// <summary>$55/mo — plugin + cloud · up to 12 users · 10 projects · 25 GB</summary>
+    Practice = 3,
+    /// <summary>$90/mo — plugin + cloud · up to 20 users · unlimited projects · 50 GB</summary>
+    Network = 4,
     /// <summary>Custom — unlimited seats + projects; SSO · SLA · on-prem option</summary>
-    Enterprise = 4,
+    Enterprise = 5,
 }
 
 public enum BillingCycle
@@ -142,7 +144,8 @@ public static class BillingPlanLimits
 
     public static Limits For(BillingPlan plan) => plan switch
     {
-        BillingPlan.Trial      => new Limits(1,  5,           3,          10_000,      0m),
+        BillingPlan.Trial      => new Limits(1,  0,           1,           5_000,      0m),
+        BillingPlan.PluginOnly => new Limits(1,  0, int.MaxValue,               0,     15m),
         BillingPlan.Studio     => new Limits(1,  5,           5,          10_000,      35m),
         BillingPlan.Practice   => new Limits(1, 11,          10,          25_000,      55m),
         BillingPlan.Network    => new Limits(1, 19, int.MaxValue,          50_000,      90m),
@@ -153,7 +156,7 @@ public static class BillingPlanLimits
     /// <summary>Map a legacy LicenseTier onto the new BillingPlan for migrations.</summary>
     public static BillingPlan FromLegacyTier(LicenseTier tier) => tier switch
     {
-        LicenseTier.Starter      => BillingPlan.Trial,
+        LicenseTier.Starter      => BillingPlan.PluginOnly,
         LicenseTier.Professional => BillingPlan.Studio,
         LicenseTier.Premium      => BillingPlan.Practice,
         LicenseTier.Enterprise   => BillingPlan.Enterprise,

--- a/StingTools.ArchiCAD/CMakeLists.txt
+++ b/StingTools.ArchiCAD/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.24)
+project(StingPlanscapeAddon CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+# ── Graphisoft ArchiCAD API location ─────────────────────────────────────────
+# Set ARCHICAD_API_DEVKIT to the root of the unpacked DevKit from
+# https://archicadapi.graphisoft.com
+if(NOT DEFINED ARCHICAD_API_DEVKIT)
+    set(ARCHICAD_API_DEVKIT "$ENV{ARCHICAD_API_DEVKIT}" CACHE PATH "ArchiCAD DevKit root")
+endif()
+
+if(NOT EXISTS "${ARCHICAD_API_DEVKIT}/Support/Inc/ACAPinc.h")
+    message(FATAL_ERROR "ArchiCAD DevKit not found at ${ARCHICAD_API_DEVKIT}. "
+        "Download from https://archicadapi.graphisoft.com and set ARCHICAD_API_DEVKIT.")
+endif()
+
+# ── Source files ──────────────────────────────────────────────────────────────
+set(SOURCES
+    src/StingPlanscapeAddon.cpp
+    src/PlanscapeClient.cpp        # to be created: HTTP implementation
+    src/LoginDialog.cpp            # to be created: DG login dialog
+    src/SettingsDialog.cpp         # to be created: DG settings dialog
+)
+
+# ── Add-On shared library ─────────────────────────────────────────────────────
+add_library(StingPlanscapeAddon SHARED ${SOURCES})
+
+target_include_directories(StingPlanscapeAddon PRIVATE
+    include/
+    "${ARCHICAD_API_DEVKIT}/Support/Inc"
+    "${ARCHICAD_API_DEVKIT}/Support/Modules/GSRoot"
+    "${ARCHICAD_API_DEVKIT}/Support/Modules/DGLib"
+)
+
+# ── Platform-specific HTTP client ─────────────────────────────────────────────
+if(WIN32)
+    # WinHTTP — ships with Windows SDK, no extra dependency
+    target_link_libraries(StingPlanscapeAddon PRIVATE winhttp.lib)
+    target_compile_definitions(StingPlanscapeAddon PRIVATE PLANSCAPE_HTTP_WINHTTP)
+elseif(APPLE)
+    # libcurl ships with macOS
+    find_package(CURL REQUIRED)
+    target_link_libraries(StingPlanscapeAddon PRIVATE CURL::libcurl)
+    target_compile_definitions(StingPlanscapeAddon PRIVATE PLANSCAPE_HTTP_CURL)
+endif()
+
+# ── ArchiCAD DevKit libraries ─────────────────────────────────────────────────
+target_link_directories(StingPlanscapeAddon PRIVATE
+    "${ARCHICAD_API_DEVKIT}/Support/Lib"
+)
+
+# Output as .apx (ArchiCAD Add-On extension)
+set_target_properties(StingPlanscapeAddon PROPERTIES
+    OUTPUT_NAME "StingPlanscape"
+    SUFFIX ".apx"
+)

--- a/StingTools.ArchiCAD/README.md
+++ b/StingTools.ArchiCAD/README.md
@@ -1,0 +1,112 @@
+# StingTools for ArchiCAD
+
+Native ArchiCAD Add-On that connects ArchiCAD models to the Planscape coordination platform — the same ISO 19650 workflow available to Revit users via StingTools, now available to ArchiCAD firms without any manual IFC export step.
+
+## Status
+
+**Scaffold** — the project structure, API client interface, and menu registration skeleton are in place. Full implementation is in progress. See implementation checklist below.
+
+## What it will do
+
+| Feature | Status |
+|---|---|
+| Login to Planscape from ArchiCAD | Scaffold |
+| One-click IFC export + upload to Planscape | Scaffold |
+| Read STING tags from `Planscape_Asset` property set and sync | Scaffold |
+| Download open issues as BCF → auto-import into BCF Manager | Scaffold |
+| Push resolved BCF topics back to Planscape | Scaffold |
+| Compliance dashboard panel inside ArchiCAD | Planned |
+| Auto-sync on Publish (Publisher workflow hook) | Planned |
+
+## In the meantime — manual workflow
+
+ArchiCAD firms can already use Planscape today without this Add-On. See the [ArchiCAD IFC Workflow guide](../docs-site/docs/howto/archicad-ifc-workflow.md).
+
+## Build requirements
+
+- **ArchiCAD API DevKit** — free download from [archicadapi.graphisoft.com](https://archicadapi.graphisoft.com)
+  - Match the DevKit version to your target ArchiCAD version (22–28)
+- **Windows**: Visual Studio 2022, MSVC v143, x64
+- **macOS**: Xcode 15, targeting arm64 + x86_64 universal binary
+- **CMake** 3.24+
+- No third-party HTTP library needed — WinHTTP on Windows, libcurl (system) on macOS
+
+## Build
+
+```bash
+# 1. Unpack ArchiCAD DevKit, set env var
+export ARCHICAD_API_DEVKIT=/path/to/ArchiCAD_API_DevKit_26
+
+# 2. Configure
+cmake -B build -DARCHICAD_API_DEVKIT=$ARCHICAD_API_DEVKIT
+
+# 3. Build
+cmake --build build --config Release
+
+# 4. Install
+# Copy build/StingPlanscape.apx to:
+#   Windows: %APPDATA%\Graphisoft\ArchiCAD <version>\Add-Ons\
+#   macOS:   ~/Library/Application Support/Graphisoft/ArchiCAD <version>/Add-Ons/
+```
+
+## Implementation checklist
+
+### Phase 1 — Auth + IFC upload (target: 4 weeks)
+- [ ] `PlanscapeClient.cpp` — WinHTTP + libcurl HTTP implementation
+- [ ] JWT token storage (Windows Credential Store / macOS Keychain)
+- [ ] Login dialog (DG::Dialog)
+- [ ] IFC export via ACAPI + upload to `/api/projects/{id}/models`
+- [ ] Settings dialog (server URL, project selector)
+
+### Phase 2 — Tag sync (target: 2 weeks after Phase 1)
+- [ ] Read `Planscape_Asset` property set from all elements
+- [ ] Fall back to `AC_Pset_*` native properties using STING_IFC_PSET_MAPPING.json rules
+- [ ] POST to `/api/tagsync/sync` (same endpoint as Revit plugin)
+- [ ] Progress dialog during bulk sync
+
+### Phase 3 — BCF round-trip (target: 2 weeks after Phase 2)
+- [ ] GET `/api/projects/{id}/bcf/export?source=archicad` → write .bcfzip
+- [ ] Auto-invoke ArchiCAD BCF Manager import (`ACAPI_Interoperability_ImportBCF`, v26+)
+- [ ] Fallback for v22–25: write file + show path in dialog
+- [ ] Upload resolved BCF back via POST `/api/projects/{id}/bcf/import`
+
+### Phase 4 — Compliance panel (target: 3 weeks after Phase 3)
+- [ ] Modeless DG panel showing compliance % per discipline
+- [ ] Pull from `/api/projects/{id}/compliance`
+- [ ] Register with ArchiCAD palette system
+
+## Property set setup in ArchiCAD
+
+To pre-populate STING coordination tags in ArchiCAD before export:
+
+1. Open **Options → Element Attributes → Properties**
+2. Click **New Property Group** → name it `Planscape_Asset`
+3. Add the following properties (all type: String):
+
+| Property name | Maps to |
+|---|---|
+| `Discipline` | `ASS_DISCIPLINE_COD_TXT` (M / E / P / A / S) |
+| `LocationCode` | `ASS_LOC_TXT` (BLD1, BLD2, EXT…) |
+| `ZoneCode` | `ASS_ZONE_TXT` (Z01, Z02…) |
+| `SystemType` | `ASS_SYSTEM_TYPE_TXT` (HVAC, DCW, SAN…) |
+| `Tag` | `ASS_TAG_1` (full ISO 19650 tag if pre-assembled) |
+
+4. Assign values to elements
+5. These properties export automatically under the `Planscape_Asset` IFC pset and are read by Planscape on upload
+
+## Architecture
+
+```
+StingTools.ArchiCAD/
+├── CMakeLists.txt                  # Build configuration
+├── include/
+│   └── PlanscapeClient.hpp         # HTTP client interface (mirrors PluginSync)
+├── src/
+│   ├── StingPlanscapeAddon.cpp     # Add-On entry point + menu handler
+│   ├── PlanscapeClient.cpp         # TODO: HTTP implementation
+│   ├── LoginDialog.cpp             # TODO: DG login dialog
+│   └── SettingsDialog.cpp          # TODO: DG settings dialog
+└── resources/
+    ├── StingPlanscape.grc          # TODO: string resources (menu names)
+    └── StingPlanscape.grd          # TODO: dialog resources
+```

--- a/StingTools.ArchiCAD/include/PlanscapeClient.hpp
+++ b/StingTools.ArchiCAD/include/PlanscapeClient.hpp
@@ -1,0 +1,109 @@
+#pragma once
+// StingTools ArchiCAD Add-On — Planscape cloud client
+// Mirrors the SyncClient in Planscape.PluginSync for the Revit plugin.
+// Uses WinHTTP on Windows, libcurl on macOS.
+
+#include <string>
+#include <vector>
+#include <functional>
+
+namespace Planscape {
+
+struct SyncElement {
+    std::string ifcGuid;        // IfcGlobalId from ArchiCAD element
+    std::string discipline;     // DISC token
+    std::string location;       // LOC token
+    std::string zone;           // ZONE token
+    std::string level;          // LVL token
+    std::string systemType;     // SYS token
+    std::string productCode;    // PROD token
+    std::string sequenceNumber; // SEQ token
+    std::string fullTag;        // assembled ISO 19650 tag
+    std::string status;         // renovation status → NEW/EXISTING/DEMOLISHED
+    std::string ifcType;        // e.g. "IfcWall", "IfcBeam"
+};
+
+struct BcfTopic {
+    std::string guid;
+    std::string title;
+    std::string description;
+    std::string priority;   // CRITICAL/HIGH/MEDIUM/LOW
+    std::string status;     // OPEN/IN_PROGRESS/RESOLVED/CLOSED
+    std::string type;       // RFI/NCR/SI/CLASH
+    std::string assignee;
+    std::string ifcGuid;    // referenced element IfcGlobalId
+    double cameraX = 0, cameraY = 0, cameraZ = 10;
+};
+
+struct AuthToken {
+    std::string accessToken;
+    std::string refreshToken;
+    long long   expiresAt = 0; // unix timestamp
+};
+
+// Callback types for async operations
+using ProgressCallback = std::function<void(int percent, const std::string& message)>;
+using ErrorCallback    = std::function<void(int httpStatus, const std::string& error)>;
+
+class PlanscapeClient {
+public:
+    explicit PlanscapeClient(const std::string& baseUrl = "https://api.planscape.app");
+
+    // ── Authentication ────────────────────────────────────────────────────
+    bool Login(const std::string& email, const std::string& password);
+    bool RefreshIfNeeded();
+    bool IsAuthenticated() const;
+    void Logout();
+
+    // ── Project ───────────────────────────────────────────────────────────
+    // Returns projectId GUID string, or empty on failure.
+    std::string GetOrCreateProject(const std::string& projectName);
+
+    // ── IFC upload ────────────────────────────────────────────────────────
+    // Uploads the IFC file at ifcPath to Planscape as a new model version.
+    // Returns model record ID, or empty on failure.
+    std::string UploadIfc(
+        const std::string& projectId,
+        const std::string& ifcPath,
+        ProgressCallback   onProgress = nullptr);
+
+    // ── Tag sync ──────────────────────────────────────────────────────────
+    // Pushes STING coordination tags for the given elements to Planscape.
+    // Called after the Add-On has resolved tag tokens from element properties.
+    bool SyncTags(
+        const std::string&             projectId,
+        const std::vector<SyncElement>& elements,
+        ProgressCallback               onProgress = nullptr);
+
+    // ── Issue / BCF ───────────────────────────────────────────────────────
+    // Downloads open issues for the project as a BCF 2.1 zip.
+    // Caller writes the bytes to disk; ArchiCAD imports via BCF Manager.
+    std::vector<uint8_t> ExportBcf(
+        const std::string& projectId,
+        const std::string& statusFilter = "OPEN");
+
+    // Pushes BCF topics resolved in ArchiCAD back to Planscape.
+    bool ImportBcf(
+        const std::string&           projectId,
+        const std::vector<uint8_t>&  bcfZipBytes);
+
+    // ── Compliance ────────────────────────────────────────────────────────
+    // Posts a compliance snapshot (% tagged, by discipline) to Planscape.
+    bool PostComplianceSnapshot(
+        const std::string& projectId,
+        int                totalElements,
+        int                taggedElements,
+        const std::string& disciplineBreakdownJson);
+
+private:
+    std::string  m_baseUrl;
+    AuthToken    m_auth;
+    std::string  m_tenantId;
+
+    std::string  HttpGet (const std::string& path);
+    std::string  HttpPost(const std::string& path, const std::string& body);
+    std::string  HttpPostMultipart(const std::string& path, const std::string& filePath, ProgressCallback cb);
+    void         SetAuthHeader(/* platform-specific request handle */);
+};
+
+} // namespace Planscape

--- a/StingTools.ArchiCAD/src/StingPlanscapeAddon.cpp
+++ b/StingTools.ArchiCAD/src/StingPlanscapeAddon.cpp
@@ -1,0 +1,180 @@
+// StingTools ArchiCAD Add-On — Main entry point
+// Built against Graphisoft ArchiCAD API (GDL Add-On SDK, C++17)
+// Mirrors the StingTools Revit plugin for ISO 19650 coordination workflows.
+//
+// Build requirements:
+//   - ArchiCAD API headers (from Graphisoft Developer portal — free registration)
+//   - ArchiCAD 22–28 SDK (matching the target ArchiCAD version)
+//   - Windows: MSVC 2022, x64. macOS: Xcode 15, arm64 + x86_64 universal.
+//
+// This file is a scaffold. Replace TODO-VERIFY-API markers before shipping.
+
+#include "ACAPinc.h"          // ArchiCAD Add-On API entry point
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+#include "DG.h"               // Dialog Manager
+
+#include "../include/PlanscapeClient.hpp"
+
+#include <string>
+#include <vector>
+#include <memory>
+
+// ── Global state ──────────────────────────────────────────────────────────────
+
+static std::unique_ptr<Planscape::PlanscapeClient> gClient;
+
+// ── Menu command IDs ─────────────────────────────────────────────────────────
+
+enum MenuCommandId {
+    Cmd_Login             = 1,
+    Cmd_SyncIfc           = 2,
+    Cmd_SyncTags          = 3,
+    Cmd_ExportBcf         = 4,
+    Cmd_ImportBcf         = 5,
+    Cmd_ComplianceDash    = 6,
+    Cmd_Settings          = 7,
+};
+
+// ── Helper: collect elements and build SyncElement list ──────────────────────
+
+static std::vector<Planscape::SyncElement> CollectElements()
+{
+    std::vector<Planscape::SyncElement> out;
+
+    // TODO-VERIFY-API: ACAPI_Element_GetDefaults / ACAPI_Element_Get
+    // Walk all elements, read user-defined properties from "Planscape_Asset"
+    // property set (defined in ArchiCAD Options → Element Attributes → Properties).
+    // Map AC_Pset_* native properties via STING_IFC_PSET_MAPPING.json rules.
+
+    // Skeleton iteration:
+    // ACAPI_Element_Filter(apiElemType_Wall, APIFilt_InMyWorkspace, ...);
+    // for each element: read IfcGlobalId, read properties, build SyncElement.
+
+    return out;
+}
+
+// ── Menu command handler ──────────────────────────────────────────────────────
+
+static GSErrCode MenuCommandHandler(const API_MenuParams* menuParams)
+{
+    if (!menuParams) return APIERR_BADPARS;
+
+    switch (menuParams->itemIndex) {
+
+    case Cmd_Login: {
+        // TODO: show login dialog (DG::Dialog subclass) collecting email + password
+        // gClient->Login(email, password);
+        DGAlert(DG_INFORMATION, "Planscape", "Login dialog — to be implemented.", nullptr, "OK");
+        break;
+    }
+
+    case Cmd_SyncIfc: {
+        // Export IFC from ArchiCAD and upload to Planscape.
+        // TODO-VERIFY-API: ACAPI_Command_Call for IFC export, or
+        // use the Publisher workflow via GS::UniString filePath = ...
+        if (!gClient || !gClient->IsAuthenticated()) {
+            DGAlert(DG_ERROR, "Planscape", "Please log in first.", nullptr, "OK");
+            return NoError;
+        }
+        // std::string modelId = gClient->UploadIfc(projectId, ifcPath, progressCb);
+        DGAlert(DG_INFORMATION, "Planscape", "IFC sync — to be implemented.", nullptr, "OK");
+        break;
+    }
+
+    case Cmd_SyncTags: {
+        // Read STING properties from elements and push to Planscape tag sync endpoint.
+        if (!gClient || !gClient->IsAuthenticated()) {
+            DGAlert(DG_ERROR, "Planscape", "Please log in first.", nullptr, "OK");
+            return NoError;
+        }
+        auto elements = CollectElements();
+        // gClient->SyncTags(projectId, elements);
+        DGAlert(DG_INFORMATION, "Planscape",
+            GS::UniString::Printf("Collected %d elements — sync to be implemented.", (int)elements.size()),
+            nullptr, "OK");
+        break;
+    }
+
+    case Cmd_ExportBcf: {
+        // Download open issues from Planscape as BCF zip, write to temp file,
+        // then call ACAPI_Interoperability_ImportBCF (ArchiCAD 26+) or prompt
+        // user to import manually via File → Interoperability → BCF Manager.
+        if (!gClient || !gClient->IsAuthenticated()) {
+            DGAlert(DG_ERROR, "Planscape", "Please log in first.", nullptr, "OK");
+            return NoError;
+        }
+        // auto bytes = gClient->ExportBcf(projectId, "OPEN");
+        // write bytes to temp .bcfzip, prompt user to import
+        DGAlert(DG_INFORMATION, "Planscape", "BCF export — to be implemented.", nullptr, "OK");
+        break;
+    }
+
+    case Cmd_ImportBcf: {
+        // Read the .bcfzip the user has exported from ArchiCAD BCF Manager
+        // (after resolving issues) and push it back to Planscape.
+        // TODO: file picker → read bytes → gClient->ImportBcf(projectId, bytes)
+        DGAlert(DG_INFORMATION, "Planscape", "BCF import — to be implemented.", nullptr, "OK");
+        break;
+    }
+
+    case Cmd_ComplianceDash: {
+        // Show compliance summary pulled from Planscape in a modeless dialog.
+        DGAlert(DG_INFORMATION, "Planscape", "Compliance dashboard — to be implemented.", nullptr, "OK");
+        break;
+    }
+
+    case Cmd_Settings: {
+        // Show settings dialog: server URL, project selection, auto-sync interval.
+        DGAlert(DG_INFORMATION, "Planscape", "Settings — to be implemented.", nullptr, "OK");
+        break;
+    }
+
+    default:
+        break;
+    }
+    return NoError;
+}
+
+// ── Add-On entry points ───────────────────────────────────────────────────────
+
+API_AddonType __ACENV_CALL CheckEnvironment(API_EnvirParams* envirParams)
+{
+    if (envirParams->serverInfo.serverApplication != APIAppl_ArchiCADID)
+        return APIAddon_DontRegister;
+
+    // Require ArchiCAD 22 or later (BCF Manager available from v22).
+    if (envirParams->serverInfo.mainVersion < 22)
+        return APIAddon_DontRegister;
+
+    RSGetIndString(&envirParams->addOnInfo.name,        32000, 1, ACAPI_GetOwnResModule());
+    RSGetIndString(&envirParams->addOnInfo.description, 32000, 2, ACAPI_GetOwnResModule());
+
+    return APIAddon_Normal;
+}
+
+GSErrCode __ACENV_CALL RegisterInterface()
+{
+    // Register "Planscape" menu under the ArchiCAD menu bar.
+    // TODO-VERIFY-API: exact signature may differ between SDK versions.
+    return ACAPI_Register_Menu(32500, 32600, MenuCode_UserDef, MenuFlag_Default);
+}
+
+GSErrCode __ACENV_CALL Initialize()
+{
+    gClient = std::make_unique<Planscape::PlanscapeClient>("https://api.planscape.app");
+
+    GSErrCode err = ACAPI_Install_MenuHandler(32500, MenuCommandHandler);
+    if (err != NoError) return err;
+
+    // TODO: register project-open observer to auto-trigger IFC sync if configured.
+    // ACAPI_Notify_RegisterEventHandler(APINotify_Open, ...);
+
+    return NoError;
+}
+
+GSErrCode __ACENV_CALL FreeData()
+{
+    gClient.reset();
+    return NoError;
+}

--- a/StingTools/Data/IFC/STING_IFC_PSET_MAPPING.json
+++ b/StingTools/Data/IFC/STING_IFC_PSET_MAPPING.json
@@ -31,5 +31,53 @@
   { "sting_param": "ASBUILT_DEVIATION_MM",   "ifc_pset": "Pset_ConstructionOperation",        "ifc_property": "AsBuiltDeviation", "ifc_data_type": "IfcLengthMeasure" },
   { "sting_param": "ASBUILT_CAPTURE_DATE_TXT","ifc_pset": "Pset_ConstructionOperation",       "ifc_property": "AsBuiltCaptureDate", "ifc_data_type": "IfcLabel" },
   { "sting_param": "ACC_ISSUE_ID_TXT",       "ifc_pset": "Pset_ConstructionOperation",        "ifc_property": "ACCIssueId", "ifc_data_type": "IfcIdentifier" },
-  { "sting_param": "HEALTH_SCORE_LAST_NR",   "ifc_pset": "Pset_ConstructionOperation",        "ifc_property": "ModelHealthScore", "ifc_data_type": "IfcInteger" }
+  { "sting_param": "HEALTH_SCORE_LAST_NR",   "ifc_pset": "Pset_ConstructionOperation",        "ifc_property": "ModelHealthScore", "ifc_data_type": "IfcInteger" },
+
+  // ── ArchiCAD native property sets (AC_Pset_*) ────────────────────────────
+  // Emitted automatically by ArchiCAD on IFC export (v22+).
+  // Planscape reads these on upload and maps them to STING coordination
+  // parameters so ArchiCAD models participate in ISO 19650 workflows
+  // without any plugin. Source field = "archicad" for audit trail.
+  // priority: lower number wins when multiple mappings target the same
+  // sting_param; default priority is 1 (highest).
+
+  // Element identity
+  { "sting_param": "ASS_SEQ_NUM_TXT",   "ifc_pset": "AC_Pset_ElementID",              "ifc_property": "ElementID",           "ifc_data_type": "IfcIdentifier",  "source": "archicad", "notes": "ArchiCAD element ID → STING sequence number" },
+  { "sting_param": "ASS_TAG_1",         "ifc_pset": "AC_Pset_ElementID",              "ifc_property": "ElementCode",         "ifc_data_type": "IfcIdentifier",  "source": "archicad", "priority": 2 },
+
+  // Zone / location
+  { "sting_param": "ASS_ZONE_TXT",      "ifc_pset": "AC_Pset_ZoneBasicProperties",   "ifc_property": "ZoneName",            "ifc_data_type": "IfcLabel",       "source": "archicad" },
+  { "sting_param": "ASS_LOC_TXT",       "ifc_pset": "AC_Pset_ZoneBasicProperties",   "ifc_property": "ZoneNo",              "ifc_data_type": "IfcLabel",       "source": "archicad", "notes": "Zone number used as location code" },
+  { "sting_param": "ASS_ZONE_TXT",      "ifc_pset": "AC_Pset_RoomBasicProperties",   "ifc_property": "RoomName",            "ifc_data_type": "IfcLabel",       "source": "archicad", "priority": 2, "notes": "Fallback: room name when zone pset absent" },
+
+  // Renovation / phase → STATUS
+  { "sting_param": "ASS_STATUS_TXT",    "ifc_pset": "AC_Pset_RenovationOverride",    "ifc_property": "RenovationStatus",    "ifc_data_type": "IfcLabel",       "source": "archicad",
+    "value_map": { "Existing": "EXISTING", "Demolition": "DEMOLISHED", "New": "NEW", "Temporary": "TEMPORARY" } },
+
+  // Classification / product code
+  { "sting_param": "ASS_PRODCT_COD_TXT","ifc_pset": "AC_Pset_ElementProperties",     "ifc_property": "Classification",      "ifc_data_type": "IfcLabel",       "source": "archicad" },
+  { "sting_param": "ASS_PRODCT_COD_TXT","ifc_pset": "AC_Pset_SectionalProperties",   "ifc_property": "ProfileName",         "ifc_data_type": "IfcLabel",       "source": "archicad", "priority": 2, "notes": "Structural profile name for beams/columns" },
+
+  // MEP system data
+  { "sting_param": "ASS_SYSTEM_TYPE_TXT","ifc_pset": "AC_Pset_MEPSystemData",        "ifc_property": "SystemName",          "ifc_data_type": "IfcLabel",       "source": "archicad" },
+  { "sting_param": "ASS_FUNC_TXT",       "ifc_pset": "AC_Pset_MEPSystemData",        "ifc_property": "SystemCode",          "ifc_data_type": "IfcLabel",       "source": "archicad" },
+  { "sting_param": "ASS_DISCIPLINE_COD_TXT","ifc_pset": "AC_Pset_MEPSystemData",     "ifc_property": "Discipline",          "ifc_data_type": "IfcLabel",       "source": "archicad" },
+
+  // Structural
+  { "sting_param": "STR_MATERIAL_TXT",  "ifc_pset": "AC_Pset_StructuralProfile",    "ifc_property": "CrossSectionMaterial", "ifc_data_type": "IfcLabel",       "source": "archicad" },
+  { "sting_param": "STR_GRADE_TXT",     "ifc_pset": "AC_Pset_StructuralProfile",    "ifc_property": "MaterialGrade",       "ifc_data_type": "IfcLabel",       "source": "archicad" },
+
+  // Room / space quantities
+  { "sting_param": "GEO_AREA_GS_M2",   "ifc_pset": "AC_Pset_RoomBasicProperties",   "ifc_property": "RoomFloorPlanArea",   "ifc_data_type": "IfcAreaMeasure", "source": "archicad" },
+  { "sting_param": "GEO_HEIGHT_MM",     "ifc_pset": "AC_Pset_RoomBasicProperties",   "ifc_property": "RoomHeight",          "ifc_data_type": "IfcLengthMeasure","source": "archicad" },
+  { "sting_param": "GEO_VOLUME_M3",     "ifc_pset": "AC_Pset_RoomBasicProperties",   "ifc_property": "RoomVolume",          "ifc_data_type": "IfcVolumeMeasure","source": "archicad" },
+
+  // User-defined "Planscape_Asset" property set — define this in ArchiCAD's
+  // Property Manager to pre-populate STING tags before IFC export.
+  // ArchiCAD: Options → Element Attributes → Properties → New property set → "Planscape_Asset"
+  { "sting_param": "ASS_DISCIPLINE_COD_TXT","ifc_pset": "Planscape_Asset",           "ifc_property": "Discipline",          "ifc_data_type": "IfcLabel",       "source": "archicad-custom" },
+  { "sting_param": "ASS_LOC_TXT",       "ifc_pset": "Planscape_Asset",               "ifc_property": "LocationCode",        "ifc_data_type": "IfcLabel",       "source": "archicad-custom" },
+  { "sting_param": "ASS_ZONE_TXT",      "ifc_pset": "Planscape_Asset",               "ifc_property": "ZoneCode",            "ifc_data_type": "IfcLabel",       "source": "archicad-custom" },
+  { "sting_param": "ASS_SYSTEM_TYPE_TXT","ifc_pset": "Planscape_Asset",              "ifc_property": "SystemType",          "ifc_data_type": "IfcLabel",       "source": "archicad-custom" },
+  { "sting_param": "ASS_TAG_1",         "ifc_pset": "Planscape_Asset",               "ifc_property": "Tag",                 "ifc_data_type": "IfcIdentifier",  "source": "archicad-custom", "notes": "Full ISO 19650 tag if pre-tagged in ArchiCAD" }
 ]

--- a/docs-site/docs/howto/archicad-ifc-workflow.md
+++ b/docs-site/docs/howto/archicad-ifc-workflow.md
@@ -1,0 +1,142 @@
+# ArchiCAD → Planscape IFC Workflow
+
+This guide walks an ArchiCAD team through connecting their model to Planscape for ISO 19650-compliant coordination, issue tracking, and document management — without leaving their authoring tool.
+
+## How it works
+
+```
+ArchiCAD  ──IFC export──▶  Planscape Upload  ──▶  Web Viewer + Issue Tracker
+                                                          │
+ArchiCAD  ◀──BCF import──  Planscape BCF Export  ◀───────┘
+```
+
+Planscape reads the IFC file ArchiCAD produces. Coordinators raise issues against elements in the viewer. You export those issues as a BCF file and import it straight back into ArchiCAD. No plugin required on the ArchiCAD side.
+
+---
+
+## Step 1 — Set up your IFC export in ArchiCAD
+
+Open **File → Publish** (or **File → Save As → IFC**) and configure:
+
+| Setting | Recommended value |
+|---|---|
+| Format | IFC 4 (preferred) or IFC 2x3 CV2 |
+| Model View Definition | Coordination View 2.0 or Reference View |
+| Export properties | ✅ All element properties |
+| Export quantities | ✅ Base quantities |
+| Export IFC type objects | ✅ |
+| Split by storey | Optional — single file is fine |
+
+> **IFC 4 vs IFC 2x3**: Use IFC 4 when possible. Planscape reads both, but IFC 4 carries richer property sets and better element classification.
+
+### Save as a Publisher Set
+
+Go to **File → Publish → New Publisher Set** and name it `Planscape Coordination`. Point the output to a shared folder or directly upload from there. This lets you re-publish with one click when the model updates.
+
+---
+
+## Step 2 — Upload to Planscape
+
+1. Open your project in Planscape → **Models** tab
+2. Click **Upload IFC**
+3. Select the `.ifc` file exported from ArchiCAD
+4. Planscape ingests the file and maps ArchiCAD property sets to STING coordination parameters automatically (see [Property mapping](#property-mapping) below)
+5. The model appears in the federated 3D viewer within 1–2 minutes for files under 200 MB
+
+### Keeping the model current
+
+Re-export from ArchiCAD and upload a new version whenever the model is updated. Planscape versions each upload and keeps the issue pin locations referenced to the element `IfcGlobalId` — so existing issues remain anchored to the right element even after geometry changes.
+
+---
+
+## Step 3 — Coordination in Planscape
+
+Once uploaded, your team works entirely in Planscape:
+
+- **Issues** — raise RFIs, NCRs, clashes, or design queries directly on elements in the 3D viewer
+- **Documents** — manage drawing transmittals, CDE state transitions (WIP → Shared → Published)
+- **Compliance dashboard** — ISO 19650 tag completeness per discipline and level
+- **Mobile app** — site team raises issues with GPS + photo from iOS/Android
+
+ArchiCAD coordinators do not need a Revit licence or the StingTools plugin. They use only the Planscape web or mobile app.
+
+---
+
+## Step 4 — Export issues as BCF and import into ArchiCAD
+
+When the coordination team has raised issues against your model:
+
+1. In Planscape, go to **Issues → Export BCF**
+2. Filter by status (e.g. `OPEN` only) or leave blank for all issues
+3. Download the `.bcfzip` file
+4. In ArchiCAD, open **File → Interoperability → BCF Manager**
+5. Click **Import** and select the `.bcfzip`
+6. Each issue appears as a BCF topic with the camera viewpoint set to the flagged location
+
+ArchiCAD will highlight the referenced element using the `IfcGlobalId` embedded in each BCF viewpoint. You can navigate directly to the issue location, resolve it in the model, and mark the topic as resolved.
+
+### Closing the loop
+
+After resolving issues in ArchiCAD:
+
+1. Re-export IFC → upload to Planscape (new model version)
+2. Open the BCF Manager in ArchiCAD → mark resolved topics as `Closed`
+3. Export BCF → import back into Planscape (**Issues → Import BCF**)
+4. Planscape updates the issue status automatically from the BCF `TopicStatus`
+
+---
+
+## Property mapping
+
+When Planscape ingests an ArchiCAD IFC file, it reads the following ArchiCAD property sets and maps them to STING coordination parameters:
+
+| ArchiCAD property | IFC Pset | STING parameter |
+|---|---|---|
+| Element ID | `AC_Pset_ElementID.ElementID` | `ASS_SEQ_NUM_TXT` |
+| Zone Name | `AC_Pset_ZoneBasicProperties.ZoneName` | `ASS_ZONE_TXT` |
+| Zone Number | `AC_Pset_ZoneBasicProperties.ZoneNo` | `ASS_LOC_TXT` |
+| Level code | `AC_Pset_RoomBasicProperties.RoomFloorPlanArea` → storey name | `ASS_LVL_COD_TXT` |
+| Renovation status | `AC_Pset_RenovationOverride.RenovationStatus` | `ASS_STATUS_TXT` |
+| Classification code | `AC_Pset_ElementProperties.Classification` | `ASS_PRODCT_COD_TXT` |
+| MEP system name | `AC_Pset_MEPSystemData.SystemName` | `ASS_SYSTEM_TYPE_TXT` |
+
+> Properties that ArchiCAD doesn't export (e.g. STING's ISO 19650 discipline code) remain empty and can be set by coordinators manually in the Planscape dashboard.
+
+---
+
+## Federated models (Revit + ArchiCAD)
+
+If your project uses both Revit and ArchiCAD (e.g. Revit for MEP, ArchiCAD for architecture):
+
+1. Upload each IFC file separately to Planscape as named **Model Sources**
+2. Planscape federates them in the viewer automatically — elements from both files appear together
+3. Clash detection runs across the federation
+4. BCF issues include the originating model's `IfcGlobalId` so each authoring tool receives only its own issues when you import BCF back
+
+---
+
+## Checklist
+
+- [ ] IFC export configured with all properties and base quantities
+- [ ] Publisher Set saved in ArchiCAD for one-click re-export
+- [ ] First IFC uploaded and model visible in Planscape viewer
+- [ ] Team members invited to Planscape project with correct roles
+- [ ] BCF Manager enabled in ArchiCAD (requires ArchiCAD 22 or later)
+- [ ] Test issue raised in Planscape, BCF exported, imported into ArchiCAD
+- [ ] Coordination cycle agreed: re-export frequency, BCF exchange cadence
+
+---
+
+## Troubleshooting
+
+**Model does not appear after upload**
+Check the file is valid IFC (not IFC-XML). ArchiCAD exports standard binary IFC by default — confirm the extension is `.ifc` not `.ifcxml`.
+
+**Elements show no properties in Planscape**
+Re-export with **Export all element properties** checked. In ArchiCAD 26+, this is under Translator Settings → Properties.
+
+**BCF import shows no camera position**
+The issue was raised without a 3D viewpoint. Ask the Planscape coordinator to anchor issues to elements in the viewer rather than raising them from the list view.
+
+**IFC Global IDs change between exports**
+This happens when elements are deleted and recreated in ArchiCAD rather than modified. Ask the ArchiCAD author to use **Modify** rather than Delete + Place. Stable `IfcGlobalId` values are the backbone of issue traceability.

--- a/docs-site/docs/reference/pricing.md
+++ b/docs-site/docs/reference/pricing.md
@@ -4,16 +4,16 @@ Planscape is priced per firm, not per seat — small teams and growing teams are
 
 ## Plans
 
-| Plan | Monthly | Includes |
-|---|---|---|
-| **Studio** | $30 | 1 author + 10 coordinators · 3 projects · 5 GB storage |
-| **Practice** | $80 | 1 author + 25 coordinators · 10 projects · 25 GB storage |
-| **Network** | $150 | 3 authors + 35 coordinators · 10 projects · 50 GB storage |
-| **Enterprise** | Custom | SSO · contractual SLA · on-prem option · audit replay · DPA |
+| Plan | Monthly | Annual (1 month free) | Includes |
+|---|---|---|---|
+| **Small** | $35 | $385 | Up to 6 users · 5 projects · 10 GB storage |
+| **Medium** | $55 | $605 | Up to 12 users · 10 projects · 25 GB storage |
+| **Large** | $90 | $990 | Up to 20 users · unlimited projects · 50 GB storage |
+| **Enterprise** | Custom | Custom | SSO · contractual SLA · on-prem option · audit replay · DPA |
 
-**Authors** are users who can sync Revit models from the plugin. **Coordinators** are users who use the web dashboard and the mobile app — viewing models, raising issues, transitioning documents, signing off gates.
+All plans include 1 author (Revit sync) seat and the remainder as coordinator seats. **Authors** sync Revit models from the plugin. **Coordinators** use the web dashboard and mobile app — viewing models, raising issues, transitioning documents, signing off gates.
 
-A 30-day free trial is available on Studio, Practice, and Network with no payment details required.
+A 30-day free trial is available on all plans with no payment details required. NGO and government organisations receive a 15% discount.
 
 ## What's included in every plan
 
@@ -32,16 +32,16 @@ We invoice in your chosen currency at signup, with no FX spread. Indicative pric
 
 | Plan | UGX | KES | TZS |
 |---|---|---|---|
-| Studio | ~UGX 110,000 | ~KES 3,900 | ~TZS 75,000 |
-| Practice | ~UGX 295,000 | ~KES 10,400 | ~TZS 200,000 |
-| Network | ~UGX 555,000 | ~KES 19,500 | ~TZS 375,000 |
+| Small | ~UGX 130,000 | ~KES 4,600 | ~TZS 88,000 |
+| Medium | ~UGX 203,000 | ~KES 7,200 | ~TZS 138,000 |
+| Large | ~UGX 332,000 | ~KES 11,700 | ~TZS 225,000 |
 
 NGN, RWF, and ZAR are also supported via Flutterwave. USD, EUR, GBP via Stripe. Exact local-currency amounts are displayed at checkout, locked for the billing cycle, and can be paid by mobile money (MTN, Airtel, M-Pesa), bank transfer, or card.
 
 ## Billing FAQ
 
 **When am I charged?**
-On signup (after the trial), then monthly on the same date. Annual billing is available with a 10% discount.
+On signup (after the 30-day trial), then monthly on the same date. Annual billing gives you 1 month free — pay for 11 months, use for 12.
 
 **How do I add a payment method?**
 **Settings → Billing → Add payment method**. Mobile money, bank transfer, and card are all supported.

--- a/docs-site/docs/reference/pricing.md
+++ b/docs-site/docs/reference/pricing.md
@@ -1,8 +1,24 @@
 # Pricing
 
-Planscape is priced per firm, not per seat — small teams and growing teams aren't penalised for adding people. All plans include the Revit plugin, the mobile app, the cloud API, ISO 19650 templates, and the audit-grade trail. The differences are seat counts, project counts, storage, and support tier.
+There are two separate products. You can buy just the **StingTools plugin** and use it entirely offline in Revit, or add **Planscape** to get cloud sync, mobile app, and team collaboration. Both share the same 30-day free trial.
 
-## Plans
+## StingTools — Plugin Only
+
+For firms that want the full Revit toolkit without a cloud subscription.
+
+| | Monthly | Annual (1 month free) |
+|---|---|---|
+| **StingTools Plugin** | $15 / firm | $165 / firm |
+
+- Full Revit 2025/2026/2027 plugin — all features unlocked
+- ISO 19650 tagging, IFC 4 export, drawing automation
+- Local file storage only — no server, no internet required
+- Unlimited Revit plugin users on one firm licence
+- 30-day free trial · NGO/government 15% discount
+
+## Planscape — Plugin + Cloud
+
+For teams that need cloud sync, mobile, and multi-user collaboration. Every Planscape plan includes the full StingTools plugin.
 
 | Plan | Monthly | Annual (1 month free) | Includes |
 |---|---|---|---|
@@ -11,11 +27,11 @@ Planscape is priced per firm, not per seat — small teams and growing teams are
 | **Large** | $90 | $990 | Up to 20 users · unlimited projects · 50 GB storage |
 | **Enterprise** | Custom | Custom | SSO · contractual SLA · on-prem option · audit replay · DPA |
 
-All plans include 1 author (Revit sync) seat and the remainder as coordinator seats. **Authors** sync Revit models from the plugin. **Coordinators** use the web dashboard and mobile app — viewing models, raising issues, transitioning documents, signing off gates.
+**Authors** sync Revit models from the plugin. **Coordinators** use the web dashboard and mobile app — viewing models, raising issues, transitioning documents, signing off gates.
 
 A 30-day free trial is available on all plans with no payment details required. NGO and government organisations receive a 15% discount.
 
-## What's included in every plan
+## What's included in every plan (StingTools + Planscape)
 
 - Revit plugin for Revit 2025/2026/2027 — all features unlocked
 - iOS and Android mobile apps — offline-first, with biometric lock
@@ -32,6 +48,7 @@ We invoice in your chosen currency at signup, with no FX spread. Indicative pric
 
 | Plan | UGX | KES | TZS |
 |---|---|---|---|
+| StingTools Plugin | ~UGX 55,000 | ~KES 1,950 | ~TZS 37,500 |
 | Small | ~UGX 130,000 | ~KES 4,600 | ~TZS 88,000 |
 | Medium | ~UGX 203,000 | ~KES 7,200 | ~TZS 138,000 |
 | Large | ~UGX 332,000 | ~KES 11,700 | ~TZS 225,000 |

--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Planscape — BIM coordination for East African firms</title>
-<meta name="description" content="ISO 19650 BIM coordination · Revit plugin · offline-first mobile · invoiced in UGX/KES/TZS. From $35/firm/month.">
+<meta name="description" content="ISO 19650 BIM coordination · Revit plugin from $15/mo · cloud platform from $35/mo · invoiced in UGX/KES/TZS.">
 <meta property="og:title" content="Planscape — BIM coordination for East African firms">
-<meta property="og:description" content="From $35/firm/month. Revit plugin + offline-first mobile + ISO 19650 templates pre-built. Invoiced in your local currency.">
+<meta property="og:description" content="Revit plugin from $15/firm/month. Add cloud sync + mobile from $35/firm/month. ISO 19650 templates pre-built. Invoiced in your local currency.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://planscape.app/">
 <meta property="og:image" content="https://planscape.app/images/og-card.png">
@@ -14,7 +14,7 @@
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Planscape — BIM coordination for East African firms">
-<meta name="twitter:description" content="From $35/firm/month. Revit plugin + offline-first mobile + ISO 19650 templates. Invoiced in UGX/KES/TZS.">
+<meta name="twitter:description" content="Revit plugin from $15/mo · cloud platform from $35/mo · ISO 19650 templates · invoiced in UGX/KES/TZS.">
 <meta name="twitter:image" content="https://planscape.app/images/og-card.png">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
@@ -153,11 +153,11 @@ details[open] .faq-q::after{transform:rotate(45deg)}
       "description": "ISO 19650 BIM coordination for East African AEC firms. Revit plugin, offline-first mobile, local currency invoicing.",
       "offers": {
         "@type": "Offer",
-        "price": "35",
+        "price": "15",
         "priceCurrency": "USD",
         "priceSpecification": {
           "@type": "UnitPriceSpecification",
-          "price": "35",
+          "price": "15",
           "priceCurrency": "USD",
           "unitText": "MONTH"
         }
@@ -192,7 +192,7 @@ details[open] .faq-q::after{transform:rotate(45deg)}
   </div>
   <p style="margin:12px 0 0;font-size:13px;color:var(--muted)">No credit card required · Cancel any time</p>
   <div class="price-strip">
-    From <strong>$35/firm/month</strong> · flat per-firm, not per seat · 10× cheaper than Autodesk Construction Cloud
+    Plugin only from <strong>$15/firm/month</strong> · add cloud from <strong>$35/firm/month</strong> · flat per-firm, not per seat
   </div>
 </section>
 

--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Planscape — BIM coordination for East African firms</title>
-<meta name="description" content="ISO 19650 BIM coordination · Revit plugin · offline-first mobile · invoiced in UGX/KES/TZS. From $30/firm/month.">
+<meta name="description" content="ISO 19650 BIM coordination · Revit plugin · offline-first mobile · invoiced in UGX/KES/TZS. From $35/firm/month.">
 <meta property="og:title" content="Planscape — BIM coordination for East African firms">
-<meta property="og:description" content="From $30/firm/month. Revit plugin + offline-first mobile + ISO 19650 templates pre-built. Invoiced in your local currency.">
+<meta property="og:description" content="From $35/firm/month. Revit plugin + offline-first mobile + ISO 19650 templates pre-built. Invoiced in your local currency.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://planscape.app/">
 <meta property="og:image" content="https://planscape.app/images/og-card.png">
@@ -14,7 +14,7 @@
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Planscape — BIM coordination for East African firms">
-<meta name="twitter:description" content="From $30/firm/month. Revit plugin + offline-first mobile + ISO 19650 templates. Invoiced in UGX/KES/TZS.">
+<meta name="twitter:description" content="From $35/firm/month. Revit plugin + offline-first mobile + ISO 19650 templates. Invoiced in UGX/KES/TZS.">
 <meta name="twitter:image" content="https://planscape.app/images/og-card.png">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
@@ -153,11 +153,11 @@ details[open] .faq-q::after{transform:rotate(45deg)}
       "description": "ISO 19650 BIM coordination for East African AEC firms. Revit plugin, offline-first mobile, local currency invoicing.",
       "offers": {
         "@type": "Offer",
-        "price": "30",
+        "price": "35",
         "priceCurrency": "USD",
         "priceSpecification": {
           "@type": "UnitPriceSpecification",
-          "price": "30",
+          "price": "35",
           "priceCurrency": "USD",
           "unitText": "MONTH"
         }
@@ -192,7 +192,7 @@ details[open] .faq-q::after{transform:rotate(45deg)}
   </div>
   <p style="margin:12px 0 0;font-size:13px;color:var(--muted)">No credit card required · Cancel any time</p>
   <div class="price-strip">
-    From <strong>$30/firm/month</strong> · ~$4.50 per seat · 10× cheaper than Autodesk Construction Cloud
+    From <strong>$35/firm/month</strong> · flat per-firm, not per seat · 10× cheaper than Autodesk Construction Cloud
   </div>
 </section>
 
@@ -233,20 +233,20 @@ details[open] .faq-q::after{transform:rotate(45deg)}
 
 <section id="compare">
   <h2>How we stack up</h2>
-  <p class="lead">Per-seat cost at a 33-person firm. We don't try to be the most feature-rich BIM platform on earth — we try to be the right one for a mid-size East African practice.</p>
+  <p class="lead">Flat per-firm pricing — add people without paying more per seat. We don't try to be the most feature-rich BIM platform on earth — we try to be the right one for a mid-size East African practice.</p>
   <table class="compare">
-    <thead><tr><th>Tool</th><th>Per seat / month</th><th>Offline mobile</th><th>Local invoicing</th></tr></thead>
+    <thead><tr><th>Tool</th><th>Pricing model</th><th>Offline mobile</th><th>Local invoicing</th></tr></thead>
     <tbody>
-      <tr><td class="us">Planscape Network</td><td class="us">$4.50</td><td class="us">Yes</td><td class="us">Yes (UGX/KES/TZS/…)</td></tr>
-      <tr><td>Autodesk Construction Cloud</td><td>$40–80</td><td>No</td><td>USD only</td></tr>
-      <tr><td>Procore</td><td>$30–80 (firm-priced)</td><td>Partial</td><td>USD only</td></tr>
-      <tr><td>Trimble Connect</td><td>$20–40</td><td>Partial</td><td>USD only</td></tr>
-      <tr><td>BIM Track</td><td>$40–55</td><td>No</td><td>USD only</td></tr>
-      <tr><td>Dalux</td><td>$30–50</td><td>Partial</td><td>USD only</td></tr>
+      <tr><td class="us">Planscape Large (20 users)</td><td class="us">$90/firm — $4.50/user</td><td class="us">Yes</td><td class="us">Yes (UGX/KES/TZS/…)</td></tr>
+      <tr><td>Autodesk Construction Cloud</td><td>$40–80/seat/mo</td><td>No</td><td>USD only</td></tr>
+      <tr><td>Procore</td><td>$375–549+/firm/mo</td><td>Partial</td><td>USD only</td></tr>
+      <tr><td>Trimble Connect</td><td>$20–40/seat/mo</td><td>Partial</td><td>USD only</td></tr>
+      <tr><td>BIM Track</td><td>$40–55/seat/mo</td><td>No</td><td>USD only</td></tr>
+      <tr><td>Dalux</td><td>$30–50/seat/mo</td><td>Partial</td><td>USD only</td></tr>
     </tbody>
   </table>
   <p style="font-size:12px;color:var(--muted);margin-top:10px">
-    Competitor pricing sourced from public rate cards, May 2026. Actual pricing varies by contract. Planscape per-seat figure based on Network plan ($150/mo ÷ 33 users).
+    Competitor pricing sourced from public rate cards, May 2026. Actual pricing varies by contract. Planscape per-user figure based on Large plan ($90/mo ÷ 20 users).
   </p>
 </section>
 

--- a/planscape-site/components/PricingCards.tsx
+++ b/planscape-site/components/PricingCards.tsx
@@ -19,42 +19,65 @@ type Plan = {
 
 const plans: Plan[] = [
   {
-    name: 'Starter',
-    price: '$0',
-    priceUnit: '/month',
-    subtext: 'For individual BIM coordinators exploring the platform.',
+    name: 'Small',
+    price: '$35',
+    priceUnit: '/firm/month',
+    subtext: 'For small practices just getting started with BIM coordination.',
     features: [
-      { text: '1 user, 1 project', included: true },
-      { text: 'Revit plugin — full tagging suite', included: true },
-      { text: 'Local file storage only', included: true },
+      { text: 'Up to 6 users (1 author + 5 coordinators)', included: true },
+      { text: 'Up to 5 active projects', included: true },
+      { text: 'Full Revit plugin suite', included: true },
+      { text: 'Cloud sync & real-time dashboard', included: true },
+      { text: 'Issue tracker (BCF 2.1)', included: true },
       { text: 'ISO 19650 compliance dashboard', included: true },
-      { text: 'Cloud sync', included: false },
-      { text: 'Multi-user collaboration', included: false },
-      { text: 'API access', included: false },
+      { text: 'Mobile app (iOS & Android)', included: true },
+      { text: 'SSO / SAML', included: false },
+      { text: 'On-premise deployment', included: false },
     ],
-    cta: 'Get Started Free',
+    cta: 'Start 30-Day Trial',
+    ctaSub: 'No credit card required',
     ctaStyle: 'outline',
   },
   {
-    name: 'Professional',
-    price: '$15',
-    priceUnit: '/user/month',
-    subtext: 'For AEC practices running active BIM projects.',
+    name: 'Medium',
+    price: '$55',
+    priceUnit: '/firm/month',
+    subtext: 'For growing practices managing multiple live projects.',
     features: [
-      { text: 'Up to 5 users', included: true },
-      { text: 'Up to 5 projects', included: true },
+      { text: 'Up to 12 users (1 author + 11 coordinators)', included: true },
+      { text: 'Up to 10 active projects', included: true },
       { text: 'Full Revit plugin suite', included: true },
       { text: 'Cloud sync & real-time dashboard', included: true },
       { text: 'Issue tracker (BCF 2.1)', included: true },
       { text: 'Document control (CDE)', included: true },
-      { text: 'Email & Slack notifications', included: true },
+      { text: 'Email & in-app notifications', included: true },
       { text: 'SSO / SAML', included: false },
       { text: 'On-premise deployment', included: false },
     ],
-    cta: 'Start 14-Day Trial',
+    cta: 'Start 30-Day Trial',
     ctaSub: 'No credit card required',
     highlighted: true,
     ctaStyle: 'primary',
+  },
+  {
+    name: 'Large',
+    price: '$90',
+    priceUnit: '/firm/month',
+    subtext: 'For established firms coordinating across multiple disciplines.',
+    features: [
+      { text: 'Up to 20 users (1 author + 19 coordinators)', included: true },
+      { text: 'Unlimited active projects', included: true },
+      { text: 'Full Revit plugin suite', included: true },
+      { text: 'Cloud sync & real-time dashboard', included: true },
+      { text: 'Issue tracker + Document control (CDE)', included: true },
+      { text: 'Email & in-app notifications', included: true },
+      { text: 'Priority support', included: true },
+      { text: 'SSO / SAML', included: false },
+      { text: 'On-premise deployment', included: false },
+    ],
+    cta: 'Start 30-Day Trial',
+    ctaSub: 'No credit card required',
+    ctaStyle: 'outline',
   },
   {
     name: 'Enterprise',
@@ -67,7 +90,7 @@ const plans: Plan[] = [
       { text: 'Dedicated implementation support', included: true },
       { text: 'SLA guarantees', included: true },
       { text: 'Custom integrations (ACC, Procore, Aconex)', included: true },
-      { text: 'Africa regional pricing available', included: true },
+      { text: 'NGO / Government 15% discount', included: true },
       { text: 'World Bank / AfDB BIM compliance package', included: true },
     ],
     cta: 'Talk to Sales',
@@ -97,7 +120,7 @@ export default function PricingCards() {
           </p>
         </motion.div>
 
-        <div className="mt-16 grid grid-cols-1 gap-6 lg:grid-cols-3 lg:gap-8">
+        <div className="mt-16 grid grid-cols-1 gap-6 lg:grid-cols-4 lg:gap-8">
           {plans.map((p, i) => {
             const isPro = p.highlighted;
             return (
@@ -182,8 +205,9 @@ export default function PricingCards() {
         </div>
 
         <p className="mx-auto mt-8 max-w-2xl text-center text-sm text-muted">
-          All plans include the full Revit 2025/2026/2027 plugin. Billing in
-          USD. Africa regional pricing available on request.
+          All plans include the full Revit 2025/2026/2027 plugin and offline-first mobile app.
+          Pay annually — get 1 month free. Invoiced in USD, UGX, KES, TZS, NGN, RWF, or ZAR.
+          NGO &amp; government: 15% discount.
         </p>
       </div>
     </section>

--- a/planscape-site/components/PricingCards.tsx
+++ b/planscape-site/components/PricingCards.tsx
@@ -98,6 +98,27 @@ const plans: Plan[] = [
   },
 ];
 
+const pluginPlan: Plan = {
+  name: 'StingTools Plugin',
+  price: '$15',
+  priceUnit: '/firm/month',
+  subtext: 'The full Revit plugin, locally. No cloud, no subscription platform needed.',
+  features: [
+    { text: 'Full Revit 2025/2026/2027 plugin', included: true },
+    { text: 'ISO 19650 tagging suite', included: true },
+    { text: 'IFC 4 export + property sets', included: true },
+    { text: 'Drawing automation & sheet manager', included: true },
+    { text: 'Unlimited Revit users (local)', included: true },
+    { text: 'No internet required', included: true },
+    { text: 'Cloud sync', included: false },
+    { text: 'Mobile app', included: false },
+    { text: 'Multi-user collaboration', included: false },
+  ],
+  cta: 'Start 30-Day Trial',
+  ctaSub: 'No credit card required',
+  ctaStyle: 'outline',
+};
+
 export default function PricingCards() {
   return (
     <section id="pricing" className="bg-white px-6 py-24">
@@ -116,11 +137,67 @@ export default function PricingCards() {
             Simple, transparent pricing
           </h2>
           <p className="mt-2 text-lg text-muted">
-            Start free. Scale as your team grows.
+            Plugin only, or plugin + cloud. You choose.
           </p>
         </motion.div>
 
-        <div className="mt-16 grid grid-cols-1 gap-6 lg:grid-cols-4 lg:gap-8">
+        {/* StingTools Plugin — standalone option */}
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-60px' }}
+          transition={{ duration: 0.5, ease: 'easeOut' }}
+          className="mt-14"
+        >
+          <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-muted">
+            Plugin only — no cloud required
+          </p>
+          <div className="relative flex flex-col rounded-2xl border border-slate-200 bg-slate-50 p-8 lg:flex-row lg:items-center lg:gap-12">
+            <div className="lg:w-64">
+              <h3 className="text-xl font-bold text-navy">{pluginPlan.name}</h3>
+              <div className="mt-3 flex items-baseline gap-1">
+                <span className="text-5xl font-extrabold text-navy">{pluginPlan.price}</span>
+                <span className="text-base text-muted">{pluginPlan.priceUnit}</span>
+              </div>
+              <p className="mt-2 text-sm text-slate-600">{pluginPlan.subtext}</p>
+              <a
+                href="#"
+                className="mt-6 block rounded-lg border border-navy px-5 py-3 text-center text-sm font-semibold text-navy transition-colors hover:bg-navy hover:text-white"
+              >
+                {pluginPlan.cta}
+              </a>
+              {pluginPlan.ctaSub && (
+                <p className="mt-2 text-center text-xs text-muted">{pluginPlan.ctaSub}</p>
+              )}
+            </div>
+            <div className="mt-6 border-t border-slate-200 pt-6 lg:mt-0 lg:flex-1 lg:border-l lg:border-t-0 lg:pl-12 lg:pt-0">
+              <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {pluginPlan.features.map((f) => (
+                  <li
+                    key={f.text}
+                    className={`flex items-center gap-2 text-sm ${
+                      f.included ? 'text-slate-700' : 'text-slate-400 line-through'
+                    }`}
+                  >
+                    {f.included ? (
+                      <Check size={15} className="shrink-0 text-success" />
+                    ) : (
+                      <X size={15} className="shrink-0 text-slate-300" />
+                    )}
+                    {f.text}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Planscape Cloud plans */}
+        <div className="mt-10">
+          <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-muted">
+            Plugin + cloud — team collaboration
+          </p>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-4 lg:gap-8">
           {plans.map((p, i) => {
             const isPro = p.highlighted;
             return (
@@ -202,6 +279,7 @@ export default function PricingCards() {
               </motion.div>
             );
           })}
+          </div>
         </div>
 
         <p className="mx-auto mt-8 max-w-2xl text-center text-sm text-muted">


### PR DESCRIPTION
## Summary

This PR introduces the initial scaffold for the **StingTools ArchiCAD Add-On** — a native ArchiCAD integration that mirrors the Revit plugin's ISO 19650 coordination workflow. It also restructures the Planscape pricing model to separate the standalone plugin offering from the cloud platform tiers.

## Key Changes

### ArchiCAD Plugin Scaffold (New)
- **`StingTools.ArchiCAD/`** — new top-level directory with complete project structure:
  - `CMakeLists.txt` — build configuration for Windows (MSVC 2022) and macOS (Xcode 15)
  - `src/StingPlanscapeAddon.cpp` — Add-On entry point, menu registration, and command handlers for Login, IFC Sync, Tag Sync, BCF export/import, Compliance Dashboard, and Settings
  - `include/PlanscapeClient.hpp` — HTTP client interface (mirrors Revit's `SyncClient`) with methods for authentication, IFC upload, tag sync, and BCF round-trip
  - `README.md` — build instructions, implementation checklist (4 phases), and property set setup guide
  - `docs-site/docs/howto/archicad-ifc-workflow.md` — end-user guide for ArchiCAD teams using Planscape without the plugin

- **Menu commands** (7 total): Login, Sync IFC, Sync Tags, Export BCF, Import BCF, Compliance Dashboard, Settings — all scaffolded with TODO markers for HTTP implementation and dialog UI

- **Property mapping** — extended `STING_IFC_PSET_MAPPING.json` with ArchiCAD native property set rules (`AC_Pset_*`) so models exported from ArchiCAD automatically populate STING coordination parameters on upload

### Pricing Model Restructure
- **New tier: "StingTools Plugin"** ($15/firm/month) — standalone Revit plugin with no cloud subscription, unlimited local users, no internet required
- **Renamed cloud tiers**: "Studio" → "Small" ($35), "Practice" → "Medium" ($55), added "Large" ($90)
- **Firm-based pricing** (not per-seat) across all tiers; user counts now represent coordinators + 1 author
- **Updated comparison table** — repositioned against ACC, Procore, Trimble, BIM Track, Dalux with emphasis on flat firm pricing
- **New discount**: NGO/government 15% (replaces Africa regional pricing)
- **Annual discount**: 1 month free (pay 11, use 12) instead of 2 months free

### Backend & Frontend Updates
- **`PricingController.cs`** — added `pluginOnly` plan to `/api/plans` endpoint; updated `BillingPlan` enum with `PluginOnly = 1` tier
- **`Tenant.cs`** — renumbered `BillingPlan` enum (Trial=0, PluginOnly=1, Studio=2, Practice=3, Network=4, Enterprise=5); updated `Limits.For()` switch with new seat/project caps
- **`PricingCards.tsx`** — new "Plugin only" section with horizontal layout; updated all plan cards with new names, prices, and feature lists
- **`pricing.md`** — restructured documentation to explain both products and their pricing separately
- **Marketing site** — updated meta descriptions and OG tags to reflect dual-product messaging

### BCF Controller Enhancement
- **`BcfController.cs`** — added `?source=archicad` query parameter to `/api/projects/{id}/bcf/export` to filter issues by originating model; updated XML comments to document ArchiCAD BCF Manager compatibility (IfcGuid in Components element for element highlighting)

## Implementation Status

The ArchiCAD plugin is a **scaffold** — all menu handlers, API client interface, and build configuration are in place, but HTTP implementation (`PlanscapeClient.cpp`), dialog UI (LoginDialog, SettingsDialog), and element collection logic are marked with `TODO-VERIFY-API` comments. The four-phase implementation plan targets:
1. Auth + IFC upload (4

https://claude.ai/code/session_018G96E239uUxp5VeGbUeNKF