### PR TITLE
Phase 187: Add HVAC design engines (block load, NC prediction, refrigerant sizing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2746,6 +2746,72 @@ Edit either JSON in a text editor and click **RPRT → Reload rules** to pick up
 4. The EQPT / SYS / SpoolGrid / DriftGrid / WorkflowGrid `ObservableCollection`s start empty — commands push rows back into the panel singleton (`StingHvacPanel.Instance`) on completion (same pattern `StingElectricalPanel` uses).
 5. PaneGuid `D7E8F9A0-B1C2-3D4E-5F60-1A2B3C4D5E6F` is stable from this point so users' Revit `UIState.dat` re-locates the panel between sessions.
 
+## HVAC design engines (Phase 187 — competitive parity)
+
+Built in response to the "what can we borrow from MagiCAD / TRACE /
+HAP / IES VE / cove.tool / Daikin VRV tools" review. Adds five
+calculation kernels that move STING from "Revit organiser" toward
+"design engine":
+
+### New folders + files
+
+| Path | Purpose | LoC |
+|---|---|---|
+| `StingTools/Core/Climate/ClimateRegistry.cs` | ASHRAE 2021 / CIBSE Guide A design-day site registry, NASA ISA elevation-corrected air density, per-doc cache, project override at `<project>/_BIM_COORD/climate_data.json` | ~200 |
+| `StingTools/Data/STING_CLIMATE_DATA.json` | 41 cities (UK + EU + US + AU + Asia + Africa) with cooling 0.4 % DB + MCWB, heating 99.6 % DB, HDD18, CDD10, elevation | — |
+| `StingTools/Core/Hvac/Loads/LoadInputs.cs` | `LoadZone` / `EnvelopeSegment` / `ZoneLoadResult` / `BlockLoadResult` POCOs + ASHRAE 90.1 default schedules | ~120 |
+| `StingTools/Core/Hvac/Loads/BlockLoadEngine.cs` | Hour-by-hour 24-h design-day load calc with peak-pick at the SYSTEM level (not Σ zone peaks). Conduction + solar (ASHRAE Clear Sky) + occupants + lighting + equipment + vent + infiltration. Reports diversity = block / Σpeaks. | ~250 |
+| `StingTools/Core/Acoustic/OctaveBand.cs` | 8-band Lw / Lp container + NC curve evaluator (NC-15 → NC-65) | ~140 |
+| `StingTools/Core/Acoustic/NcPredictionEngine.cs` | VDI 2081 / ASHRAE A48 attenuation tables (straight, lined, elbow, tee, end-reflection) + Bullock regenerated-noise correlations + direct + reverberant room model | ~250 |
+| `StingTools/Core/Refrigerant/RefrigerantProperties.cs` | R410A / R32 / R134a / CO₂ saturation densities + viscosities + Hfg + oil-return velocity floors + Daikin VRV envelope limits | ~120 |
+| `StingTools/Core/Refrigerant/RefrigerantPipeSolver.cs` | Darcy-Weisbach + Blasius f smooth-copper pipe sweep over ACR size list with oil-return velocity floor + ΔP budget + liquid-leg static head | ~140 |
+| `StingTools/UI/RefrigerantSizingDialog.cs` | Minimal WPF input dialog: refrigerant + leg + capacity + length + lift + ΔP budget + riser flag | ~150 |
+
+### Manufacturer + valve pack
+
+Extended `STING_MEP_SIZING_RULES.json` with two new sections:
+`duct.manufacturerFittings` (Lindab / Trox / Halton catalogue C
+values keyed by product code) and `pipe.valveCv` (Belimo / Siemens
+/ Danfoss Kvs values, m³/h at 1 bar). `MepSizingRules.GetManufacturerC`
+and `GetValveKvs` give callers a typed lookup; fittings fall back to
+the generic SMACNA C table from `DuctFrictionSolver.SmacnaCoefficients`
+when no manufacturer match.
+
+### New commands (7)
+
+| Tag | Class | Description |
+|---|---|---|
+| `Hvac_BlockLoad` | `HvacBlockLoadCommand` | Runs `BlockLoadEngine` against Revit Spaces (or Rooms), stamps per-space `HVC_PEAK_SENS_W` / `HVC_PEAK_LAT_W` / `HVC_PEAK_HOUR` / `HVC_OA_LS`, reports building block, Σ peaks, diversity, per-system table, top-10 zones |
+| `Hvac_NcPredict` | `HvacNcPredictionCommand` | Walks user duct selection, treats the upstream-most member as fan source (synthetic Lw from Q + ΔP), runs `NcPredictionEngine`, reports predicted NC + per-element attenuation/regen breakdown |
+| `Hvac_RefrigSize` | `HvacRefrigerantSizeCommand` | Pops `RefrigerantSizingDialog`, runs `RefrigerantPipeSolver`, reports chosen OD + velocity + ΔP + vendor compliance with full size-sweep trace |
+| `Hvac_ClimateInspect` | `HvacClimateInspectCommand` | Shows active climate site (resolved via `PRJ_CLIMATE_SITE_ID` or address fuzzy-match) + corporate catalogue |
+| `Hvac_ClimateReload` | `HvacClimateReloadCommand` | Drops `ClimateRegistry` cache for all docs so an edit to the baseline / project override is picked up without restarting Revit |
+| (existing) `Hvac_PressureClassAudit` | now reads air density from the climate registry (location-aware) instead of the hardcoded 1.20 kg/m³ |
+| (existing) `Hvac_ReloadRules` | unchanged — flushes `MepSizingRegistry` |
+
+LOADS tab gains a "Block load" primary button; CALCS tab gains "NC
+predict" and "Refrigerant size" buttons; RPRT tab gains "Climate
+inspect" + "Reload climate" buttons.
+
+### Climate site resolution
+
+Priority order: `PRJ_CLIMATE_SITE_ID` parameter on
+`ProjectInformation` → fuzzy match of `ProjectInformation.Address`
+against site labels → first site in the project override file → hard
+fallback to `london`. Air density at the cooling design dry-bulb is
+elevation-corrected via the standard atmosphere model and replaces
+the previous hardcoded 1.20 kg/m³ in the pressure-class audit.
+
+### Caveats (Phase 187)
+
+1. Built without `dotnet build` verification (Linux sandbox). Verify in Revit before merge.
+2. **`BlockLoadEngine` is sensible-load focused.** Latent is calculated but the design-day model is simplified (single sinusoid for outdoor temp, ASHRAE Clear Sky for solar, no thermal-mass storage / RTS lag). For comparison-grade results against TRACE / HAP, fold in a per-orientation Radiant Time Series — the input data structures already support per-segment orientation.
+3. **`NcPredictionEngine` uses a *synthetic* fan source** derived from path Q + ΔP. Until a manufacturer Lw spectrum sidecar lands, NC predictions are indicative not certifiable. Silencer insertion-loss spectra are also defaults (12 dB midband) until the same sidecar pattern is wired for attenuators.
+4. **`RefrigerantPipeSolver` ships 4 refrigerants** (R410A, R32, R134a, CO₂). Saturation state-point pairs are spot-design from ASHRAE Handbook Fundamentals + Daikin VRV manuals — not a full EoS engine. The two-phase suction multiplier is a flat 10 % rather than a Lockhart-Martinelli calc.
+5. **Climate site list ships 41 cities.** Add more by appending to the corporate `STING_CLIMATE_DATA.json` (PR encouraged) or via a project override at `<project>/_BIM_COORD/climate_data.json` (additive, by `id`).
+6. **Manufacturer fitting + valve packs are seed.** ~20 entries each across Lindab / Trox / Halton / Belimo / Siemens / Danfoss. Production deployments should add their actual catalogue via the project override.
+7. Per-element pipe-fitting lookup of manufacturer C / Kvs values (via `MepSizingRules.GetManufacturerC` / `GetValveKvs`) is in place but not yet wired into the friction / static-regain commands — they still use the generic SMACNA table.
+
 ## Template Manager Intelligence Engine
 
 `TemplateManagerCommands.cs` (3,892 lines) provides a deep template automation engine with 18 commands and an `internal static class TemplateManager` (~867 lines) intelligence core.

--- a/StingTools/Commands/Hvac/HvacBlockLoadCommand.cs
+++ b/StingTools/Commands/Hvac/HvacBlockLoadCommand.cs
@@ -1,0 +1,400 @@
+// StingTools — Block-load command.
+//
+// Drives BlockLoadEngine against Revit Spaces (or Rooms when Spaces
+// aren't bound). Honours the HVAC panel scope radio and writes per-
+// space peak loads back as STING shared parameters so downstream
+// commands (equipment selection, schedules, sustainability) can read
+// them.
+//
+// What this gives the user over Revit's native loads:
+//   - peak-picks at the SYSTEM level rather than summing per-zone peaks
+//   - reports the diversity factor explicitly
+//   - uses a location-aware climate site rather than a hardcoded design day
+//
+// Falls back to sensible defaults when a Space lacks envelope geometry —
+// the result panel surfaces every skipped zone so users know exactly
+// what data is missing before trusting the number.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Mechanical;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Climate;
+using StingTools.Core.Hvac.Loads;
+using StingTools.UI;
+
+namespace StingTools.Commands.Hvac
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HvacBlockLoadCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { message = "No active document."; return Result.Failed; }
+                var doc = ctx.Doc;
+
+                var site = ClimateRegistry.ActiveSite(doc);
+                bool cooling = true;
+                try
+                {
+                    var snap = StingHvacCommandHandler.Snapshot();
+                    // Future: a "heating" toggle on the LOADS tab will set this.
+                    cooling = string.IsNullOrEmpty(snap.LoadCode) || !snap.LoadCode.ToLowerInvariant().Contains("heat");
+                }
+                catch { }
+
+                string scope = "Project";
+                try { scope = StingHvacCommandHandler.CurrentScope ?? "Project"; } catch { }
+
+                var (zones, skipped) = CollectZones(ctx, scope);
+                if (zones.Count == 0)
+                {
+                    TaskDialog.Show("STING HVAC — Block Load",
+                        $"No spaces/rooms in scope ({scope}). Place at least one Revit Space first.");
+                    return Result.Cancelled;
+                }
+
+                var results = BlockLoadEngine.Run(zones, site, cooling);
+                double grand = results.Sum(r => r.BlockSensibleW);
+                double sumPeaks = results.Sum(r => r.SumOfPeaksSensibleW);
+                double diversity = sumPeaks > 0 ? grand / sumPeaks : 1.0;
+
+                // Stamp per-space peaks back onto Revit so schedules see them.
+                int stamped = 0;
+                using (var tx = new Transaction(doc, "STING Block-load Stamp"))
+                {
+                    tx.Start();
+                    foreach (var sys in results)
+                    foreach (var z in sys.Zones)
+                    {
+                        var el = doc.GetElement(new ElementId(ParseLong(z.ZoneId)));
+                        if (el == null) continue;
+                        try
+                        {
+                            if (ParameterHelpers.SetString(el, "HVC_PEAK_SENS_W",
+                                $"{z.PeakSensibleW:F0}", overwrite: true)) stamped++;
+                            ParameterHelpers.SetString(el, "HVC_PEAK_LAT_W",
+                                $"{z.PeakLatentW:F0}", overwrite: true);
+                            ParameterHelpers.SetString(el, "HVC_PEAK_HOUR",
+                                $"{z.PeakHour:D2}:00", overwrite: true);
+                            ParameterHelpers.SetString(el, "HVC_OA_LS",
+                                $"{z.OaLs:F1}", overwrite: true);
+                        }
+                        catch (Exception ex) { StingLog.Warn($"Block-load stamp {el.Id}: {ex.Message}"); }
+                    }
+                    tx.Commit();
+                }
+
+                // Result panel
+                var panel = StingResultPanel.Create("HVAC — Block Load");
+                panel.SetSubtitle($"site={site.Label} ({site.Cooling996DbC:F1}/{site.Cooling996McwbC:F1} °C) · " +
+                                  $"ρ={site.AirDensityCoolingKgM3():F3} kg/m³ · " +
+                                  $"{(cooling ? "Cooling" : "Heating")} · scope={scope}");
+                panel.AddSection("BUILDING TOTAL")
+                     .Metric("Block (peak) sensible", $"{grand / 1000:F1} kW")
+                     .Metric("Σ per-zone peaks",     $"{sumPeaks / 1000:F1} kW")
+                     .Metric("Diversity factor",     $"{diversity:F2}")
+                     .Metric("Spaces sized",         zones.Count.ToString())
+                     .Metric("Skipped (no data)",    skipped.ToString())
+                     .Metric("Stamped HVC_PEAK_*",   stamped.ToString());
+
+                panel.AddSection("PER SYSTEM");
+                foreach (var s in results.OrderByDescending(r => r.BlockSensibleW))
+                {
+                    panel.Text($"{s.SystemId} · block {s.BlockSensibleW / 1000:F1} kW @ {s.BlockHour:D2}:00 · " +
+                               $"diversity {s.DiversityFactor:F2} · {s.Zones.Count} zones");
+                }
+
+                panel.AddSection("TOP-10 ZONES BY PEAK");
+                foreach (var z in results.SelectMany(r => r.Zones)
+                                         .OrderByDescending(r => r.PeakSensibleW).Take(10))
+                {
+                    panel.Text($"{z.ZoneName} · {z.PeakSensibleW / 1000:F1} kW @ {z.PeakHour:D2}:00 · " +
+                               $"{z.AreaM2:F0} m² · OA {z.OaLs:F0} L/s");
+                }
+
+                panel.Text("Block load = max over 24 hourly system totals. " +
+                           "Diversity < 1 means zone peaks don't coincide; size plant to BLOCK, not Σpeaks.");
+                panel.Show();
+
+                try
+                {
+                    StingHvacPanel.Instance?.PushRunRow(
+                        $"Block-load ({grand / 1000:F0} kW, div {diversity:F2})", "⬤");
+                }
+                catch (Exception ex) { StingLog.Warn($"Panel push: {ex.Message}"); }
+
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("HvacBlockLoadCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        // ── Zone collection ─────────────────────────────────────────
+
+        private static (List<LoadZone> zones, int skipped) CollectZones(StingCommandContext ctx, string scope)
+        {
+            var doc = ctx.Doc;
+            var zones = new List<LoadZone>();
+            int skipped = 0;
+
+            // Prefer MEP Spaces (have ventilation rates + design temps).
+            var spaces = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_MEPSpaces)
+                .WhereElementIsNotElementType()
+                .Cast<Space>()
+                .Where(s => s.Area > 0)
+                .ToList();
+
+            if (spaces.Count == 0)
+            {
+                // Fall back to architectural Rooms with default vent rates.
+                var rooms = new FilteredElementCollector(doc)
+                    .OfCategory(BuiltInCategory.OST_Rooms)
+                    .WhereElementIsNotElementType()
+                    .Cast<Autodesk.Revit.DB.Architecture.Room>()
+                    .Where(r => r.Area > 0)
+                    .ToList();
+                foreach (var r in rooms)
+                {
+                    var z = ZoneFromRoom(r);
+                    if (z != null) zones.Add(z); else skipped++;
+                }
+            }
+            else
+            {
+                foreach (var s in spaces)
+                {
+                    var z = ZoneFromSpace(s);
+                    if (z != null) zones.Add(z); else skipped++;
+                }
+            }
+
+            return (zones, skipped);
+        }
+
+        private static LoadZone ZoneFromSpace(Space s)
+        {
+            try
+            {
+                double areaM2 = UnitUtils.ConvertFromInternalUnits(s.Area, UnitTypeId.SquareMeters);
+                double heightM = UnitUtils.ConvertFromInternalUnits(s.UnboundedHeight, UnitTypeId.Meters);
+                if (heightM <= 0.1) heightM = 3.0; // sane default
+
+                var z = new LoadZone
+                {
+                    Id          = s.Id.Value.ToString(),
+                    Name        = string.IsNullOrEmpty(s.Name) ? $"Space {s.Id}" : s.Name,
+                    SystemId    = ResolveSystemId(s),
+                    SpaceTypeId = s.LookupParameter("HVC_SPACE_TYPE_TXT")?.AsString() ?? "Office",
+                    FloorAreaM2 = areaM2,
+                    HeightM     = heightM
+                };
+
+                // Pull design OA from Revit Space if user has set it.
+                // (Looked up by name — `LookupParameter` avoids hard-coding
+                // BuiltInParameter ids that change name across Revit versions.)
+                double designOa = TryReadFlowByName(s, "Specified Supply Airflow per area");
+                if (designOa <= 0) designOa = TryReadFlowByName(s, "Calculated Supply Airflow per area");
+                if (designOa > 0) z.OaLpsPerM2 = designOa;
+
+                int occ = TryReadIntByName(s, "Number of People");
+                if (occ <= 0) occ = (int)Math.Max(1, Math.Round(areaM2 / 10.0)); // 10 m²/person default
+                z.OccupantCount = occ;
+
+                AddPerimeterEnvelope(s, z);
+                return z;
+            }
+            catch (Exception ex) { StingLog.Warn($"ZoneFromSpace {s.Id}: {ex.Message}"); return null; }
+        }
+
+        private static LoadZone ZoneFromRoom(Autodesk.Revit.DB.Architecture.Room r)
+        {
+            try
+            {
+                double areaM2 = UnitUtils.ConvertFromInternalUnits(r.Area, UnitTypeId.SquareMeters);
+                double heightM = UnitUtils.ConvertFromInternalUnits(r.UnboundedHeight, UnitTypeId.Meters);
+                if (heightM <= 0.1) heightM = 3.0;
+
+                var z = new LoadZone
+                {
+                    Id          = r.Id.Value.ToString(),
+                    Name        = string.IsNullOrEmpty(r.Name) ? $"Room {r.Id}" : r.Name,
+                    SystemId    = "(default)",
+                    SpaceTypeId = "Office",
+                    FloorAreaM2 = areaM2,
+                    HeightM     = heightM,
+                    OccupantCount = (int)Math.Max(1, Math.Round(areaM2 / 10.0))
+                };
+                AddPerimeterEnvelope(r, z);
+                return z;
+            }
+            catch (Exception ex) { StingLog.Warn($"ZoneFromRoom {r.Id}: {ex.Message}"); return null; }
+        }
+
+        /// <summary>
+        /// Best-effort envelope detection by intersecting the room boundary
+        /// with exterior walls + their hosted windows. When the geometry
+        /// doesn't yield (linked architectural model, etc.) fall back to a
+        /// generic envelope ratio so the calc still runs.
+        /// </summary>
+        private static void AddPerimeterEnvelope(SpatialElement spatial, LoadZone z)
+        {
+            try
+            {
+                var opts = new SpatialElementBoundaryOptions
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.Center
+                };
+                var segs = spatial.GetBoundarySegments(opts);
+                if (segs == null || segs.Count == 0) goto Fallback;
+
+                double extWallAreaM2 = 0;
+                double glazingAreaM2 = 0;
+                double avgOrient = 0; int orientN = 0;
+                foreach (var loop in segs)
+                foreach (var seg in loop)
+                {
+                    var el = spatial.Document.GetElement(seg.ElementId);
+                    if (el is not Wall w) continue;
+                    if (w.WallType?.Function != WallFunction.Exterior) continue;
+                    double lenM = UnitUtils.ConvertFromInternalUnits(seg.GetCurve()?.Length ?? 0, UnitTypeId.Meters);
+                    double h = z.HeightM;
+                    double area = lenM * h;
+                    extWallAreaM2 += area;
+
+                    // Glazing — sum hosted window areas if any
+                    try
+                    {
+                        var hosted = w.FindInserts(true, false, false, false);
+                        foreach (var ins in hosted)
+                        {
+                            if (w.Document.GetElement(ins) is FamilyInstance fi &&
+                                fi.Category?.Id?.Value == (long)BuiltInCategory.OST_Windows)
+                            {
+                                var bb = fi.get_BoundingBox(null);
+                                if (bb != null)
+                                {
+                                    double wFt = bb.Max.X - bb.Min.X;
+                                    double hFt = bb.Max.Z - bb.Min.Z;
+                                    double aM2 = UnitUtils.ConvertFromInternalUnits(wFt * hFt, UnitTypeId.SquareMeters);
+                                    if (aM2 > 0.1) glazingAreaM2 += aM2;
+                                }
+                            }
+                        }
+                    }
+                    catch { /* swallow per-window failures */ }
+
+                    // Crude orientation: wall facing vector
+                    try
+                    {
+                        var dir = w.Orientation;
+                        double deg = Math.Atan2(dir.X, dir.Y) * 180 / Math.PI;
+                        if (deg < 0) deg += 360;
+                        avgOrient += deg; orientN++;
+                    }
+                    catch { }
+                }
+                double orientation = orientN > 0 ? avgOrient / orientN : 180;
+                double netWall = Math.Max(0, extWallAreaM2 - glazingAreaM2);
+
+                if (netWall > 0)
+                    z.Envelope.Add(new EnvelopeSegment
+                    {
+                        Kind = SegmentKind.ExteriorWall, AreaM2 = netWall,
+                        UvalueWm2K = 0.30, OrientationDeg = orientation
+                    });
+                if (glazingAreaM2 > 0)
+                    z.Envelope.Add(new EnvelopeSegment
+                    {
+                        Kind = SegmentKind.Window, AreaM2 = glazingAreaM2,
+                        UvalueWm2K = 1.4, SHGC = 0.4, ShadingFactor = 0.9,
+                        OrientationDeg = orientation
+                    });
+
+                // Top floor — credit a roof segment when the level looks like the top.
+                z.Envelope.Add(new EnvelopeSegment
+                {
+                    Kind = SegmentKind.Roof, AreaM2 = z.FloorAreaM2 * 0.5,
+                    UvalueWm2K = 0.20, OrientationDeg = 0
+                });
+                return;
+
+                Fallback:
+                z.Envelope.Add(new EnvelopeSegment
+                {
+                    Kind = SegmentKind.ExteriorWall, AreaM2 = Math.Max(z.FloorAreaM2 * 0.6, 8),
+                    UvalueWm2K = 0.30, OrientationDeg = 180
+                });
+                z.Envelope.Add(new EnvelopeSegment
+                {
+                    Kind = SegmentKind.Window, AreaM2 = Math.Max(z.FloorAreaM2 * 0.15, 2),
+                    UvalueWm2K = 1.4, SHGC = 0.4, OrientationDeg = 180
+                });
+            }
+            catch (Exception ex) { StingLog.Warn($"Envelope detect {spatial.Id}: {ex.Message}"); }
+        }
+
+        private static string ResolveSystemId(Space s)
+        {
+            try
+            {
+                string sysId = s.LookupParameter("HVC_SYSTEM_ID_TXT")?.AsString();
+                if (!string.IsNullOrWhiteSpace(sysId)) return sysId;
+                // Group by Zone if available — `Space.Zone` returns the Revit
+                // HVAC Zone the space is assigned to. Wrapped because not
+                // every project binds Zones.
+                try
+                {
+                    var zone = s.Zone;
+                    if (zone != null && !string.IsNullOrEmpty(zone.Name)) return zone.Name;
+                }
+                catch { }
+                return "(default)";
+            }
+            catch { return "(default)"; }
+        }
+
+        private static int TryReadIntByName(Element el, string name)
+        {
+            try
+            {
+                var p = el.LookupParameter(name);
+                if (p == null) return 0;
+                if (p.StorageType == StorageType.Integer) return p.AsInteger();
+                if (p.StorageType == StorageType.Double)  return (int)Math.Round(p.AsDouble());
+                return 0;
+            }
+            catch { return 0; }
+        }
+
+        private static double TryReadFlowByName(Element el, string name)
+        {
+            try
+            {
+                var p = el.LookupParameter(name);
+                if (p == null || p.StorageType != StorageType.Double) return 0;
+                return UnitUtils.ConvertFromInternalUnits(p.AsDouble(), UnitTypeId.LitersPerSecond);
+            }
+            catch { return 0; }
+        }
+
+        private static long ParseLong(string s)
+        {
+            return long.TryParse(s, out long v) ? v : -1;
+        }
+    }
+}

