### PR TITLE
Phase 185: Family library readiness & footprint-aware placement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,94 @@ cleanly; eleven required `ours` conflict resolution. After consolidation
 `git branch -r --no-merged HEAD` reports zero remote branches with
 unique commits not in HEAD. Verify in Revit before merging to `main`.
 
+### Phase 185 — Family library readiness (placeholder review)
+
+The family authoring surface received a four-part hardening pass on
+branch `claude/family-authoring-review-1ZmAG` after a review that
+clarified a common misconception:
+
+**The placeholders are not 3D — they are 2D symbolic curves.** When a
+real 3D family is missing, `FixturePlacementEngine.ResolveSymbol`
+returns null and the placement is **silently skipped** (`SkippedNoSymbol++`).
+No synthetic 3D placeholder geometry is created. The "draft" 164
+ISO 6412 symbol set is intentionally schematic — see the
+authoring-rule note at the top of
+`StingTools/Data/Symbols/STING_ISO6412_SYMBOLS.json`.
+
+The four changes:
+
+1. **`Families/README.md`** — new root README laying out the two
+   authoring tracks (Track A: 3D model families with real product
+   geometry; Track B: 2D schematic symbols), the family resolution
+   tier order, and the vendor-intake SOP (Conformance check → stamp
+   with `FamilyParamCreator` `PurgeMode.None` → drop in the right
+   folder → tune the placement rule). Codifies the priority
+   acquisition list (MGS → luminaires → AHU/FCU → panel boards →
+   bedhead trunks → fire devices).
+2. **Footprint-aware placement spacing**
+   (`Core/Placement/PlacementRule.cs` + `FixturePlacementEngine.cs`).
+   New fields: `FamilyBboxAware`, `ReferenceFootprintMm` (default
+   150 mm), `MinSymbolFootprintMm` (100 mm floor), `MaxFootprintScale`
+   (8× cap). When enabled, the engine pre-resolves the family symbol,
+   measures `BoundingBoxXYZ.Max - Min` in plan, and scales
+   `MinSpacingMm` / `CoverageRadiusMm` / `ObstructionClearanceMm` /
+   `WallClearanceMm` / `OffsetXMm` / `OffsetYMm` by
+   `clamp(max(footprintMm, floor) / reference, 1.0, cap)`. One rule
+   now serves 150 mm switches and 1200 mm AHUs without per-vendor
+   JSON edits. `OffsetZMm` is intentionally not scaled — mounting
+   height comes from `MountingHeightMm` and `MountingReference`.
+   Default `false` ⇒ legacy behaviour preserved.
+3. **Type-catalog (`.txt` sidecar) loader**. New
+   `PlacementRule.TypeCatalogKey` field. When set and a `.txt`
+   sidecar exists next to the `.rfa`, the engine routes through
+   `Document.LoadFamilySymbol(path, typeName)` instead of bulk
+   `LoadFamily` — only the matching type is loaded. Avoids bloating
+   the project with 200-type valve / fitting libraries. Catalog
+   format follows the Revit standard (first column = type name; rows
+   starting with `,` treated as headers). Key may be an exact type
+   name or a regex (`^DN20-PN1[06]$`). Empty key (default) ⇒ legacy
+   bulk-load behaviour.
+4. **Family Conformance Checker** —
+   `StingTools/Tags/FamilyConformanceCheckCommand.cs` +
+   `FamilyConformanceInspector`. New read-only command tag
+   `FamilyConformanceCheck` (Dock-panel button next to "Tag Family
+   Params"). Audits a user-picked folder of `.rfa` files against the
+   STING contract: 4 placement params bound by GUID + tag style
+   matrix (when tag-like) + tag visibility tiers + Ring 1/2 position
+   types + placement type vs category sanity + loads-cleanly bonus.
+   100-point scale ⇒ PASS ≥85 / WARN 70-84 / BLOCK <70. CSV report
+   to `<project>/_BIM_COORD/` + summary TaskDialog with the 10
+   lowest-scoring families. **Run this BEFORE bulk-stamping any
+   vendor library** — catches the "manufacturer family uses
+   'Mounting Height' instead of `MNT_HGT_MM`" class of failure
+   before it costs a transaction.
+
+The 46 fabrication / LPS / pricing constants in `AssyParams /
+LpsParams / CostParams` are NOT touched — Phase 169 already replaced
+the `v4-YYYY-xxxx` placeholders with deterministic UUIDv5 hashes
+under namespace `7f9f5e3a-a7c0-b2e4-4d91-4a557c5e3a00`, so the
+"freeze GUIDs first" step from the review is already done.
+
+#### Caveats (Phase 185)
+
+1. Built without `dotnet build` verification (Linux sandbox). Every
+   Revit API call uses the documented signature (`Document.LoadFamilySymbol`,
+   `FamilySymbol.get_BoundingBox`, `FamilyParameter.IsShared`,
+   `FamilyManager.Types`) but has not been compile-checked. Verify in
+   Revit before merge.
+2. The Conformance Checker uses `OpenDocumentFile` to open each `.rfa`
+   read-only — slow on large libraries (1-2 s per file). For a 500-family
+   vendor drop, expect ~15 minutes. The CSV is the artefact; the
+   TaskDialog is a 10-row summary.
+3. Footprint scaling reads the symbol's bounding box, which for some
+   hosted families returns a degenerate box (Min == Max) until a real
+   instance exists. The `MinSymbolFootprintMm = 100 mm` floor + the
+   `scale < 1.0 → 1.0` clamp protect against silently zero'd spacings.
+4. Type-catalog loading requires the `.txt` sidecar to follow Revit's
+   exact format. Malformed catalogs cause the engine to fall through
+   to bulk `LoadFamily` (the legacy path) with a warning — never
+   abort.
+
 ## Documentation Map
 
 This repository's AI-assistant documentation is split across three files to keep each one small and easy to update:

--- a/Families/README.md
+++ b/Families/README.md
@@ -1,0 +1,258 @@
+# Families — Drop Zone for STING-Compatible Revit Family Libraries
+
+This directory is the on-disk family library that the placement, symbol,
+fabrication and tag engines search at runtime. Drop your `.rfa` files
+into the right subdirectory and they get picked up automatically — no
+code change needed.
+
+---
+
+## CRITICAL: Two tracks, do not confuse them
+
+STING uses families for two structurally different jobs. The rules for
+authoring and replacement are not the same. If you put a 3D model
+family where a symbol belongs, or vice versa, the placement pipeline
+breaks silently.
+
+### Track A — 3D model families (real product geometry)
+
+**What:** luminaires, AHUs, FCUs, valves, panels, MGS terminal units,
+beds, scrub sinks, doors, windows, sanitary ware, fire devices, any
+piece of equipment that occupies real space in the model.
+
+**Where:** `Families/MEP/`, `Families/MedGas/`, `Families/Healthcare/`,
+plus discipline subfolders authors create as needed.
+
+**Template:** Revit category-appropriate **3D family template**
+(`Metric Lighting Fixture.rft`, `Metric Generic Model.rft`, etc.). Must
+be a 3D Generic Model or category-specific 3D family — **NOT** a
+Generic Annotation.
+
+**Sizing:** carry **real product dimensions**. A 1200 mm AHU should be
+1200 mm in the family. The placement engine will read the bounding box
+at placement time when `FamilyBboxAware: true` is set on the rule.
+
+**Status today:** these are **what you should replace placeholders
+with**. There are currently **zero** shipped `.rfa` files for 3D
+equipment in this repo — placement rules exist in
+`Data/Placement/STING_PLACEMENT_RULES.*.json` but silently skip
+elements when the real family is missing. See **§ Priority acquisition
+list** below.
+
+### Track B — 2D symbol families (schematic representation)
+
+**What:** ISO 6412 spool symbols, MEP single-line symbols, electrical
+SLD symbols, fire-protection symbols, plumbing symbols.
+
+**Where:** `Families/ISO6412/`, `Families/SLD/`, `Families/Seeds/`,
+`Families/Annotation/`.
+
+**Template:** **Generic Annotation** (`.rft`) — 2D only. A 3D Generic
+Model here will be rejected by `IsoSymbolPlacer.cs:823-842` with a
+warning, and placement will fall back to the auto-generated draft
+symbol.
+
+**Sizing:** symbols are **schematic** by design. ISO 6412 symbols
+target 6 mm paper height regardless of the real product size. **Do not
+replace symbol families with photoreal product geometry** — it will
+break spool sheets, single-line diagrams and detail views, all of
+which rely on consistent paper-space symbol sizing.
+
+**Status today:** 164 ISO 6412 symbols are auto-generated draft
+families (line-work approximations). Replacing them with hand-drafted
+standard-accurate seed families is a quality upgrade, not a structural
+change. See `Families/ISO6412/README.md` for the seed authoring spec.
+
+---
+
+## How families are resolved at runtime
+
+Tier order (`MepSymbolEngine.cs:663-698`,
+`FixturePlacementEngine.cs:812-920`):
+
+1. **Tier 0 — already loaded.** Family already in the project document.
+2. **Tier 1 — seed families on disk.** Files in `Families/<subdir>/`
+   matching the expected name. These beat everything else.
+3. **Tier 2 — auto-generated drafts.** Symbols produced by
+   `SymbolLibraryCreator` in `<project>/_BIM_COORD/Families/Symbols/`.
+   Only used when Tier 1 missing.
+4. **Tier 3 — category match.** Any loaded family whose
+   `Category.Name` matches the rule's `CategoryFilter`. Last-ditch
+   fallback.
+5. **No 3D placeholder fallback.** If all four tiers miss, placement
+   is **silently skipped** with a warning in `PlacementResult.Warnings`.
+   The engine does **not** synthesise a generic box. The only
+   exception is `PlaceHangersCommand`, which falls back to 2D
+   DetailCurve crosshair previews when no Generic Model hanger family
+   exists.
+
+---
+
+## Vendor / manufacturer family intake — Standard Operating Procedure
+
+When importing a manufacturer's `.rfa` library (Beaconmedaes, GCE,
+Pattons, Victaulic, Megasan, Wandsworth, Static Systems,
+manufacturer-supplied REL/REL Revit Add-ins, etc.):
+
+### Step 1 — Sanity check before stamping
+
+Run the **Tag `FamilyConformanceCheck`** dock-panel button (Tags →
+QA → Conformance Check) against each `.rfa`. The checker is
+read-only — it reports:
+
+- Is the family template appropriate for its category? (3D vs
+  annotation)
+- Are the STING shared parameters bound by **GUID**, not just name?
+- Does the family expose `MNT_HGT_MM`, `ASS_PLACE_ANCHOR_TXT`,
+  `ASS_PLACE_OFFSET_X_MM`, `ASS_PLACE_SIDE_TXT`?
+- For tag families: are the 128 `TAG_{size}{style}_{colour}_BOOL`
+  visibility parameters present?
+- Score: 0–100. **Treat <70 as a blocker.**
+
+Catches the most common failure mode: manufacturer family uses
+`Mounting Height` (typed parameter) instead of `MNT_HGT_MM` (STING
+shared parameter), so the placement engine silently fails to write
+the mounting height.
+
+### Step 2 — Stamp the family (additive)
+
+Run `FamilyParamCreator` (Tags → Setup → Family Param Creator) with:
+
+| Option | Value | Rationale |
+|---|---|---|
+| `PurgeMode` | `None` | Keep the manufacturer's own parameters; only add what's missing. |
+| `InjectFormulas` | `true` | Add the 16-branch TAG_POS nested-if formula chain. |
+| `InjectTagPos` | `true` | Add the `STING_TAG_POS` integer parameter. |
+| `CreatePositionTypes` | `true` | Mint Ring 1 / Ring 2 position types so tag placement works. |
+| `LoadAfterSave` | `true` | Reload the stamped family into the active project. |
+| `LoadOverwriteParameterValues` | `false` | Don't clobber existing values on the in-project copy. |
+
+The flow is **idempotent** — running it twice does not duplicate
+parameters. It only adds what's missing.
+
+### Step 3 — Drop into the right subdirectory
+
+| Family kind | Target folder |
+|---|---|
+| 3D MEP equipment | `Families/MEP/` |
+| 3D Medical gas equipment | `Families/MedGas/` |
+| 3D Healthcare clinical equipment | `Families/Healthcare/` (create if absent) |
+| 3D Fire protection devices | `Families/FP/` (create if absent) |
+| 2D ISO 6412 symbols | `Families/ISO6412/` (see folder README) |
+| 2D SLD symbols | `Families/SLD/` |
+| 2D Annotation seeds | `Families/Annotation/` or `Families/Seeds/` |
+| Title-block (sheet) | `Families/AssemblyTitleBlocks/` |
+
+### Step 4 — Tune the placement rule (if 3D)
+
+If the family has a footprint significantly different from the
+~150 mm default the legacy rules were tuned for (e.g. AHU at 1200 mm),
+either:
+
+- **Manually adjust** the rule's `MinSpacingMm` / `OffsetXMm` /
+  `CoverageRadiusMm` in `Data/Placement/STING_PLACEMENT_RULES.*.json`,
+  or
+- **Enable `FamilyBboxAware: true`** on the rule. The engine then reads
+  the resolved `FamilySymbol`'s bounding box and scales the
+  ~150 mm-tuned spacings proportionally to
+  `ReferenceFootprintMm` (default 150). This keeps one rule usable
+  across multiple manufacturers without per-vendor JSON edits.
+
+### Step 5 — Type catalog for libraries with > 20 sizes
+
+If the manufacturer family ships 50+ types (valves, fittings, wire
+sizes), pair it with a **`.txt` type catalog sidecar** next to the
+`.rfa`. The placement engine will load-on-demand from the catalog
+when the rule specifies a `TypeCatalogKey`, avoiding the bloat of
+loading 200 types into the project. See § Type catalogs below.
+
+---
+
+## Type catalogs (`.txt` next to `.rfa`)
+
+Revit natively supports `.txt` type catalogs that let one `.rfa`
+expose hundreds of types without all loading. STING's placement
+engine reads these via the optional `TypeCatalogKey` field on
+`PlacementRule`.
+
+### Filename convention
+
+`YourFamily.rfa` is paired with `YourFamily.txt` in the same folder.
+Revit looks for the `.txt` automatically on `Document.LoadFamily`.
+
+### Catalog format (Revit standard)
+
+First row: parameter headers. Subsequent rows: one per type.
+
+```
+,Nominal_Diameter_mm##length##millimetres,Pressure_Rating_bar##other##
+DN15-PN16,15,16
+DN20-PN16,20,16
+DN25-PN16,25,16
+...
+```
+
+### How STING picks one
+
+A placement rule sets `TypeCatalogKey` to one of the type-name strings
+(or a regex like `^DN20-PN1[06]$`). At resolve time the engine loads
+only the matching type rather than the whole catalog. If multiple
+match, the first one wins (rule's `FamilyTypeRegex` further refines).
+
+If a rule has no `TypeCatalogKey`, the engine ignores the catalog and
+behaves as before (loads all types — the legacy path).
+
+---
+
+## Priority acquisition list
+
+These categories have placement rules that silently fail today
+because no shipped family exists. Acquire in this order:
+
+1. **MGS terminal units / manifolds** — `Families/MedGas/` (per
+   `Families/MedGas/README.md`). Vendor: Beaconmedaes / GCE / Pattons.
+2. **Luminaires** — `Families/MEP/Lighting/`. Vendor: Erco / Zumtobel
+   / Fagerhult / regional equivalents.
+3. **AHU / FCU** — `Families/MEP/HVAC/`. Vendor: Carrier / Daikin /
+   Trane / regional equivalents.
+4. **Distribution panel boards** — `Families/MEP/Electrical/`.
+   Vendor: Schneider / ABB / Eaton / Siemens.
+5. **Bedhead trunking + medical service panels** —
+   `Families/Healthcare/`. Vendor: Wandsworth / Static Systems.
+6. **Fire detection devices** — `Families/FP/`. Vendor: Apollo /
+   Hochiki / Notifier.
+
+For each, follow the vendor-intake SOP above.
+
+---
+
+## Where the engine code lives
+
+| Concern | File |
+|---|---|
+| Placement rule schema | `StingTools/Core/Placement/PlacementRule.cs` |
+| Family resolution + auto-load | `StingTools/Core/Placement/FixturePlacementEngine.cs:812-984` |
+| Family bbox-aware scaling | `StingTools/Core/Placement/PlacementRule.cs` (`FamilyBboxAware`, `ReferenceFootprintMm`) + engine helper `ScaleByFootprint(rule, symbol)` |
+| Type catalog support | `StingTools/Core/Placement/FixturePlacementEngine.cs` (`TryLoadFromCatalog`) |
+| Symbol resolver (Tier 1→3) | `StingTools/Core/Symbols/MepSymbolEngine.cs:663-698` |
+| Symbol auto-generator (drafts) | `StingTools/Core/Symbols/SymbolLibraryCreator.cs` |
+| Family-mutation engine | `StingTools/Tags/FamilyParamCreatorCommand.cs` |
+| Conformance checker | `StingTools/Tags/FamilyConformanceCheckCommand.cs` |
+| Tag family creator | `StingTools/Tags/TagFamilyCreatorCommand.cs` |
+| Hanger resolver (Tier 1→3 + 2D crosshair fallback) | `StingTools/Core/Calc/HangerFamilyResolver.cs` |
+
+---
+
+## Caveats
+
+1. The 7 title-block families in `Families/AssemblyTitleBlocks/` are
+   shipped as parameter-spec stubs only. `ShopDrawingComposer.ResolveTitleBlock`
+   falls back to the first available title block in the project with
+   a warning. Fab sheets produced today have generic (not
+   discipline-specific) layout until real `.rfa`s are dropped in.
+2. The 164 ISO 6412 symbol families are auto-generated drafts. Their
+   line work is approximate; replacing them with hand-drafted ISO-
+   compliant seeds is a quality upgrade. **Do not** replace them with
+   3D product geometry — symbols are intentionally schematic.
+3. None of these changes have been verified in Revit on this branch
+   (Linux sandbox). Verify in Revit before merging to `main`.

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -522,35 +522,51 @@ namespace StingTools.Core.Placement
             // Phase 139.27 — per-rule diagnostic entry for this room+rule pair.
             var diagRoom = result.Diag(rule.MergeKey);
 
+            // Phase 185 (footprint-aware spacing): when the rule opts in via
+            // FamilyBboxAware, resolve the family symbol BEFORE scoring and
+            // rebuild the rule with spacing fields scaled to the family's
+            // real footprint. Lets one rule serve 150 mm switches and
+            // 1200 mm AHUs without per-vendor JSON edits. No-op when the
+            // flag is false (legacy behaviour preserved).
+            PlacementRule effRule = rule;
+            if (rule.FamilyBboxAware && !dryRun)
+            {
+                var preSym = ResolveSymbol(doc, rule.CategoryFilter, rule, perCategorySymbol, result);
+                if (preSym != null)
+                {
+                    effRule = ScaleByFootprint(rule, preSym, result);
+                }
+            }
+
             var placedPoints = new List<XYZ>(); // for spacing scoring
 
             // PC-13 — RELATIVE_TO / EQUIPMENT_PAIR: short-circuit by stamping the
             // predecessor's last point as the only candidate.
-            string anchor = (rule.AnchorType ?? "").ToUpperInvariant();
+            string anchor = (effRule.AnchorType ?? "").ToUpperInvariant();
             List<PlacementCandidate> candidates;
             if ((anchor == "RELATIVE_TO" || anchor == "EQUIPMENT_PAIR")
-                && !string.IsNullOrEmpty(rule.DependsOn)
-                && state.LastPointByRule.TryGetValue(rule.DependsOn, out var prev))
+                && !string.IsNullOrEmpty(effRule.DependsOn)
+                && state.LastPointByRule.TryGetValue(effRule.DependsOn, out var prev))
             {
-                XYZ pt = new XYZ(prev.X + rule.OffsetXMm / 304.8,
-                                 prev.Y + rule.OffsetYMm / 304.8,
-                                 prev.Z + rule.OffsetZMm / 304.8);
+                XYZ pt = new XYZ(prev.X + effRule.OffsetXMm / 304.8,
+                                 prev.Y + effRule.OffsetYMm / 304.8,
+                                 prev.Z + effRule.OffsetZMm / 304.8);
                 candidates = new List<PlacementCandidate>
                 {
-                    new PlacementCandidate { Position = pt, RoomId = room.Id, Rule = rule, Score = 1.0 }
+                    new PlacementCandidate { Position = pt, RoomId = room.Id, Rule = effRule, Score = 1.0 }
                 };
                 result.CandidatesEvaluated += 1;
             }
             else
             {
-                candidates = scorer.Score(room, rule, placedPoints, alreadyInRoom);
+                candidates = scorer.Score(room, effRule, placedPoints, alreadyInRoom);
                 result.CandidatesEvaluated += candidates.Count;
             }
             if (candidates.Count == 0) return;
 
             // PC-12 — derive the count for Density / Linear rules from the room's
             // area, occupancy or perimeter, capped by MaxPerRoom when set.
