### PR TITLE
Add shared parameter and default value support to symbol library

### DIFF
--- a/StingTools/Core/Symbols/SymbolLibraryCreator.cs
+++ b/StingTools/Core/Symbols/SymbolLibraryCreator.cs
@@ -231,7 +231,7 @@ namespace StingTools.Core.Symbols
                 {
                     tx.Start();
                     DrawGeometry(fdoc, def, std, result);
-                    AddParameters(fdoc, def, result);
+                    AddParameters(app, fdoc, def, result);
                     bool hasSymbolConnectors  = def.Connectors != null && def.Connectors.Count > 0;
                     bool hasVariantConnectors = def.TypeVariants != null
                         && def.TypeVariants.Exists(v => v?.Connectors != null && v.Connectors.Count > 0);
@@ -915,11 +915,29 @@ namespace StingTools.Core.Symbols
             }
         }
 
-        private static void AddParameters(Document fdoc, SymbolDefinition def, SymbolCreationResult result)
+        private static void AddParameters(Application app, Document fdoc,
+            SymbolDefinition def, SymbolCreationResult result)
         {
             if (def.Parameters == null || def.Parameters.Count == 0) return;
             if (!fdoc.IsFamilyDocument) return;
             var fm = fdoc.FamilyManager;
+
+            // Need a seed type to receive default values. Some templates ship
+            // with no types at all; create one so fm.Set has a target.
+            bool anyDefault = def.Parameters.Exists(p => p != null && !string.IsNullOrEmpty(p.Default));
+            if (anyDefault && fm.CurrentType == null)
+            {
+                try { fm.CurrentType = fm.NewType("Default"); }
+                catch (Exception ex)
+                {
+                    result.Warnings.Add($"{def.Id}: seed type for defaults failed — {ex.Message}");
+                }
+            }
+
+            // Lazy-load the shared parameter file once per family — only if any
+            // parameter actually requests shared: true.
+            DefinitionFile sharedFile = null;
+            bool sharedFileResolved = false;
 
             foreach (var p in def.Parameters)
             {
@@ -928,15 +946,120 @@ namespace StingTools.Core.Symbols
                 {
                     if (fm.get_Parameter(p.Name) != null) continue; // already exists
 
-                    // Fix 1b — GroupTypeId is correct; SpecTypeId usage verified for 2025.
                     var groupTypeId = GroupTypeId.IdentityData;
                     var specTypeId  = ResolveSpecTypeId(p.Type);
-                    fm.AddParameter(p.Name, groupTypeId, specTypeId, p.IsInstance);
+
+                    FamilyParameter fp = null;
+                    if (p.IsShared)
+                    {
+                        if (!sharedFileResolved)
+                        {
+                            sharedFile = TryOpenSharedParameterFile(app, def, result);
+                            sharedFileResolved = true;
+                        }
+                        fp = TryAddSharedParameter(fm, sharedFile, p, groupTypeId, def, result);
+                        if (fp == null)
+                        {
+                            // Fallback: bind as a regular family parameter so the
+                            // type/instance property still appears in the family.
+                            fp = fm.AddParameter(p.Name, groupTypeId, specTypeId, p.IsInstance);
+                        }
+                    }
+                    else
+                    {
+                        fp = fm.AddParameter(p.Name, groupTypeId, specTypeId, p.IsInstance);
+                    }
+
+                    if (fp != null && !string.IsNullOrEmpty(p.Default))
+                        TrySetDefault(fm, fp, p.Default, def, result);
                 }
                 catch (Exception ex)
                 {
                     result.Warnings.Add($"{def.Id}: param '{p.Name}' add failed — {ex.Message}");
                 }
+            }
+        }
+
+        private static DefinitionFile TryOpenSharedParameterFile(Application app,
+            SymbolDefinition def, SymbolCreationResult result)
+        {
+            try
+            {
+                var file = app.OpenSharedParameterFile();
+                if (file == null)
+                    result.Warnings.Add($"{def.Id}: shared parameter file not set — shared params fall back to family params");
+                return file;
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"{def.Id}: OpenSharedParameterFile failed — {ex.Message}");
+                return null;
+            }
+        }
+
+        private static FamilyParameter TryAddSharedParameter(FamilyManager fm,
+            DefinitionFile defFile, ParameterDefinition p, ForgeTypeId groupTypeId,
+            SymbolDefinition def, SymbolCreationResult result)
+        {
+            if (defFile == null) return null;
+            try
+            {
+                ExternalDefinition extDef = null;
+                foreach (DefinitionGroup g in defFile.Groups)
+                {
+                    foreach (Definition d in g.Definitions)
+                    {
+                        if (string.Equals(d.Name, p.Name, StringComparison.OrdinalIgnoreCase))
+                        { extDef = d as ExternalDefinition; break; }
+                    }
+                    if (extDef != null) break;
+                }
+                if (extDef == null)
+                {
+                    result.Warnings.Add($"{def.Id}: shared param '{p.Name}' not found in shared file — bound as family param");
+                    return null;
+                }
+                return fm.AddParameter(extDef, groupTypeId, p.IsInstance);
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"{def.Id}: shared param '{p.Name}' add failed — {ex.Message}");
+                return null;
+            }
+        }
+
+        private static void TrySetDefault(FamilyManager fm, FamilyParameter fp,
+            string value, SymbolDefinition def, SymbolCreationResult result)
+        {
+            if (fp == null || value == null) return;
+            try
+            {
+                switch (fp.StorageType)
+                {
+                    case StorageType.String:
+                        fm.Set(fp, value);
+                        break;
+                    case StorageType.Integer:
+                        if (int.TryParse(value, out int i))
+                            fm.Set(fp, i);
+                        else if (bool.TryParse(value, out bool b))
+                            fm.Set(fp, b ? 1 : 0);
+                        break;
+                    case StorageType.Double:
+                        if (double.TryParse(value,
+                            System.Globalization.NumberStyles.Any,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out double d))
+                            fm.Set(fp, d);
+                        break;
+                    case StorageType.ElementId:
+                        // Material / reference defaults aren't expressible as JSON strings.
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"{def.Id}: default for '{fp.Definition?.Name}' failed — {ex.Message}");
             }
         }
 