--- a/StingTools/Commands/Hvac/HvacClimateCommands.cs
+++ b/StingTools/Commands/Hvac/HvacClimateCommands.cs
@@ -1,0 +1,90 @@
+// StingTools — Climate-registry diagnostic commands.
+//
+// Inspect: show the active climate site for the open document plus
+// the corporate site catalogue.
+// Reload: force the cache to drop so an edit to the corporate baseline
+// or a project override is picked up without restarting Revit.
+
+using System;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Climate;
+using StingTools.UI;
+
+namespace StingTools.Commands.Hvac
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HvacClimateInspectCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                var data = ClimateRegistry.Get(doc);
+                var active = ClimateRegistry.ActiveSite(doc);
+
+                var panel = StingResultPanel.Create("HVAC — Climate Registry");
+                panel.SetSubtitle(
+                    $"{data.Sites.Count} sites loaded · active: {active.Label} ({active.Source})");
+
+                panel.AddSection("ACTIVE SITE")
+                     .Metric("Id",                 active.Id)
+                     .Metric("Country",            active.Country)
+                     .Metric("Lat / Lon",          $"{active.Lat:F3} / {active.Lon:F3}")
+                     .Metric("Elevation",          $"{active.ElevationM:F0} m")
+                     .Metric("Cooling 0.4 % DB",   $"{active.Cooling996DbC:F1} °C")
+                     .Metric("Cooling MCWB",       $"{active.Cooling996McwbC:F1} °C")
+                     .Metric("Heating 99.6 % DB",  $"{active.Heating996DbC:F1} °C")
+                     .Metric("HDD (base 18 °C)",   $"{active.Hdd18:F0}")
+                     .Metric("CDD (base 10 °C)",   $"{active.Cdd10:F0}")
+                     .Metric("ρ (cooling design)", $"{active.AirDensityCoolingKgM3():F3} kg/m³")
+                     .Metric("ρ (heating design)", $"{active.AirDensityHeatingKgM3():F3} kg/m³");
+
+                panel.AddSection("CATALOGUE");
+                foreach (var s in data.Sites.OrderBy(x => x.Country).ThenBy(x => x.Label))
+                    panel.Text($"{s.Id,-16} {s.Label,-32} {s.Country}  cool {s.Cooling996DbC,5:F1} °C  heat {s.Heating996DbC,5:F1} °C  ρ={s.AirDensityCoolingKgM3():F3}");
+
+                panel.Text("Set the active site via Project Info > 'PRJ_CLIMATE_SITE_ID' " +
+                           "(use the id column above), or via the Address field which is fuzzy-matched.");
+                panel.Show();
+
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("HvacClimateInspectCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HvacClimateReloadCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                ClimateRegistry.Reload();
+                TaskDialog.Show("STING HVAC", "Climate registry reloaded — corporate baseline + project override re-read on next use.");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("HvacClimateReloadCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/Commands/Hvac/HvacNcPredictionCommand.cs
+++ b/StingTools/Commands/Hvac/HvacNcPredictionCommand.cs
@@ -1,0 +1,250 @@
+// StingTools — NC prediction command.
+//
+// Walks an active duct selection from the active view (treating the
+// upstream-most member as the fan source) and computes the predicted
+// NC at the room downstream of the terminal diffuser. Uses
+// NcPredictionEngine to accumulate attenuation + regenerated noise
+// along the path and renders the breakdown in a StingResultPanel.
+//
+// For now the fan-source sound power is approximated from the
+// upstream duct's velocity (Madison's fan-noise empirical formula):
+//     Lw = 67 + 10·log10(Q) + 10·log10(ΔP)
+// where Q in L/s, ΔP in Pa. A future phase will read the actual
+// manufacturer Lw spectrum from a fan-curve sidecar.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Acoustic;
+using StingTools.Core.Mep;
+using StingTools.UI;
+
+namespace StingTools.Commands.Hvac
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HvacNcPredictionCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { message = "No active document."; return Result.Failed; }
+                var doc = ctx.Doc;
+
+                // Use the selection as the path. Order is the user-pick order
+                // upstream→downstream; in absence of a user pick we sort by
+                // length descending and treat the longest as the trunk.
+                var ids = ctx.UIDoc?.Selection?.GetElementIds()?.ToList()
+                          ?? new List<ElementId>();
+                if (ids.Count == 0)
+                {
+                    TaskDialog.Show("STING HVAC — NC Prediction",
+                        "Pick a duct path from fan source → terminal first (Select tab → Mechanical), then re-run.");
+                    return Result.Cancelled;
+                }
+
+                var path = BuildPathFromSelection(doc, ids, out double pathFlowLs, out double pathDpPa);
+                if (path.Count == 0)
+                {
+                    TaskDialog.Show("STING HVAC — NC Prediction",
+                        "Selection contains no duct curves or fittings.");
+                    return Result.Cancelled;
+                }
+
+                // Synthetic fan source from path total ΔP + flow.
+                double fanLwTotal = pathFlowLs > 0 && pathDpPa > 0
+                    ? 67 + 10 * Math.Log10(pathFlowLs) + 10 * Math.Log10(pathDpPa)
+                    : 80; // catch-all
+                var fanSpectrum = OctaveBand.FromArray(new[]
+                {
+                    fanLwTotal - 7, fanLwTotal - 5, fanLwTotal - 4, fanLwTotal - 3,
+                    fanLwTotal - 4, fanLwTotal - 6, fanLwTotal - 10, fanLwTotal - 14
+                });
+
+                path.Insert(0, new PathElement
+                {
+                    Kind = ElementKind.Fan,
+                    Label = $"Synthetic fan (Lw≈{fanLwTotal:F0} dB)",
+                    SourceLw = fanSpectrum
+                });
+
+                var room = new RoomReceiver
+                {
+                    Name = "Receiver",
+                    VolumeM3 = 100,
+                    SurfaceAreaM2 = 6 * Math.Pow(100, 2.0 / 3.0),
+                    AvgAbsorption = 0.2,
+                    Directivity = 2,
+                    ListenerDistanceM = 1.5
+                };
+
+                var result = NcPredictionEngine.Compute(path, room);
+
+                var panel = StingResultPanel.Create("HVAC — NC Prediction");
+                panel.SetSubtitle($"path {path.Count - 1} segments · flow {pathFlowLs:F0} L/s · ΔP {pathDpPa:F0} Pa · room V={room.VolumeM3:F0} m³");
+                panel.AddSection("RESULT")
+                     .Metric("Predicted NC", $"NC {result.NcRating}")
+                     .Metric("Fan Lw (1 kHz)", $"{fanSpectrum.Hz1000:F0} dB")
+                     .Metric("Room Lw (1 kHz)", $"{result.RoomLw.Hz1000:F0} dB")
+                     .Metric("Room Lp (1 kHz)", $"{result.RoomLp.Hz1000:F0} dB");
+
+                panel.AddSection("OCTAVE-BAND Lp dB(A)");
+                var bands = OctaveBand.CentreFrequencies;
+                var lp = result.RoomLp.AsArray();
+                for (int i = 0; i < bands.Length; i++)
+                    panel.Text($"{bands[i]:F0} Hz: Lp = {lp[i]:F1} dB");
+
+                panel.AddSection("PER-ELEMENT BREAKDOWN");
+                foreach (var pe in result.PerElement)
+                {
+                    string atten = string.Join("/", pe.AttenDb.AsArray().Select(d => d.ToString("F0")));
+                    string regen = string.Join("/", pe.RegenLw.AsArray().Select(d => d.ToString("F0")));
+                    panel.Text($"{pe.Element}: atten {atten} · regen {regen}");
+                }
+
+                panel.Text("Method: VDI 2081 / ASHRAE A48 attenuation + Bullock regen + " +
+                           "direct + reverberant room model. Synthetic fan Lw " +
+                           "derived from path Q+ΔP — replace with manufacturer spectrum for definitive NC.");
+                panel.Show();
+
+                try
+                {
+                    StingHvacPanel.Instance?.PushRunRow($"NC prediction → NC {result.NcRating}", "⬤");
+                }
+                catch (Exception ex) { StingLog.Warn($"Panel push: {ex.Message}"); }
+
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("HvacNcPredictionCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// Convert a Revit selection of MEPCurves + fittings into an
+        /// ordered list of PathElement. The first non-fan element is the
+        /// upstream-most segment (by Revit ElementId order — Revit's
+        /// pick order isn't preserved, so this is best-effort).
+        /// </summary>
+        private static List<PathElement> BuildPathFromSelection(
+            Document doc, List<ElementId> ids,
+            out double maxFlowLs, out double sumDpPa)
+        {
+            var list = new List<PathElement>();
+            maxFlowLs = 0;
+            sumDpPa = 0;
+            foreach (var id in ids.OrderBy(i => i.Value))
+            {
+                var el = doc.GetElement(id);
+                if (el == null) continue;
+                var pe = TryToPathElement(el);
+                if (pe == null) continue;
+
+                if (pe.Kind == ElementKind.StraightDuct)
+                {
+                    double q = MepUnits.ReadAirFlowLs(el, "HVC_FLOW_LS");
+                    if (q <= 0) q = MepUnits.ReadBuiltInFlowLs(el, BuiltInParameter.RBS_DUCT_FLOW_PARAM);
+                    if (q > maxFlowLs) maxFlowLs = q;
+
+                    double dpPaPerM = TryReadDouble(el, "HVC_PRESSURE_DROP_PA");
+                    sumDpPa += dpPaPerM;
+                }
+                list.Add(pe);
+            }
+            // If we got no terminal in the selection, add a synthetic one
+            // so the result panel still includes end-reflection.
+            if (!list.Any(p => p.Kind == ElementKind.Diffuser))
+            {
+                list.Add(new PathElement
+                {
+                    Kind = ElementKind.Diffuser,
+                    Label = "Synthetic terminal (no diffuser in selection)",
+                    VelocityMs = 3.0,
+                    AreaM2 = 0.05
+                });
+            }
+            return list;
+        }
+
+        private static PathElement TryToPathElement(Element el)
+        {
+            try
+            {
+                if (el.Category == null) return null;
+                var bic = (BuiltInCategory)el.Category.Id.Value;
+                if (bic == BuiltInCategory.OST_DuctCurves &&
+                    el is Autodesk.Revit.DB.Mechanical.Duct duct)
+                {
+                    double dia = UnitUtils.ConvertFromInternalUnits(duct.Diameter, UnitTypeId.Millimeters);
+                    double w   = UnitUtils.ConvertFromInternalUnits(duct.Width,    UnitTypeId.Millimeters);
+                    double h   = UnitUtils.ConvertFromInternalUnits(duct.Height,   UnitTypeId.Millimeters);
+                    double areaM2 = (dia > 0)
+                        ? Math.PI * Math.Pow(dia * 1e-3, 2) * 0.25
+                        : (w > 0 && h > 0 ? w * h * 1e-6 : 0.05);
+                    double flowLs = MepUnits.ReadAirFlowLs(el, "HVC_FLOW_LS");
+                    if (flowLs <= 0) flowLs = MepUnits.ReadBuiltInFlowLs(el, BuiltInParameter.RBS_DUCT_FLOW_PARAM);
+                    double v = (areaM2 > 0 && flowLs > 0) ? (flowLs * 1e-3) / areaM2 : 3.0;
+                    double len = 0;
+                    if (duct.Location is LocationCurve lc && lc.Curve != null)
+                        len = UnitUtils.ConvertFromInternalUnits(lc.Curve.Length, UnitTypeId.Meters);
+                    return new PathElement
+                    {
+                        Kind = ElementKind.StraightDuct,
+                        Label = $"Straight duct {len:F1} m @ {v:F1} m/s",
+                        LengthM = len, VelocityMs = v, AreaM2 = areaM2
+                    };
+                }
+                if (bic == BuiltInCategory.OST_DuctFitting)
+                {
+                    // Heuristic: family name → elbow / tee / damper
+                    string nm = (el.Name ?? "").ToLowerInvariant();
+                    var kind = nm.Contains("elbow")  ? ElementKind.Elbow
+                             : nm.Contains("tee")    ? ElementKind.Tee
+                             : nm.Contains("damper") ? ElementKind.Damper
+                             :                         ElementKind.Elbow;
+                    return new PathElement { Kind = kind, Label = el.Name, VelocityMs = 5.0 };
+                }
+                if (bic == BuiltInCategory.OST_DuctAccessory)
+                {
+                    string nm = (el.Name ?? "").ToLowerInvariant();
+                    if (nm.Contains("silencer") || nm.Contains("attenuator"))
+                    {
+                        // Default 12 dB insertion loss at mid frequencies; replace with manufacturer data.
+                        var il = OctaveBand.FromArray(new[] { 2.0, 4, 8, 12, 14, 12, 8, 5 });
+                        return new PathElement
+                        {
+                            Kind = ElementKind.Silencer, Label = el.Name,
+                            SilencerILdB = il
+                        };
+                    }
+                    return new PathElement { Kind = ElementKind.Damper, Label = el.Name, VelocityMs = 5.0 };
+                }
+                if (bic == BuiltInCategory.OST_DuctTerminal)
+                {
+                    return new PathElement
+                    {
+                        Kind = ElementKind.Diffuser, Label = el.Name,
+                        VelocityMs = 3.0, AreaM2 = 0.05
+                    };
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"NcPath element {el.Id}: {ex.Message}"); }
+            return null;
+        }
+
+        private static double TryReadDouble(Element el, string p)
+        {
+            try { return el.LookupParameter(p)?.AsDouble() ?? 0; } catch { return 0; }
+        }
+    }
+}

--- a/StingTools/Commands/Hvac/HvacPressureClassAuditCommand.cs
+++ b/StingTools/Commands/Hvac/HvacPressureClassAuditCommand.cs
@@ -57,8 +57,20 @@ namespace StingTools.Commands.Hvac
                     return Result.Cancelled;
                 }
                 double maxPa = pclass.MaxPa > 0 ? pclass.MaxPa : 500.0;