-            int cap = ComputeCap(rule, room, candidates.Count, alreadyInRoom);
+            int cap = ComputeCap(effRule, room, candidates.Count, alreadyInRoom);
             if (cap == 0) return;
 
             var chosen = candidates.Take(cap).ToList();
@@ -575,7 +591,7 @@ namespace StingTools.Core.Placement
                 return;
             }
 
-            FamilySymbol symbol = ResolveSymbol(doc, rule.CategoryFilter, rule, perCategorySymbol, result);
+            FamilySymbol symbol = ResolveSymbol(doc, effRule.CategoryFilter, effRule, perCategorySymbol, result);
             if (symbol == null) return;
 
             if (!symbol.IsActive)
@@ -603,7 +619,7 @@ namespace StingTools.Core.Placement
                         if (lst != null) existingNearby.AddRange(lst);
             }
             catch (Exception ex) { StingLog.Warn($"[FixturePlacementEngine] Collect existing PlacedByRule for dedup: {ex.Message}"); }
-            double dedupFt = Math.Max(rule.ToleranceMm, 25.0) * MmToFt;
+            double dedupFt = Math.Max(effRule.ToleranceMm, 25.0) * MmToFt;
             double dedupSq = dedupFt * dedupFt;
 
             foreach (var c in chosen)