--- a/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
@@ -12,7 +12,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true, "default": "13" }
+        { "name": "RATING_A", "type": "Text", "shared": true, "default": "13", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -33,7 +33,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true, "default": "13" }
+        { "name": "RATING_A", "type": "Text", "shared": true, "default": "13", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -59,7 +59,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "FUSE_RATING", "type": "Text", "shared": true, "default": "13" }
+        { "name": "FUSE_RATING", "type": "Text", "shared": true, "default": "13", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -85,8 +85,8 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "POWER_KW", "type": "Text", "shared": true, "default": "7.4" },
-        { "name": "MODE_TYPE", "type": "Text", "shared": true, "default": "Mode 3" }
+        { "name": "POWER_KW", "type": "Text", "shared": true, "default": "7.4", "instance": false },
+        { "name": "MODE_TYPE", "type": "Text", "shared": true, "default": "Mode 3", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -234,7 +234,7 @@
       "symbolSize": 8.0,
       "parameters": [
         { "name": "DB_REF", "type": "Text", "shared": true },
-        { "name": "WAYS", "type": "Integer", "shared": true, "default": "12" }
+        { "name": "WAYS", "type": "Integer", "shared": true, "default": "12", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -263,7 +263,7 @@
       "symbolSize": 8.0,
       "parameters": [
         { "name": "DB_REF", "type": "Text", "shared": true },
-        { "name": "WAYS", "type": "Integer", "shared": true }
+        { "name": "WAYS", "type": "Integer", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -291,7 +291,7 @@
       "symbolSize": 12.0,
       "parameters": [
         { "name": "PANEL_REF", "type": "Text", "shared": true },
-        { "name": "INCOMER_A", "type": "Text", "shared": true }
+        { "name": "INCOMER_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -316,7 +316,7 @@
       "subcategory": "Protection",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.45, "startDeg": 0, "endDeg": 360 } ],
@@ -362,7 +362,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "DEVICE_REF", "type": "Text", "shared": true },
-        { "name": "RESOLUTION", "type": "Text", "shared": true, "default": "1080p" }
+        { "name": "RESOLUTION", "type": "Text", "shared": true, "default": "1080p", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.45, "startDeg": 0, "endDeg": 360 } ],
@@ -390,7 +390,7 @@
       "symbolSize": 4.5,
       "parameters": [
         { "name": "DEVICE_REF", "type": "Text", "shared": true },
-        { "name": "IP_RATING", "type": "Text", "shared": true, "default": "IP66" }
+        { "name": "IP_RATING", "type": "Text", "shared": true, "default": "IP66", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -487,7 +487,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "DEVICE_REF", "type": "Text", "shared": true },
-        { "name": "POWER_W", "type": "Text", "shared": true, "default": "6" }
+        { "name": "POWER_W", "type": "Text", "shared": true, "default": "6", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -569,10 +569,10 @@
       "symbolSize": 4.0,
       "description": "Oxygen (O2) medical pipeline outlet — BS HTM 02-01 / NFPA 99 §5.1",
       "parameters": [
-        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "O2"  },
-        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 10    },
-        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400   },
-        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder" },
+        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "O2", "instance": false  },
+        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 10, "instance": false    },
+        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400, "instance": false   },
+        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder", "instance": false },
         { "name": "MG_ZONE_TXT",            "type": "Text",   "shared": true }
       ],
       "geometry": {
@@ -596,10 +596,10 @@
       "symbolSize": 4.0,
       "description": "Nitrous oxide (N2O) medical pipeline outlet — BS HTM 02-01 / NFPA 99",
       "parameters": [
-        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "N2O" },
-        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 10    },
-        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400   },
-        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder" },
+        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "N2O", "instance": false },
+        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 10, "instance": false    },
+        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400, "instance": false   },
+        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder", "instance": false },
         { "name": "MG_ZONE_TXT",            "type": "Text",   "shared": true }
       ],
       "geometry": {
@@ -623,10 +623,10 @@
       "symbolSize": 4.0,
       "description": "Carbon dioxide (CO2) medical pipeline outlet — BS HTM 02-01",
       "parameters": [
-        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "CO2" },
-        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 5     },
-        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400   },
-        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder" },
+        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "CO2", "instance": false },
+        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 5, "instance": false     },
+        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400, "instance": false   },
+        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder", "instance": false },
         { "name": "MG_ZONE_TXT",            "type": "Text",   "shared": true }
       ],
       "geometry": {
@@ -650,10 +650,10 @@
       "symbolSize": 4.0,
       "description": "Medical compressed air outlet (400 kPa / 7 bar variants) — BS HTM 02-01 / NFPA 99 §5.1.3",
       "parameters": [
-        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "AIR" },
-        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 40    },
-        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400   },
-        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder" },
+        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "AIR", "instance": false },
+        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 40, "instance": false    },
+        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": 400, "instance": false   },
+        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder", "instance": false },
         { "name": "MG_ZONE_TXT",            "type": "Text",   "shared": true }
       ],
       "geometry": {
@@ -677,10 +677,10 @@
       "symbolSize": 4.0,
       "description": "Medical vacuum (MEDIVAC) pipeline outlet — BS HTM 02-01 / NFPA 99 §5.1.5",
       "parameters": [
-        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "VAC" },
-        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 40    },
-        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": -80   },
-        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder" },
+        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "VAC", "instance": false },
+        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 40, "instance": false    },
+        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": -80, "instance": false   },
+        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "Schraeder", "instance": false },
         { "name": "MG_ZONE_TXT",            "type": "Text",   "shared": true }
       ],
       "geometry": {
@@ -704,10 +704,10 @@
       "symbolSize": 4.0,
       "description": "Anaesthetic Gas Scavenging System (AGSS) outlet — BS HTM 02-01 §4.4 / ISO 7396-2",
       "parameters": [
-        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "AGSS" },
-        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 50     },
-        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": -25    },
-        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "AGSS-30mm" },
+        { "name": "GAS_TYPE_TXT",           "type": "Text",   "shared": true, "default": "AGSS", "instance": false },
+        { "name": "FLOW_RATE_L_MIN",        "type": "Number", "shared": true, "default": 50, "instance": false     },
+        { "name": "WORKING_PRESSURE_KPA",   "type": "Number", "shared": true, "default": -25, "instance": false    },
+        { "name": "OUTLET_TYPE_TXT",        "type": "Text",   "shared": true, "default": "AGSS-30mm", "instance": false },
         { "name": "MG_ZONE_TXT",            "type": "Text",   "shared": true }
       ],
       "geometry": {
@@ -732,8 +732,8 @@
       "description": "Hazardous area zone boundary line marker for electrical floor plan drawings — IEC 60079-10-1 / ATEX Directive 2014/34/EU",
       "parameters": [
         { "name": "ATEX_ZONE_CLASS",  "type": "Text", "shared": true, "default": "Zone 1" },
-        { "name": "ATEX_GAS_GROUP",   "type": "Text", "shared": true, "default": "IIA"    },
-        { "name": "ATEX_T_CLASS",     "type": "Text", "shared": true, "default": "T3"     },
+        { "name": "ATEX_GAS_GROUP",   "type": "Text", "shared": true, "default": "IIA", "instance": false    },
+        { "name": "ATEX_T_CLASS",     "type": "Text", "shared": true, "default": "T3", "instance": false     },
         { "name": "ATEX_AREA_REF",    "type": "Text", "shared": true }
       ],
       "geometry": {
@@ -754,8 +754,8 @@
       "symbolSize": 4.0,
       "description": "Flameproof (Ex d) equipment marker for use on electrical floor plan drawings — IEC 60079-1",
       "parameters": [
-        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex d IIA T3 Gb" },
-        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true },
+        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex d IIA T3 Gb", "instance": false },
+        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true, "instance": false },
         { "name": "EQUIPMENT_REF",    "type": "Text", "shared": true }
       ],
       "geometry": {

--- a/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
@@ -12,8 +12,8 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "K_FACTOR", "type": "Text", "shared": true, "default": "80" },
-        { "name": "TEMP_RATING_C", "type": "Text", "shared": true, "default": "68" },
+        { "name": "K_FACTOR", "type": "Text", "shared": true, "default": "80", "instance": false },
+        { "name": "TEMP_RATING_C", "type": "Text", "shared": true, "default": "68", "instance": false },
         { "name": "STATUS", "type": "Text", "shared": true }
       ],
       "geometry": {
@@ -38,7 +38,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "K_FACTOR", "type": "Text", "shared": true }
+        { "name": "K_FACTOR", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -112,7 +112,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "K_FACTOR", "type": "Text", "shared": true, "default": "200" }
+        { "name": "K_FACTOR", "type": "Text", "shared": true, "default": "200", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -195,7 +195,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "TEMP_TRIP_C", "type": "Text", "shared": true, "default": "60" }
+        { "name": "TEMP_TRIP_C", "type": "Text", "shared": true, "default": "60", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -254,7 +254,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "BEAM_LENGTH_M", "type": "Text", "shared": true }
+        { "name": "BEAM_LENGTH_M", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -305,7 +305,7 @@
       "symbolSize": 4.5,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "DETECTION_TYPE", "type": "Text", "shared": true, "default": "UV/IR" }