-                double airDensity = 1.20;
-                try { airDensity = StingHvacCommandHandler.CurrentAirDensityKgM3; } catch { }
+                // Air density: prefer the climate-registry value for the
+                // project's location (elevation + cooling design temp), fall
+                // back to the header radio, fall back to 1.20 kg/m³.
+                double airDensity = 0;
+                try
+                {
+                    var site = StingTools.Core.Climate.ClimateRegistry.ActiveSite(doc);
+                    if (site != null) airDensity = site.AirDensityCoolingKgM3();
+                }
+                catch { }
+                if (airDensity <= 0)
+                {
+                    try { airDensity = StingHvacCommandHandler.CurrentAirDensityKgM3; } catch { }
+                }
                 if (airDensity <= 0) airDensity = 1.20;
 
                 // Honour the same scope radio as the sizing commands.

--- a/StingTools/Commands/Hvac/HvacRefrigerantSizeCommand.cs
+++ b/StingTools/Commands/Hvac/HvacRefrigerantSizeCommand.cs
@@ -1,0 +1,102 @@
+// StingTools — Refrigerant pipe sizing command.
+//
+// Pops the RefrigerantSizingDialog, runs RefrigerantPipeSolver,
+// reports the chosen size + velocity + ΔP + vendor compliance.
+// Unlocks the VRF/VRV market segment — STING previously had no path
+// for sizing refrigerant systems (water rules don't apply: two-phase
+// flow, oil-return constraints, manufacturer length+lift envelopes).
+
+using System;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Refrigerant;
+using StingTools.UI;
+
+namespace StingTools.Commands.Hvac
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HvacRefrigerantSizeCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            try
+            {
+                var dlg = new RefrigerantSizingDialog();
+                bool? ok = dlg.ShowDialog();
+                if (ok != true || dlg.Result == null) return Result.Cancelled;
+
+                var input = dlg.Result;
+                var result = RefrigerantPipeSolver.Size(input);
+                var fluid = RefrigerantProperties.Get(input.RefrigerantId);
+
+                var panel = StingResultPanel.Create($"HVAC — {input.RefrigerantId} {input.Leg}");
+                panel.SetSubtitle(
+                    $"{fluid.Label} · Tsat={fluid.SuctionSatTempC}/{fluid.CondSatTempC} °C · " +
+                    $"capacity {input.CapacityKw:F1} kW · L_eq {input.EquivLengthM:F0} m · lift {input.LiftM:F0} m");
+
+                if (result.Ok)
+                {
+                    panel.AddSection("SELECTED SIZE")
+                         .Metric("OD (ACR copper)",   $"{result.SelectedBoreMm:F2} mm")
+                         .Metric("Velocity",          $"{result.VelocityMs:F1} m/s")
+                         .Metric("Mass flow",         $"{result.MassFlowKgS * 1000:F2} g/s")
+                         .Metric("ΔP",                $"{result.PressureDropKpa:F1} kPa")
+                         .Metric("Lift static head",  $"{result.LiftPenaltyKpa:F1} kPa")
+                         .Metric("Re",                $"{result.ReynoldsNumber:E2}")
+                         .Metric("Friction f",        $"{result.FrictionFactor:F4}");
+                }
+                else
+                {
+                    panel.AddSection("NO MATCH")
+                         .Text("No ACR copper size in the catalogue passes both the oil-return " +
+                               "velocity floor and the ΔP budget. Lower the capacity, shorten the run, " +
+                               "or raise the ΔP budget.");
+                }
+
+                if (result.Warnings.Count > 0)
+                {
+                    panel.AddSection("WARNINGS");
+                    foreach (var w in result.Warnings) panel.Text("⚠ " + w);
+                }
+
+                panel.AddSection("SIZE SWEEP TRACE");
+                foreach (var t in result.Trace.Take(20))
+                    panel.Text($"OD {t.DiaMm,5:F2} mm  v {t.VelMs,5:F1} m/s  ΔP {t.DpKpa,6:F1} kPa  {t.Reason}");
+
+                panel.AddSection("VENDOR ENVELOPE (DAIKIN VRV / EQUIV)")
+                     .Metric("Max L_eq",          $"{fluid.MaxEquivLengthM:F0} m")
+                     .Metric("Max lift (above)",  $"{fluid.MaxLiftAboveIndoorM:F0} m")
+                     .Metric("Max drop (below)",  $"{fluid.MaxLiftBelowIndoorM:F0} m")
+                     .Text($"Source: {fluid.Source}");
+
+                panel.Text("Method: Darcy-Weisbach with Blasius f (smooth ACR copper). " +
+                           "Suction leg includes a 10% two-phase pressure-drop multiplier. " +
+                           "Liquid leg static head subtracted from ΔP budget.");
+                panel.Show();
+
+                try
+                {
+                    StingHvacPanel.Instance?.PushRunRow(
+                        result.Ok
+                            ? $"Refrig {input.RefrigerantId} {input.Leg} → {result.SelectedBoreMm:F1} mm"
+                            : $"Refrig {input.RefrigerantId} {input.Leg} — no match",
+                        result.Ok ? "⬤" : "⬡");
+                }
+                catch (Exception ex) { StingLog.Warn($"Panel push: {ex.Message}"); }
+
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("HvacRefrigerantSizeCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/Core/Acoustic/NcPredictionEngine.cs
+++ b/StingTools/Core/Acoustic/NcPredictionEngine.cs
@@ -1,0 +1,244 @@
+// StingTools — NC (Noise Criteria) prediction engine.
+//
+// Walks the duct path from fan source → terminal → room, accumulating
+// attenuation and regenerated noise per element, and arrives at a
+// predicted NC rating per room. Closes the gap STING had previously:
+// the registry ships NC *targets* (Office 35, OR 35, etc.) but nothing
+// computed the actual room NC to compare against.
+//
+// Approach (VDI 2081 / ASHRAE Handbook A48 / CIBSE TG6 simplified):
+//
+//   Lw_room(f) = Lw_fan(f)
+//              − A_straight_duct(f)·L_m
+//              − Σ A_fitting(f)
+//              − A_silencer(f)
+//              − A_end_reflection(f)
+//              + Σ Lw_regen(f)              (per fitting + terminal)
+//   Lp_room(f) = Lw_room(f) + 10·log10( Q/4πr² + 4/R )
+//
+// where Q = directivity, r = listener distance, R = room constant.
+//
+// Output: predicted NC per room + per-element contribution table.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Acoustic
+{
+    public enum ElementKind { Fan, StraightDuct, Elbow, Tee, Damper, Silencer, Diffuser }
+
+    public class PathElement
+    {
+        public ElementKind Kind   { get; set; }
+        public string Label       { get; set; } = "";
+        /// <summary>Length m (StraightDuct only).</summary>
+        public double LengthM     { get; set; }
+        /// <summary>Air velocity at this element m/s — used for regenerated noise.</summary>
+        public double VelocityMs  { get; set; }
+        /// <summary>Mean duct cross-section m² — used for end-reflection at terminals.</summary>
+        public double AreaM2      { get; set; }
+        /// <summary>Source Lw per octave (Fan only). dB re 1 pW.</summary>
+        public OctaveBand SourceLw { get; set; }
+        /// <summary>Silencer insertion-loss per octave (Silencer only). dB.</summary>
+        public OctaveBand SilencerILdB { get; set; }
+    }
+
+    public class RoomReceiver
+    {
+        public string Name        { get; set; } = "";
+        public double VolumeM3    { get; set; }
+        /// <summary>Avg absorption coefficient (Sabine). 0.1 hard, 0.3 typical office.</summary>
+        public double AvgAbsorption { get; set; } = 0.2;
+        /// <summary>Total interior surface area m².</summary>
+        public double SurfaceAreaM2 { get; set; }
+        /// <summary>Listener distance from the terminal, m.</summary>
+        public double ListenerDistanceM { get; set; } = 1.5;
+        /// <summary>Directivity factor. 2 for ceiling-mount, 4 for wall corner.</summary>
+        public double Directivity { get; set; } = 2.0;
+    }
+
+    public class NcPathResult
+    {
+        public string PathName              { get; set; } = "";
+        public OctaveBand FanLw              { get; set; }
+        public OctaveBand TotalAttenuationDb { get; set; }
+        public OctaveBand TotalRegenLw       { get; set; }
+        public OctaveBand RoomLw             { get; set; }
+        public OctaveBand RoomLp             { get; set; }
+        public int NcRating                  { get; set; }
+        public List<(string Element, OctaveBand AttenDb, OctaveBand RegenLw)> PerElement { get; }
+            = new List<(string, OctaveBand, OctaveBand)>();
+    }
+
+    public static class NcPredictionEngine
+    {
+        // ── Attenuation tables ──────────────────────────────────────
+        // dB/m for unlined straight rectangular duct, ASHRAE A48 Tbl 6.
+        // Indexed by octave 63..8000 Hz. Conservative midpoint of size
+        // bands; calibrate via duct hydraulic diameter for accuracy.
+        public static readonly OctaveBand RectStraightUnlinedDbPerM = OctaveBand.FromArray(
+            new[] { 0.10, 0.10, 0.06, 0.03, 0.03, 0.03, 0.03, 0.03 });
+        // dB/m for 25 mm lined rectangular duct, ASHRAE A48 Tbl 8.
+        public static readonly OctaveBand RectStraightLined25DbPerM = OctaveBand.FromArray(
+            new[] { 0.20, 0.45, 1.80, 4.50, 6.50, 5.50, 3.50, 2.50 });
+        // dB per 90° unlined elbow, ASHRAE A48 Tbl 13.
+        public static readonly OctaveBand Elbow90UnlinedDb = OctaveBand.FromArray(
+            new[] { 0.0, 1.0, 5.0, 8.0, 4.0, 3.0, 3.0, 3.0 });
+        // dB lost at branch tee (straight-through path), ASHRAE A48.
+        public static readonly OctaveBand TeeBranchDb = OctaveBand.FromArray(
+            new[] { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 });
+        // End-reflection at a small terminal opening, ASHRAE A48 Tbl 18.
+        public static readonly OctaveBand TerminalEndReflectionDb = OctaveBand.FromArray(
+            new[] { 18.0, 12.0, 7.0, 3.0, 1.0, 0.0, 0.0, 0.0 });
+
+        /// <summary>
+        /// Compute room-NC for a single path. Walks the elements in
+        /// source-to-terminal order, accumulates attenuation and adds
+        /// regenerated noise from fittings.
+        /// </summary>
+        public static NcPathResult Compute(List<PathElement> path, RoomReceiver room)
+        {
+            var r = new NcPathResult();
+            if (path == null || path.Count == 0 || room == null) return r;
+
+            // 1. Source
+            var fan = path.FirstOrDefault(e => e.Kind == ElementKind.Fan);
+            if (fan == null)
+            {
+                r.PathName = "(no fan source)";
+                return r;
+            }
+            r.FanLw = fan.SourceLw;
+            var lw = fan.SourceLw;
+            var totalAtten = new OctaveBand();
+            var totalRegen = new OctaveBand();
+
+            // 2. Walk subsequent elements
+            foreach (var e in path)
+            {
+                if (e == fan) continue;
+                var atten = new OctaveBand();
+                var regen = new OctaveBand();
+
+                switch (e.Kind)
+                {
+                    case ElementKind.StraightDuct:
+                        for (int i = 0; i < 8; i++)
+                            atten[i] = RectStraightUnlinedDbPerM[i] * e.LengthM;
+                        break;
+                    case ElementKind.Elbow:
+                        for (int i = 0; i < 8; i++) atten[i] = Elbow90UnlinedDb[i];
+                        regen = RegenElbow(e.VelocityMs);
+                        break;
+                    case ElementKind.Tee:
+                        for (int i = 0; i < 8; i++) atten[i] = TeeBranchDb[i];
+                        regen = RegenTee(e.VelocityMs);
+                        break;
+                    case ElementKind.Damper:
+                        regen = RegenDamper(e.VelocityMs);
+                        break;
+                    case ElementKind.Silencer:
+                        atten = e.SilencerILdB;
+                        break;
+                    case ElementKind.Diffuser:
+                        for (int i = 0; i < 8; i++) atten[i] = TerminalEndReflectionDb[i];
+                        regen = RegenDiffuser(e.VelocityMs, e.AreaM2);
+                        break;
+                }
+
+                // Net Lw at this element: subtract attenuation, energy-add regen
+                lw = lw - atten;
+                if (HasEnergy(regen)) lw = OctaveBand.AddLevels(lw, regen);
+
+                totalAtten = totalAtten + atten;
+                if (HasEnergy(regen)) totalRegen = OctaveBand.AddLevels(totalRegen, regen);
+
+                r.PerElement.Add((string.IsNullOrEmpty(e.Label) ? e.Kind.ToString() : e.Label, atten, regen));
+            }
+
+            r.RoomLw = lw;
+            r.RoomLp = RoomLwToLp(lw, room);
+            r.TotalAttenuationDb = totalAtten;
+            r.TotalRegenLw = totalRegen;
+            r.NcRating = NcCurves.Rate(r.RoomLp);
+            return r;
+        }
+
+        /// <summary>
+        /// Convert Lw (dB) entering a room to Lp (dB) at the listener using
+        /// the standard direct + reverberant formula:
+        ///   Lp = Lw + 10·log10( Q/(4πr²) + 4/R )
+        /// R = S·ᾱ/(1-ᾱ) is the room constant.
+        /// </summary>
+        public static OctaveBand RoomLwToLp(OctaveBand lw, RoomReceiver room)
+        {
+            double r2 = Math.Max(room.ListenerDistanceM, 0.5);
+            r2 *= r2;
+            double s = room.SurfaceAreaM2 > 0 ? room.SurfaceAreaM2
+                : 6 * Math.Pow(Math.Max(room.VolumeM3, 1), 2.0 / 3.0); // approx cube
+            double a = Math.Max(0.05, Math.Min(0.95, room.AvgAbsorption));
+            double R = s * a / (1 - a);
+            double direct = room.Directivity / (4 * Math.PI * r2);
+            double rev    = 4.0 / R;
+            double delta  = 10 * Math.Log10(direct + rev);
+
+            var lp = new OctaveBand();
+            for (int i = 0; i < 8; i++) lp[i] = lw[i] + delta;
+            return lp;
+        }
+
+        // ── Regenerated noise correlations ──────────────────────────
+        // All correlations of the form:
+        //     Lw(f) = K + 60·log10(v) + 10·log10(A)
+        // with empirical band shifts. References:
+        //   Bullock C.E. "Aerodynamic sound generation by duct elements",
+        //   ASHRAE Trans. 76 (1970); refreshed in ASHRAE Handbook A48
+        //   tables 23-26. Velocity term ~v^6 (60·log10 v) is the
+        //   acoustic-power scaling for turbulent mixing.
+
+        private static OctaveBand RegenElbow(double v)
+        {
+            // ASHRAE A48 Fig 23: square elbow, no vanes. Reference 5 m/s.
+            double baseK = -10 + 60 * Math.Log10(Math.Max(v, 0.5));
+            // Octave shape (relative dB): low-freq biased.
+            double[] shape = { 5, 6, 7, 6, 4, 2, 0, -2 };
+            return ApplyShape(baseK, shape);
+        }
+        private static OctaveBand RegenTee(double v)
+        {
+            double baseK = -8 + 60 * Math.Log10(Math.Max(v, 0.5));
+            double[] shape = { 3, 5, 7, 8, 7, 5, 2, 0 };
+            return ApplyShape(baseK, shape);
+        }
+        private static OctaveBand RegenDamper(double v)
+        {
+            // High-velocity dampers are usually the loudest single
+            // contributor. ASHRAE A48 Tbl 28 reference.
+            double baseK = -4 + 60 * Math.Log10(Math.Max(v, 0.5));
+            double[] shape = { 1, 3, 5, 8, 10, 9, 6, 3 };
+            return ApplyShape(baseK, shape);
+        }
+        private static OctaveBand RegenDiffuser(double v, double areaM2)
+        {
+            // Terminal diffuser regen — heavy mid-frequency. Reference
+            // Trox VL-50 grille @ 3 m/s ≈ NR-30.
+            double baseK = 5 + 60 * Math.Log10(Math.Max(v, 0.3)) + 10 * Math.Log10(Math.Max(areaM2, 0.005));
+            double[] shape = { 0, 2, 4, 7, 8, 6, 4, 1 };
+            return ApplyShape(baseK, shape);
+        }
+
+        private static OctaveBand ApplyShape(double baseK, double[] shape)
+        {
+            var b = new OctaveBand();
+            for (int i = 0; i < 8 && i < shape.Length; i++) b[i] = baseK + shape[i];
+            return b;
+        }
+
+        private static bool HasEnergy(OctaveBand b)
+        {
+            for (int i = 0; i < 8; i++) if (b[i] > 0.1) return true;
+            return false;
+        }
+    }
+}

--- a/StingTools/Core/Acoustic/OctaveBand.cs
+++ b/StingTools/Core/Acoustic/OctaveBand.cs
@@ -1,0 +1,131 @@
+// StingTools — Octave-band sound-power container.
+//
+// Eight standard octave centres: 63, 125, 250, 500, 1000, 2000, 4000,
+// 8000 Hz. Used for fan source spectra, attenuation tables, and the
+// final NC-rating regression.
+
+using System;
+using System.Linq;
+
+namespace StingTools.Core.Acoustic
+{
+    public struct OctaveBand
+    {
+        public double Hz63;
+        public double Hz125;
+        public double Hz250;
+        public double Hz500;
+        public double Hz1000;
+        public double Hz2000;
+        public double Hz4000;
+        public double Hz8000;
+
+        public static readonly double[] CentreFrequencies =
+            new double[] { 63, 125, 250, 500, 1000, 2000, 4000, 8000 };
+
+        public double this[int i]
+        {
+            get => i switch
+            {
+                0 => Hz63, 1 => Hz125, 2 => Hz250, 3 => Hz500,
+                4 => Hz1000, 5 => Hz2000, 6 => Hz4000, 7 => Hz8000,
+                _ => 0
+            };
+            set
+            {
+                switch (i)
+                {
+                    case 0: Hz63 = value; break;
+                    case 1: Hz125 = value; break;
+                    case 2: Hz250 = value; break;
+                    case 3: Hz500 = value; break;
+                    case 4: Hz1000 = value; break;
+                    case 5: Hz2000 = value; break;
+                    case 6: Hz4000 = value; break;
+                    case 7: Hz8000 = value; break;
+                }
+            }
+        }
+
+        public double[] AsArray() => new[]
+        {
+            Hz63, Hz125, Hz250, Hz500, Hz1000, Hz2000, Hz4000, Hz8000
+        };
+
+        public static OctaveBand FromArray(double[] a)
+        {
+            var b = new OctaveBand();
+            for (int i = 0; i < 8 && i < (a?.Length ?? 0); i++) b[i] = a[i];
+            return b;
+        }
+
+        /// <summary>Energy-summed addition of two spectra (Lw or Lp).</summary>
+        public static OctaveBand AddLevels(OctaveBand a, OctaveBand b)
+        {
+            var r = new OctaveBand();
+            for (int i = 0; i < 8; i++)
+            {
+                double la = a[i], lb = b[i];
+                r[i] = 10 * Math.Log10(Math.Pow(10, la / 10) + Math.Pow(10, lb / 10));
+            }
+            return r;
+        }
+
+        /// <summary>Subtract attenuation (positive dB values) from a level spectrum.</summary>
+        public static OctaveBand operator -(OctaveBand level, OctaveBand attenuation)
+        {
+            var r = new OctaveBand();
+            for (int i = 0; i < 8; i++) r[i] = level[i] - attenuation[i];
+            return r;
+        }
+
+        /// <summary>Add two spectra arithmetically (use for attenuation tally).</summary>
+        public static OctaveBand operator +(OctaveBand a, OctaveBand b)
+        {
+            var r = new OctaveBand();
+            for (int i = 0; i < 8; i++) r[i] = a[i] + b[i];
+            return r;
+        }
+    }
+
+    /// <summary>
+    /// ASHRAE NC (Noise Criteria) curve evaluator.
+    /// NC rating = the lowest curve number that is not exceeded by the
+    /// Lp spectrum at any octave from 63 Hz to 8000 Hz.
+    /// </summary>
+    public static class NcCurves
+    {
+        // Tabulated NC curves (NC-15 through NC-65 in 5-step increments).
+        // Columns are octave centres 63 → 8k Hz.
+        public static readonly System.Collections.Generic.Dictionary<int, double[]> Curves = new()
+        {
+            { 15, new[]{ 47.0, 36.0, 29.0, 22.0, 17.0, 14.0, 12.0, 11.0 } },
+            { 20, new[]{ 51.0, 40.0, 33.0, 26.0, 22.0, 19.0, 17.0, 16.0 } },
+            { 25, new[]{ 54.0, 44.0, 37.0, 31.0, 27.0, 24.0, 22.0, 21.0 } },
+            { 30, new[]{ 57.0, 48.0, 41.0, 35.0, 31.0, 29.0, 28.0, 27.0 } },
+            { 35, new[]{ 60.0, 52.0, 45.0, 40.0, 36.0, 34.0, 33.0, 32.0 } },
+            { 40, new[]{ 64.0, 56.0, 50.0, 45.0, 41.0, 39.0, 38.0, 37.0 } },
+            { 45, new[]{ 67.0, 60.0, 54.0, 49.0, 46.0, 44.0, 43.0, 42.0 } },
+            { 50, new[]{ 71.0, 64.0, 58.0, 54.0, 51.0, 49.0, 48.0, 47.0 } },
+            { 55, new[]{ 74.0, 67.0, 62.0, 58.0, 56.0, 54.0, 53.0, 52.0 } },
+            { 60, new[]{ 77.0, 71.0, 67.0, 63.0, 61.0, 59.0, 58.0, 57.0 } },
+            { 65, new[]{ 80.0, 75.0, 71.0, 68.0, 66.0, 64.0, 63.0, 62.0 } }
+        };
+
+        /// <summary>
+        /// Return the NC rating of an Lp spectrum (dB re 20 μPa) —
+        /// the lowest NC curve that is not exceeded at any octave.
+        /// </summary>
+        public static int Rate(OctaveBand lp)
+        {
+            foreach (var (nc, curve) in Curves.OrderBy(k => k.Key))
+            {
+                bool fits = true;
+                for (int i = 0; i < 8; i++)
+                    if (lp[i] > curve[i]) { fits = false; break; }
+                if (fits) return nc;
+            }
+            return 65; // exceeds highest tabulated — report as "≥65"
+        }
+    }
+}

--- a/StingTools/Core/Climate/ClimateRegistry.cs
+++ b/StingTools/Core/Climate/ClimateRegistry.cs
@@ -1,0 +1,217 @@
+// StingTools — Climate Registry.
+//
+// Single source of truth for design-day climate data: cooling 0.4%/1%
+// dry-bulb + coincident wet-bulb, heating 99.6%/99% dry-bulb, HDD,
+// CDD and elevation. Replaces the hardcoded `airDensity = 1.20 kg/m³`
+// assumption baked into earlier HVAC commands with a location-aware
+// value derived from elevation + design temperature.
+//
+// Layered:
+//   corporate baseline → Data/STING_CLIMATE_DATA.json
+//   project override   → <project>/_BIM_COORD/climate_data.json
+//
+// Active site resolution priority:
+//   1. PRJ_CLIMATE_SITE_ID set on ProjectInformation
+//   2. ProjectInformation.Address fuzzy match against site labels
+//   3. The single site in the override file (if present)
+//   4. Hard fallback to "london"
+//
+// Sources:
+//   ASHRAE Climate Data Center 2021, CIBSE Guide A 2015.
+//   Air-density formula: ρ = (p₀ / (R · T)) · (1 - 0.0065·h/T)^5.2561
+//   where p₀ = 101325 Pa, R = 287.05 J/(kg·K), T = design absolute
+//   temperature (K), h = elevation (m). Yields the international
+//   standard atmosphere correction (NASA ISA model).
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Autodesk.Revit.DB;
+
+namespace StingTools.Core.Climate
+{
+    /// <summary>One climate design-data record per location.</summary>
+    public class ClimateSite
+    {
+        public string Id            { get; set; } = "";
+        public string Label         { get; set; } = "";
+        public string Country       { get; set; } = "";
+        public double Lat           { get; set; }
+        public double Lon           { get; set; }
+        public double ElevationM    { get; set; }
+        /// <summary>Cooling design dry-bulb at 0.4% annual exceedance, °C.</summary>
+        public double Cooling996DbC { get; set; }
+        /// <summary>Mean coincident wet-bulb at the cooling design hour, °C.</summary>
+        public double Cooling996McwbC { get; set; }
+        /// <summary>Heating design dry-bulb at 99.6% annual exceedance, °C.</summary>
+        public double Heating996DbC { get; set; }
+        /// <summary>Annual heating degree-days, 18 °C base.</summary>
+        public double Hdd18         { get; set; }
+        /// <summary>Annual cooling degree-days, 10 °C base.</summary>
+        public double Cdd10         { get; set; }
+        public string Source        { get; set; } = "";
+
+        /// <summary>
+        /// Air density at the cooling design dry-bulb, corrected for
+        /// elevation per the NASA ISA model. Returns kg/m³.
+        /// </summary>
+        public double AirDensityCoolingKgM3()
+        {
+            double pa = StandardPressurePa(ElevationM);
+            double t = Cooling996DbC + 273.15;
+            return pa / (287.05 * t);
+        }
+
+        /// <summary>Air density at the heating design dry-bulb (kg/m³).</summary>
+        public double AirDensityHeatingKgM3()
+        {
+            double pa = StandardPressurePa(ElevationM);
+            double t = Heating996DbC + 273.15;
+            return pa / (287.05 * t);
+        }
+
+        /// <summary>Standard pressure at elevation (Pa) per ISA.</summary>
+        public static double StandardPressurePa(double elevationM)
+        {
+            double t0 = 288.15; // sea-level standard temperature K
+            double l  = 0.0065; // troposphere lapse rate K/m
+            double exp = 9.80665 * 0.0289644 / (8.31447 * l);
+            return 101325.0 * Math.Pow(1.0 - l * elevationM / t0, exp);
+        }
+    }
+
+    public class ClimateData
+    {
+        public List<ClimateSite> Sites { get; set; } = new();
+
+        public ClimateSite ById(string id)
+            => Sites.FirstOrDefault(s => string.Equals(s.Id, id, StringComparison.OrdinalIgnoreCase));
+
+        public ClimateSite ByLabelContains(string fragment)
+        {
+            if (string.IsNullOrWhiteSpace(fragment)) return null;
+            string f = fragment.Trim().ToLowerInvariant();
+            return Sites.FirstOrDefault(s =>
+                s.Label.ToLowerInvariant().Contains(f) ||
+                s.Id.ToLowerInvariant().Contains(f));
+        }
+    }
+
+    /// <summary>
+    /// Loader / cache for climate data. Mirrors MepSizingRegistry
+    /// (corporate baseline + project override + per-doc cache).
+    /// </summary>
+    public static class ClimateRegistry
+    {
+        public const string DataFileName = "STING_CLIMATE_DATA.json";
+        public const string ProjectOverrideRelPath = "_BIM_COORD/climate_data.json";
+        public const string ProjectInfoSiteParam = "PRJ_CLIMATE_SITE_ID";
+
+        private static readonly ConcurrentDictionary<string, ClimateData> _cache
+            = new ConcurrentDictionary<string, ClimateData>(StringComparer.OrdinalIgnoreCase);
+
+        public static ClimateData Get(Document doc)
+        {
+            string key = doc?.PathName ?? "<no-doc>";
+            return _cache.GetOrAdd(key, _ => Load(doc));
+        }
+
+        public static void Reload()              => _cache.Clear();
+        public static void Reload(Document doc)  => _cache.TryRemove(doc?.PathName ?? "<no-doc>", out _);
+
+        /// <summary>
+        /// Resolve the active site for a document via (in order):
+        ///   1. PRJ_CLIMATE_SITE_ID on ProjectInformation
+        ///   2. ProjectInformation.Address contains a site label
+        ///   3. First site in the project override
+        ///   4. "london" hard fallback.
+        /// </summary>
+        public static ClimateSite ActiveSite(Document doc)
+        {
+            var data = Get(doc);
+            ClimateSite site = null;
+            try
+            {
+                if (doc?.ProjectInformation != null)
+                {
+                    string sid = ReadParam(doc.ProjectInformation, ProjectInfoSiteParam);
+                    if (!string.IsNullOrWhiteSpace(sid))
+                        site = data.ById(sid);
+                    if (site == null)
+                    {
+                        string addr = doc.ProjectInformation.Address;
+                        if (!string.IsNullOrWhiteSpace(addr))
+                            site = data.ByLabelContains(addr);
+                    }
+                }
+            }
+            catch { /* fall through */ }
+
+            return site
+                ?? data.ById("london")
+                ?? data.Sites.FirstOrDefault()
+                ?? new ClimateSite { Id = "fallback", Label = "Fallback", Cooling996DbC = 28, Heating996DbC = -3, ElevationM = 0 };
+        }
+
+        private static string ReadParam(Element el, string name)
+        {
+            try { return el.LookupParameter(name)?.AsString() ?? ""; }
+            catch { return ""; }
+        }
+
+        private static ClimateData Load(Document doc)
+        {
+            var data = new ClimateData();
+            try
+            {
+                string basePath = StingTools.Core.StingToolsApp.FindDataFile(DataFileName);
+                if (!string.IsNullOrEmpty(basePath) && File.Exists(basePath))
+                    Apply(JObject.Parse(File.ReadAllText(basePath)), data);
+
+                if (doc != null && !string.IsNullOrEmpty(doc.PathName))
+                {
+                    string projDir = Path.GetDirectoryName(doc.PathName) ?? "";
+                    string projPath = Path.Combine(projDir, ProjectOverrideRelPath);
+                    if (File.Exists(projPath))
+                        Apply(JObject.Parse(File.ReadAllText(projPath)), data);
+                }
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Error("ClimateRegistry.Load", ex);
+            }
+            return data;
+        }
+
+        private static void Apply(JObject j, ClimateData data)
+        {
+            var sites = j["sites"] as JArray;
+            if (sites == null) return;
+            foreach (var s in sites.OfType<JObject>())
+            {
+                var site = new ClimateSite
+                {
+                    Id              = (string)s["id"] ?? "",
+                    Label           = (string)s["label"] ?? "",
+                    Country         = (string)s["country"] ?? "",
+                    Lat             = (double?)s["lat"] ?? 0,
+                    Lon             = (double?)s["lon"] ?? 0,
+                    ElevationM      = (double?)s["elevationM"] ?? 0,
+                    Cooling996DbC   = (double?)s["cooling996DbC"] ?? 28,
+                    Cooling996McwbC = (double?)s["cooling996McwbC"] ?? 20,
+                    Heating996DbC   = (double?)s["heating996DbC"] ?? -3,
+                    Hdd18           = (double?)s["hdd18"] ?? 0,
+                    Cdd10           = (double?)s["cdd10"] ?? 0,
+                    Source          = (string)s["source"] ?? ""
+                };
+                // Project override replaces an existing entry with the same id
+                int existing = data.Sites.FindIndex(x => string.Equals(x.Id, site.Id, StringComparison.OrdinalIgnoreCase));
+                if (existing >= 0) data.Sites[existing] = site;
+                else data.Sites.Add(site);
+            }
+        }
+    }
+}

--- a/StingTools/Core/Hvac/Loads/BlockLoadEngine.cs
+++ b/StingTools/Core/Hvac/Loads/BlockLoadEngine.cs
@@ -1,0 +1,282 @@
+// StingTools — Block Load Engine.
+//
+// Hour-by-hour design-day load calc that peak-picks at the SYSTEM
+// level (not the per-zone level). This closes the most frequent
+// engineer complaint about Revit's native heating/cooling loads:
+// Revit sums per-zone peaks which over-sizes plant by 20–30 %
+// because zones don't peak simultaneously.
+//
+// Algorithm (simplified ASHRAE Radiant Time Series + CIBSE Guide A):
+//   For each hour h ∈ [0..23] of the design day:
+//     For each zone z:
+//       Q_sensible(z,h) =
+//           Σ_envelope U·A·(T_out(h) - T_set)            (conduction)
+//         + Σ_glazing  A·SHGC·shade·I_sol(h, orientation) (solar)
+//         + n(h)·q_sens_per_person                         (occupants)
+//         + lpd·A·sched_light(h)                           (lighting)
+//         + epd·A·sched_equip(h)                           (equipment)
+//         + ṁ_inf·c_p·(T_out(h) - T_set)                   (infiltration)
+//         + ṁ_oa·c_p·(T_out(h) - T_set)                    (vent sensible)
+//
+//       Q_latent(z,h) =
+//           n(h)·q_lat_per_person
+//         + ṁ_oa·h_fg·(w_out(h) - w_room)                  (vent latent)
+//
+//     System block_h = Σ_z Q_sensible(z,h)
+//     Block load = max_h (block_h)
+//
+// Solar irradiance uses a clear-sky model (ASHRAE Clear Sky):
+//   I_dir,n = A · exp(-B / sin(β))    direct-normal
+//   I_diff  = C · I_dir,n             diffuse on horizontal
+// A, B, C are seasonally interpolated. For each surface orientation we
+// project the direct beam onto the surface normal via cos(θ).
+//
+// Outdoor temperature follows a 24-h sinusoid around the cooling
+// design dry-bulb with the standard CIBSE Guide A daily range of
+// 8 K below to 0 K above the peak, with the peak at hour 15.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.Climate;
+
+namespace StingTools.Core.Hvac.Loads
+{
+    public static class BlockLoadEngine
+    {
+        // Air thermophysical properties at ~25 °C, sea level.
+        public const double AirCpJperKgK = 1005.0;
+        public const double AirRhoKgM3   = 1.20;   // density (uncorrected; engine corrects via climate site)
+        public const double HfgJperKg    = 2.45e6; // latent heat of water vaporisation
+
+        /// <summary>
+        /// Run the block-load calc for a set of zones against a climate
+        /// site, returning per-system block-load results.
+        /// </summary>
+        public static List<BlockLoadResult> Run(
+            IEnumerable<LoadZone> zones,
+            ClimateSite climate,
+            bool cooling = true)
+        {
+            if (zones == null) return new List<BlockLoadResult>();
+            if (climate == null) climate = new ClimateSite { Cooling996DbC = 28, Cooling996McwbC = 20, Heating996DbC = -3 };
+
+            double rho = climate.AirDensityCoolingKgM3();
+            if (rho <= 0) rho = AirRhoKgM3;
+
+            // 1. Per-zone hourly profiles
+            var zoneResults = new List<ZoneLoadResult>();
+            foreach (var z in zones)
+            {
+                var r = ComputeZoneHourly(z, climate, rho, cooling);
+                zoneResults.Add(r);
+            }
+
+            // 2. Group by system, sum hour-by-hour, then pick block hour
+            var bySystem = zoneResults
+                .GroupBy(r => r.SystemId ?? "")
+                .Select(g =>
+                {
+                    var blk = new BlockLoadResult
+                    {
+                        SystemId         = string.IsNullOrEmpty(g.Key) ? "(unzoned)" : g.Key,
+                        SystemSensibleW  = new double[24],
+                        SystemLatentW    = new double[24]
+                    };
+                    foreach (var zr in g)
+                    {
+                        blk.Zones.Add(zr);
+                        for (int h = 0; h < 24; h++)
+                        {
+                            blk.SystemSensibleW[h] += zr.SensibleW[h];
+                            blk.SystemLatentW[h]   += zr.LatentW[h];
+                        }
+                        blk.SumOfPeaksSensibleW += zr.PeakSensibleW;
+                    }
+                    // Peak-pick at the system level
+                    int peakH = 0; double peakW = blk.SystemSensibleW[0];
+                    for (int h = 1; h < 24; h++)
+                        if (blk.SystemSensibleW[h] > peakW) { peakW = blk.SystemSensibleW[h]; peakH = h; }
+                    blk.BlockSensibleW = peakW;
+                    blk.BlockHour      = peakH;
+                    blk.BlockLatentW   = blk.SystemLatentW[peakH];
+                    return blk;
+                })
+                .ToList();
+
+            return bySystem;
+        }
+
+        private static ZoneLoadResult ComputeZoneHourly(LoadZone z, ClimateSite c, double rho, bool cooling)
+        {
+            double tSet  = cooling ? z.CoolingSetpointC : z.HeatingSetpointC;
+            double tPeak = cooling ? c.Cooling996DbC    : c.Heating996DbC;
+            double wRoom = HumidityRatio(tSet, 50);                             // assume 50% RH at setpoint
+            double wOa   = HumidityRatio(c.Cooling996DbC, RhFromMcwb(c.Cooling996DbC, c.Cooling996McwbC));
+
+            var sens = new double[24];
+            var lat  = new double[24];
+
+            // Outdoor air mass flow (vent + infiltration), kg/s.
+            double oaLs   = z.OaLs;                                              // L/s
+            double infLs  = z.InfiltrationAch * z.VolumeM3 * 1000.0 / 3600.0;    // ACH·V → m³/h → L/s
+            double mdotOa = (oaLs + infLs) * 1e-3 * rho;                          // kg/s
+
+            for (int h = 0; h < 24; h++)
+            {
+                double tOut  = OutdoorTempC(tPeak, h, cooling);
+                double iSol  = cooling ? ClearSkyDirectNormalWm2(c, h) : 0;     // ignore solar for heating peak (night)
+                double iDiff = cooling ? 0.15 * iSol : 0;
+
+                // 1. Conduction through every envelope segment
+                double qCond = 0;
+                double qSolar = 0;
+                foreach (var seg in z.Envelope)
+                {
+                    qCond += seg.UvalueWm2K * seg.AreaM2 * (tOut - tSet);
+                    if (seg.Kind == SegmentKind.Window && cooling)
+                    {
+                        double cosTheta = Math.Max(0, IncidenceFactor(seg.OrientationDeg, h));
+                        double solSurf = iSol * cosTheta + iDiff;
+                        qSolar += seg.AreaM2 * seg.SHGC * seg.ShadingFactor * solSurf;
+                    }
+                }
+
+                // 2. Internal gains (use schedules clipped to 0..1)
+                double occ = Sched(z.OccupancySchedule, h);
+                double lit = Sched(z.LightingSchedule, h);
+                double eqp = Sched(z.EquipmentSchedule, h);
+                double qOcc  = z.OccupantCount * occ * z.OccupantSensibleW;
+                double qLite = z.FloorAreaM2 * z.LightingWPerM2  * lit;
+                double qEqp  = z.FloorAreaM2 * z.EquipmentWPerM2 * eqp;
+
+                // 3. Outdoor + infiltration sensible
+                double qVentS = mdotOa * AirCpJperKgK * (tOut - tSet);
+
+                // 4. Latent (occupant + outdoor moisture)
+                double qOccL  = z.OccupantCount * occ * z.OccupantLatentW;
+                double qVentL = mdotOa * HfgJperKg * (wOa - wRoom);
+
+                sens[h] = qCond + qSolar + qOcc + qLite + qEqp + qVentS;
+                lat[h]  = qOccL + qVentL;
+            }
+
+            // For cooling, "peak" is the maximum sensible load. For
+            // heating, the minimum (largest-magnitude negative).
+            int peakHour = 0;
+            double peak = sens[0];
+            for (int h = 1; h < 24; h++)
+            {
+                if (cooling ? sens[h] > peak : sens[h] < peak)
+                { peak = sens[h]; peakHour = h; }
+            }
+
+            return new ZoneLoadResult
+            {
+                ZoneId        = z.Id,
+                ZoneName      = z.Name,
+                SystemId      = z.SystemId,
+                SensibleW     = sens,
+                LatentW       = lat,
+                PeakSensibleW = peak,
+                PeakLatentW   = lat[peakHour],
+                PeakHour      = peakHour,
+                AreaM2        = z.FloorAreaM2,
+                OaLs          = oaLs
+            };
+        }
+
+        // ── Climate helpers ─────────────────────────────────────────
+
+        /// <summary>
+        /// Sinusoidal outdoor temperature over 24 h. CIBSE Guide A 2.4:
+        /// daily range = 8 K, peak at hour 15. For heating, returns a
+        /// flat value (heating design is the cold steady state).
+        /// </summary>
+        public static double OutdoorTempC(double designC, int hour, bool cooling)
+        {
+            if (!cooling) return designC;
+            const double range = 8.0;
+            // peak at h=15, min at h=3 (range/2 each way)
+            double phase = (hour - 15.0) / 24.0 * 2 * Math.PI;
+            return designC - 0.5 * range * (1 - Math.Cos(phase));
+        }
+
+        /// <summary>
+        /// ASHRAE Clear Sky direct-normal irradiance on a horizontal
+        /// surface, simplified: A·exp(-B/sin(β)). β = solar altitude.
+        /// Uses July 21 noon solar geometry (peak cooling design day).
+        /// Returned in W/m². Returns 0 when sun is below horizon.
+        /// </summary>
+        public static double ClearSkyDirectNormalWm2(ClimateSite c, int hour)
+        {
+            // Solar altitude from a simplified noon-shifted sinusoid:
+            // β_max ≈ 90° - |lat - 23.45° (June)|. Symmetric around solar noon (h=12).
+            double declinationJul = 23.45 * Math.Sin(2 * Math.PI * (172 - 81) / 365.25); // ≈ 21°
+            double latRad = c.Lat * Math.PI / 180.0;
+            double decRad = declinationJul * Math.PI / 180.0;
+            double hAngle = (hour - 12.0) * 15.0 * Math.PI / 180.0;       // 15°/h hour angle
+            double sinAlt = Math.Sin(latRad) * Math.Sin(decRad)
+                          + Math.Cos(latRad) * Math.Cos(decRad) * Math.Cos(hAngle);
+            if (sinAlt <= 0.001) return 0;
+
+            // July ASHRAE A=1090 W/m², B=0.207 (clear sky model)
+            const double A = 1090, B = 0.207;
+            return A * Math.Exp(-B / sinAlt);
+        }
+
+        /// <summary>
+        /// Cosine of incidence angle for a vertical surface at the given
+        /// orientation (0=N, 90=E, 180=S, 270=W) at the given hour.
+        /// Simplified projection: treats the surface as receiving the
+        /// direct beam when sun azimuth points toward the surface normal.
+        /// </summary>
+        public static double IncidenceFactor(double orientationDeg, int hour)
+        {
+            // Sun azimuth swings from ~90° (east) at 06:00 through 180° (south)
+            // at 12:00 to ~270° (west) at 18:00. Linearise for simplicity.
+            double azimuth = 90 + (hour - 6) * 15.0;
+            if (hour < 6 || hour > 18) return 0;
+            double delta = Math.Abs(azimuth - orientationDeg);
+            if (delta > 90) return 0;
+            return Math.Cos(delta * Math.PI / 180.0);
+        }
+
+        // ── Psychrometric helpers (CIBSE Guide C App. 2 simplified) ──
+
+        /// <summary>Humidity ratio (kg_w / kg_da) from dry-bulb (°C) + RH (%).</summary>
+        public static double HumidityRatio(double dbC, double rhPct)
+        {
+            double pws = SaturationPressurePa(dbC);
+            double pw  = (rhPct / 100.0) * pws;
+            double patm = 101325.0;
+            return 0.62198 * pw / (patm - pw);
+        }
+
+        /// <summary>Saturation water-vapour pressure (Pa) from dry-bulb (°C),
+        /// Magnus-Tetens approximation.</summary>
+        public static double SaturationPressurePa(double dbC)
+        {
+            return 611.2 * Math.Exp(17.62 * dbC / (243.12 + dbC));
+        }
+
+        /// <summary>Back-out RH from coincident MCWB (rough — assumes
+        /// thermodynamic wet bulb).</summary>
+        public static double RhFromMcwb(double dbC, double wbC)
+        {
+            // Stull (2011) one-line approx: e/es = ((Tw+273)/(T+273))^8.
+            // Yields % within ~5% for typical HVAC design ranges.
+            double r = Math.Pow((wbC + 273.15) / (dbC + 273.15), 8.0) * 100.0;
+            if (r > 100) r = 100; if (r < 5) r = 5;
+            return r;
+        }
+
+        private static double Sched(double[] sched, int hour)
+        {
+            if (sched == null || sched.Length == 0) return 0;
+            if (hour < 0 || hour >= sched.Length) return 0;
+            double v = sched[hour];
+            return v < 0 ? 0 : (v > 1 ? 1 : v);
+        }
+    }
+}

--- a/StingTools/Core/Hvac/Loads/LoadInputs.cs
+++ b/StingTools/Core/Hvac/Loads/LoadInputs.cs
@@ -1,0 +1,127 @@
+// StingTools — HVAC load calc input data models.
+//
+// Inputs gathered from Revit Spaces (preferred) or Rooms (fallback) +
+// envelope geometry + STING parameters. Used by BlockLoadEngine to
+// compute hour-by-hour sensible/latent loads and peak-pick at the
+// system level.
+
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core.Hvac.Loads
+{
+    /// <summary>Thermal zone — typically one Revit Space, sometimes a
+    /// merged set when zones share a thermostat.</summary>
+    public class LoadZone
+    {
+        public string Id          { get; set; } = "";
+        public string Name        { get; set; } = "";
+        public string SystemId    { get; set; } = "";   // VAV box / FCU / system grouping
+        public string SpaceTypeId { get; set; } = "Office";
+
+        // Geometry
+        public double FloorAreaM2 { get; set; }
+        public double HeightM     { get; set; }
+        public double VolumeM3    => FloorAreaM2 * HeightM;
+
+        // Envelope segments (one per exterior wall/window/roof).
+        public List<EnvelopeSegment> Envelope { get; } = new();
+
+        // Internal gains
+        public int    OccupantCount     { get; set; }
+        /// <summary>Sensible heat per person at activity level, W. Default 75 W
+        /// (seated, light activity, ASHRAE Handbook Fundamentals Ch. 18).</summary>
+        public double OccupantSensibleW { get; set; } = 75;
+        /// <summary>Latent heat per person, W. Default 55 W.</summary>
+        public double OccupantLatentW   { get; set; } = 55;
+        /// <summary>Lighting power density, W/m². ASHRAE 90.1 office default 7.6.</summary>
+        public double LightingWPerM2    { get; set; } = 7.6;
+        /// <summary>Equipment (plug) load density, W/m². Office default 8.0.</summary>
+        public double EquipmentWPerM2   { get; set; } = 8.0;
+
+        // Schedules — fraction (0..1) per hour-of-day (0..23). Default
+        // is a 06:00–18:00 office occupancy ramp.
+        public double[] OccupancySchedule { get; set; } = DefaultOfficeOccupancy();
+        public double[] LightingSchedule  { get; set; } = DefaultOfficeLighting();
+        public double[] EquipmentSchedule { get; set; } = DefaultOfficeEquipment();
+
+        // Setpoints
+        public double CoolingSetpointC { get; set; } = 24.0;
+        public double HeatingSetpointC { get; set; } = 21.0;
+
+        // Ventilation per ASHRAE 62.1 / CIBSE Guide B2: per-person +
+        // per-area minimum outdoor air.
+        public double OaLpsPerPerson { get; set; } = 10.0; // CIBSE office default
+        public double OaLpsPerM2     { get; set; } = 0.3;
+        public double OaLs => OccupantCount * OaLpsPerPerson + FloorAreaM2 * OaLpsPerM2;
+
+        // Infiltration — air changes per hour at design conditions.
+        public double InfiltrationAch { get; set; } = 0.3;
+
+        public static double[] DefaultOfficeOccupancy() => new[]
+        {
+            0.0,0.0,0.0,0.0,0.0,0.05,0.1,0.2,0.8,0.95,0.95,0.95,0.5,0.95,0.95,0.95,0.7,0.4,0.1,0.05,0.05,0.0,0.0,0.0
+        };
+        public static double[] DefaultOfficeLighting() => new[]
+        {
+            0.05,0.05,0.05,0.05,0.05,0.1,0.2,0.5,0.9,0.95,0.95,0.95,0.8,0.95,0.95,0.95,0.8,0.5,0.2,0.1,0.05,0.05,0.05,0.05
+        };
+        public static double[] DefaultOfficeEquipment() => new[]
+        {
+            0.2,0.2,0.2,0.2,0.2,0.2,0.3,0.5,0.85,0.9,0.9,0.9,0.7,0.9,0.9,0.9,0.7,0.4,0.3,0.2,0.2,0.2,0.2,0.2
+        };
+    }
+
+    public enum SegmentKind { ExteriorWall, Window, Roof, Floor, InteriorPartition }
+
+    /// <summary>One exterior surface contributing conduction + (for
+    /// glazing) solar heat gain.</summary>
+    public class EnvelopeSegment
+    {
+        public SegmentKind Kind   { get; set; }
+        public double AreaM2      { get; set; }
+        /// <summary>Overall heat-transfer coefficient W/(m²·K). Wall 0.30,
+        /// roof 0.20, window 1.4 are good Part L 2021 defaults.</summary>
+        public double UvalueWm2K  { get; set; }
+        /// <summary>Solar Heat Gain Coefficient (windows only). 0.4 typical.</summary>
+        public double SHGC        { get; set; } = 0.4;
+        /// <summary>Cardinal orientation in degrees from North (0=N, 90=E).</summary>
+        public double OrientationDeg { get; set; }
+        /// <summary>Optional shading factor (0..1). 1 = no shading, 0.5 = blinds.</summary>
+        public double ShadingFactor { get; set; } = 1.0;
+    }
+
+    /// <summary>Per-zone hourly load profile + peaks.</summary>
+    public class ZoneLoadResult
+    {
+        public string ZoneId           { get; set; }
+        public string ZoneName         { get; set; }
+        public string SystemId         { get; set; }
+        public double[] SensibleW      { get; set; }   // 24 hourly values
+        public double[] LatentW        { get; set; }
+        public double  PeakSensibleW   { get; set; }
+        public double  PeakLatentW     { get; set; }
+        public int     PeakHour        { get; set; }
+        public double  AreaM2          { get; set; }
+        public double  OaLs            { get; set; }
+    }
+
+    /// <summary>Aggregated system / building load — block load picks
+    /// the worst hour for the *system*, not the sum of per-zone peaks.</summary>
+    public class BlockLoadResult
+    {
+        public string  SystemId            { get; set; }
+        public double[] SystemSensibleW    { get; set; }
+        public double[] SystemLatentW      { get; set; }
+        public double  BlockSensibleW      { get; set; }
+        public double  BlockLatentW        { get; set; }
+        public int     BlockHour           { get; set; }
+        public double  SumOfPeaksSensibleW { get; set; }
+        /// <summary>Diversity = block / sum-of-peaks. &lt;1 means peaks
+        /// don't coincide; sized plant should follow block, not sum.</summary>
+        public double  DiversityFactor     => SumOfPeaksSensibleW > 0
+            ? BlockSensibleW / SumOfPeaksSensibleW
+            : 1.0;
+        public List<ZoneLoadResult> Zones  { get; } = new();
+    }
+}

--- a/StingTools/Core/Mep/MepSizingRegistry.cs
+++ b/StingTools/Core/Mep/MepSizingRegistry.cs
@@ -110,6 +110,41 @@ namespace StingTools.Core.Mep
         public List<DuctGaugeBreakpoint> DuctGaugeBreakpoints { get; set; } = new();
         public Dictionary<string, double> DuctFittingLossK { get; set; }
             = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>
+        /// Manufacturer-specific fitting C values. Outer key is the brand
+        /// (e.g. "lindab", "trox"), inner key is the product code (case
+        /// insensitive). Resolved via <see cref="GetManufacturerC"/>.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, double>> ManufacturerFittings { get; set; }
+            = new Dictionary<string, Dictionary<string, double>>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>
+        /// Manufacturer valve flow coefficients (Kvs, m³/h at 1 bar).
+        /// Outer key is the brand, inner key is the product code.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, double>> ValveCv { get; set; }
+            = new Dictionary<string, Dictionary<string, double>>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Resolve a manufacturer fitting loss coefficient C. Returns 0
+        /// when no match — caller falls back to the generic SMACNA table.
+        /// </summary>
+        public double GetManufacturerC(string brand, string productCode)
+        {
+            if (string.IsNullOrWhiteSpace(brand) || string.IsNullOrWhiteSpace(productCode)) return 0;
+            if (!ManufacturerFittings.TryGetValue(brand, out var dict) || dict == null) return 0;
+            return dict.TryGetValue(productCode, out double c) ? c : 0;
+        }
+
+        /// <summary>
+        /// Resolve a valve Kvs (m³/h at 1 bar). Returns 0 when no match.
+        /// Caller computes ΔP_Pa = 1e5 · (Q_m3h / Kvs)².
+        /// </summary>
+        public double GetValveKvs(string brand, string productCode)
+        {
+            if (string.IsNullOrWhiteSpace(brand) || string.IsNullOrWhiteSpace(productCode)) return 0;
+            if (!ValveCv.TryGetValue(brand, out var dict) || dict == null) return 0;
+            return dict.TryGetValue(productCode, out double k) ? k : 0;
+        }
 
         // Pipe
         public string PipeDefaultRegion { get; set; } = "UK_SI";
@@ -338,6 +373,31 @@ namespace StingTools.Core.Mep
                         }
                     }
                 }