@@ -632,7 +648,7 @@ namespace StingTools.Core.Placement
                     // when the placement type isn't supported, instead of
                     // silently creating a host-less ghost instance that
                     // schedules later miss in QTO / COBie.
-                    var pf = PlacementHostPreflight.Place(doc, symbol, room, c.Position, rule);
+                    var pf = PlacementHostPreflight.Place(doc, symbol, room, c.Position, effRule);
                     FamilyInstance fi = pf.Placed;
                     if (pf.Skipped || fi == null)
                     {
@@ -642,7 +658,7 @@ namespace StingTools.Core.Placement
                         continue;
                     }
 
-                    WriteAnchorParameters(fi, rule);
+                    WriteAnchorParameters(fi, effRule);
                     // Pack 123 / Gap E — stamp provenance so BOQ / cleanup /
                     // audit can identify auto-created fixtures. Centre's
                     // "Stamp provenance" checkbox flips PlaceFixturesOptions.
@@ -674,7 +690,7 @@ namespace StingTools.Core.Placement
                     }
 
                     // PC-17 — optional post-placement hook: data-tag pipeline + COBie seed.
-                    try { PostPlacementHooks.RunFor(fi, rule); }
+                    try { PostPlacementHooks.RunFor(fi, effRule); }
                     catch (Exception hkEx) { result.Warnings.Add($"PC-17 post-place hook for {fi.Id}: {hkEx.Message}"); }
                 }
                 catch (Exception ex2)