+        { "name": "DETECTION_TYPE", "type": "Text", "shared": true, "default": "UV/IR", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -350,7 +350,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "DB_RATING", "type": "Text", "shared": true, "default": "100" }
+        { "name": "DB_RATING", "type": "Text", "shared": true, "default": "100", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -392,7 +392,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "EN54_CATEGORY", "type": "Text", "shared": true, "default": "C-3-15" }
+        { "name": "EN54_CATEGORY", "type": "Text", "shared": true, "default": "C-3-15", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -417,8 +417,8 @@
       "symbolSize": 8.0,
       "parameters": [
         { "name": "PANEL_REF", "type": "Text", "shared": true },
-        { "name": "EN54_PART", "type": "Text", "shared": true, "default": "EN54-2" },
-        { "name": "ZONE_COUNT", "type": "Integer", "shared": true }
+        { "name": "EN54_PART", "type": "Text", "shared": true, "default": "EN54-2", "instance": false },
+        { "name": "ZONE_COUNT", "type": "Integer", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -469,7 +469,7 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "VALVE_REF", "type": "Text", "shared": true },
-        { "name": "SIZE_MM", "type": "Text", "shared": true, "default": "100" }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "default": "100", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -581,7 +581,7 @@
       "subcategory": "Monitor",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "RANGE_BAR", "type": "Text", "shared": true, "default": "0-16" }
+        { "name": "RANGE_BAR", "type": "Text", "shared": true, "default": "0-16", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -650,7 +650,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "VALVE_REF", "type": "Text", "shared": true },
-        { "name": "SIZE_MM", "type": "Text", "shared": true, "default": "100" }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "default": "100", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],

--- a/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
@@ -12,10 +12,10 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LAMP_TYPE", "type": "Text", "shared": true },
-        { "name": "WATTAGE", "type": "Text", "shared": true },
-        { "name": "LUMEN_OUTPUT", "type": "Text", "shared": true },
-        { "name": "EMERGENCY", "type": "YesNo", "shared": true }
+        { "name": "LAMP_TYPE", "type": "Text", "shared": true, "instance": false },
+        { "name": "WATTAGE", "type": "Text", "shared": true, "instance": false },
+        { "name": "LUMEN_OUTPUT", "type": "Text", "shared": true, "instance": false },
+        { "name": "EMERGENCY", "type": "YesNo", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -36,8 +36,8 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LAMP_TYPE", "type": "Text", "shared": true },
-        { "name": "WATTAGE", "type": "Text", "shared": true }
+        { "name": "LAMP_TYPE", "type": "Text", "shared": true, "instance": false },
+        { "name": "WATTAGE", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -61,8 +61,8 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LAMP_TYPE", "type": "Text", "shared": true },
-        { "name": "WATTAGE", "type": "Text", "shared": true }
+        { "name": "LAMP_TYPE", "type": "Text", "shared": true, "instance": false },
+        { "name": "WATTAGE", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -89,7 +89,7 @@
       "symbolSize": 4.5,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "WATTAGE", "type": "Text", "shared": true }
+        { "name": "WATTAGE", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "filledRegions": [
@@ -113,7 +113,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "DROP_HEIGHT_MM", "type": "Text", "shared": true }
+        { "name": "DROP_HEIGHT_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -133,8 +133,8 @@
       "symbolSize": 10.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "TRACK_LENGTH_MM", "type": "Text", "shared": true },
-        { "name": "HEAD_COUNT", "type": "Integer", "shared": true }
+        { "name": "TRACK_LENGTH_MM", "type": "Text", "shared": true, "instance": false },
+        { "name": "HEAD_COUNT", "type": "Integer", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -161,8 +161,8 @@
       "symbolSize": 12.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LENGTH_MM", "type": "Text", "shared": true, "default": "1200" },
-        { "name": "WATTAGE", "type": "Text", "shared": true, "default": "36" }
+        { "name": "LENGTH_MM", "type": "Text", "shared": true, "default": "1200", "instance": false },
+        { "name": "WATTAGE", "type": "Text", "shared": true, "default": "36", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -185,7 +185,7 @@
       "symbolSize": 12.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LENGTH_MM", "type": "Text", "shared": true, "default": "1200" }
+        { "name": "LENGTH_MM", "type": "Text", "shared": true, "default": "1200", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -209,8 +209,8 @@
       "symbolSize": 10.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LENGTH_MM", "type": "Text", "shared": true },
-        { "name": "WATTS_PER_M", "type": "Text", "shared": true }
+        { "name": "LENGTH_MM", "type": "Text", "shared": true, "instance": false },
+        { "name": "WATTS_PER_M", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -233,8 +233,8 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "BATTERY_RUNTIME_MIN", "type": "Text", "shared": true, "default": "180" },
-        { "name": "EMERGENCY", "type": "YesNo", "shared": true, "default": "true" }
+        { "name": "BATTERY_RUNTIME_MIN", "type": "Text", "shared": true, "default": "180", "instance": false },
+        { "name": "EMERGENCY", "type": "YesNo", "shared": true, "default": "true", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0.05, "r": 0.45, "startDeg": 0, "endDeg": 360 } ],
@@ -256,7 +256,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "EMERGENCY", "type": "YesNo", "shared": true, "default": "true" }
+        { "name": "EMERGENCY", "type": "YesNo", "shared": true, "default": "true", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.45, "startDeg": 0, "endDeg": 360 } ],
@@ -274,7 +274,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "DIRECTION", "type": "Text", "shared": true, "default": "Right" }
+        { "name": "DIRECTION", "type": "Text", "shared": true, "default": "Right", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -299,7 +299,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "BEAM_ANGLE", "type": "Text", "shared": true }
+        { "name": "BEAM_ANGLE", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -344,8 +344,8 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "WATTAGE", "type": "Text", "shared": true },
-        { "name": "IP_RATING", "type": "Text", "shared": true, "default": "IP65" }
+        { "name": "WATTAGE", "type": "Text", "shared": true, "instance": false },
+        { "name": "IP_RATING", "type": "Text", "shared": true, "default": "IP65", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -370,7 +370,7 @@
       "symbolSize": 2.5,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "HEIGHT_MM", "type": "Text", "shared": true, "default": "800" }
+        { "name": "HEIGHT_MM", "type": "Text", "shared": true, "default": "800", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.3, "startDeg": 0, "endDeg": 360 } ],
@@ -391,7 +391,7 @@
       "symbolSize": 4.5,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "COLUMN_HEIGHT_M", "type": "Text", "shared": true, "default": "6" }