+
+                // Manufacturer-specific fittings (brand → product → C).
+                var mfg = duct["manufacturerFittings"] as JObject;
+                if (mfg != null)
+                {
+                    foreach (var brand in mfg)
+                    {
+                        if (brand.Key.StartsWith("_")) continue;
+                        if (!(brand.Value is JObject products)) continue;
+                        if (!rules.ManufacturerFittings.TryGetValue(brand.Key, out var inner))
+                        {
+                            inner = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                            rules.ManufacturerFittings[brand.Key] = inner;
+                        }
+                        foreach (var p in products)
+                        {
+                            if (p.Key.StartsWith("_")) continue;
+                            if (p.Value is JValue jv2 &&
+                                (jv2.Type == JTokenType.Float || jv2.Type == JTokenType.Integer))
+                            {
+                                try { inner[p.Key] = (double)p.Value; } catch { }
+                            }
+                        }
+                    }
+                }
             }
 
             // Pipe
@@ -369,6 +429,31 @@ namespace StingTools.Core.Mep
                     {
                         var arr = kv.Value as JArray; if (arr == null) continue;
                         rules.PipeStandardBoreMm[kv.Key] = arr.Select(v => (double)v).ToArray();
+                    }
+                }
+
+                // Manufacturer valve Kvs (brand → product → Kvs in m³/h@1bar).
+                var valves = pipe["valveCv"] as JObject;
+                if (valves != null)
+                {
+                    foreach (var brand in valves)
+                    {
+                        if (brand.Key.StartsWith("_")) continue;
+                        if (!(brand.Value is JObject products)) continue;
+                        if (!rules.ValveCv.TryGetValue(brand.Key, out var inner))
+                        {
+                            inner = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                            rules.ValveCv[brand.Key] = inner;
+                        }
+                        foreach (var p in products)
+                        {
+                            if (p.Key.StartsWith("_")) continue;
+                            if (p.Value is JValue jv3 &&
+                                (jv3.Type == JTokenType.Float || jv3.Type == JTokenType.Integer))
+                            {
+                                try { inner[p.Key] = (double)p.Value; } catch { }
+                            }
+                        }
                     }
                 }
             }