@@ -903,10 +919,12 @@ namespace StingTools.Core.Placement
 
             // PC-16 — auto-load missing families from the on-disk library so a
             // project that doesn't yet contain a sample of the rule's category
-            // can still be served by the engine.
+            // can still be served by the engine. Phase 185: when the rule
+            // sets TypeCatalogKey, the loader only mints the matching type
+            // (avoids loading 200-type fitting libraries).
             if (picked == null && firstForCategory == null)
             {
-                picked = TryAutoLoadFromLibrary(doc, categoryName, hint, result);
+                picked = TryAutoLoadFromLibrary(doc, categoryName, hint, result, rule?.TypeCatalogKey ?? "");
                 firstForCategory = picked;
             }
 
@@ -927,7 +945,8 @@ namespace StingTools.Core.Placement
         /// document and returns its first symbol. Caller already owns a
         /// Transaction (the engine's "STING v4 Place Fixtures" tx).
         /// </summary>
-        private static FamilySymbol TryAutoLoadFromLibrary(Document doc, string categoryName, string hint, PlacementResult result)
+        private static FamilySymbol TryAutoLoadFromLibrary(
+            Document doc, string categoryName, string hint, PlacementResult result, string typeCatalogKey = "")
         {
             try
             {
@@ -955,6 +974,16 @@ namespace StingTools.Core.Placement
                 {
                     try
                     {
+                        // Phase 185 — if the rule specifies a type-catalog key
+                        // AND a .txt sidecar exists, try the catalog path first
+                        // so only the matching type loads (avoids 200-type bloat).
+                        if (!string.IsNullOrEmpty(typeCatalogKey))
+                        {
+                            var catSym = TryLoadFromCatalog(doc, path, typeCatalogKey, categoryName, result);
+                            if (catSym != null) return catSym;
+                            // fall through to bulk LoadFamily — catalog miss is non-fatal
+                        }
+
                         Family loaded;
                         if (!doc.LoadFamily(path, out loaded) || loaded == null) continue;
                         FamilySymbol first = null;
@@ -980,6 +1009,194 @@ namespace StingTools.Core.Placement
                 }
             }
             catch (Exception ex) { StingLog.Warn($"PC-16 TryAutoLoadFromLibrary: {ex.Message}"); }
+            return null;
+        }
+
+        /// <summary>
+        /// Phase 185 — footprint-aware spacing. When a rule sets
+        /// <see cref="PlacementRule.FamilyBboxAware"/>, read the resolved
+        /// symbol's bounding-box footprint (max of X / Y extent in mm)
+        /// and rebuild the rule with spacing fields scaled to it.
+        /// scale = clamp( max(footprintMm, MinSymbolFootprintMm) /
+        ///                 ReferenceFootprintMm,
+        ///                1.0, MaxFootprintScale ).
+        /// Lower bound is 1.0 — bbox-aware never *shrinks* spacings below
+        /// the rule's authored value, only grows them when the real
+        /// family is bigger than the reference.
+        /// </summary>
+        private static PlacementRule ScaleByFootprint(
+            PlacementRule rule,
+            FamilySymbol symbol,
+            PlacementResult result)
+        {
+            if (rule == null || symbol == null) return rule;
+            try
+            {
+                double footprintMm = MeasureSymbolFootprintMm(symbol);
+                double floorMm = Math.Max(1.0, rule.MinSymbolFootprintMm);
+                double refMm   = Math.Max(1.0, rule.ReferenceFootprintMm);
+                double cap     = Math.Max(1.0, rule.MaxFootprintScale);
+                double scale = Math.Max(footprintMm, floorMm) / refMm;
+                if (scale < 1.0) scale = 1.0;           // never shrink
+                if (scale > cap) scale = cap;           // never explode
+                if (Math.Abs(scale - 1.0) < 1e-6) return rule; // nothing to do
+
+                var scaled = rule.Clone();
+                scaled.MinSpacingMm           *= scale;
+                scaled.CoverageRadiusMm       *= scale;
+                scaled.ObstructionClearanceMm *= scale;
+                scaled.WallClearanceMm        *= scale;
+                // Offsets scale too — a 1200 mm AHU placed with a 50 mm
+                // wall offset is wrong; the offset should also be ~8× larger.
+                scaled.OffsetXMm *= scale;
+                scaled.OffsetYMm *= scale;
+                // OffsetZMm is intentionally NOT scaled — mounting height
+                // is set by MountingHeightMm and MountingReference, not
+                // by the family footprint.
+
+                result.Warnings.Add(
+                    $"Phase 185 footprint-aware: rule '{rule.RuleId}' / category " +
+                    $"'{rule.CategoryFilter}' scaled spacings ×{scale:F2} " +
+                    $"(footprint {footprintMm:F0} mm vs reference {refMm:F0} mm).");
+                return scaled;
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"Phase 185 footprint scale for '{rule?.RuleId}': {ex.Message}");
+                return rule;
+            }
+        }
+
+        /// <summary>
+        /// Max of the symbol's plan bounding-box extent (mm). Falls back to
+        /// the family's own bbox via Symbol-then-Family probing.
+        /// </summary>
+        private static double MeasureSymbolFootprintMm(FamilySymbol symbol)
+        {
+            try
+            {
+                BoundingBoxXYZ bb = symbol?.get_BoundingBox(null);
+                if (bb != null && bb.Max != null && bb.Min != null)
+                {
+                    double dx = Math.Abs(bb.Max.X - bb.Min.X);
+                    double dy = Math.Abs(bb.Max.Y - bb.Min.Y);
+                    double footFt = Math.Max(dx, dy);
+                    return footFt * 304.8; // ft → mm
+                }
+            }
+            catch { }
+            return 0.0;
+        }
+
+        /// <summary>
+        /// Phase 185 — type-catalog loader. When a rule sets
+        /// <see cref="PlacementRule.TypeCatalogKey"/> and a `.txt` sidecar
+        /// exists next to the `.rfa`, only the matching type is loaded —
+        /// avoids bloating the project with 200-type valve / fittings
+        /// libraries.
+        ///
+        /// Returns the loaded FamilySymbol, or null when:
+        /// - TypeCatalogKey is empty (caller falls through to bulk LoadFamily)
+        /// - No `.txt` sidecar exists (caller falls through to bulk LoadFamily)
+        /// - No catalog row matches (caller falls through, with a warning)
+        ///
+        /// Catalog format (Revit standard, comma-delimited):
+        ///   ,Param1##type##unit,Param2##type##unit
+        ///   Type-A,value1,value2
+        ///   Type-B,value3,value4
+        /// First column = type name. Header row identified by leading comma.
+        /// </summary>
+        private static FamilySymbol TryLoadFromCatalog(
+            Document doc,
+            string rfaPath,
+            string typeCatalogKey,
+            string categoryName,
+            PlacementResult result)
+        {
+            if (string.IsNullOrEmpty(typeCatalogKey)) return null;
+            if (string.IsNullOrEmpty(rfaPath)) return null;
+            string txtPath;
+            try
+            {
+                string dir  = Path.GetDirectoryName(rfaPath) ?? "";
+                string name = Path.GetFileNameWithoutExtension(rfaPath) ?? "";
+                txtPath = Path.Combine(dir, name + ".txt");
+            }
+            catch { return null; }
+            if (!File.Exists(txtPath)) return null;
+
+            // Resolve the type name to load.
+            string matchedType = ResolveCatalogType(txtPath, typeCatalogKey, result);
+            if (string.IsNullOrEmpty(matchedType))
+            {
+                result.Warnings.Add(
+                    $"Type catalog '{Path.GetFileName(txtPath)}': no type matches " +
+                    $"TypeCatalogKey='{typeCatalogKey}' — falling back to bulk LoadFamily.");
+                return null;
+            }
+
+            try
+            {
+                FamilySymbol loaded;
+                if (doc.LoadFamilySymbol(rfaPath, matchedType, out loaded) && loaded != null)
+                {
+                    if (loaded.Category != null &&
+                        !string.IsNullOrEmpty(categoryName) &&
+                        !string.Equals(loaded.Category.Name, categoryName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Warnings.Add(
+                            $"Type catalog load: '{matchedType}' from '{Path.GetFileName(rfaPath)}' " +
+                            $"resolved category '{loaded.Category.Name}', expected '{categoryName}'.");
+                    }
+                    result.Warnings.Add(
+                        $"Phase 185 type-catalog: loaded '{matchedType}' from " +
+                        $"'{Path.GetFileName(rfaPath)}' (key='{typeCatalogKey}').");
+                    return loaded;
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Phase 185 LoadFamilySymbol '{matchedType}' from '{rfaPath}': {ex.Message}");
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Read the type-catalog .txt and return the first type-name (first
+        /// column of a non-header row) whose name matches the key — either
+        /// exact case-insensitive, or via regex when the key looks regex-like.
+        /// </summary>
+        private static string ResolveCatalogType(string txtPath, string key, PlacementResult result)
+        {
+            try
+            {
+                bool regexMode = IsRegexLike(key);
+                System.Text.RegularExpressions.Regex rx = null;
+                if (regexMode)
+                {
+                    try { rx = new System.Text.RegularExpressions.Regex(key, System.Text.RegularExpressions.RegexOptions.IgnoreCase); }
+                    catch (Exception ex) { result?.Warnings.Add($"TypeCatalogKey regex '{key}': {ex.Message}"); return null; }
+                }
+                foreach (var raw in File.ReadAllLines(txtPath))
+                {
+                    if (string.IsNullOrEmpty(raw)) continue;
+                    // Header row starts with comma (no type name).
+                    if (raw.StartsWith(",")) continue;
+                    // First field = type name.
+                    int comma = raw.IndexOf(',');
+                    string typeName = (comma >= 0 ? raw.Substring(0, comma) : raw).Trim();
+                    if (string.IsNullOrEmpty(typeName)) continue;
+                    if (regexMode)
+                    {
+                        if (rx != null && rx.IsMatch(typeName)) return typeName;
+                    }
+                    else if (string.Equals(typeName, key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return typeName;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"ResolveCatalogType '{txtPath}': {ex.Message}"); }
             return null;
         }
 

--- a/StingTools/Core/Placement/PlacementRule.cs
+++ b/StingTools/Core/Placement/PlacementRule.cs
@@ -275,6 +275,55 @@ namespace StingTools.Core.Placement
         /// <summary>Manufacturer catalogue reference / part number.</summary>
         public string CatalogueRef { get; set; } = "";
 
+        // ── Footprint-aware spacing (real-size 3D families) ─────────
+
+        /// <summary>
+        /// When true, FixturePlacementEngine reads the resolved FamilySymbol's
+        /// bounding box at placement time and scales MinSpacingMm /
+        /// CoverageRadiusMm / OffsetXMm / ObstructionClearanceMm /
+        /// WallClearanceMm proportionally to <see cref="ReferenceFootprintMm"/>.
+        /// Lets one rule serve multiple manufacturers — a 1200 mm AHU lands
+        /// with appropriately scaled spacing without per-vendor JSON edits.
+        /// Defaults to false: legacy rules retain hard-coded values.
+        /// </summary>
+        public bool FamilyBboxAware { get; set; } = false;
+
+        /// <summary>
+        /// Reference footprint in millimetres against which the rule's
+        /// spacing fields were tuned. The engine computes
+        /// scale = max(symbolFootprintMm, MinSymbolFootprintMm) / ReferenceFootprintMm
+        /// and multiplies the spacing fields by scale. Default 150 mm matches
+        /// the small-fixture defaults the legacy rules were authored to.
+        /// </summary>
+        public double ReferenceFootprintMm { get; set; } = 150.0;
+
+        /// <summary>
+        /// Floor on the measured family footprint when FamilyBboxAware is set —
+        /// prevents pathological 0-bbox families from collapsing spacing to 0.
+        /// Default 100 mm.
+        /// </summary>
+        public double MinSymbolFootprintMm { get; set; } = 100.0;
+
+        /// <summary>
+        /// Cap on the bbox-derived scale factor. Default 8.0 — a 1200 mm
+        /// family against a 150 mm reference scales spacings 8× and stops.
+        /// Without a cap a 12 m AHU shell would scale spacings to 80 m and
+        /// silently break room-area coverage rules.
+        /// </summary>
+        public double MaxFootprintScale { get; set; } = 8.0;
+
+        // ── Type-catalog (.txt sidecar) ─────────────────────────────
+
+        /// <summary>
+        /// When set, the engine treats this rule's family as a Revit type
+        /// catalog (`YourFamily.txt` sidecar next to `YourFamily.rfa`).
+        /// The value is matched (case-insensitively, exact or regex) against
+        /// the type names in the catalog. Only the matching type is loaded —
+        /// avoids bloating the project with 200-type valve / fittings libraries.
+        /// Empty (default) ⇒ legacy behaviour: all types load.
+        /// </summary>
+        public string TypeCatalogKey { get; set; } = "";
+
         /// <summary>Nominal back-box or enclosure depth in millimetres.</summary>
         public double BoxDepthMm { get; set; } = 0.0;
 
@@ -542,6 +591,13 @@ namespace StingTools.Core.Placement
                 EmitSupports         = this.EmitSupports,
                 SourcePack           = this.SourcePack,
                 Material             = this.Material,
+                // Footprint-aware spacing
+                FamilyBboxAware      = this.FamilyBboxAware,
+                ReferenceFootprintMm = this.ReferenceFootprintMm,
+                MinSymbolFootprintMm = this.MinSymbolFootprintMm,
+                MaxFootprintScale    = this.MaxFootprintScale,
+                // Type catalog
+                TypeCatalogKey       = this.TypeCatalogKey,
             };
         }
 

--- a/StingTools/Data/Symbols/STING_ISO6412_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_ISO6412_SYMBOLS.json
@@ -2,6 +2,7 @@
   "version": "1.0",
   "standard": "ISO 6412 / BS 308 Part 3 \u2014 Piping, Duct, Conduit Spool Symbols",
   "description": "GenericAnnotation families for isometric spool drawings. symbolSize in mm. All geometry normalised -0.5..+0.5.",
+  "_authoring_rule": "TRACK B - SYMBOLIC, NOT PRODUCT GEOMETRY. Every entry below is a 2D schematic symbol drawn on a GenericAnnotation template, targeting ~6mm paper height regardless of the real product size. Do NOT replace these with photoreal 3D valve / fitting / pipe families - that breaks spool sheets, SLDs and detail views which all rely on consistent paper-space symbol sizing. Hand-drafted seeds drop into Families/ISO6412/ for line-work fidelity improvements. See Families/README.md for the full intake SOP.",
   "symbols": [
     {
       "id": "ISO6412_ELBOW_90_BW",

--- a/StingTools/Tags/FamilyConformanceCheckCommand.cs
+++ b/StingTools/Tags/FamilyConformanceCheckCommand.cs
@@ -1,0 +1,454 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+
+namespace StingTools.Tags
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  FAMILY CONFORMANCE CHECKER  (Phase 185)
+    //
+    //  Read-only audit of one or more .rfa files against the STING family
+    //  contract. Surfaces what's missing BEFORE you stamp a manufacturer
+    //  library and discover at placement time that nothing writes the
+    //  mounting height because the family uses 'Mounting Height' instead
+    //  of MNT_HGT_MM.
+    //
+    //  Score (0..100):
+    //      Family template appropriate for category          ( 15 pts )
+    //      4 STING placement params bound by GUID            ( 25 pts )
+    //      Tag style matrix present (when family is a tag)   ( 20 pts )
+    //      Tag visibility tiers present (when family is tag) ( 10 pts )
+    //      Position types Ring 1 / Ring 2 (when family is tag) ( 10 pts )
+    //      No obviously-wrong placement type vs category     ( 10 pts )
+    //      Loads cleanly into the target document            ( 10 pts )
+    //
+    //  Result is a CSV report at <outputDir>/FamilyConformanceReport_yyyyMMdd_HHmmss.csv
+    //  plus a TaskDialog summary listing the lowest-scoring families.
+    //
+    //  This command never mutates the source .rfa — every family is
+    //  opened standalone via app.OpenDocumentFile, scored, and closed
+    //  with saveModified=false. The active project document is never
+    //  touched; the command is [Transaction(ReadOnly)] for that reason.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// One row in the conformance report — one family, one score, one delta list.
+    /// </summary>
+    public class ConformanceReportRow
+    {
+        public string Path { get; set; } = "";
+        public string FamilyName { get; set; } = "";
+        public string Category { get; set; } = "";
+        public string FamilyTemplate { get; set; } = "";  // 3D / Annotation / Detail / Unknown
+        public int    Score { get; set; }
+        public string Verdict { get; set; } = "";          // PASS / WARN / BLOCK
+        public List<string> Missing { get; } = new List<string>();
+        public List<string> Warnings { get; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Pure-data inspector — opens a family doc, inspects it, returns the
+    /// score row. Engine is separate from the command so it's testable.
+    /// </summary>
+    public static class FamilyConformanceInspector
+    {
+        // Tag-only param fingerprints. The full ASS_TAG_* container set is
+        // big; we sample a handful that any STING-conformant tag must carry.
+        private static readonly string[] PlacementParams = new[]
+        {
+            ParamRegistry.PLACE_ANCHOR,
+            ParamRegistry.PLACE_OFFSET_X_MM,
+            ParamRegistry.PLACE_SIDE,
+            "MNT_HGT_MM",
+        };
+
+        private static readonly string[] TagFingerprint = new[]
+        {
+            "ASS_TAG_1_TXT",
+            "ASS_TAG_2_TXT",
+            "ASS_TAG_7_TXT",
+        };
+
+        private static readonly string[] TagVisibilityFingerprint = new[]
+        {
+            "TAG_PARA_STATE_1_BOOL",
+            "TAG_PARA_STATE_2_BOOL",
+            "WARN_VISIBLE_BOOL",
+        };
+
+        // Sample of the 128 TAG_{size}{style}_{colour}_BOOL style matrix. If
+        // these aren't present, the family was not stamped with the
+        // automation/presentation pack.
+        private static readonly string[] TagStyleFingerprint = new[]
+        {
+            "TAG_2_5_NOM_BLACK_BOOL",
+            "TAG_3_BOLD_BLUE_BOOL",
+        };
+
+        /// <summary>
+        /// Inspect one family file. Returns a populated row.
+        /// Caller wraps the application context — this method opens the file,
+        /// audits, and closes without saving.
+        /// </summary>
+        public static ConformanceReportRow Inspect(UIApplication uiApp, string rfaPath)
+        {
+            var row = new ConformanceReportRow { Path = rfaPath };
+            row.FamilyName = Path.GetFileNameWithoutExtension(rfaPath) ?? "";
+            Document famDoc = null;
+            try
+            {
+                // Match the codebase's standard family-open pattern
+                // (FamilyParamCreatorCommand.cs:1012, TagFamilyCreatorCommand.cs:1932).
+                famDoc = uiApp.Application.OpenDocumentFile(rfaPath);
+                if (famDoc == null || !famDoc.IsFamilyDocument)
+                {
+                    row.Warnings.Add("Not a family document.");
+                    row.Verdict = "BLOCK";
+                    row.Score = 0;
+                    return row;
+                }
+
+                ScoreFamily(famDoc, row);
+            }
+            catch (Exception ex)
+            {
+                row.Warnings.Add($"Open failed: {ex.Message}");
+                row.Verdict = "BLOCK";
+                row.Score = 0;
+            }
+            finally
+            {
+                try { famDoc?.Close(false); } catch { /* swallow */ }
+            }
+            return row;
+        }
+
+        private static void ScoreFamily(Document famDoc, ConformanceReportRow row)
+        {
+            var fm = famDoc.FamilyManager;
+            int score = 0;
+
+            // ── (1) Category + template classification (15 pts) ──────
+            string catName = "";
+            try { catName = famDoc.OwnerFamily?.FamilyCategory?.Name ?? ""; } catch { }
+            row.Category = catName;
+            // Heuristic: families with placement type "Invalid" or category
+            // null / "Generic Annotations" are 2D. Anything else is treated
+            // as 3D.
+            bool is2D = string.Equals(catName, "Generic Annotations", StringComparison.OrdinalIgnoreCase)
+                     || string.Equals(catName, "Detail Items", StringComparison.OrdinalIgnoreCase)
+                     || string.Equals(catName, "Tags", StringComparison.OrdinalIgnoreCase)
+                     || catName.IndexOf("Tags", StringComparison.OrdinalIgnoreCase) >= 0;
+            row.FamilyTemplate = is2D ? "Annotation/Detail (2D)" : "3D Model";
+            if (!string.IsNullOrEmpty(catName)) score += 15;
+            else row.Missing.Add("Family has no category — cannot infer template.");
+
+            // Build the parameter-by-name index once.
+            var paramsByName = new Dictionary<string, FamilyParameter>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                foreach (FamilyParameter fp in fm.Parameters)
+                {
+                    if (fp?.Definition?.Name != null && !paramsByName.ContainsKey(fp.Definition.Name))
+                        paramsByName[fp.Definition.Name] = fp;
+                }
+            }
+            catch (Exception ex) { row.Warnings.Add($"Enumerate parameters: {ex.Message}"); }
+
+            // ── (2) Placement parameters bound by GUID (25 pts) ──────
+            // For each of the 4 STING placement params, check that the
+            // parameter exists AND is bound by GUID rather than just a name
+            // collision. Counts 6 pts per parameter (max 24, rounded to 25).
+            int placePts = 0;
+            foreach (var name in PlacementParams)
+            {
+                if (!paramsByName.TryGetValue(name, out var fp))
+                {
+                    row.Missing.Add($"Placement param missing: {name}");
+                    continue;
+                }
+                if (!fp.IsShared)
+                {
+                    row.Missing.Add($"'{name}' is a family parameter, not shared — placement engine writes by GUID and will skip.");
+                    continue;
+                }
+                placePts += 6;
+            }
+            // Bonus point if all 4 are present, to get to 25.
+            if (placePts >= 24) placePts = 25;
+            score += placePts;
+
+            // Tag-specific checks only fire when this looks like a tag family.
+            bool isTagLike = catName.IndexOf("Tags", StringComparison.OrdinalIgnoreCase) >= 0;
+            if (isTagLike)
+            {
+                // ── (3) Tag fingerprint params (10 pts) ──────────────
+                int tagPts = 0;
+                foreach (var name in TagFingerprint)
+                {
+                    if (paramsByName.ContainsKey(name)) tagPts += 3;
+                    else row.Missing.Add($"Tag param missing: {name}");
+                }
+                score += Math.Min(tagPts, 10);
+
+                // ── (4) Tag style matrix sample (10 pts) ─────────────
+                int stylePts = 0;
+                foreach (var name in TagStyleFingerprint)
+                {
+                    if (paramsByName.ContainsKey(name)) stylePts += 5;
+                    else row.Missing.Add($"Tag style param missing: {name} (run FamilyParamCreator with InjectAutomationPack=true)");
+                }
+                score += Math.Min(stylePts, 10);
+
+                // ── (5) Tag visibility tiers (10 pts) ────────────────
+                int visPts = 0;
+                foreach (var name in TagVisibilityFingerprint)
+                {
+                    if (paramsByName.ContainsKey(name)) visPts += 4;
+                    else row.Missing.Add($"Tag visibility param missing: {name}");
+                }
+                score += Math.Min(visPts, 10);
+
+                // ── (6) Position types Ring 1 / Ring 2 (10 pts) ──────
+                bool foundRing1 = false, foundRing2 = false;
+                try
+                {
+                    foreach (FamilyType ft in fm.Types)
+                    {
+                        string n = ft?.Name ?? "";
+                        if (n.IndexOf("1x", StringComparison.OrdinalIgnoreCase) >= 0) foundRing1 = true;
+                        if (n.IndexOf("1.5x", StringComparison.OrdinalIgnoreCase) >= 0) foundRing2 = true;
+                    }
+                }
+                catch (Exception ex) { row.Warnings.Add($"Enumerate types: {ex.Message}"); }
+                if (foundRing1) score += 5; else row.Missing.Add("Ring 1 position types (1x-…) missing.");
+                if (foundRing2) score += 5; else row.Missing.Add("Ring 2 position types (1.5x-…) missing.");
+            }
+            else
+            {
+                // Non-tag families get the 40 tag-only points scored as
+                // 'pass by N/A' — distribute evenly so the score still
+                // reaches 100 when nothing else is wrong.
+                score += 40;
+            }
+
+            // ── (7) Placement type vs category sanity (10 pts) ───────
+            // For tag/annotation families, placement type should be ViewBased.
+            // For 3D model families, it should be a 3D placement type.
+            // Wrong template breaks the placement pipeline downstream.
+            try
+            {
+                var ft = famDoc.OwnerFamily?.FamilyPlacementType;
+                bool ok;
+                if (isTagLike || is2D)
+                {
+                    ok = (ft == FamilyPlacementType.ViewBased)
+                      || (ft == FamilyPlacementType.Invalid); // some annotation templates report Invalid
+                    if (!ok) row.Missing.Add($"FamilyPlacementType={ft} on a 2D family — placement on plan/section views may fail.");
+                }
+                else
+                {
+                    ok = (ft == FamilyPlacementType.OneLevelBased)
+                      || (ft == FamilyPlacementType.TwoLevelsBased)
+                      || (ft == FamilyPlacementType.WorkPlaneBased)
+                      || (ft == FamilyPlacementType.OneLevelBasedHosted);
+                    if (!ok) row.Missing.Add($"FamilyPlacementType={ft} on a 3D family — placement engine may not find a host.");
+                }
+                if (ok) score += 10;
+            }
+            catch (Exception ex) { row.Warnings.Add($"Inspect FamilyPlacementType: {ex.Message}"); }
+
+            // ── (8) Loaded-cleanly bonus (10 pts) ────────────────────
+            // We got here without an Open exception — credit the bonus.
+            score += 10;
+
+            // Clamp + verdict.
+            row.Score = Math.Max(0, Math.Min(100, score));
+            row.Verdict = row.Score >= 85 ? "PASS"
+                        : row.Score >= 70 ? "WARN"
+                        : "BLOCK";
+        }
+    }
+
+    /// <summary>
+    /// Read-only command: pick a folder of .rfa files, run the inspector
+    /// against each, write a CSV report, show a TaskDialog summary with
+    /// the lowest-scoring families.
+    ///
+    /// Read-only because the command never opens a Transaction on the
+    /// active project document — every family is opened standalone and
+    /// closed without save.
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class FamilyConformanceCheckCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var uiApp = commandData.Application;
+
+                // Pick the folder to scan.
+                string folder = PickFolder(uiApp);
+                if (string.IsNullOrEmpty(folder)) return Result.Cancelled;
+
+                var rfas = Directory.EnumerateFiles(folder, "*.rfa", SearchOption.AllDirectories)
+                                    .ToList();
+                if (rfas.Count == 0)
+                {
+                    TaskDialog.Show("STING Family Conformance",
+                        $"No .rfa files found under:\n{folder}");
+                    return Result.Cancelled;
+                }
+
+                // Inspect each (modal progress with periodic UI yield).
+                var rows = new List<ConformanceReportRow>(rfas.Count);
+                int i = 0;
+                foreach (var p in rfas)
+                {
+                    i++;
+                    try
+                    {
+                        var row = FamilyConformanceInspector.Inspect(uiApp, p);
+                        rows.Add(row);
+                    }
+                    catch (Exception ex)
+                    {
+                        var failed = new ConformanceReportRow { Path = p, FamilyName = Path.GetFileNameWithoutExtension(p) ?? "" };
+                        failed.Warnings.Add($"Inspect failed: {ex.Message}");
+                        failed.Verdict = "BLOCK";
+                        rows.Add(failed);
+                    }
+                    if (i % 10 == 0) StingLog.Info($"FamilyConformanceCheck: {i}/{rfas.Count} ({p})");
+                }
+
+                // Write CSV.
+                string outDir = ResolveOutputDir(commandData);
+                string outPath = Path.Combine(outDir,
+                    $"FamilyConformanceReport_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
+                WriteCsv(outPath, rows);
+
+                // Summary dialog.
+                ShowSummary(outPath, rows);
+
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("FamilyConformanceCheck", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        private static string PickFolder(UIApplication uiApp)
+        {
+            // Folder picker via WinForms FolderBrowserDialog (Revit ships
+            // System.Windows.Forms; this is the lightest dependency).
+            try
+            {
+                using (var dlg = new System.Windows.Forms.FolderBrowserDialog())
+                {
+                    dlg.Description = "Select a folder of .rfa families to audit (subfolders are scanned).";
+                    dlg.ShowNewFolderButton = false;
+                    var res = dlg.ShowDialog();
+                    if (res != System.Windows.Forms.DialogResult.OK) return null;
+                    return dlg.SelectedPath;
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"FamilyConformanceCheck PickFolder: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static string ResolveOutputDir(ExternalCommandData cd)
+        {
+            // Prefer the project's _BIM_COORD folder; fall back to %TEMP%.
+            try
+            {
+                var doc = cd?.Application?.ActiveUIDocument?.Document;
+                if (doc != null && !string.IsNullOrEmpty(doc.PathName))
+                {
+                    string projDir = Path.GetDirectoryName(doc.PathName);
+                    if (!string.IsNullOrEmpty(projDir))
+                    {
+                        string bim = Path.Combine(projDir, "_BIM_COORD");
+                        Directory.CreateDirectory(bim);
+                        return bim;
+                    }
+                }
+            }
+            catch { }
+            return Path.GetTempPath();
+        }
+
+        private static void WriteCsv(string outPath, List<ConformanceReportRow> rows)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("FamilyName,Category,Template,Score,Verdict,Path,Missing,Warnings");
+            foreach (var r in rows)
+            {
+                sb.Append(CsvCell(r.FamilyName)).Append(',');
+                sb.Append(CsvCell(r.Category)).Append(',');
+                sb.Append(CsvCell(r.FamilyTemplate)).Append(',');
+                sb.Append(r.Score).Append(',');
+                sb.Append(r.Verdict).Append(',');
+                sb.Append(CsvCell(r.Path)).Append(',');
+                sb.Append(CsvCell(string.Join(" | ", r.Missing))).Append(',');
+                sb.Append(CsvCell(string.Join(" | ", r.Warnings)));
+                sb.AppendLine();
+            }
+            File.WriteAllText(outPath, sb.ToString(), Encoding.UTF8);
+        }
+
+        private static string CsvCell(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return "";
+            if (s.IndexOfAny(new[] { ',', '"', '\n', '\r' }) >= 0)
+                return "\"" + s.Replace("\"", "\"\"") + "\"";
+            return s;
+        }
+
+        private static void ShowSummary(string csvPath, List<ConformanceReportRow> rows)
+        {
+            int total = rows.Count;
+            int pass  = rows.Count(r => r.Verdict == "PASS");
+            int warn  = rows.Count(r => r.Verdict == "WARN");
+            int block = rows.Count(r => r.Verdict == "BLOCK");
+
+            var bottom = rows.OrderBy(r => r.Score).Take(10).ToList();
+            var sb = new StringBuilder();
+            sb.AppendLine($"Audited {total} families:");
+            sb.AppendLine($"   PASS  ≥85 :   {pass}");
+            sb.AppendLine($"   WARN  70–84:  {warn}");
+            sb.AppendLine($"   BLOCK  <70 :  {block}");
+            sb.AppendLine();
+            sb.AppendLine("Lowest-scoring (first 10):");
+            foreach (var r in bottom)
+            {
+                sb.AppendLine($"   [{r.Score,3}] {r.Verdict,-5} {r.FamilyName}");
+                if (r.Missing.Count > 0)
+                    sb.AppendLine($"          missing: {string.Join("; ", r.Missing.Take(3))}{(r.Missing.Count > 3 ? "…" : "")}");
+            }
+            sb.AppendLine();
+            sb.AppendLine($"Full CSV report:\n{csvPath}");
+
+            var td = new TaskDialog("STING Family Conformance")
+            {
+                MainInstruction = $"{pass}/{total} families pass; {block} block.",
+                MainContent = sb.ToString(),
+                CommonButtons = TaskDialogCommonButtons.Close,
+            };
+            td.Show();
+        }
+    }
+}

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -2805,6 +2805,10 @@ namespace StingTools.UI
 
                     // Family tooling (FamilyParamCreatorCommand.cs, StingTools.Tags)
                     case "FamilyParamCreator": RunCommand<Tags.FamilyParamCreatorCommand>(app); break;
+                    // Family conformance audit (FamilyConformanceCheckCommand.cs, Phase 185) —
+                    // read-only audit of a folder of .rfa families against the STING contract.
+                    // Use BEFORE bulk-stamping a manufacturer library.
+                    case "FamilyConformanceCheck": RunCommand<Tags.FamilyConformanceCheckCommand>(app); break;
 
                     // Family quick-edit (FamilyQuickEditCommands.cs, StingTools.Tags) —
                     // rehost, swap category, inject automation pack, quick-edit dialog

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -2561,8 +2561,9 @@
                                     <Button Style="{StaticResource ActionBtn}" Content="Swap Category" Tag="FamilySwapCategory" Click="Cmd_Click" ToolTip="Change the family's category via EditFamily + reload (Generic Model ↔ Furniture ↔ Equipment etc.)"/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Automation Pack" Tag="FamilyInjectAutomationPack" Click="Cmd_Click" ToolTip="Inject clearance, fire rating, acoustic, cost, CO₂, manufacturer, model, datasheet URL, warranty, LOD switches, workset hint, OmniClass"/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Tag Family Params" Tag="FamilyParamCreator" Click="Cmd_Click" ToolTip="Batch-inject STING tag parameters into tag family .rfa files. Regular families → Temp › Family Parameter Processor."/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="Conformance Check" Tag="FamilyConformanceCheck" Click="Cmd_Click" ToolTip="Phase 185: read-only audit of a folder of .rfa families against the STING contract. Surfaces missing placement params / tag style matrix / wrong placement type BEFORE you bulk-stamp a manufacturer library. CSV report + summary, no mutations. Run this before any vendor intake."/>
                                 </WrapPanel>
-                                <TextBlock Text="Rehost · recategorise · inject params — all without leaving the project." FontSize="8" Foreground="#AAA" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                                <TextBlock Text="Rehost · recategorise · inject params · pre-stamp audit — all without leaving the project." FontSize="8" Foreground="#AAA" Margin="0,4,0,0" TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
 


### PR DESCRIPTION
## Summary

This PR hardens the family authoring surface with four complementary changes that clarify the distinction between 3D model families (real product geometry) and 2D schematic symbols, and add tooling to validate and optimize family placement rules.

## Key Changes

### 1. Family Library Documentation (`Families/README.md`)
- New root README codifying the **two authoring tracks**: Track A (3D model families with real product geometry) and Track B (2D schematic symbols)
- Documents the family resolution tier order (already-loaded → seed families on disk → auto-generated drafts → category match → silent skip)
- Vendor intake SOP: Conformance check → stamp with `FamilyParamCreator` → drop in right folder → tune placement rule
- Priority acquisition list (MGS terminal units → luminaires → AHU/FCU → panel boards → bedhead trunks → fire devices)
- Clarifies that 164 ISO 6412 symbols are intentionally schematic drafts, not 3D placeholders

### 2. Footprint-Aware Placement Spacing
**Files**: `StingTools/Core/Placement/PlacementRule.cs`, `FixturePlacementEngine.cs`

New `PlacementRule` fields:
- `FamilyBboxAware` (bool, default false): Enable bbox-derived spacing scaling
- `ReferenceFootprintMm` (double, default 150): Reference footprint the rule was tuned for
- `MinSymbolFootprintMm` (double, default 100): Floor on measured footprint
- `MaxFootprintScale` (double, default 8.0): Cap on scale factor

**Engine behavior** (`FixturePlacementEngine.ProcessRoomRule`):
- When `FamilyBboxAware=true`, pre-resolve the family symbol and measure its bounding-box footprint (max of X/Y extent in mm)
- Compute `scale = clamp(max(footprintMm, floor) / reference, 1.0, cap)`
- Scale `MinSpacingMm`, `CoverageRadiusMm`, `ObstructionClearanceMm`, `WallClearanceMm`, `OffsetXMm`, `OffsetYMm` by scale
- `OffsetZMm` intentionally not scaled (mounting height comes from `MountingHeightMm` / `MountingReference`)
- Never shrinks spacings below authored value (scale floor = 1.0)

**Benefit**: One rule now serves 150 mm switches and 1200 mm AHUs without per-vendor JSON edits.

### 3. Type-Catalog (`.txt` Sidecar) Loader
**Files**: `StingTools/Core/Placement/PlacementRule.cs`, `FixturePlacementEngine.cs`

New `PlacementRule.TypeCatalogKey` field:
- When set and a `.txt` sidecar exists next to the `.rfa`, routes through `Document.LoadFamilySymbol(path, typeName)` instead of bulk `LoadFamily`
- Only the matching type is loaded (avoids bloating project with 200-type valve/fitting libraries)
- Key may be exact type name or regex (`^DN20-PN1[06]$`)
- Empty key (default) preserves legacy bulk-load behaviour

**Implementation** (`TryAutoLoadFromLibrary`):
- New `TryLoadFromCatalog` helper attempts catalog path first when `TypeCatalogKey` is set
- Falls through to bulk `LoadFamily` if catalog miss (non-fatal)

### 4. Family Conformance Checker
**Files**: `StingTools/Tags/FamilyConformanceCheckCommand.cs` (new)

New read-only command `FamilyConformanceCheck` (Tags → QA → Conformance Check):
- Audits a user-picked folder of `.rfa` files against the STING contract
- **Scoring** (0–100 points):
  - Family template appropriate for category (15 pts)
  - 4 STING placement params bound by GUID

https://claude.ai/code/session_01MRZYKG5rmBkJnWSwAXg1ET