### PR TITLE
Fix compile-breaking duplicate block in ThemeManager.ApplyTheme

### DIFF
--- a/StingTools/UI/ThemeManager.cs
+++ b/StingTools/UI/ThemeManager.cs
@@ -247,20 +247,6 @@ namespace StingTools.UI
                 // still resolve against the in-memory Corporate map.
                 CurrentTheme = FallbackTheme;
             }
-
-            // Set resources on the host element FIRST (direct, always works in Revit)
-            ApplyToTarget(theme, _targetElement?.Resources);
-
-            // Also set on Application.Current for any child windows/dialogs
-            ApplyToTarget(theme, Application.Current?.Resources);
-
-            CurrentTheme = themeName;
-            StingLog.Info($"ThemeManager: applied '{themeName}' theme");
-
-            // Notify subscribers (modeless windows like BCC) so they can
-            // refresh code-behind brushes that don't go through DynamicResource.
-            try { ThemeChanged?.Invoke(null, EventArgs.Empty); }
-            catch (Exception ex) { StingLog.Warn($"ThemeManager.ThemeChanged: {ex.Message}"); }
         }
 
 


### PR DESCRIPTION
Merges unmerged branch `claude/great-volta-Sko8v` into `main`.

Removes a compile-breaking duplicate block in `StingTools/UI/ThemeManager.cs`. Group A (build/compile fix).

Opened as part of branch-cleanup triage to preserve work before branch deletion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5aGwxY9iznAn6LU1Y1hff)_