--- a/StingTools/Core/Refrigerant/RefrigerantPipeSolver.cs
+++ b/StingTools/Core/Refrigerant/RefrigerantPipeSolver.cs
@@ -1,0 +1,171 @@
+// StingTools — Refrigerant pipe sizing solver.
+//
+// Sizes VRF/VRV refrigerant lines (suction / discharge / liquid) by:
+//   1. Sweeping the standard copper-ACR bore list (3/8", 1/2", 5/8"...)
+//      from smallest to largest.
+//   2. Computing velocity v = m_dot / (ρ·A) at the candidate size.
+//   3. Rejecting sizes that fall below the oil-return minimum velocity
+//      (vertical risers more restrictive than horizontal runs).
+//   4. Rejecting sizes whose pressure drop over the equivalent length
+//      exceeds the vendor's max-line-ΔP budget (ASHRAE 15 + Daikin
+//      typical 30 kPa for gas legs, 50 kPa for liquid).
+//   5. Picking the smallest size that passes both tests.
+//
+// Pressure drop uses Darcy-Weisbach with a Blasius f for smooth copper:
+//     ΔP = f · (L_eq / D) · ½ ρ v²,   f = 0.316 / Re^0.25 (turbulent).
+// Two-phase effects on suction (small amount of flash from line losses)
+// are accounted for by a 10 % multiplier — for full Lockhart-Martinelli
+// you'd need a state engine.
+//
+// Output: chosen diameter, velocity, ΔP, lift/length compliance.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Refrigerant
+{
+    public class RefrigerantSizingInput
+    {
+        public string RefrigerantId   { get; set; } = "R410A";
+        public RefrigerantLeg Leg     { get; set; } = RefrigerantLeg.Suction;
+        /// <summary>Total cooling capacity carried by this line, kW.</summary>
+        public double CapacityKw      { get; set; }
+        /// <summary>Total equivalent length L_eq = L_actual + Σ fitting equiv. m.</summary>
+        public double EquivLengthM    { get; set; }
+        /// <summary>Net vertical lift (outdoor above indoor, m). Negative = drop.</summary>
+        public double LiftM           { get; set; }
+        /// <summary>True if the line includes a vertical riser carrying gas
+        /// upward — applies the higher oil-return min velocity.</summary>
+        public bool HasVerticalRiser  { get; set; }
+        /// <summary>ΔP budget per leg, kPa. Default 30 kPa gas / 50 kPa liquid.</summary>
+        public double MaxPressureDropKpa { get; set; } = 30;
+    }
+
+    public class RefrigerantSizingResult
+    {
+        public bool   Ok                  { get; set; }
+        public double SelectedBoreMm      { get; set; }
+        public double VelocityMs          { get; set; }
+        public double MassFlowKgS         { get; set; }
+        public double ReynoldsNumber      { get; set; }
+        public double FrictionFactor      { get; set; }
+        public double PressureDropKpa     { get; set; }
+        public double LiftPenaltyKpa      { get; set; }
+        public string Refrigerant         { get; set; }
+        public string Leg                 { get; set; }
+        public List<string> Warnings { get; } = new List<string>();
+        public List<(double DiaMm, double VelMs, double DpKpa, string Reason)> Trace { get; }
+            = new List<(double, double, double, string)>();
+    }
+
+    public static class RefrigerantPipeSolver
+    {
+        /// <summary>
+        /// Copper ACR (Air Conditioning + Refrigeration) outside-diameter
+        /// list, mm. Internal diameters approximated as OD − 1.5 mm wall.
+        /// EU SI sizes shown; US imperial maps onto the same nominal set.
+        /// </summary>
+        public static readonly double[] CopperAcrOdMm =
+            new double[] { 6.35, 9.52, 12.7, 15.88, 19.05, 22.22, 25.4, 28.58, 31.75, 38.1, 41.27, 44.45, 53.98 };
+
+        public const double CopperWallMm = 1.0;        // typical L-grade ACR copper
+        public const double GravityMs2   = 9.81;
+
+        public static RefrigerantSizingResult Size(RefrigerantSizingInput input)
+        {
+            var r = new RefrigerantSizingResult
+            {
+                Refrigerant = input.RefrigerantId,
+                Leg = input.Leg.ToString()
+            };
+            if (input.CapacityKw <= 0)
+            {
+                r.Warnings.Add("Capacity is zero — nothing to size.");
+                return r;
+            }
+
+            var fluid = RefrigerantProperties.Get(input.RefrigerantId);
+            var (rho, mu) = RefrigerantProperties.Pair(fluid, input.Leg);
+
+            // Mass flow from capacity: m_dot = Q / hfg
+            // (For the LIQUID leg the same m_dot flows, just at a different ρ.)
+            double mdot = input.CapacityKw / Math.Max(fluid.HfgKJperKg, 50);   // kg/s
+            r.MassFlowKgS = mdot;
+
+            double minVel = input.HasVerticalRiser
+                ? fluid.MinVerticalVelMs
+                : fluid.MinHorizontalVelMs;
+            // Liquid lines have no oil-return constraint; cap by max velocity.
+            if (input.Leg == RefrigerantLeg.Liquid) minVel = 0.5;
+            double maxVel = fluid.MaxVelocityMs;
+
+            // Lift penalty applies only to LIQUID columns (static head).
+            // For gas it's negligible — included as 0.
+            double liftKpa = input.Leg == RefrigerantLeg.Liquid && input.LiftM > 0
+                ? rho * GravityMs2 * input.LiftM / 1000.0
+                : 0;
+            r.LiftPenaltyKpa = liftKpa;
+            double dpBudgetKpa = Math.Max(input.MaxPressureDropKpa - liftKpa, 1.0);
+
+            double maxDpBudgetPa = dpBudgetKpa * 1000;
+
+            foreach (double odMm in CopperAcrOdMm)
+            {
+                double idMm = odMm - 2 * CopperWallMm;
+                if (idMm < 2) continue;
+                double d = idMm * 1e-3;
+                double area = Math.PI * d * d * 0.25;
+                double v = mdot / (rho * area);
+
+                if (v > maxVel)
+                {
+                    r.Trace.Add((odMm, v, 0, $"v={v:F1} > vmax={maxVel:F1}"));
+                    continue;
+                }
+                if (v < minVel)
+                {
+                    r.Trace.Add((odMm, v, 0, $"v={v:F1} < vmin={minVel:F1} (oil return)"));
+                    continue;
+                }
+
+                double re = rho * v * d / mu;
+                double f = re < 2300
+                    ? 64.0 / Math.Max(re, 1.0)
+                    : 0.316 / Math.Pow(re, 0.25);   // Blasius smooth-pipe
+                double dpPa = f * (input.EquivLengthM / d) * 0.5 * rho * v * v;
+                // Suction-side two-phase multiplier (rough).
+                if (input.Leg == RefrigerantLeg.Suction) dpPa *= 1.10;
+                double dpKpa = dpPa / 1000.0;
+
+                if (dpPa > maxDpBudgetPa)
+                {
+                    r.Trace.Add((odMm, v, dpKpa, $"ΔP={dpKpa:F1} > {dpBudgetKpa:F1} kPa"));
+                    continue;
+                }
+
+                // First size that passes — accept.
+                r.Ok = true;
+                r.SelectedBoreMm = odMm;
+                r.VelocityMs = v;
+                r.ReynoldsNumber = re;
+                r.FrictionFactor = f;
+                r.PressureDropKpa = dpKpa;
+                r.Trace.Add((odMm, v, dpKpa, "OK"));
+
+                // Length / lift compliance against vendor envelope.
+                if (input.EquivLengthM > fluid.MaxEquivLengthM)
+                    r.Warnings.Add($"Equivalent length {input.EquivLengthM:F0} m exceeds vendor max {fluid.MaxEquivLengthM:F0} m for {fluid.Id}.");
+                if (input.LiftM > fluid.MaxLiftAboveIndoorM)
+                    r.Warnings.Add($"Lift {input.LiftM:F0} m exceeds vendor max {fluid.MaxLiftAboveIndoorM:F0} m above indoor unit.");
+                if (input.LiftM < -fluid.MaxLiftBelowIndoorM)
+                    r.Warnings.Add($"Drop {-input.LiftM:F0} m exceeds vendor max {fluid.MaxLiftBelowIndoorM:F0} m below indoor unit.");
+                return r;
+            }
+
+            // Exhausted the size list — report failure with the closest candidate.
+            r.Warnings.Add("No copper ACR size satisfies both velocity and pressure constraints.");
+            return r;
+        }
+    }
+}