+        { "name": "COLUMN_HEIGHT_M", "type": "Text", "shared": true, "default": "6", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.4, "startDeg": 0, "endDeg": 360 } ],
@@ -416,7 +416,7 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LUMEN_OUTPUT", "type": "Text", "shared": true, "default": "20000" }
+        { "name": "LUMEN_OUTPUT", "type": "Text", "shared": true, "default": "20000", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -439,7 +439,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "LUMEN_OUTPUT", "type": "Text", "shared": true }
+        { "name": "LUMEN_OUTPUT", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.45, "startDeg": 0, "endDeg": 360 } ],
@@ -460,7 +460,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "IK_RATING", "type": "Text", "shared": true, "default": "IK10" }
+        { "name": "IK_RATING", "type": "Text", "shared": true, "default": "IK10", "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -480,7 +480,7 @@
       "symbolSize": 8.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "IP_RATING", "type": "Text", "shared": true, "default": "IP65" }
+        { "name": "IP_RATING", "type": "Text", "shared": true, "default": "IP65", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -527,7 +527,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "SENSOR_TYPE", "type": "Text", "shared": true, "default": "PIR" }
+        { "name": "SENSOR_TYPE", "type": "Text", "shared": true, "default": "PIR", "instance": false }
       ],
       "geometry": {
         "arcs": [

--- a/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
@@ -12,8 +12,8 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "SYSTEM_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true },
-        { "name": "NECK_SIZE_MM", "type": "Text", "shared": true, "default": "300" }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false },
+        { "name": "NECK_SIZE_MM", "type": "Text", "shared": true, "default": "300", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -44,8 +44,8 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "SYSTEM_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true },
-        { "name": "NECK_DIA_MM", "type": "Text", "shared": true, "default": "200" }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false },
+        { "name": "NECK_DIA_MM", "type": "Text", "shared": true, "default": "200", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -73,7 +73,7 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "SYSTEM_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -104,7 +104,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "SYSTEM_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -132,8 +132,8 @@
       "symbolSize": 12.0,
       "parameters": [
         { "name": "SYSTEM_REF", "type": "Text", "shared": true },
-        { "name": "LENGTH_MM", "type": "Text", "shared": true, "default": "1200" },
-        { "name": "SLOT_COUNT", "type": "Integer", "shared": true, "default": "2" }
+        { "name": "LENGTH_MM", "type": "Text", "shared": true, "default": "1200", "instance": false },
+        { "name": "SLOT_COUNT", "type": "Integer", "shared": true, "default": "2", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -159,7 +159,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "SYSTEM_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -194,7 +194,7 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "SYSTEM_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -252,7 +252,7 @@
       "subcategory": "AirTerminal",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -278,9 +278,9 @@
       "subcategory": "Damper",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "FIRE_RATING", "type": "Text", "shared": true, "default": "EI 60" },
-        { "name": "SIZE_W_MM", "type": "Text", "shared": true },
-        { "name": "SIZE_H_MM", "type": "Text", "shared": true }
+        { "name": "FIRE_RATING", "type": "Text", "shared": true, "default": "EI 60", "instance": false },
+        { "name": "SIZE_W_MM", "type": "Text", "shared": true, "instance": false },
+        { "name": "SIZE_H_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -333,7 +333,7 @@
       "subcategory": "Damper",
       "symbolSize": 5.5,
       "parameters": [
-        { "name": "FIRE_RATING", "type": "Text", "shared": true, "default": "EIS 60" }
+        { "name": "FIRE_RATING", "type": "Text", "shared": true, "default": "EIS 60", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -384,7 +384,7 @@
       "subcategory": "Damper",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "ACTUATOR_TYPE", "type": "Text", "shared": true, "default": "Modulating" }
+        { "name": "ACTUATOR_TYPE", "type": "Text", "shared": true, "default": "Modulating", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -438,9 +438,9 @@
       "symbolSize": 8.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "COOLING_KW", "type": "Text", "shared": true },
-        { "name": "HEATING_KW", "type": "Text", "shared": true },
-        { "name": "AIRFLOW_LS", "type": "Text", "shared": true }
+        { "name": "COOLING_KW", "type": "Text", "shared": true, "instance": false },
+        { "name": "HEATING_KW", "type": "Text", "shared": true, "instance": false },
+        { "name": "AIRFLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -500,8 +500,8 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "MAX_FLOW_LS", "type": "Text", "shared": true },
-        { "name": "MIN_FLOW_LS", "type": "Text", "shared": true }
+        { "name": "MAX_FLOW_LS", "type": "Text", "shared": true, "instance": false },
+        { "name": "MIN_FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -531,7 +531,7 @@
       "subcategory": "Equipment",
       "symbolSize": 6.0,
       "parameters": [
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -561,9 +561,9 @@
       "symbolSize": 16.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "AIRFLOW_LS", "type": "Text", "shared": true },
-        { "name": "COOLING_KW", "type": "Text", "shared": true },
-        { "name": "HEATING_KW", "type": "Text", "shared": true }
+        { "name": "AIRFLOW_LS", "type": "Text", "shared": true, "instance": false },
+        { "name": "COOLING_KW", "type": "Text", "shared": true, "instance": false },
+        { "name": "HEATING_KW", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -600,7 +600,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -626,7 +626,7 @@
       "symbolSize": 6.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [

--- a/StingTools/Data/Symbols/STING_PIPE_ACCESSORIES.json
+++ b/StingTools/Data/Symbols/STING_PIPE_ACCESSORIES.json
@@ -11,8 +11,8 @@
       "subcategory": "Valve",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true },
-        { "name": "RATING", "type": "Text", "shared": true, "default": "PN16" },
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false },
+        { "name": "RATING", "type": "Text", "shared": true, "default": "PN16", "instance": false },
         { "name": "SERVICE_LABEL", "type": "Text", "shared": true }
       ],
       "geometry": {
@@ -40,7 +40,7 @@
       "subcategory": "Valve",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -64,7 +64,7 @@
       "subcategory": "Valve",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -89,7 +89,7 @@
       "subcategory": "Valve",
       "symbolSize": 4.5,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -135,7 +135,7 @@
       "subcategory": "Valve",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -212,7 +212,7 @@
       "subcategory": "Valve",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "VOLTAGE", "type": "Text", "shared": true, "default": "230VAC" }
+        { "name": "VOLTAGE", "type": "Text", "shared": true, "default": "230VAC", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -241,7 +241,7 @@
       "subcategory": "Valve",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "SET_PRESSURE_BAR", "type": "Text", "shared": true }
+        { "name": "SET_PRESSURE_BAR", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -429,7 +429,7 @@
       "subcategory": "Instrument",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "RANGE_BAR", "type": "Text", "shared": true, "default": "0-10" }
+        { "name": "RANGE_BAR", "type": "Text", "shared": true, "default": "0-10", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -453,7 +453,7 @@
       "subcategory": "Instrument",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "RANGE_C", "type": "Text", "shared": true, "default": "0-100" }
+        { "name": "RANGE_C", "type": "Text", "shared": true, "default": "0-100", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -477,7 +477,7 @@
       "subcategory": "Instrument",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -502,8 +502,8 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "FLOW_LS", "type": "Text", "shared": true },
-        { "name": "HEAD_M", "type": "Text", "shared": true }
+        { "name": "FLOW_LS", "type": "Text", "shared": true, "instance": false },
+        { "name": "HEAD_M", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.35, "startDeg": 0, "endDeg": 360 } ],

--- a/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
@@ -12,7 +12,7 @@
       "symbolSize": 5.5,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "FLUSH_VOLUME_L", "type": "Text", "shared": true, "default": "6" }
+        { "name": "FLUSH_VOLUME_L", "type": "Text", "shared": true, "default": "6", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -273,7 +273,7 @@
       "symbolSize": 8.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "TRAY_SIZE_MM", "type": "Text", "shared": true, "default": "800" }
+        { "name": "TRAY_SIZE_MM", "type": "Text", "shared": true, "default": "800", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -305,7 +305,7 @@
       "symbolSize": 17.0,
       "parameters": [
         { "name": "ZONE_REF", "type": "Text", "shared": true },
-        { "name": "BATH_SIZE_MM", "type": "Text", "shared": true, "default": "1700x700" }
+        { "name": "BATH_SIZE_MM", "type": "Text", "shared": true, "default": "1700x700", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -435,7 +435,7 @@
       "subcategory": "Valve",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true, "default": "25" }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "default": "25", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -462,7 +462,7 @@
       "subcategory": "Valve",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -486,7 +486,7 @@
       "subcategory": "Valve",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -511,7 +511,7 @@
       "subcategory": "Valve",
       "symbolSize": 4.5,
       "parameters": [
-        { "name": "SIZE_MM", "type": "Text", "shared": true }
+        { "name": "SIZE_MM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -619,7 +619,7 @@
       "subcategory": "Valve",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "SET_PRESSURE_BAR", "type": "Text", "shared": true, "default": "3" }
+        { "name": "SET_PRESSURE_BAR", "type": "Text", "shared": true, "default": "3", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -649,7 +649,7 @@
       "symbolSize": 7.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "CAPACITY_L", "type": "Text", "shared": true, "default": "150" }
+        { "name": "CAPACITY_L", "type": "Text", "shared": true, "default": "150", "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.5, "startDeg": 0, "endDeg": 360 } ],
@@ -678,7 +678,7 @@
       "symbolSize": 7.0,
       "parameters": [
         { "name": "EQUIPMENT_REF", "type": "Text", "shared": true },
-        { "name": "CAPACITY_L", "type": "Text", "shared": true, "default": "180" }
+        { "name": "CAPACITY_L", "type": "Text", "shared": true, "default": "180", "instance": false }
       ],
       "geometry": {
         "arcs": [

--- a/StingTools/Data/Symbols/STING_SLD_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_SLD_SYMBOLS.json
@@ -12,8 +12,8 @@
       "symbolSize": 3.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true },
-        { "name": "POLES", "type": "Text", "shared": true },
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false },
+        { "name": "POLES", "type": "Text", "shared": true, "instance": false },
         { "name": "LABEL", "type": "Text", "shared": true }
       ],
       "geometry": {
@@ -40,8 +40,8 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true },
-        { "name": "BREAKING_KA", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false },
+        { "name": "BREAKING_KA", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -67,7 +67,7 @@
       "symbolSize": 5.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -95,8 +95,8 @@
       "symbolSize": 3.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true },
-        { "name": "FUSE_TYPE", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false },
+        { "name": "FUSE_TYPE", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -122,7 +122,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -149,7 +149,7 @@
       "symbolSize": 3.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -172,8 +172,8 @@
       "symbolSize": 3.5,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true },
-        { "name": "COIL_VOLTAGE", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false },
+        { "name": "COIL_VOLTAGE", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -196,7 +196,7 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_KW", "type": "Text", "shared": true }
+        { "name": "RATING_KW", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -226,8 +226,8 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_KW", "type": "Text", "shared": true },
-        { "name": "FREQUENCY_HZ", "type": "Text", "shared": true }
+        { "name": "RATING_KW", "type": "Text", "shared": true, "instance": false },
+        { "name": "FREQUENCY_HZ", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -258,7 +258,7 @@
       "symbolSize": 3.5,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "TRIP_MA", "type": "Text", "shared": true }
+        { "name": "TRIP_MA", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.25, "startDeg": 0, "endDeg": 360 } ],
@@ -283,8 +283,8 @@
       "symbolSize": 4.0,
       "parameters": [
         { "name": "CIRCUIT_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true },
-        { "name": "TRIP_MA", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false },
+        { "name": "TRIP_MA", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -310,8 +310,8 @@
       "subcategory": "Protection",
       "symbolSize": 3.5,
       "parameters": [
-        { "name": "SPD_CLASS", "type": "Text", "shared": true },
-        { "name": "RATING_KA", "type": "Text", "shared": true }
+        { "name": "SPD_CLASS", "type": "Text", "shared": true, "instance": false },
+        { "name": "RATING_KA", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -338,10 +338,10 @@
       "subcategory": "Transformer",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "RATING_KVA", "type": "Text", "shared": true },
-        { "name": "PRIMARY_V", "type": "Text", "shared": true },
-        { "name": "SECONDARY_V", "type": "Text", "shared": true },
-        { "name": "VECTOR_GROUP", "type": "Text", "shared": true }
+        { "name": "RATING_KVA", "type": "Text", "shared": true, "instance": false },
+        { "name": "PRIMARY_V", "type": "Text", "shared": true, "instance": false },
+        { "name": "SECONDARY_V", "type": "Text", "shared": true, "instance": false },
+        { "name": "VECTOR_GROUP", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -363,8 +363,8 @@
       "subcategory": "Transformer",
       "symbolSize": 5.5,
       "parameters": [
-        { "name": "RATING_KVA", "type": "Text", "shared": true },
-        { "name": "VECTOR_GROUP", "type": "Text", "shared": true }
+        { "name": "RATING_KVA", "type": "Text", "shared": true, "instance": false },
+        { "name": "VECTOR_GROUP", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -388,7 +388,7 @@
       "subcategory": "Transformer",
       "symbolSize": 4.5,
       "parameters": [
-        { "name": "RATING_KVA", "type": "Text", "shared": true }
+        { "name": "RATING_KVA", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -413,8 +413,8 @@
       "subcategory": "Transformer",
       "symbolSize": 6.0,
       "parameters": [
-        { "name": "RATING_KVA", "type": "Text", "shared": true },
-        { "name": "VECTOR_GROUP", "type": "Text", "shared": true, "default": "Dyn11" }
+        { "name": "RATING_KVA", "type": "Text", "shared": true, "instance": false },
+        { "name": "VECTOR_GROUP", "type": "Text", "shared": true, "default": "Dyn11", "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -444,7 +444,7 @@
       "subcategory": "Instrument",
       "symbolSize": 3.0,
       "parameters": [
-        { "name": "RANGE_A", "type": "Text", "shared": true }
+        { "name": "RANGE_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.3, "startDeg": 0, "endDeg": 360 } ],
@@ -463,7 +463,7 @@
       "discipline": "Electrical",
       "subcategory": "Instrument",
       "symbolSize": 3.0,
-      "parameters": [ { "name": "RANGE_V", "type": "Text", "shared": true } ],
+      "parameters": [ { "name": "RANGE_V", "type": "Text", "shared": true, "instance": false } ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.3, "startDeg": 0, "endDeg": 360 } ],
         "text": [ { "x": 0, "y": 0, "value": "V", "heightMm": 1.5 } ],
@@ -481,7 +481,7 @@
       "discipline": "Electrical",
       "subcategory": "Instrument",
       "symbolSize": 3.0,
-      "parameters": [ { "name": "RANGE_KW", "type": "Text", "shared": true } ],
+      "parameters": [ { "name": "RANGE_KW", "type": "Text", "shared": true, "instance": false } ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.3, "startDeg": 0, "endDeg": 360 } ],
         "text": [ { "x": 0, "y": 0, "value": "W", "heightMm": 1.5 } ]
@@ -524,8 +524,8 @@
       "subcategory": "Instrument",
       "symbolSize": 3.0,
       "parameters": [
-        { "name": "CT_RATIO", "type": "Text", "shared": true },
-        { "name": "CT_CLASS", "type": "Text", "shared": true }
+        { "name": "CT_RATIO", "type": "Text", "shared": true, "instance": false },
+        { "name": "CT_CLASS", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.18, "startDeg": 0, "endDeg": 360 } ],
@@ -546,7 +546,7 @@
       "discipline": "Electrical",
       "subcategory": "Instrument",
       "symbolSize": 2.5,
-      "parameters": [ { "name": "VT_RATIO", "type": "Text", "shared": true } ],
+      "parameters": [ { "name": "VT_RATIO", "type": "Text", "shared": true, "instance": false } ],
       "geometry": {
         "arcs": [
           { "cx": -0.08, "cy": 0, "r": 0.12, "startDeg": 0, "endDeg": 360 },
@@ -568,7 +568,7 @@
       "symbolSize": 8.0,
       "parameters": [
         { "name": "BUS_REF", "type": "Text", "shared": true },
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -657,8 +657,8 @@
       "subcategory": "Source",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "RATING_KVA", "type": "Text", "shared": true },
-        { "name": "FUEL_TYPE", "type": "Text", "shared": true }
+        { "name": "RATING_KVA", "type": "Text", "shared": true, "instance": false },
+        { "name": "FUEL_TYPE", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -681,8 +681,8 @@
       "subcategory": "Source",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "RATING_KVA", "type": "Text", "shared": true },
-        { "name": "RUNTIME_MIN", "type": "Text", "shared": true }
+        { "name": "RATING_KVA", "type": "Text", "shared": true, "instance": false },
+        { "name": "RUNTIME_MIN", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -709,8 +709,8 @@
       "subcategory": "Source",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "CAPACITY_AH", "type": "Text", "shared": true },
-        { "name": "VOLTAGE_DC", "type": "Text", "shared": true }
+        { "name": "CAPACITY_AH", "type": "Text", "shared": true, "instance": false },
+        { "name": "VOLTAGE_DC", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -736,7 +736,7 @@
       "subcategory": "Source",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "ARRAY_KWP", "type": "Text", "shared": true }
+        { "name": "ARRAY_KWP", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -762,7 +762,7 @@
       "subcategory": "Switching",
       "symbolSize": 5.0,
       "parameters": [
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -789,8 +789,8 @@
       "subcategory": "Load",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "RATING_KW", "type": "Text", "shared": true },
-        { "name": "RPM", "type": "Text", "shared": true }
+        { "name": "RATING_KW", "type": "Text", "shared": true, "instance": false },
+        { "name": "RPM", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.35, "startDeg": 0, "endDeg": 360 } ],
@@ -816,7 +816,7 @@
       "subcategory": "Load",
       "symbolSize": 3.5,
       "parameters": [
-        { "name": "RATING_KW", "type": "Text", "shared": true }
+        { "name": "RATING_KW", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [ { "cx": 0, "cy": 0, "r": 0.3, "startDeg": 0, "endDeg": 360 } ],
@@ -835,7 +835,7 @@
       "subcategory": "Load",
       "symbolSize": 3.0,
       "parameters": [
-        { "name": "RATING_KVAR", "type": "Text", "shared": true }
+        { "name": "RATING_KVAR", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -857,7 +857,7 @@
       "subcategory": "Load",
       "symbolSize": 3.5,
       "parameters": [
-        { "name": "RATING_KW", "type": "Text", "shared": true }
+        { "name": "RATING_KW", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -959,7 +959,7 @@
       "subcategory": "Protection",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -985,7 +985,7 @@
       "subcategory": "Switching",
       "symbolSize": 4.0,
       "parameters": [
-        { "name": "RATING_A", "type": "Text", "shared": true }
+        { "name": "RATING_A", "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -1010,8 +1010,8 @@
       "symbolSize": 5.0,
       "description": "Air terminal / finial — BS EN 62305-3 / NFPA 780",
       "parameters": [
-        { "name": "STRIKE_RADIUS_M",      "type": "Number", "shared": true, "default": "20" },
-        { "name": "LPS_PROTECTION_LEVEL", "type": "Text",   "shared": true, "default": "II" }
+        { "name": "STRIKE_RADIUS_M",      "type": "Number", "shared": true, "default": "20", "instance": false },
+        { "name": "LPS_PROTECTION_LEVEL", "type": "Text",   "shared": true, "default": "II", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -1034,7 +1034,7 @@
       "symbolSize": 4.0,
       "description": "Down conductor routing symbol — BS EN 62305-3 §5.3",
       "parameters": [
-        { "name": "CONDUCTOR_CSA_MM2", "type": "Number", "shared": true, "default": "50" },
+        { "name": "CONDUCTOR_CSA_MM2", "type": "Number", "shared": true, "default": "50", "instance": false },
         { "name": "LPS_DC_NUMBER",     "type": "Text",   "shared": true, "default": "DC-01" }
       ],
       "geometry": {
@@ -1114,8 +1114,8 @@
       "description": "Zone 0 — continuous presence of explosive atmosphere (IEC 60079-10-1 / DSEAR)",
       "parameters": [
         { "name": "ATEX_ZONE_REF",   "type": "Text", "shared": true },
-        { "name": "ATEX_GAS_GROUP",  "type": "Text", "shared": true, "default": "IIA" },
-        { "name": "ATEX_T_CLASS",    "type": "Text", "shared": true, "default": "T3" }
+        { "name": "ATEX_GAS_GROUP",  "type": "Text", "shared": true, "default": "IIA", "instance": false },
+        { "name": "ATEX_T_CLASS",    "type": "Text", "shared": true, "default": "T3", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -1140,8 +1140,8 @@
       "description": "Zone 1 — likely presence of explosive atmosphere (IEC 60079-10-1 / DSEAR)",
       "parameters": [
         { "name": "ATEX_ZONE_REF",  "type": "Text", "shared": true },
-        { "name": "ATEX_GAS_GROUP", "type": "Text", "shared": true, "default": "IIA" },
-        { "name": "ATEX_T_CLASS",   "type": "Text", "shared": true, "default": "T3" }
+        { "name": "ATEX_GAS_GROUP", "type": "Text", "shared": true, "default": "IIA", "instance": false },
+        { "name": "ATEX_T_CLASS",   "type": "Text", "shared": true, "default": "T3", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -1164,8 +1164,8 @@
       "description": "Zone 2 — unlikely presence of explosive atmosphere (IEC 60079-10-1 / DSEAR)",
       "parameters": [
         { "name": "ATEX_ZONE_REF",  "type": "Text", "shared": true },
-        { "name": "ATEX_GAS_GROUP", "type": "Text", "shared": true, "default": "IIA" },
-        { "name": "ATEX_T_CLASS",   "type": "Text", "shared": true, "default": "T3" }
+        { "name": "ATEX_GAS_GROUP", "type": "Text", "shared": true, "default": "IIA", "instance": false },
+        { "name": "ATEX_T_CLASS",   "type": "Text", "shared": true, "default": "T3", "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -1187,8 +1187,8 @@
       "symbolSize": 4.0,
       "description": "Ex d flameproof enclosure protection concept — IEC 60079-1 / ATEX Directive",
       "parameters": [
-        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex d IIA T3 Gb" },
-        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true }
+        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex d IIA T3 Gb", "instance": false },
+        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "lines": [
@@ -1210,8 +1210,8 @@
       "symbolSize": 4.0,
       "description": "Ex e increased safety protection concept — IEC 60079-7 / ATEX Directive",
       "parameters": [
-        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex e IIA T3 Gc" },
-        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true }
+        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex e IIA T3 Gc", "instance": false },
+        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -1230,8 +1230,8 @@
       "symbolSize": 4.0,
       "description": "Ex i intrinsic safety protection concept — IEC 60079-11 / ATEX Directive",
       "parameters": [
-        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex ia IIA T3 Ga" },
-        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true }
+        { "name": "ATEX_MARKING_TXT", "type": "Text", "shared": true, "default": "Ex ia IIA T3 Ga", "instance": false },
+        { "name": "ATEX_CERT_NO",     "type": "Text", "shared": true, "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -1253,7 +1253,7 @@
       "symbolSize": 4.0,
       "description": "ABC (positive / clockwise) phase rotation notation — IEC 60034-8",
       "parameters": [
-        { "name": "PHASE_SEQUENCE_TXT", "type": "Text", "shared": true, "default": "ABC" }
+        { "name": "PHASE_SEQUENCE_TXT", "type": "Text", "shared": true, "default": "ABC", "instance": false }
       ],
       "geometry": {
         "arcs": [
@@ -1280,7 +1280,7 @@
       "symbolSize": 4.0,
       "description": "ACB (negative / counter-clockwise) phase rotation notation — IEC 60034-8",
       "parameters": [
-        { "name": "PHASE_SEQUENCE_TXT", "type": "Text", "shared": true, "default": "ACB" }
+        { "name": "PHASE_SEQUENCE_TXT", "type": "Text", "shared": true, "default": "ACB", "instance": false }
       ],
       "geometry": {
         "arcs": [

--- a/StingTools/Data/Symbols/STING_SLD_SYMBOLS_IEEE.json
+++ b/StingTools/Data/Symbols/STING_SLD_SYMBOLS_IEEE.json
@@ -11,8 +11,8 @@
       "symbolSize": 3.0,
       "parameters": [
         {"name": "CIRCUIT_REF", "type": "Text",    "shared": true, "default": ""},
-        {"name": "RATING_A",    "type": "Text",    "shared": true, "default": ""},
-        {"name": "POLES",       "type": "Integer", "shared": true, "default": 1},
+        {"name": "RATING_A",    "type": "Text",    "shared": true, "default": "", "instance": false},
+        {"name": "POLES",       "type": "Integer", "shared": true, "default": 1, "instance": false},
         {"name": "LABEL",       "type": "Text",    "shared": true, "default": ""}
       ],
       "geometry": {
@@ -38,9 +38,9 @@
       "symbolSize": 4.0,
       "parameters": [
         {"name": "CIRCUIT_REF",  "type": "Text",    "shared": true, "default": ""},
-        {"name": "RATING_A",     "type": "Text",    "shared": true, "default": ""},
-        {"name": "BREAKING_KA",  "type": "Text",    "shared": true, "default": ""},
-        {"name": "POLES",        "type": "Integer", "shared": true, "default": 3},
+        {"name": "RATING_A",     "type": "Text",    "shared": true, "default": "", "instance": false},
+        {"name": "BREAKING_KA",  "type": "Text",    "shared": true, "default": "", "instance": false},
+        {"name": "POLES",        "type": "Integer", "shared": true, "default": 3, "instance": false},
         {"name": "LABEL",        "type": "Text",    "shared": true, "default": ""}
       ],
       "geometry": {
@@ -70,9 +70,9 @@
       "symbolSize": 5.0,
       "parameters": [
         {"name": "CIRCUIT_REF",  "type": "Text",    "shared": true, "default": ""},
-        {"name": "RATING_A",     "type": "Text",    "shared": true, "default": ""},
-        {"name": "BREAKING_KA",  "type": "Text",    "shared": true, "default": ""},
-        {"name": "POLES",        "type": "Integer", "shared": true, "default": 3},
+        {"name": "RATING_A",     "type": "Text",    "shared": true, "default": "", "instance": false},
+        {"name": "BREAKING_KA",  "type": "Text",    "shared": true, "default": "", "instance": false},
+        {"name": "POLES",        "type": "Integer", "shared": true, "default": 3, "instance": false},
         {"name": "LABEL",        "type": "Text",    "shared": true, "default": ""}
       ],
       "geometry": {
@@ -103,8 +103,8 @@
       "symbolSize": 3.0,
       "parameters": [
         {"name": "CIRCUIT_REF", "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A",    "type": "Text", "shared": true, "default": ""},
-        {"name": "FUSE_TYPE",   "type": "Text", "shared": true, "default": ""},
+        {"name": "RATING_A",    "type": "Text", "shared": true, "default": "", "instance": false},
+        {"name": "FUSE_TYPE",   "type": "Text", "shared": true, "default": "", "instance": false},
         {"name": "LABEL",       "type": "Text", "shared": true, "default": ""}
       ],
       "geometry": {
@@ -130,7 +130,7 @@
       "symbolSize": 3.5,
       "parameters": [
         {"name": "CIRCUIT_REF", "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A",    "type": "Text", "shared": true, "default": ""},
+        {"name": "RATING_A",    "type": "Text", "shared": true, "default": "", "instance": false},
         {"name": "LABEL",       "type": "Text", "shared": true, "default": ""}
       ],
       "geometry": {
@@ -160,8 +160,8 @@
       "symbolSize": 3.0,
       "parameters": [
         {"name": "CIRCUIT_REF", "type": "Text",    "shared": true, "default": ""},
-        {"name": "RATING_A",    "type": "Text",    "shared": true, "default": ""},
-        {"name": "POLES",       "type": "Integer", "shared": true, "default": 3},
+        {"name": "RATING_A",    "type": "Text",    "shared": true, "default": "", "instance": false},
+        {"name": "POLES",       "type": "Integer", "shared": true, "default": 3, "instance": false},
         {"name": "LABEL",       "type": "Text",    "shared": true, "default": ""}
       ],
       "geometry": {
@@ -184,9 +184,9 @@
       "symbolSize": 3.0,
       "parameters": [
         {"name": "CIRCUIT_REF",  "type": "Text",    "shared": true, "default": ""},
-        {"name": "RATING_A",     "type": "Text",    "shared": true, "default": ""},
+        {"name": "RATING_A",     "type": "Text",    "shared": true, "default": "", "instance": false},
         {"name": "SENSITIVITY_MA","type": "Text",    "shared": true, "default": "30"},
-        {"name": "POLES",        "type": "Integer", "shared": true, "default": 2},
+        {"name": "POLES",        "type": "Integer", "shared": true, "default": 2, "instance": false},
         {"name": "LABEL",        "type": "Text",    "shared": true, "default": ""}
       ],
       "geometry": {
@@ -214,7 +214,7 @@
       "symbolSize": 3.0,
       "parameters": [
         {"name": "CIRCUIT_REF", "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A",    "type": "Text", "shared": true, "default": ""},
+        {"name": "RATING_A",    "type": "Text", "shared": true, "default": "", "instance": false},
         {"name": "LABEL",       "type": "Text", "shared": true, "default": ""}
       ],
       "geometry": {
@@ -242,7 +242,7 @@
       "symbolSize": 5.0,
       "parameters": [
         {"name": "LABEL",    "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A", "type": "Text", "shared": true, "default": ""},
+        {"name": "RATING_A", "type": "Text", "shared": true, "default": "", "instance": false},
         {"name": "VOLTAGE_PRI", "type": "Text", "shared": true, "default": ""},
         {"name": "VOLTAGE_SEC", "type": "Text", "shared": true, "default": ""}
       ],
@@ -269,8 +269,8 @@
       "symbolSize": 4.0,
       "parameters": [
         {"name": "LABEL",    "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A", "type": "Text", "shared": true, "default": ""},
-        {"name": "LOAD_KW",  "type": "Text", "shared": true, "default": ""}
+        {"name": "RATING_A", "type": "Text", "shared": true, "default": "", "instance": false},
+        {"name": "LOAD_KW",  "type": "Text", "shared": true, "default": "", "instance": false}
       ],
       "geometry": {
         "lines": [
@@ -296,8 +296,8 @@
       "symbolSize": 4.0,
       "parameters": [
         {"name": "LABEL",    "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A", "type": "Text", "shared": true, "default": ""},
-        {"name": "LOAD_KW",  "type": "Text", "shared": true, "default": ""}
+        {"name": "RATING_A", "type": "Text", "shared": true, "default": "", "instance": false},
+        {"name": "LOAD_KW",  "type": "Text", "shared": true, "default": "", "instance": false}
       ],
       "geometry": {
         "lines": [
@@ -323,8 +323,8 @@
       "symbolSize": 4.0,
       "parameters": [
         {"name": "LABEL",       "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A",    "type": "Text", "shared": true, "default": ""},
-        {"name": "RUNTIME_MIN", "type": "Text", "shared": true, "default": ""}
+        {"name": "RATING_A",    "type": "Text", "shared": true, "default": "", "instance": false},
+        {"name": "RUNTIME_MIN", "type": "Text", "shared": true, "default": "", "instance": false}
       ],
       "geometry": {
         "lines": [
@@ -352,7 +352,7 @@
       "symbolSize": 4.0,
       "parameters": [
         {"name": "LABEL",    "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A", "type": "Text", "shared": true, "default": ""}
+        {"name": "RATING_A", "type": "Text", "shared": true, "default": "", "instance": false}
       ],
       "geometry": {
         "lines": [
@@ -383,7 +383,7 @@
       "symbolSize": 3.0,
       "parameters": [
         {"name": "LABEL",      "type": "Text", "shared": true, "default": ""},
-        {"name": "RATING_A",   "type": "Text", "shared": true, "default": ""}
+        {"name": "RATING_A",   "type": "Text", "shared": true, "default": "", "instance": false}
       ],
       "geometry": {
         "lines": [


### PR DESCRIPTION
## Summary

Extends the symbol library creation pipeline to support shared parameters and default values in family parameters. Updates all symbol definition JSON files to mark non-instance parameters with `"instance": false`, and adds logic to bind parameters to the shared parameter file when requested.

## Key Changes

### Symbol Definition JSON Files
- **STING_SLD_SYMBOLS.json**: Added `"instance": false` to 30+ rating/poles/breaking capacity parameters across circuit breaker, fuse, and protection device symbols
- **STING_ELEC_SYMBOLS.json**: Added `"instance": false` to 15+ parameters; added `"default"` values for RATING_A, FUSE_RATING, POWER_KW, MODE_TYPE, WAYS, INCOMER_A, RESOLUTION, IP_RATING, POWER_W, and medical gas outlet parameters
- **STING_LIGHTING_SYMBOLS.json**: Added `"instance": false` to 20+ lamp/wattage/lumen parameters; added `"default"` values for LENGTH_MM, WATTAGE, BATTERY_RUNTIME_MIN, EMERGENCY
- **STING_MEP_SYMBOLS.json**: Added `"instance": false` to 15+ flow/size/slot parameters; added `"default"` values for NECK_SIZE_MM, NECK_DIA_MM, FIRE_RATING, SLOT_COUNT
- **STING_SLD_SYMBOLS_IEEE.json**: Added `"instance": false` to 25+ rating/poles/breaking capacity parameters
- **STING_FP_SYMBOLS.json**: Added `"instance": false` to 10+ K_FACTOR/TEMP parameters; added `"default"` values
- **STING_PIPE_ACCESSORIES.json**: Added `"instance": false` to SIZE_MM and RATING parameters; added `"default"` values
- **STING_PLUMBING_SYMBOLS.json**: Added `"instance": false` to fixture size parameters; added `"default"` values

### SymbolLibraryCreator.cs
- **AddParameters method signature**: Now accepts `Application` parameter to enable shared parameter file access
- **Seed type creation**: Creates a default family type when any parameter has a default value (required for `FamilyManager.Set` to work)
- **Shared parameter resolution**: Lazy-loads the shared parameter file once per family; searches all definition groups for matching external definitions (case-insensitive)
- **Fallback mechanism**: If shared parameter file is unavailable or parameter not found, falls back to binding as a regular family parameter
- **Default value assignment**: New `TrySetDefault` method handles type-safe conversion for String, Integer, Double, and ElementId storage types; uses invariant culture for numeric parsing
- **Error handling**: All operations wrapped in try-catch with warnings logged to `SymbolCreationResult.Warnings`

## Implementation Details

- The `"instance": false` flag is now consistently applied to all specification/rating parameters that should be type-level (shared across all instances) rather than instance-level
- Default values are only set if a seed type exists; the method gracefully handles families with no types
- Shared parameter file is opened via `Application.OpenSharedParameterFile()` and cached for the duration of the family creation
- External definitions are searched by name with case-insensitive comparison to match Revit's parameter naming conventions
- Numeric defaults use `System.Globalization.CultureInfo.InvariantCulture` to ensure consistent parsing regardless of system locale

https://claude.ai/code/session_01BpX21AtW2bHxtTGf8oNKrX