### PR TITLE
Surface silent failures in StingElectricalCommandHandler

### DIFF
--- a/StingTools/UI/StingElectricalCommandHandler.cs
+++ b/StingTools/UI/StingElectricalCommandHandler.cs
@@ -460,12 +460,20 @@ namespace StingTools.UI
                 var cmd = new T();
                 string msg = "";
                 var els = new ElementSet();
-                cmd.Execute(null, ref msg, els);
-                StingLog.Info($"ElecRunCommand<{typeof(T).Name}>: done");
+                var result = cmd.Execute(null, ref msg, els);
+                StingLog.Info($"ElecRunCommand<{typeof(T).Name}>: done ({result})");
+                if (result == Result.Failed && !string.IsNullOrEmpty(msg))
+                    TaskDialog.Show("STING Electrical", $"{typeof(T).Name} failed:\n{msg}");
             }
             catch (Exception ex)
             {
                 StingLog.Error($"ElecRunCommand<{typeof(T).Name}>: {ex.Message}", ex);
+                try
+                {
+                    TaskDialog.Show("STING Electrical",
+                        $"Command '{typeof(T).Name}' threw an unexpected error:\n{ex.Message}\n\nCheck StingTools.log for details.");
+                }
+                catch (Exception ex2) { StingLog.Warn($"Suppressed TaskDialog: {ex2.Message}"); }
             }
         }
 


### PR DESCRIPTION
Merges unmerged branch `claude/laughing-babbage-s5yob` into `main`.

Surfaces previously-silent failures in `StingTools/UI/StingElectricalCommandHandler.cs`. Group A (reliability fix).

Opened as part of branch-cleanup triage to preserve work before branch deletion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5aGwxY9iznAn6LU1Y1hff)_