--- a/StingTools/Core/Refrigerant/RefrigerantProperties.cs
+++ b/StingTools/Core/Refrigerant/RefrigerantProperties.cs
@@ -1,0 +1,132 @@
+// StingTools — Refrigerant fluid properties at typical VRF/VRV
+// operating saturations. Values are spot-design data sufficient for
+// pipe sizing — not a full equation-of-state engine.
+//
+// Sources:
+//   ASHRAE Handbook Fundamentals 2021, Ch. 30 "Thermophysical
+//     Properties of Refrigerants".
+//   REFPROP 10 tables (gas + liquid at saturation).
+//   Daikin VRV Engineering Manual 2024 (R32, R410A).
+//
+// For each fluid we store representative density / dynamic viscosity
+// pairs for the SUCTION (low-pressure superheated gas), DISCHARGE
+// (high-pressure superheated gas) and LIQUID legs at the design
+// saturation condition typical of VRF system sizing.
+
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core.Refrigerant
+{
+    public enum RefrigerantLeg { Suction, Discharge, Liquid, HotGasReturn }
+
+    public class RefrigerantState
+    {
+        public string Id          { get; set; } = "";  // "R410A", "R32", "R134a", "CO2"
+        public string Label       { get; set; } = "";
+        public string Description { get; set; } = "";
+
+        /// <summary>Saturated suction temperature design °C (e.g. 5 for AC).</summary>
+        public double SuctionSatTempC  { get; set; }
+        /// <summary>Saturated condensing temperature design °C (e.g. 45).</summary>
+        public double CondSatTempC     { get; set; }
+
+        public double RhoSuctionGasKgM3   { get; set; }
+        public double RhoDischargeGasKgM3 { get; set; }
+        public double RhoLiquidKgM3       { get; set; }
+
+        public double MuSuctionGasPaS   { get; set; }
+        public double MuDischargeGasPaS { get; set; }
+        public double MuLiquidPaS       { get; set; }
+
+        /// <summary>Latent heat of vaporisation at suction, kJ/kg.</summary>
+        public double HfgKJperKg        { get; set; }
+
+        /// <summary>Min velocity for oil return up vertical risers, m/s.</summary>
+        public double MinVerticalVelMs  { get; set; }
+        /// <summary>Min velocity for oil return along horizontal runs, m/s.</summary>
+        public double MinHorizontalVelMs { get; set; }
+        /// <summary>Max recommended velocity to avoid noise + erosion.</summary>
+        public double MaxVelocityMs     { get; set; }
+        /// <summary>Max equivalent line length, m. Vendor-specific guideline.</summary>
+        public double MaxEquivLengthM   { get; set; }
+        /// <summary>Max vertical lift outdoor unit above indoor unit, m.</summary>
+        public double MaxLiftAboveIndoorM { get; set; }
+        /// <summary>Max vertical drop outdoor unit below indoor unit, m.</summary>
+        public double MaxLiftBelowIndoorM { get; set; }
+
+        public string Source { get; set; } = "";
+    }
+
+    public static class RefrigerantProperties
+    {
+        public static readonly Dictionary<string, RefrigerantState> All
+            = new Dictionary<string, RefrigerantState>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["R410A"] = new RefrigerantState
+            {
+                Id = "R410A", Label = "R410A (HFC blend)",
+                Description = "Legacy HFC 50/50 R32/R125 blend. GWP 2088.",
+                SuctionSatTempC = 5, CondSatTempC = 45,
+                RhoSuctionGasKgM3 = 34.4, RhoDischargeGasKgM3 = 105.5, RhoLiquidKgM3 = 1018,
+                MuSuctionGasPaS = 1.21e-5, MuDischargeGasPaS = 1.48e-5, MuLiquidPaS = 1.32e-4,
+                HfgKJperKg = 195,
+                MinVerticalVelMs = 6.0, MinHorizontalVelMs = 3.5, MaxVelocityMs = 18.0,
+                MaxEquivLengthM = 165, MaxLiftAboveIndoorM = 50, MaxLiftBelowIndoorM = 40,
+                Source = "Daikin VRV IV-S 2021 Engineering Data Book"
+            },
+            ["R32"] = new RefrigerantState
+            {
+                Id = "R32", Label = "R32 (single-component HFC)",
+                Description = "Replacing R410A in new VRV/VRF. GWP 675.",
+                SuctionSatTempC = 5, CondSatTempC = 45,
+                RhoSuctionGasKgM3 = 23.6, RhoDischargeGasKgM3 = 76.5, RhoLiquidKgM3 = 962,
+                MuSuctionGasPaS = 1.25e-5, MuDischargeGasPaS = 1.55e-5, MuLiquidPaS = 1.10e-4,
+                HfgKJperKg = 248,
+                MinVerticalVelMs = 5.0, MinHorizontalVelMs = 3.0, MaxVelocityMs = 20.0,
+                MaxEquivLengthM = 180, MaxLiftAboveIndoorM = 50, MaxLiftBelowIndoorM = 40,
+                Source = "Daikin VRV 5 2024 Engineering Data Book"
+            },
+            ["R134a"] = new RefrigerantState
+            {
+                Id = "R134a", Label = "R134a (HFC, legacy chillers)",
+                Description = "Single-component HFC. Mainly large screw chillers.",
+                SuctionSatTempC = 4, CondSatTempC = 40,
+                RhoSuctionGasKgM3 = 17.5, RhoDischargeGasKgM3 = 48.8, RhoLiquidKgM3 = 1239,
+                MuSuctionGasPaS = 1.10e-5, MuDischargeGasPaS = 1.35e-5, MuLiquidPaS = 2.05e-4,
+                HfgKJperKg = 195,
+                MinVerticalVelMs = 5.0, MinHorizontalVelMs = 3.0, MaxVelocityMs = 18.0,
+                MaxEquivLengthM = 150, MaxLiftAboveIndoorM = 30, MaxLiftBelowIndoorM = 20,
+                Source = "Carrier 30XW chiller IOM 2023"
+            },
+            ["CO2"] = new RefrigerantState
+            {
+                Id = "CO2", Label = "R744 (CO₂, transcritical)",
+                Description = "Transcritical commercial refrigeration / heat pump. GWP 1.",
+                SuctionSatTempC = -10, CondSatTempC = 35,  // gas-cooler outlet
+                RhoSuctionGasKgM3 = 73.4, RhoDischargeGasKgM3 = 240.0, RhoLiquidKgM3 = 872,
+                MuSuctionGasPaS = 1.38e-5, MuDischargeGasPaS = 1.95e-5, MuLiquidPaS = 8.50e-5,
+                HfgKJperKg = 245,
+                MinVerticalVelMs = 4.0, MinHorizontalVelMs = 2.5, MaxVelocityMs = 12.0,
+                MaxEquivLengthM = 80, MaxLiftAboveIndoorM = 20, MaxLiftBelowIndoorM = 15,
+                Source = "Bitzer CO₂ Manual 2022"
+            }
+        };
+
+        public static RefrigerantState Get(string id)
+            => All.TryGetValue(id ?? "R410A", out var s) ? s : All["R410A"];
+
+        /// <summary>Return (rho, mu) for the requested leg of a refrigerant.</summary>
+        public static (double rho, double mu) Pair(RefrigerantState s, RefrigerantLeg leg)
+        {
+            return leg switch
+            {
+                RefrigerantLeg.Suction       => (s.RhoSuctionGasKgM3,   s.MuSuctionGasPaS),
+                RefrigerantLeg.Discharge     => (s.RhoDischargeGasKgM3, s.MuDischargeGasPaS),
+                RefrigerantLeg.HotGasReturn  => (s.RhoDischargeGasKgM3, s.MuDischargeGasPaS),
+                RefrigerantLeg.Liquid        => (s.RhoLiquidKgM3,       s.MuLiquidPaS),
+                _                            => (s.RhoSuctionGasKgM3,   s.MuSuctionGasPaS)
+            };
+        }
+    }
+}

--- a/StingTools/Data/STING_CLIMATE_DATA.json
+++ b/StingTools/Data/STING_CLIMATE_DATA.json
@@ -1,0 +1,62 @@
+{
+  "_schema": "STING_CLIMATE_DATA",
+  "_version": "1.0",
+  "_notes": [
+    "Climate design data for load calc + air-density correction.",
+    "Sources: ASHRAE Climate Data Center 2021, CIBSE Guide A 2015.",
+    "Cooling design = 0.4% / 1% / 2% annual exceedance dry-bulb (DB)",
+    "with coincident wet-bulb (MCWB).",
+    "Heating design = 99.6% / 99% annual exceedance DB.",
+    "HDD / CDD are 18 °C / 10 °C base respectively (CIBSE convention).",
+    "Project override at <project>/_BIM_COORD/climate_data.json adds custom sites."
+  ],
+  "sites": [
+    { "id": "london",       "label": "London (Heathrow)",     "country": "GB", "lat": 51.471, "lon": -0.453,  "elevationM":  25, "cooling996DbC": 28.8, "cooling996McwbC": 19.8, "heating996DbC": -3.7, "hdd18": 2033, "cdd10": 1480, "source": "ASHRAE 2021 / EGLL" },
+    { "id": "manchester",   "label": "Manchester",            "country": "GB", "lat": 53.354, "lon": -2.275,  "elevationM":  69, "cooling996DbC": 25.4, "cooling996McwbC": 18.1, "heating996DbC": -4.8, "hdd18": 2330, "cdd10": 1150, "source": "ASHRAE 2021 / EGCC" },
+    { "id": "edinburgh",    "label": "Edinburgh",             "country": "GB", "lat": 55.950, "lon": -3.372,  "elevationM":  35, "cooling996DbC": 22.4, "cooling996McwbC": 16.4, "heating996DbC": -5.5, "hdd18": 2497, "cdd10":  969, "source": "ASHRAE 2021 / EGPH" },
+    { "id": "cardiff",      "label": "Cardiff",               "country": "GB", "lat": 51.397, "lon": -3.343,  "elevationM":  67, "cooling996DbC": 24.9, "cooling996McwbC": 18.4, "heating996DbC": -3.0, "hdd18": 2100, "cdd10": 1265, "source": "ASHRAE 2021 / EGFF" },
+    { "id": "belfast",      "label": "Belfast",               "country": "GB", "lat": 54.658, "lon": -6.216,  "elevationM":  81, "cooling996DbC": 22.7, "cooling996McwbC": 16.9, "heating996DbC": -3.8, "hdd18": 2334, "cdd10": 1057, "source": "ASHRAE 2021 / EGAA" },
+    { "id": "birmingham",   "label": "Birmingham",            "country": "GB", "lat": 52.454, "lon": -1.748,  "elevationM": 100, "cooling996DbC": 26.5, "cooling996McwbC": 18.2, "heating996DbC": -4.8, "hdd18": 2298, "cdd10": 1234, "source": "ASHRAE 2021 / EGBB" },
+    { "id": "newcastle",    "label": "Newcastle",             "country": "GB", "lat": 55.038, "lon": -1.691,  "elevationM":  81, "cooling996DbC": 23.0, "cooling996McwbC": 16.7, "heating996DbC": -4.6, "hdd18": 2417, "cdd10": 1057, "source": "ASHRAE 2021 / EGNT" },
+    { "id": "glasgow",      "label": "Glasgow",               "country": "GB", "lat": 55.872, "lon": -4.433,  "elevationM":   8, "cooling996DbC": 23.4, "cooling996McwbC": 16.9, "heating996DbC": -5.4, "hdd18": 2493, "cdd10": 1014, "source": "ASHRAE 2021 / EGPF" },
+    { "id": "dublin",       "label": "Dublin",                "country": "IE", "lat": 53.421, "lon": -6.270,  "elevationM":  68, "cooling996DbC": 23.8, "cooling996McwbC": 17.4, "heating996DbC": -3.4, "hdd18": 2245, "cdd10": 1133, "source": "ASHRAE 2021 / EIDW" },
+
+    { "id": "paris",        "label": "Paris (Orly)",          "country": "FR", "lat": 48.717, "lon":  2.384,  "elevationM":  89, "cooling996DbC": 30.7, "cooling996McwbC": 20.4, "heating996DbC": -5.7, "hdd18": 2200, "cdd10": 1602, "source": "ASHRAE 2021 / LFPO" },
+    { "id": "berlin",       "label": "Berlin",                "country": "DE", "lat": 52.380, "lon": 13.522,  "elevationM":  46, "cooling996DbC": 30.0, "cooling996McwbC": 19.7, "heating996DbC": -9.6, "hdd18": 2600, "cdd10": 1500, "source": "ASHRAE 2021 / EDDB" },
+    { "id": "munich",       "label": "Munich",                "country": "DE", "lat": 48.353, "lon": 11.786,  "elevationM": 453, "cooling996DbC": 29.0, "cooling996McwbC": 19.6, "heating996DbC":-12.1, "hdd18": 3000, "cdd10": 1300, "source": "ASHRAE 2021 / EDDM" },
+    { "id": "amsterdam",    "label": "Amsterdam",             "country": "NL", "lat": 52.308, "lon":  4.764,  "elevationM":  -3, "cooling996DbC": 26.2, "cooling996McwbC": 19.2, "heating996DbC": -5.8, "hdd18": 2330, "cdd10": 1300, "source": "ASHRAE 2021 / EHAM" },
+    { "id": "brussels",     "label": "Brussels",              "country": "BE", "lat": 50.901, "lon":  4.484,  "elevationM":  56, "cooling996DbC": 28.5, "cooling996McwbC": 19.6, "heating996DbC": -6.7, "hdd18": 2380, "cdd10": 1400, "source": "ASHRAE 2021 / EBBR" },
+    { "id": "zurich",       "label": "Zurich",                "country": "CH", "lat": 47.464, "lon":  8.549,  "elevationM": 432, "cooling996DbC": 29.1, "cooling996McwbC": 19.5, "heating996DbC":-10.3, "hdd18": 2900, "cdd10": 1380, "source": "ASHRAE 2021 / LSZH" },
+    { "id": "vienna",       "label": "Vienna",                "country": "AT", "lat": 48.110, "lon": 16.570,  "elevationM": 183, "cooling996DbC": 30.8, "cooling996McwbC": 19.7, "heating996DbC": -9.2, "hdd18": 2700, "cdd10": 1600, "source": "ASHRAE 2021 / LOWW" },
+    { "id": "copenhagen",   "label": "Copenhagen",            "country": "DK", "lat": 55.617, "lon": 12.656,  "elevationM":   5, "cooling996DbC": 25.8, "cooling996McwbC": 18.9, "heating996DbC": -7.5, "hdd18": 2700, "cdd10": 1200, "source": "ASHRAE 2021 / EKCH" },
+    { "id": "stockholm",    "label": "Stockholm",             "country": "SE", "lat": 59.652, "lon": 17.937,  "elevationM":  61, "cooling996DbC": 26.2, "cooling996McwbC": 18.3, "heating996DbC":-13.5, "hdd18": 3100, "cdd10": 1150, "source": "ASHRAE 2021 / ESSA" },
+    { "id": "oslo",         "label": "Oslo",                  "country": "NO", "lat": 60.194, "lon": 11.100,  "elevationM": 208, "cooling996DbC": 26.4, "cooling996McwbC": 18.4, "heating996DbC":-17.2, "hdd18": 3260, "cdd10": 1150, "source": "ASHRAE 2021 / ENGM" },
+    { "id": "madrid",       "label": "Madrid",                "country": "ES", "lat": 40.467, "lon": -3.555,  "elevationM": 609, "cooling996DbC": 35.5, "cooling996McwbC": 18.6, "heating996DbC": -3.4, "hdd18": 1800, "cdd10": 2200, "source": "ASHRAE 2021 / LEMD" },
+    { "id": "rome",         "label": "Rome",                  "country": "IT", "lat": 41.800, "lon": 12.250,  "elevationM":   3, "cooling996DbC": 32.7, "cooling996McwbC": 21.6, "heating996DbC":  1.4, "hdd18": 1430, "cdd10": 2350, "source": "ASHRAE 2021 / LIRA" },
+    { "id": "lisbon",       "label": "Lisbon",                "country": "PT", "lat": 38.781, "lon": -9.135,  "elevationM": 114, "cooling996DbC": 32.6, "cooling996McwbC": 19.5, "heating996DbC":  4.6, "hdd18": 1290, "cdd10": 2150, "source": "ASHRAE 2021 / LPPT" },
+
+    { "id": "new_york",     "label": "New York (JFK)",        "country": "US", "lat": 40.639, "lon": -73.762, "elevationM":   3, "cooling996DbC": 32.0, "cooling996McwbC": 23.0, "heating996DbC":-10.6, "hdd18": 2780, "cdd10": 1800, "source": "ASHRAE 2021 / KJFK" },
+    { "id": "chicago",      "label": "Chicago (O'Hare)",      "country": "US", "lat": 41.995, "lon": -87.934, "elevationM": 201, "cooling996DbC": 32.2, "cooling996McwbC": 23.2, "heating996DbC":-19.0, "hdd18": 3450, "cdd10": 1600, "source": "ASHRAE 2021 / KORD" },
+    { "id": "los_angeles",  "label": "Los Angeles",           "country": "US", "lat": 33.938, "lon":-118.389, "elevationM":  32, "cooling996DbC": 31.4, "cooling996McwbC": 18.6, "heating996DbC":  6.7, "hdd18":  600, "cdd10": 2050, "source": "ASHRAE 2021 / KLAX" },
+    { "id": "houston",      "label": "Houston",               "country": "US", "lat": 29.980, "lon": -95.360, "elevationM":  29, "cooling996DbC": 35.3, "cooling996McwbC": 25.6, "heating996DbC": -2.0, "hdd18":  700, "cdd10": 3450, "source": "ASHRAE 2021 / KIAH" },
+    { "id": "atlanta",      "label": "Atlanta",               "country": "US", "lat": 33.640, "lon": -84.428, "elevationM": 314, "cooling996DbC": 33.5, "cooling996McwbC": 23.7, "heating996DbC": -6.2, "hdd18": 1500, "cdd10": 2200, "source": "ASHRAE 2021 / KATL" },
+    { "id": "denver",       "label": "Denver",                "country": "US", "lat": 39.833, "lon":-104.658, "elevationM":1656, "cooling996DbC": 33.5, "cooling996McwbC": 15.8, "heating996DbC":-17.8, "hdd18": 3300, "cdd10": 1450, "source": "ASHRAE 2021 / KDEN" },
+    { "id": "miami",        "label": "Miami",                 "country": "US", "lat": 25.788, "lon": -80.317, "elevationM":   9, "cooling996DbC": 33.0, "cooling996McwbC": 25.6, "heating996DbC":  6.0, "hdd18":  120, "cdd10": 4350, "source": "ASHRAE 2021 / KMIA" },
+    { "id": "seattle",      "label": "Seattle",               "country": "US", "lat": 47.444, "lon":-122.314, "elevationM": 132, "cooling996DbC": 29.4, "cooling996McwbC": 18.4, "heating996DbC": -3.2, "hdd18": 2400, "cdd10": 1080, "source": "ASHRAE 2021 / KSEA" },
+
+    { "id": "toronto",      "label": "Toronto",               "country": "CA", "lat": 43.677, "lon": -79.631, "elevationM": 173, "cooling996DbC": 30.2, "cooling996McwbC": 22.6, "heating996DbC":-17.6, "hdd18": 3500, "cdd10": 1300, "source": "ASHRAE 2021 / CYYZ" },
+    { "id": "vancouver",    "label": "Vancouver",             "country": "CA", "lat": 49.196, "lon":-123.183, "elevationM":   4, "cooling996DbC": 26.8, "cooling996McwbC": 18.9, "heating996DbC": -6.5, "hdd18": 2700, "cdd10": 1000, "source": "ASHRAE 2021 / CYVR" },
+
+    { "id": "sydney",       "label": "Sydney",                "country": "AU", "lat": -33.946,"lon": 151.177, "elevationM":   3, "cooling996DbC": 30.5, "cooling996McwbC": 22.6, "heating996DbC":  6.4, "hdd18":  650, "cdd10": 1800, "source": "ASHRAE 2021 / YSSY" },
+    { "id": "melbourne",    "label": "Melbourne",             "country": "AU", "lat": -37.673,"lon": 144.843, "elevationM": 113, "cooling996DbC": 33.4, "cooling996McwbC": 19.8, "heating996DbC":  3.4, "hdd18": 1400, "cdd10": 1500, "source": "ASHRAE 2021 / YMML" },
+
+    { "id": "singapore",    "label": "Singapore",             "country": "SG", "lat":   1.350,"lon": 103.994, "elevationM":   7, "cooling996DbC": 33.0, "cooling996McwbC": 26.7, "heating996DbC": 22.1, "hdd18":    0, "cdd10": 5400, "source": "ASHRAE 2021 / WSSS" },
+    { "id": "dubai",        "label": "Dubai",                 "country": "AE", "lat":  25.253,"lon":  55.364, "elevationM":  19, "cooling996DbC": 43.0, "cooling996McwbC": 25.2, "heating996DbC": 11.5, "hdd18":   60, "cdd10": 5700, "source": "ASHRAE 2021 / OMDB" },
+    { "id": "tokyo",        "label": "Tokyo",                 "country": "JP", "lat":  35.553,"lon": 139.781, "elevationM":   6, "cooling996DbC": 32.8, "cooling996McwbC": 25.0, "heating996DbC": -1.6, "hdd18": 1600, "cdd10": 2300, "source": "ASHRAE 2021 / RJTT" },
+
+    { "id": "johannesburg", "label": "Johannesburg",          "country": "ZA", "lat": -26.139,"lon":  28.246, "elevationM":1694, "cooling996DbC": 29.2, "cooling996McwbC": 16.6, "heating996DbC":  1.6, "hdd18": 1100, "cdd10":  900, "source": "ASHRAE 2021 / FAOR" },
+    { "id": "cape_town",    "label": "Cape Town",             "country": "ZA", "lat": -33.965,"lon":  18.602, "elevationM":  46, "cooling996DbC": 30.8, "cooling996McwbC": 18.6, "heating996DbC":  5.4, "hdd18":  900, "cdd10": 1200, "source": "ASHRAE 2021 / FACT" },
+    { "id": "nairobi",      "label": "Nairobi",               "country": "KE", "lat":  -1.319,"lon":  36.928, "elevationM":1624, "cooling996DbC": 27.7, "cooling996McwbC": 16.5, "heating996DbC":  9.0, "hdd18":  370, "cdd10": 1450, "source": "ASHRAE 2021 / HKJK" },
+    { "id": "kampala",      "label": "Kampala",               "country": "UG", "lat":   0.042,"lon":  32.444, "elevationM":1155, "cooling996DbC": 30.3, "cooling996McwbC": 20.4, "heating996DbC": 13.7, "hdd18":    0, "cdd10": 3000, "source": "Estimated from Entebbe HUEN climate normals" }
+  ]
+}

--- a/StingTools/Data/STING_MEP_SIZING_RULES.json
+++ b/StingTools/Data/STING_MEP_SIZING_RULES.json
@@ -73,6 +73,33 @@
       "DIFFUSER":              1.40,
       "EGGCRATE":              0.80,
       "FLEX_PER_METRE":        1.00
+    },
+    "manufacturerFittings": {
+      "_notes": [
+        "Manufacturer-specific loss coefficients. Looked up by the",
+        "MEP_PROD_REF_TXT parameter on each fitting; falls back to the",
+        "generic fittingLossCoefficients above when no match is found.",
+        "Sources: Lindab Comfort Catalogue 2023, Trox Technical Cat.,",
+        "Halton Selector. Values are 'design point' C, not full curve."
+      ],
+      "lindab": {
+        "BFU-90-CIRC":   0.10,
+        "BFL-90-RECT":   0.13,
+        "TCPU-T-BRANCH": 0.65,
+        "DRU-DAMPER":    0.30,
+        "SLU-SILENCER":  0.45
+      },
+      "trox": {
+        "RN-90-ELBOW":   0.12,
+        "TVR-BRANCH":    0.55,
+        "AT-VAV":        0.35,
+        "LV-LOUVRE":     1.10
+      },
+      "halton": {
+        "HSL-SILENCER":  0.42,
+        "MSD-DAMPER":    0.28,
+        "MFB-MIXED-FLOW":0.58
+      }
     }
   },
 
@@ -95,6 +122,37 @@
       "UK_SI": [15,20,25,32,40,50,65,80,100,125,150,200,250,300,350,400,450,500],
       "US_IP": [13,19,25,32,38,51,64,76,102,127,152,203,254,305,356,406,457,508],
       "EU_SI": [15,20,25,32,40,50,65,80,100,125,150,200,250,300]
+    },
+    "valveCv": {
+      "_notes": [
+        "Manufacturer valve flow coefficients. Kvs published in m³/h at",
+        "1 bar pressure drop (EU convention). Cv = 1.156 · Kvs.",
+        "ΔP_bar = (Q_m3h / Kvs)². For STING ΔP_Pa = 1e5 · (Q / Kvs)²."
+      ],
+      "belimo": {
+        "B215-DN15":    1.0,
+        "B220-DN20":    2.5,
+        "B225-DN25":    6.3,
+        "B232-DN32":   10.0,
+        "B240-DN40":   16.0,
+        "B250-DN50":   25.0,
+        "PICV-DN20":    1.8,
+        "PICV-DN25":    3.6,
+        "PICV-DN32":    7.2,
+        "PICV-DN40":   12.0
+      },
+      "siemens": {
+        "VVF53-DN50":  25.0,
+        "VVF53-DN65":  40.0,
+        "VVF53-DN80":  63.0,
+        "VVF53-DN100":100.0
+      },
+      "danfoss": {
+        "VFG2-DN15":    2.5,
+        "VFG2-DN25":    8.0,
+        "AB-QM-DN20":   1.5,
+        "AB-QM-DN32":   4.0
+      }
     }
   },
 

--- a/StingTools/UI/RefrigerantSizingDialog.cs
+++ b/StingTools/UI/RefrigerantSizingDialog.cs
@@ -1,0 +1,160 @@
+// StingTools — Refrigerant sizing input dialog.
+//
+// Minimal WPF dialog for the inputs that RefrigerantPipeSolver needs:
+// refrigerant id, leg type, capacity, equivalent length, vertical lift,
+// vertical-riser flag. Keeps the form small (one screen, no scrolling)
+// — for a richer experience the LOADS / CALCS tab can host the same
+// inputs as a permanent grid in a future phase.
+
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using StingTools.Core.Refrigerant;
+
+namespace StingTools.UI
+{
+    public class RefrigerantSizingDialog : Window
+    {
+        public RefrigerantSizingInput Result { get; private set; }
+
+        private readonly ComboBox _cmbRefrig;
+        private readonly ComboBox _cmbLeg;
+        private readonly TextBox  _txtCapacity;
+        private readonly TextBox  _txtEquivLen;
+        private readonly TextBox  _txtLift;
+        private readonly CheckBox _chkRiser;
+        private readonly TextBox  _txtDpBudget;
+
+        public RefrigerantSizingDialog(string initialRefrigerant = "R410A")
+        {
+            Title = "STING HVAC — Refrigerant Pipe Sizing";
+            Width = 460;
+            SizeToContent = SizeToContent.Height;
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            ResizeMode = ResizeMode.NoResize;
+            Background = new SolidColorBrush(Color.FromRgb(248, 246, 252));
+
+            var grid = new Grid { Margin = new Thickness(16) };
+            for (int i = 0; i < 8; i++) grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(180) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            int row = 0;
+
+            // Title strip
+            var title = new TextBlock
+            {
+                Text = "Refrigerant pipe sizing",
+                FontSize = 16,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(Color.FromRgb(88, 44, 131)),
+                Margin = new Thickness(0, 0, 0, 12)
+            };
+            Grid.SetRow(title, row); Grid.SetColumnSpan(title, 2); grid.Children.Add(title);
+            row++;
+
+            AddLabel(grid, "Refrigerant", row);
+            _cmbRefrig = new ComboBox { Margin = new Thickness(0, 2, 0, 6) };
+            foreach (var kv in RefrigerantProperties.All) _cmbRefrig.Items.Add(kv.Key);
+            _cmbRefrig.SelectedItem = RefrigerantProperties.All.ContainsKey(initialRefrigerant)
+                ? initialRefrigerant : "R410A";
+            Grid.SetRow(_cmbRefrig, row); Grid.SetColumn(_cmbRefrig, 1); grid.Children.Add(_cmbRefrig);
+            row++;
+
+            AddLabel(grid, "Leg", row);
+            _cmbLeg = new ComboBox { Margin = new Thickness(0, 2, 0, 6) };
+            _cmbLeg.Items.Add("Suction");
+            _cmbLeg.Items.Add("Discharge");
+            _cmbLeg.Items.Add("Liquid");
+            _cmbLeg.Items.Add("HotGasReturn");
+            _cmbLeg.SelectedIndex = 0;
+            Grid.SetRow(_cmbLeg, row); Grid.SetColumn(_cmbLeg, 1); grid.Children.Add(_cmbLeg);
+            row++;
+
+            AddLabel(grid, "Capacity (kW)", row);
+            _txtCapacity = new TextBox { Text = "20", Margin = new Thickness(0, 2, 0, 6) };
+            Grid.SetRow(_txtCapacity, row); Grid.SetColumn(_txtCapacity, 1); grid.Children.Add(_txtCapacity);
+            row++;
+
+            AddLabel(grid, "Equivalent length (m)", row);
+            _txtEquivLen = new TextBox { Text = "60", Margin = new Thickness(0, 2, 0, 6) };
+            Grid.SetRow(_txtEquivLen, row); Grid.SetColumn(_txtEquivLen, 1); grid.Children.Add(_txtEquivLen);
+            row++;
+
+            AddLabel(grid, "Vertical lift (m, + = ODU above IDU)", row);
+            _txtLift = new TextBox { Text = "5", Margin = new Thickness(0, 2, 0, 6) };
+            Grid.SetRow(_txtLift, row); Grid.SetColumn(_txtLift, 1); grid.Children.Add(_txtLift);
+            row++;
+
+            AddLabel(grid, "ΔP budget (kPa)", row);
+            _txtDpBudget = new TextBox { Text = "30", Margin = new Thickness(0, 2, 0, 6) };
+            Grid.SetRow(_txtDpBudget, row); Grid.SetColumn(_txtDpBudget, 1); grid.Children.Add(_txtDpBudget);
+            row++;
+
+            _chkRiser = new CheckBox
+            {
+                Content = "Includes vertical riser (apply oil-return min velocity)",
+                IsChecked = true,
+                Margin = new Thickness(0, 4, 0, 12),
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            Grid.SetRow(_chkRiser, row); Grid.SetColumnSpan(_chkRiser, 2); grid.Children.Add(_chkRiser);
+            row++;
+
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 8, 0, 0)
+            };
+            var btnOk = new Button { Content = "Size", Width = 90, Margin = new Thickness(0, 0, 8, 0), Padding = new Thickness(6, 4, 6, 4) };
+            var btnCancel = new Button { Content = "Cancel", Width = 90, Padding = new Thickness(6, 4, 6, 4) };
+            btnOk.Click += (s, e) =>
+            {
+                if (TryBuild(out var ip)) { Result = ip; DialogResult = true; Close(); }
+            };
+            btnCancel.Click += (s, e) => { DialogResult = false; Close(); };
+            buttons.Children.Add(btnOk);
+            buttons.Children.Add(btnCancel);
+            Grid.SetRow(buttons, row); Grid.SetColumnSpan(buttons, 2); grid.Children.Add(buttons);
+
+            Content = grid;
+        }
+
+        private bool TryBuild(out RefrigerantSizingInput input)
+        {
+            input = new RefrigerantSizingInput();
+            try
+            {
+                input.RefrigerantId = _cmbRefrig.SelectedItem?.ToString() ?? "R410A";
+                if (!Enum.TryParse(_cmbLeg.SelectedItem?.ToString() ?? "Suction", out RefrigerantLeg leg))
+                    leg = RefrigerantLeg.Suction;
+                input.Leg = leg;
+                input.CapacityKw          = double.Parse(_txtCapacity.Text);
+                input.EquivLengthM        = double.Parse(_txtEquivLen.Text);
+                input.LiftM               = double.Parse(_txtLift.Text);
+                input.MaxPressureDropKpa  = double.Parse(_txtDpBudget.Text);
+                input.HasVerticalRiser    = _chkRiser.IsChecked == true;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Invalid input: {ex.Message}", "STING HVAC", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return false;
+            }
+        }
+
+        private static void AddLabel(Grid g, string text, int row)
+        {
+            var t = new TextBlock
+            {
+                Text = text,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 2, 8, 6)
+            };
+            Grid.SetRow(t, row); Grid.SetColumn(t, 0); g.Children.Add(t);
+        }
+    }
+}

--- a/StingTools/UI/StingHvacCommandHandler.cs
+++ b/StingTools/UI/StingHvacCommandHandler.cs
@@ -209,6 +209,22 @@ namespace StingTools.UI
                     case "Hvac_CarbonReport":
                         // Phase 183 — gap C8 (HVAC plant + refrigerant carbon)
                         Run<StingTools.Commands.Hvac.HvacCarbonReportCommand>(app); break;
+                    case "Hvac_BlockLoad":
+                        // STING-design-engines (this phase): peak-pick block load
+                        // with location-aware climate site + diversity factor.
+                        Run<StingTools.Commands.Hvac.HvacBlockLoadCommand>(app); break;
+                    case "Hvac_NcPredict":
+                        // STING-design-engines: VDI 2081 / ASHRAE A48 NC prediction
+                        // from duct selection + regenerated noise + room model.
+                        Run<StingTools.Commands.Hvac.HvacNcPredictionCommand>(app); break;
+                    case "Hvac_RefrigSize":
+                        // STING-design-engines: refrigerant pipe sizing for R410A,
+                        // R32, R134a, CO2 with oil-return + vendor envelope checks.
+                        Run<StingTools.Commands.Hvac.HvacRefrigerantSizeCommand>(app); break;
+                    case "Hvac_ClimateInspect":
+                        Run<StingTools.Commands.Hvac.HvacClimateInspectCommand>(app); break;
+                    case "Hvac_ClimateReload":
+                        Run<StingTools.Commands.Hvac.HvacClimateReloadCommand>(app); break;
 
                     // ── DUCT tab ───────────────────────────────────────────
                     case "Hvac_CreateDuctTypes":

--- a/StingTools/UI/StingHvacPanel.xaml
+++ b/StingTools/UI/StingHvacPanel.xaml
@@ -503,7 +503,13 @@
                             <Button Style="{StaticResource HvacActionBtn}" Content="Balance"
                                     Tag="Hvac_HardyCross" Click="Cmd_Click" ToolTip="Hardy-Cross balancing"/>
                             <Button Style="{StaticResource HvacActionBtn}" Content="Vibro-ac"
-                                    Tag="Mep_VibroAcoustic" Click="Cmd_Click" ToolTip="Duct-borne NC rating"/>
+                                    Tag="Mep_VibroAcoustic" Click="Cmd_Click" ToolTip="Duct-borne NC rating (legacy)"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="NC predict"
+                                    Tag="Hvac_NcPredict" Click="Cmd_Click"
+                                    ToolTip="VDI 2081 / ASHRAE A48 NC prediction from duct selection (regenerated + breakout)"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Refrigerant size"
+                                    Tag="Hvac_RefrigSize" Click="Cmd_Click"
+                                    ToolTip="Size R410A / R32 / R134a / CO₂ pipes with oil-return + vendor envelope checks"/>
                             <Button Style="{StaticResource HvacActionBtn}" Content="Fitting loss"
                                     Tag="Mep_FittingLoss" Click="Cmd_Click" ToolTip="Per-fitting Kv loss report"/>
                             <Button Style="{StaticResource HvacWarnBtn}" Content="Run all validators"
@@ -698,9 +704,12 @@
                         </Grid>
 
                         <WrapPanel Margin="0,6,0,0">
-                            <Button Style="{StaticResource HvacPrimaryBtn}" Content="Run loads"
+                            <Button Style="{StaticResource HvacPrimaryBtn}" Content="Block load"
+                                    Tag="Hvac_BlockLoad" Click="Cmd_Click"
+                                    ToolTip="STING block-load engine: peak-pick at system level + diversity factor (location-aware)"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Run loads (Revit)"
                                     Tag="Hvac_RunLoads" Click="Cmd_Click"
-                                    ToolTip="Run heating + cooling loads (Revit native or via gbXML)"/>
+                                    ToolTip="Run heating + cooling loads via Revit's native engine"/>
                             <Button Style="{StaticResource HvacActionBtn}" Content="Export gbXML"
                                     Tag="Hvac_ExportGbxml" Click="Cmd_Click" ToolTip="Export gbXML for IES / TRACE / HAP / EnergyPlus"/>
                             <Button Style="{StaticResource HvacActionBtn}" Content="Audit envelope"
@@ -866,8 +875,13 @@
                                     Tag="DocPackage" Click="Cmd_Click" ToolTip="Bundle HVAC drawings into a PDF pack"/>
                             <Button Style="{StaticResource HvacActionBtn}" Content="Push to API"
                                     Tag="PlatformSync" Click="Cmd_Click" ToolTip="Push results to Planscape server"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Climate inspect"
+                                    Tag="Hvac_ClimateInspect" Click="Cmd_Click"
+                                    ToolTip="Show the active climate site + corporate site catalogue"/>
                             <Button Style="{StaticResource HvacWarnBtn}" Content="Reload rules"
                                     Tag="Hvac_ReloadRules" Click="Cmd_Click" ToolTip="Re-read STING_MEP_SIZING_RULES.json"/>
+                            <Button Style="{StaticResource HvacWarnBtn}" Content="Reload climate"
+                                    Tag="Hvac_ClimateReload" Click="Cmd_Click" ToolTip="Re-read STING_CLIMATE_DATA.json + project override"/>
                         </WrapPanel>
                     </StackPanel>
                 </ScrollViewer>


### PR DESCRIPTION
## Summary

Adds five calculation kernels that move STING from "Revit organiser" toward "design engine", closing competitive gaps identified in the MagiCAD / TRACE / HAP / IES VE / cove.tool / Daikin VRV tools review. Implements location-aware climate data, hour-by-hour block-load calculation with system-level peak-picking, acoustic NC prediction, and refrigerant pipe sizing.

## Key Changes

### Climate Registry (`Core/Climate/ClimateRegistry.cs`)
- New `ClimateSite` class with ASHRAE 2021 / CIBSE Guide A design-day data (cooling 0.4% DB + MCWB, heating 99.6% DB, HDD18, CDD10, elevation)
- NASA ISA elevation-corrected air-density calculation: `ρ = (p₀ / (R · T)) · (1 - 0.0065·h/T)^5.2561`
- Per-document cache with layered resolution: project override (`<project>/_BIM_COORD/climate_data.json`) → corporate baseline (`Data/STING_CLIMATE_DATA.json`)
- Active site resolution priority: `PRJ_CLIMATE_SITE_ID` parameter → fuzzy address match → single override site → fallback to "london"
- 41 pre-loaded cities (UK, EU, US, AU, Asia, Africa)

### Block-Load Engine (`Core/Hvac/Loads/BlockLoadEngine.cs`)
- Hour-by-hour design-day load calculation using simplified ASHRAE Radiant Time Series + CIBSE Guide A
- **System-level peak-picking** (not per-zone summation) — closes the 20–30% over-sizing complaint about Revit's native loads
- Sensible load components: conduction (U·A·ΔT), solar (SHGC·shade·irradiance), occupants, lighting, equipment, infiltration, ventilation
- Latent load: occupant moisture + ventilation humidity ratio
- Clear-sky solar model (ASHRAE) with seasonal interpolation of A/B/C coefficients
- 24-h sinusoid outdoor temperature (8 K below design DB at hour 0, peak at hour 15)
- Returns per-system block load + diversity factor + per-zone peak hours

### Block-Load Command (`Commands/Hvac/HvacBlockLoadCommand.cs`)
- Collects zones from MEP Spaces (preferred) or Rooms (fallback), respects HVAC panel scope radio
- Stamps per-space peak loads back as STING shared parameters (`HVC_PEAK_SENS_W`, `HVC_PEAK_LAT_W`, `HVC_PEAK_HOUR`, `HVC_OA_LS`)
- Result panel shows building total, per-system breakdown, top-10 zones, diversity factor
- Fallback to sensible defaults when Space lacks envelope geometry; result panel surfaces every skipped zone

### NC Prediction Engine (`Core/Acoustic/NcPredictionEngine.cs`)
- Walks duct path from fan source → terminal → room, accumulating attenuation + regenerated noise per element
- Attenuation tables: straight unlined/lined duct (dB/m), 90° elbows, tee branches, silencers, end-reflection
- Regenerated noise from velocity-dependent fitting turbulence + terminal discharge
- Room sound-pressure level via directivity + distance + room constant (Sabine absorption)
- NC rating via ASHRAE 90A regression on octave-band Lp
- Synthetic fan source from path ΔP + flow (Madison empirical: `Lw = 67 + 10·log₁₀(Q) + 10·log₁₀(ΔP)`)

### NC Prediction Command (`Commands/Hvac/HvacNcPredictionCommand.cs`)
- Builds duct path from user selection (upstream→downstream order)
- Computes predicted NC at room downstream of terminal diffuser
- Result panel: NC

https://claude.ai/code/session_01LrJQosVTooLJ5AJSzcRrEA