### PR TITLE
Switch domain from planscape.app to planscape.co

### DIFF
--- a/marketing-site/DEPLOY.md
+++ b/marketing-site/DEPLOY.md
@@ -1,6 +1,6 @@
 # Deploying Planscape marketing site
 
-Step-by-step walkthrough from "no domain" to "live on planscape.app with HTTPS". Estimated time: 30 minutes if you've never done this before, 5 minutes if you have.
+Step-by-step walkthrough from "no domain" to "live on planscape.co with HTTPS". Estimated time: 30 minutes if you've never done this before, 5 minutes if you have.
 
 **Total cost:** ~$10/year (domain only). Cloudflare Pages hosting, Cloudflare DNS, SSL certificate are all free.
 
@@ -16,7 +16,7 @@ Cloudflare sells domains **at cost** — no markup. A `.com` is $10.44/yr at the
 
 1. Sign up at <https://dash.cloudflare.com/sign-up> (free Cloudflare account).
 2. In the dashboard, click **Domain Registration → Register Domains**.
-3. Search for `planscape.app` (or whatever you've chosen).
+3. Search for `planscape.co` (or whatever you've chosen).
 4. The `.app` TLD is $13.18/yr at cost. The `.com` is $10.44/yr. Pick whichever.
 5. Pay with card. Domain is active within ~5 minutes.
 
@@ -39,7 +39,7 @@ If for some reason Cloudflare Registrar isn't available in your country:
 ### What to register
 
 - Always register the `.com` if available. It's the default people type.
-- Register the `.app` if you're using it as your canonical (we use planscape.app).
+- Register the `.app` if you're using it as your canonical (we use planscape.co).
 - Optionally register your country TLD too (e.g. `.co.ug`) — costs more (~$25/yr) but useful if you want to localise eventually.
 
 ---
@@ -122,12 +122,12 @@ From now on, every `git push` to `main` triggers an automatic deploy. PRs get pr
 
 1. In Cloudflare dashboard, open your Pages project → **Custom domains** tab.
 2. Click **Set up a custom domain**.
-3. Type your apex domain: `planscape.app`.
+3. Type your apex domain: `planscape.co`.
 4. Cloudflare auto-creates the right DNS record (a CNAME or AAAA flattened to the Pages worker).
-5. Repeat for `www.planscape.app` — Cloudflare creates a redirect to the apex.
+5. Repeat for `www.planscape.co` — Cloudflare creates a redirect to the apex.
 6. Wait 1–2 minutes for the certificate to issue. You'll see "Active" with a green checkmark.
 
-Now <https://planscape.app> serves your marketing site.
+Now <https://planscape.co> serves your marketing site.
 
 ---
 
@@ -142,7 +142,7 @@ Before sharing the URL publicly, swap out the placeholders:
 | `DEMO_VIDEO_ID` | `index.html` | YouTube video ID for your 90-second demo |
 | `+256700000000` | every page | Your real WhatsApp Business number |
 | `https://cal.com/planscape/demo` | `contact.html` | Your Cal.com / Calendly booking link |
-| `https://api.planscape.app/marketing/...` | `index.html`, `contact.html` | Your API base URL (or change endpoints to whatever's live) |
+| `https://api.planscape.co/marketing/...` | `index.html`, `contact.html` | Your API base URL (or change endpoints to whatever's live) |
 
 Quickest way:
 
@@ -173,10 +173,10 @@ Forward all incoming mail to your existing Gmail / Outlook inbox.
 2. Enable it. Cloudflare auto-creates the MX records.
 3. Add destination email (your existing inbox). Verify via the click-link they email you.
 4. Add custom routes:
-   - `hello@planscape.app` → your Gmail
-   - `support@planscape.app` → your Gmail
-   - `security@planscape.app` → your Gmail
-   - `*@planscape.app` (catch-all) → your Gmail
+   - `hello@planscape.co` → your Gmail
+   - `support@planscape.co` → your Gmail
+   - `security@planscape.co` → your Gmail
+   - `*@planscape.co` (catch-all) → your Gmail
 
 For sending email FROM the domain (replying, transactional), see Stage 8.
 
@@ -205,7 +205,7 @@ Free up to 300 emails/day. African-friendly support.
 3. Generate an SMTP key for your API server.
 4. Set the SMTP env vars on your API host (Render.com → Environment).
 
-You already have the contact form posting to `https://api.planscape.app/marketing/contact` — wire that endpoint to send via Brevo SMTP.
+You already have the contact form posting to `https://api.planscape.co/marketing/contact` — wire that endpoint to send via Brevo SMTP.
 
 ---
 
@@ -216,7 +216,7 @@ You already have the contact form posting to `https://api.planscape.app/marketin
 Privacy-first, no cookies, GDPR-friendly. Built into Cloudflare. Free.
 
 1. Cloudflare dashboard → **Analytics → Web Analytics**.
-2. Click **Add a site** → enter `planscape.app`.
+2. Click **Add a site** → enter `planscape.co`.
 3. Cloudflare gives you a snippet. Paste into `marketing-site/index.html` just before `</body>`.
 4. Copy the same snippet into every other page (or put it in a shared script — but the snippet is so small that inlining works fine).
 
@@ -233,9 +233,9 @@ Industry standard but cookie-based — you'll need a cookie banner.
 ## Stage 10 — Submit to search engines (10 min)
 
 1. **Google Search Console** — <https://search.google.com/search-console>
-   - Add the property `https://planscape.app`.
+   - Add the property `https://planscape.co`.
    - Verify via DNS TXT record (Cloudflare DNS, takes 2 minutes).
-   - Submit your sitemap: `https://planscape.app/sitemap.xml`.
+   - Submit your sitemap: `https://planscape.co/sitemap.xml`.
 
 2. **Bing Webmaster Tools** — <https://www.bing.com/webmasters>
    - Add the site.
@@ -312,7 +312,7 @@ You haven't replaced `PLANSCAPE_MAPBOX_TOKEN` in `index.html`. The site detects 
 
 ### "Forms don't submit"
 
-The contact and demo forms post to `https://api.planscape.app/marketing/*` — these endpoints need to exist on your API. Until the API is deployed, the forms will show the error path and ask users to email instead.
+The contact and demo forms post to `https://api.planscape.co/marketing/*` — these endpoints need to exist on your API. Until the API is deployed, the forms will show the error path and ask users to email instead.
 
 ---
 
@@ -321,10 +321,10 @@ The contact and demo forms post to `https://api.planscape.app/marketing/*` — t
 1. Test every form by submitting yourself.
 2. Test the WhatsApp link — make sure your business number receives the message.
 3. Share the URL with a friend on a slow phone — confirm it loads in &lt;2s.
-4. Run a Lighthouse audit (`https://pagespeed.web.dev/?url=https://planscape.app`) — aim for &gt;90 on Performance, Accessibility, Best Practices, SEO.
+4. Run a Lighthouse audit (`https://pagespeed.web.dev/?url=https://planscape.co`) — aim for &gt;90 on Performance, Accessibility, Best Practices, SEO.
 5. Submit the sitemap to Google Search Console.
 6. Start writing the next blog post.
 
 ---
 
-Questions: <hello@planscape.app>.
+Questions: <hello@planscape.co>.

--- a/marketing-site/DEPLOY.md
+++ b/marketing-site/DEPLOY.md
@@ -1,0 +1,330 @@
+# Deploying Planscape marketing site
+
+Step-by-step walkthrough from "no domain" to "live on planscape.app with HTTPS". Estimated time: 30 minutes if you've never done this before, 5 minutes if you have.
+
+**Total cost:** ~$10/year (domain only). Cloudflare Pages hosting, Cloudflare DNS, SSL certificate are all free.
+
+---
+
+## Stage 1 — Buy the domain (5 min, ~$10/yr)
+
+### Best option: Cloudflare Registrar
+
+Cloudflare sells domains **at cost** — no markup. A `.com` is $10.44/yr at the time of writing. They don't try to upsell you. They renew at the same price.
+
+**Steps:**
+
+1. Sign up at <https://dash.cloudflare.com/sign-up> (free Cloudflare account).
+2. In the dashboard, click **Domain Registration → Register Domains**.
+3. Search for `planscape.app` (or whatever you've chosen).
+4. The `.app` TLD is $13.18/yr at cost. The `.com` is $10.44/yr. Pick whichever.
+5. Pay with card. Domain is active within ~5 minutes.
+
+Cloudflare automatically adds the domain to your account with their DNS — saves you a step later.
+
+### Alternative: Namecheap
+
+If for some reason Cloudflare Registrar isn't available in your country:
+
+1. Go to <https://www.namecheap.com>.
+2. Search and buy your domain (~$11/yr for `.com`).
+3. **Important**: opt into WhoisGuard (free — keeps your details private).
+4. Later you'll point DNS at Cloudflare (Stage 2).
+
+### Domains to avoid
+
+- **GoDaddy** — upsells aggressively, hikes renewal prices, generally hostile UX.
+- **Free domains** (`.tk`, `.ga`, etc.) — unreliable, often blacklisted by spam filters, terrible for SEO.
+
+### What to register
+
+- Always register the `.com` if available. It's the default people type.
+- Register the `.app` if you're using it as your canonical (we use planscape.app).
+- Optionally register your country TLD too (e.g. `.co.ug`) — costs more (~$25/yr) but useful if you want to localise eventually.
+
+---
+
+## Stage 2 — Set up Cloudflare for the domain (5 min)
+
+Skip this stage if you bought through Cloudflare Registrar — already done.
+
+If you bought elsewhere:
+
+1. In the Cloudflare dashboard, click **Add a Site**.
+2. Type your domain. Pick the **Free** plan.
+3. Cloudflare scans existing DNS records and lists them. Confirm.
+4. Cloudflare shows two **nameservers** (e.g. `kane.ns.cloudflare.com`, `april.ns.cloudflare.com`).
+5. Go back to your registrar's dashboard (Namecheap), find **Nameservers**, switch to "Custom DNS", paste the two Cloudflare nameservers.
+6. Save. Propagation takes 5 minutes to a few hours.
+7. Cloudflare emails you when the site is **Active**.
+
+---
+
+## Stage 3 — Push the site to GitHub (5 min)
+
+Cloudflare Pages deploys from GitHub. (You can also drag-drop files, but Git-based is the right long-term move.)
+
+The marketing site is already in your repo at `marketing-site/`. You have two options:
+
+### Option A — Use the existing monorepo
+
+Cloudflare Pages can deploy a subdirectory. Skip to Stage 4 if you're happy with that.
+
+### Option B — Split to a dedicated repo (recommended)
+
+Cleaner deploys, doesn't trigger on every backend change.
+
+```bash
+# From your existing repo
+cd /tmp
+git clone --filter=blob:none --no-checkout https://github.com/beckykyomugisha/stingtools.git planscape-marketing
+cd planscape-marketing
+git sparse-checkout init --cone
+git sparse-checkout set marketing-site
+git checkout main
+mv marketing-site/* marketing-site/.* . 2>/dev/null
+rmdir marketing-site
+git remote remove origin
+
+# Create new GitHub repo at github.com/beckykyomugisha/planscape-marketing (public or private — Pages works with both)
+git remote add origin git@github.com:beckykyomugisha/planscape-marketing.git
+git add -A
+git commit -m "Initial commit — Planscape marketing site"
+git push -u origin main
+```
+
+---
+
+## Stage 4 — Connect Cloudflare Pages to GitHub (5 min)
+
+1. In the Cloudflare dashboard, go to **Workers & Pages → Create application → Pages → Connect to Git**.
+2. Authorize Cloudflare to access your GitHub.
+3. Pick the repo (`stingtools` for monorepo, or `planscape-marketing` for split).
+4. Configure the build:
+
+   | Field | Value |
+   |---|---|
+   | Project name | `planscape-marketing` |
+   | Production branch | `main` |
+   | Framework preset | **None** |
+   | Build command | (leave empty) |
+   | Build output directory | `marketing-site` (monorepo) or `/` (split repo) |
+   | Root directory | `/` |
+
+5. Click **Save and Deploy**. First deploy takes ~30 seconds.
+6. Cloudflare gives you a preview URL like `https://planscape-marketing.pages.dev`. Open it — your site is live (on the temporary URL).
+
+From now on, every `git push` to `main` triggers an automatic deploy. PRs get preview deploys with their own URLs.
+
+---
+
+## Stage 5 — Point the domain at Cloudflare Pages (3 min)
+
+1. In Cloudflare dashboard, open your Pages project → **Custom domains** tab.
+2. Click **Set up a custom domain**.
+3. Type your apex domain: `planscape.app`.
+4. Cloudflare auto-creates the right DNS record (a CNAME or AAAA flattened to the Pages worker).
+5. Repeat for `www.planscape.app` — Cloudflare creates a redirect to the apex.
+6. Wait 1–2 minutes for the certificate to issue. You'll see "Active" with a green checkmark.
+
+Now <https://planscape.app> serves your marketing site.
+
+---
+
+## Stage 6 — Replace placeholder tokens (5 min)
+
+Before sharing the URL publicly, swap out the placeholders:
+
+| Token | File(s) | What to set |
+|---|---|---|
+| `PLANSCAPE_MAPBOX_TOKEN` | `index.html` | Free public token from <https://account.mapbox.com> — no card required |
+| `__CRISP_WEBSITE_ID__` | `index.html` | Crisp Chat website ID from <https://app.crisp.chat> (optional; widget silently no-ops without it) |
+| `DEMO_VIDEO_ID` | `index.html` | YouTube video ID for your 90-second demo |
+| `+256700000000` | every page | Your real WhatsApp Business number |
+| `https://cal.com/planscape/demo` | `contact.html` | Your Cal.com / Calendly booking link |
+| `https://api.planscape.app/marketing/...` | `index.html`, `contact.html` | Your API base URL (or change endpoints to whatever's live) |
+
+Quickest way:
+
+```bash
+cd marketing-site
+
+# Mapbox token
+sed -i 's/PLANSCAPE_MAPBOX_TOKEN/pk.eyJ1Ijoi...your-real-token/' index.html
+
+# WhatsApp number
+grep -rl "+256700000000" . | xargs sed -i 's/+256700000000/+256777YOUR_REAL/g'
+grep -rl "256700000000" . | xargs sed -i 's/256700000000/256777YOUR_REAL/g'
+```
+
+Commit and push — Pages auto-redeploys.
+
+---
+
+## Stage 7 — Connect email (10 min)
+
+Your domain needs email for `hello@`, `support@`, `security@`, etc.
+
+### Cheapest: Cloudflare Email Routing (free)
+
+Forward all incoming mail to your existing Gmail / Outlook inbox.
+
+1. Cloudflare dashboard → your domain → **Email → Email Routing**.
+2. Enable it. Cloudflare auto-creates the MX records.
+3. Add destination email (your existing inbox). Verify via the click-link they email you.
+4. Add custom routes:
+   - `hello@planscape.app` → your Gmail
+   - `support@planscape.app` → your Gmail
+   - `security@planscape.app` → your Gmail
+   - `*@planscape.app` (catch-all) → your Gmail
+
+For sending email FROM the domain (replying, transactional), see Stage 8.
+
+### Better: Google Workspace (~$6/user/month)
+
+Real email accounts at the domain. Full Gmail/Drive/Calendar.
+
+1. Sign up at <https://workspace.google.com/business>.
+2. Add the domain during onboarding — Google walks you through DNS setup.
+3. Add the DNS records they specify into Cloudflare.
+
+Skip this for now if you're bootstrapping — Email Routing is fine for the first months.
+
+---
+
+## Stage 8 — Set up transactional email (15 min, free tier)
+
+For the contact form, demo-request form, and trial expiry notifications.
+
+### Use Brevo (recommended)
+
+Free up to 300 emails/day. African-friendly support.
+
+1. Sign up at <https://www.brevo.com>.
+2. Verify your domain (add the SPF + DKIM records to Cloudflare DNS — Brevo provides them).
+3. Generate an SMTP key for your API server.
+4. Set the SMTP env vars on your API host (Render.com → Environment).
+
+You already have the contact form posting to `https://api.planscape.app/marketing/contact` — wire that endpoint to send via Brevo SMTP.
+
+---
+
+## Stage 9 — Add analytics (5 min, free)
+
+### Cloudflare Web Analytics (recommended)
+
+Privacy-first, no cookies, GDPR-friendly. Built into Cloudflare. Free.
+
+1. Cloudflare dashboard → **Analytics → Web Analytics**.
+2. Click **Add a site** → enter `planscape.app`.
+3. Cloudflare gives you a snippet. Paste into `marketing-site/index.html` just before `</body>`.
+4. Copy the same snippet into every other page (or put it in a shared script — but the snippet is so small that inlining works fine).
+
+### Alternative: Plausible Analytics ($9/mo)
+
+If you want named visitor counts, page paths, and a nicer UI. Self-host for free if you have a VPS.
+
+### Alternative: Google Analytics 4 (free)
+
+Industry standard but cookie-based — you'll need a cookie banner.
+
+---
+
+## Stage 10 — Submit to search engines (10 min)
+
+1. **Google Search Console** — <https://search.google.com/search-console>
+   - Add the property `https://planscape.app`.
+   - Verify via DNS TXT record (Cloudflare DNS, takes 2 minutes).
+   - Submit your sitemap: `https://planscape.app/sitemap.xml`.
+
+2. **Bing Webmaster Tools** — <https://www.bing.com/webmasters>
+   - Add the site.
+   - You can auto-import settings from Google Search Console.
+
+3. **DuckDuckGo** — auto-crawls based on Bing data, no submission needed.
+
+Don't bother with directory submissions (Yandex, Baidu, etc.) unless you're targeting those markets.
+
+---
+
+## Maintenance
+
+### Updating the site
+
+Edit any file → commit → push. Cloudflare Pages auto-redeploys within 60 seconds.
+
+### Rolling back a bad deploy
+
+Cloudflare dashboard → Pages project → Deployments tab → find a previous deployment → click **Rollback to this deployment**. Takes 5 seconds.
+
+### Adding a new guide / tutorial / blog post
+
+1. Copy `assets/template-guide.html` (or one of the existing posts) as the starting point.
+2. Edit content.
+3. Add an entry to the relevant hub page (`/guides/`, `/tutorials/`, `/blog/`).
+4. Add to `sitemap.xml`.
+5. For blog posts: also add an item to `blog/rss.xml`.
+6. Commit and push.
+
+### Monitoring
+
+- Cloudflare Pages dashboard shows deploy logs, bandwidth, and edge-cache hit rate.
+- Cloudflare Analytics shows visitor counts, top pages, top countries, top referrers.
+- Brevo dashboard shows email open/click rates if you wire transactional emails through it.
+
+---
+
+## Budget summary
+
+| Item | Cost | Frequency |
+|---|---|---|
+| Domain (.com or .app via Cloudflare Registrar) | ~$10 | per year |
+| Cloudflare Pages hosting (unlimited bandwidth) | $0 | — |
+| Cloudflare DNS | $0 | — |
+| SSL certificate (Let's Encrypt via Cloudflare) | $0 | — |
+| Cloudflare Web Analytics | $0 | — |
+| Cloudflare Email Routing (forwarding) | $0 | — |
+| Brevo SMTP (up to 300 emails/day) | $0 | — |
+| Google Workspace (optional, real email accounts) | $6/user | per month |
+| Plausible Analytics (optional, nicer UI) | $9 | per month |
+
+**Minimum viable: ~$10/year.** Everything else is optional.
+
+---
+
+## Troubleshooting
+
+### "Deploy succeeded but the site shows old content"
+
+Cloudflare's edge cache is aggressive. Either wait 5 minutes (HTML has a 5-min cache per `_headers`) or purge cache manually: Cloudflare dashboard → Caching → Purge Cache → Purge Everything.
+
+### "DNS doesn't resolve yet"
+
+Propagation can take up to 24 hours but usually finishes in 5–15 minutes. Check progress at <https://dnschecker.org>.
+
+### "Email Routing isn't delivering"
+
+Check Cloudflare's MX records are still in your DNS (sometimes a manual record gets in the way). Email Routing → Routes → check the destination is verified.
+
+### "Page works but Mapbox map is blank"
+
+You haven't replaced `PLANSCAPE_MAPBOX_TOKEN` in `index.html`. The site detects this and shows a fallback "awaits Mapbox token" message in place of the map — replace the token with a real one from <https://account.mapbox.com>.
+
+### "Forms don't submit"
+
+The contact and demo forms post to `https://api.planscape.app/marketing/*` — these endpoints need to exist on your API. Until the API is deployed, the forms will show the error path and ask users to email instead.
+
+---
+
+## Next steps after the site is live
+
+1. Test every form by submitting yourself.
+2. Test the WhatsApp link — make sure your business number receives the message.
+3. Share the URL with a friend on a slow phone — confirm it loads in &lt;2s.
+4. Run a Lighthouse audit (`https://pagespeed.web.dev/?url=https://planscape.app`) — aim for &gt;90 on Performance, Accessibility, Best Practices, SEO.
+5. Submit the sitemap to Google Search Console.
+6. Start writing the next blog post.
+
+---
+
+Questions: <hello@planscape.app>.

--- a/marketing-site/README.md
+++ b/marketing-site/README.md
@@ -1,35 +1,133 @@
 # Planscape marketing site
 
-Single-page marketing site, no build step. Deploy targets:
+Multi-page marketing site, no build step. Plain HTML + shared CSS.
+Deploys to Cloudflare Pages (recommended), GitHub Pages, Netlify,
+or any static-file host.
 
-- Cloudflare Pages (recommended, free tier covers our traffic forever)
-- GitHub Pages
-- Any static-file host (Netlify, S3 + CloudFront, MinIO + Bunny)
+## Structure
 
-## Pages
+```
+marketing-site/
+├── index.html             — landing page (hero, features, compare, Africa map, FAQ)
+├── features.html          — full feature catalogue grouped by audience
+├── pricing.html           — 5 tiers, comparison table, FAQ, currency support
+├── about.html             — mission, team, roadmap
+├── contact.html           — contact form + WhatsApp + office details
+├── privacy.html           — privacy policy
+├── terms.html             — terms of service
+├── robots.txt
+├── sitemap.xml
+├── assets/
+│   ├── site.css           — shared styles (nav, footer, cards, forms, articles)
+│   ├── nav.html           — nav reference (copy into each page)
+│   ├── footer.html        — footer reference (copy into each page)
+│   └── template-guide.html — boilerplate for new guides/tutorials
+├── guides/
+│   ├── index.html         — guides hub (30+ guide links by category)
+│   ├── getting-started.html
+│   ├── revit-plugin-setup.html
+│   ├── mobile-onboarding.html
+│   └── … (more to write — use assets/template-guide.html as the starting point)
+└── tutorials/
+    ├── index.html         — tutorials hub (25+ tutorial cards)
+    ├── raise-issue-from-mobile.html
+    └── … (more to write)
+```
 
-- `/`           — landing page (hero + features + compare + testimonial + CTAs)
-- `/signup`     — proxy to `https://api.planscape.app/auth/signup` (handled by app router; this site only links)
-- `/api/pricing/html` — pricing page served by the API server
-- `/privacy`    — TODO (S7.5)
-- `/terms`      — TODO (S7.5)
+## Design system
+
+- **Brand colour**: `#E8912D` (orange) — defined in CSS as `--accent`
+- **Ink**: `#1c1f26` (near-black for text)
+- **Muted**: `#6c7280`
+- **Font**: system stack (`-apple-system, system-ui, Segoe UI, Roboto, sans-serif`)
+- **CSS variables** live in `assets/site.css` — change once, propagates everywhere
+- **No JS framework** — vanilla JS for form submission and the menu toggle
+
+Component classes (in `site.css`):
+
+| Class | Use |
+|---|---|
+| `nav.site` | The top navigation bar |
+| `footer.site` | The footer (4-column grid) |
+| `.hero` | Big homepage hero |
+| `.page-header` | Smaller header for sub-pages |
+| `section` | Standard 64px-padded section, 1100px max-width |
+| `.card` | Generic feature card with icon + title + description |
+| `.tier` | Pricing tier card |
+| `.tier.highlight` | "Most popular" tier (orange border) |
+| `.tbl` | Comparison table |
+| `.cta-band` | Dark CTA strip |
+| `.form-stack`, `.form-row` | Form layouts |
+| `article.doc` | Guide / tutorial article container |
+| `.callout`, `.callout.warn`, `.callout.danger` | Inline callout boxes |
+| `.faq-list`, `.faq-item` | Collapsible FAQ |
+| `.chip` | Small inline pill |
+
+## Adding a new guide or tutorial
+
+1. Copy `assets/template-guide.html` to `guides/<slug>.html` (or `tutorials/<slug>.html`).
+2. Replace the `{{TOKEN}}` placeholders.
+3. Add a card on the relevant hub page (`guides/index.html` or `tutorials/index.html`).
+4. Add a `<url>` entry to `sitemap.xml`.
 
 ## Deploy
 
+### Cloudflare Pages (recommended — free, fast, no card)
+
 ```bash
-# Cloudflare Pages — drag-drop or:
+# Drag-drop in the Cloudflare dashboard, or:
 wrangler pages deploy marketing-site --project-name=planscape-marketing
 ```
 
-Set DNS:
+DNS in Cloudflare:
 
 ```
-A  planscape.app    → Cloudflare proxy
-A  www.planscape.app → Cloudflare proxy
+A     planscape.app      → Cloudflare proxy
+CNAME www.planscape.app  → planscape.app
 ```
 
-CNAME flatten if needed.
+### GitHub Pages
 
-## Editing
+Add the `marketing-site/` folder as the Pages source (Settings → Pages → branch `main`, folder `/marketing-site`).
+Cloudflare DNS / CNAME pointing at `<user>.github.io` if you want a custom domain.
 
-Plain HTML + inline CSS, no framework. Add images to `marketing-site/images/`. Keep page weight under 200 KB so it loads fast on EA mobile networks.
+### Netlify
+
+```bash
+netlify deploy --dir=marketing-site --prod
+```
+
+## Environment placeholders
+
+Replace these tokens before going live:
+
+| Token | File | What to set it to |
+|---|---|---|
+| `PLANSCAPE_MAPBOX_TOKEN` | `index.html` | A free Mapbox public token (no card required) |
+| `__CRISP_WEBSITE_ID__` | `index.html` | Crisp Chat website ID (optional — silently no-ops without it) |
+| `DEMO_VIDEO_ID` | `index.html` | YouTube video ID for the 90-second demo |
+| `+256700000000` | every page | Your real WhatsApp Business number |
+| `https://cal.com/planscape/demo` | `contact.html` | Your Cal.com / Calendly link |
+
+## Performance budget
+
+Keep each page under 200 KB on the wire so it loads fast on slow East African mobile connections. Current state:
+
+- `index.html` ~ 30 KB (+ Mapbox GL JS lazy-loaded only when scrolled into view)
+- `features.html` ~ 24 KB
+- `pricing.html` ~ 20 KB
+- Guides / tutorials ~ 12 KB each
+- `site.css` ~ 11 KB (shared, cached)
+
+## What's not built yet
+
+Most guide and tutorial pages on the hubs link to pages that don't yet exist. The hub pages are deliberately comprehensive so the SEO structure and editorial direction are clear. Fill in the actual articles using `assets/template-guide.html` as the starting point.
+
+Priority guides to write next (highest impact for trial conversions):
+
+1. `guides/iso-19650-workflow.html`
+2. `guides/billing-and-trials.html`
+3. `guides/self-hosting.html`
+4. `tutorials/install-mobile-app.html`
+5. `tutorials/install-revit-plugin.html`
+6. `tutorials/sync-revit-to-cloud.html`

--- a/marketing-site/README.md
+++ b/marketing-site/README.md
@@ -15,23 +15,43 @@ marketing-site/
 ├── contact.html           — contact form + WhatsApp + office details
 ├── privacy.html           — privacy policy
 ├── terms.html             — terms of service
-├── robots.txt
-├── sitemap.xml
+├── robots.txt             — search-engine policy
+├── sitemap.xml            — all URLs for crawlers
+├── _headers               — Cloudflare/Netlify HTTP headers (CSP, caching, HSTS)
+├── _redirects             — Cloudflare/Netlify redirect rules (/features → /features.html etc.)
+├── wrangler.toml          — Cloudflare Pages config for `wrangler pages deploy`
+├── DEPLOY.md              — step-by-step deploy + domain-purchase walkthrough
+├── README.md              — this file
 ├── assets/
-│   ├── site.css           — shared styles (nav, footer, cards, forms, articles)
+│   ├── site.css           — shared styles (nav, footer, cards, forms, articles, blog)
 │   ├── nav.html           — nav reference (copy into each page)
 │   ├── footer.html        — footer reference (copy into each page)
 │   └── template-guide.html — boilerplate for new guides/tutorials
-├── guides/
-│   ├── index.html         — guides hub (30+ guide links by category)
+├── guides/                — 9 complete guides + hub with 30+ link slots
+│   ├── index.html
 │   ├── getting-started.html
 │   ├── revit-plugin-setup.html
 │   ├── mobile-onboarding.html
-│   └── … (more to write — use assets/template-guide.html as the starting point)
-└── tutorials/
-    ├── index.html         — tutorials hub (25+ tutorial cards)
-    ├── raise-issue-from-mobile.html
-    └── … (more to write)
+│   ├── inviting-team.html
+│   ├── creating-first-project.html
+│   ├── iso-19650-workflow.html
+│   ├── billing-and-trials.html
+│   ├── self-hosting.html
+│   ├── raising-issues.html
+│   └── gps-site-map.html
+├── tutorials/             — 5 complete tutorials + hub with 25+ link slots
+│   ├── index.html
+│   ├── create-first-project.html
+│   ├── install-mobile-app.html
+│   ├── install-revit-plugin.html
+│   ├── raise-issue-from-mobile.html
+│   └── capture-site-photos.html
+└── blog/                  — 3 posts + RSS feed
+    ├── index.html
+    ├── rss.xml
+    ├── 2026-05-23-why-we-built-planscape.html
+    ├── 2026-05-20-iso-19650-in-east-africa.html
+    └── 2026-05-15-offline-first-mobile-bim.html
 ```
 
 ## Design system
@@ -72,30 +92,19 @@ Component classes (in `site.css`):
 
 ## Deploy
 
-### Cloudflare Pages (recommended — free, fast, no card)
+**Full walkthrough in [DEPLOY.md](./DEPLOY.md)** — covers domain purchase, Cloudflare Pages setup, DNS, email, analytics, and search-engine submission. Total cost: ~$10/year (domain only).
+
+Quick TL;DR for someone who's done this before:
 
 ```bash
-# Drag-drop in the Cloudflare dashboard, or:
-wrangler pages deploy marketing-site --project-name=planscape-marketing
+# Deploy to Cloudflare Pages via CLI
+wrangler pages deploy . --project-name=planscape-marketing
+
+# Or connect GitHub repo in the dashboard: Workers & Pages → Create → Pages → Connect to Git
+# Build settings: framework = None, build command = empty, output dir = marketing-site
 ```
 
-DNS in Cloudflare:
-
-```
-A     planscape.app      → Cloudflare proxy
-CNAME www.planscape.app  → planscape.app
-```
-
-### GitHub Pages
-
-Add the `marketing-site/` folder as the Pages source (Settings → Pages → branch `main`, folder `/marketing-site`).
-Cloudflare DNS / CNAME pointing at `<user>.github.io` if you want a custom domain.
-
-### Netlify
-
-```bash
-netlify deploy --dir=marketing-site --prod
-```
+The `_headers`, `_redirects`, and `wrangler.toml` are pre-configured for Cloudflare Pages. They also work on Netlify with minimal changes.
 
 ## Environment placeholders
 
@@ -119,15 +128,20 @@ Keep each page under 200 KB on the wire so it loads fast on slow East African mo
 - Guides / tutorials ~ 12 KB each
 - `site.css` ~ 11 KB (shared, cached)
 
-## What's not built yet
+## What's already written vs still to write
 
-Most guide and tutorial pages on the hubs link to pages that don't yet exist. The hub pages are deliberately comprehensive so the SEO structure and editorial direction are clear. Fill in the actual articles using `assets/template-guide.html` as the starting point.
+**Top-level pages** — all complete: index, features, pricing, about, contact, privacy, terms.
 
-Priority guides to write next (highest impact for trial conversions):
+**Guides** — 9 complete (getting-started, revit-plugin-setup, mobile-onboarding, inviting-team, creating-first-project, iso-19650-workflow, billing-and-trials, self-hosting, raising-issues, gps-site-map). ~20 more linked from the hub for editorial direction.
 
-1. `guides/iso-19650-workflow.html`
-2. `guides/billing-and-trials.html`
-3. `guides/self-hosting.html`
-4. `tutorials/install-mobile-app.html`
-5. `tutorials/install-revit-plugin.html`
-6. `tutorials/sync-revit-to-cloud.html`
+**Tutorials** — 5 complete (create-first-project, install-mobile-app, install-revit-plugin, raise-issue-from-mobile, capture-site-photos). ~20 more linked from the hub.
+
+**Blog** — 3 complete posts (why-we-built-planscape, iso-19650-in-east-africa, offline-first-mobile-bim) + RSS feed.
+
+Priority articles to write next:
+
+1. `guides/photo-capture.html` (referenced by raising-issues + capture-site-photos)
+2. `guides/auto-tagging.html` (highest-volume Revit-plugin command)
+3. `tutorials/sync-revit-to-cloud.html` (key conversion driver for Revit users)
+4. `tutorials/gps-site-map.html` (key mobile-first workflow)
+5. `tutorials/tag-elements-in-revit.html` (advanced ISO 19650 workflow)

--- a/marketing-site/_headers
+++ b/marketing-site/_headers
@@ -1,0 +1,38 @@
+# Cloudflare Pages / Netlify _headers
+# Sets HTTP response headers per path. Improves security + caching.
+
+# ---------- Default for all paths ----------
+/*
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(self), microphone=(), camera=(self), payment=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://api.mapbox.com https://client.crisp.chat; style-src 'self' 'unsafe-inline' https://api.mapbox.com; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.planscape.app https://api.mapbox.com https://events.mapbox.com https://client.crisp.chat wss://client.relay.crisp.chat; frame-ancestors 'none'
+
+# ---------- Long-lived static assets ----------
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/images/*
+  Cache-Control: public, max-age=2592000
+
+# ---------- HTML — short cache so updates propagate ----------
+/*.html
+  Cache-Control: public, max-age=300, must-revalidate
+
+/
+  Cache-Control: public, max-age=300, must-revalidate
+
+# ---------- Feeds + sitemap ----------
+/blog/rss.xml
+  Content-Type: application/rss+xml; charset=utf-8
+  Cache-Control: public, max-age=900
+
+/sitemap.xml
+  Content-Type: application/xml; charset=utf-8
+  Cache-Control: public, max-age=3600
+
+/robots.txt
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: public, max-age=3600

--- a/marketing-site/_headers
+++ b/marketing-site/_headers
@@ -8,7 +8,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(self), microphone=(), camera=(self), payment=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://api.mapbox.com https://client.crisp.chat; style-src 'self' 'unsafe-inline' https://api.mapbox.com; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.planscape.app https://api.mapbox.com https://events.mapbox.com https://client.crisp.chat wss://client.relay.crisp.chat; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://api.mapbox.com https://client.crisp.chat; style-src 'self' 'unsafe-inline' https://api.mapbox.com; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.planscape.co https://api.mapbox.com https://events.mapbox.com https://client.crisp.chat wss://client.relay.crisp.chat; frame-ancestors 'none'
 
 # ---------- Long-lived static assets ----------
 /assets/*

--- a/marketing-site/_redirects
+++ b/marketing-site/_redirects
@@ -1,0 +1,28 @@
+# Cloudflare Pages / Netlify redirects
+# Format: <from> <to> <status>
+# 301 = permanent, 302 = temporary
+
+# Legacy URLs
+/docs           https://docs.planscape.app/    301
+/docs/*         https://docs.planscape.app/:splat 301
+
+# Cleaner URLs without .html
+/features       /features.html                 301
+/pricing        /pricing.html                  301
+/about          /about.html                    301
+/contact        /contact.html                  301
+/privacy        /privacy.html                  301
+/terms          /terms.html                    301
+
+# App routes — proxy to the API for signup / login
+/signup         https://api.planscape.app/auth/signup 302
+/login          https://api.planscape.app/auth/login  302
+/app            https://app.planscape.app/             302
+/app/*          https://app.planscape.app/:splat       302
+
+# API
+/api/*          https://api.planscape.app/:splat       200
+
+# Old WordPress-style paths (just in case)
+/?p=*           /blog/                          301
+/category/*     /blog/                          301

--- a/marketing-site/_redirects
+++ b/marketing-site/_redirects
@@ -3,8 +3,8 @@
 # 301 = permanent, 302 = temporary
 
 # Legacy URLs
-/docs           https://docs.planscape.app/    301
-/docs/*         https://docs.planscape.app/:splat 301
+/docs           https://docs.planscape.co/    301
+/docs/*         https://docs.planscape.co/:splat 301
 
 # Cleaner URLs without .html
 /features       /features.html                 301
@@ -15,13 +15,13 @@
 /terms          /terms.html                    301
 
 # App routes — proxy to the API for signup / login
-/signup         https://api.planscape.app/auth/signup 302
-/login          https://api.planscape.app/auth/login  302
-/app            https://app.planscape.app/             302
-/app/*          https://app.planscape.app/:splat       302
+/signup         https://api.planscape.co/auth/signup 302
+/login          https://api.planscape.co/auth/login  302
+/app            https://app.planscape.co/             302
+/app/*          https://app.planscape.co/:splat       302
 
 # API
-/api/*          https://api.planscape.app/:splat       200
+/api/*          https://api.planscape.co/:splat       200
 
 # Old WordPress-style paths (just in case)
 /?p=*           /blog/                          301

--- a/marketing-site/about.html
+++ b/marketing-site/about.html
@@ -23,6 +23,7 @@
     <a href="/pricing.html">Pricing</a>
     <a href="/guides/">Guides</a>
     <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/">Blog</a>
     <a href="/about.html" style="color:var(--accent)">About</a>
     <a href="/contact.html">Contact</a>
   </div>

--- a/marketing-site/about.html
+++ b/marketing-site/about.html
@@ -7,10 +7,10 @@
 <meta name="description" content="Planscape is built by AEC practitioners in Kampala, Uganda. ISO 19650 BIM coordination for the African delivery context.">
 <meta property="og:title" content="About — Planscape">
 <meta property="og:description" content="Built by AEC practitioners in Kampala. ISO 19650 coordination for the African delivery context.">
-<meta property="og:url" content="https://planscape.app/about.html">
+<meta property="og:url" content="https://planscape.co/about.html">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/about.html">
+<link rel="canonical" href="https://planscape.co/about.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -64,8 +64,8 @@
   </ul>
 
   <h2>How to reach us</h2>
-  <p>Email <a href="mailto:hello@planscape.app">hello@planscape.app</a> or <a href="https://wa.me/256700000000" target="_blank" rel="noopener">message us on WhatsApp</a>. We typically respond within 4 business hours (East Africa Time).</p>
-  <p>For procurement, partnership, or media enquiries: <a href="mailto:partners@planscape.app">partners@planscape.app</a>.</p>
+  <p>Email <a href="mailto:hello@planscape.co">hello@planscape.co</a> or <a href="https://wa.me/256700000000" target="_blank" rel="noopener">message us on WhatsApp</a>. We typically respond within 4 business hours (East Africa Time).</p>
+  <p>For procurement, partnership, or media enquiries: <a href="mailto:partners@planscape.co">partners@planscape.co</a>.</p>
 </section>
 
 <div class="cta-band">
@@ -80,7 +80,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -93,7 +93,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/about.html
+++ b/marketing-site/about.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>About — Planscape</title>
+<meta name="description" content="Planscape is built by AEC practitioners in Kampala, Uganda. ISO 19650 BIM coordination for the African delivery context.">
+<meta property="og:title" content="About — Planscape">
+<meta property="og:description" content="Built by AEC practitioners in Kampala. ISO 19650 coordination for the African delivery context.">
+<meta property="og:url" content="https://planscape.app/about.html">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/about.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html" style="color:var(--accent)">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<header class="page-header">
+  <h1>About Planscape</h1>
+  <p>BIM coordination built by AEC practitioners in Kampala, for AEC practitioners across Africa.</p>
+</header>
+
+<section style="max-width:760px">
+  <h2>The problem we set out to solve</h2>
+  <p>Africa's AEC sector delivers world-class projects — donor-funded hospitals, sovereign airports, sustainable mixed-use developments — but the software it relies on is built for a different reality. Per-seat USD subscriptions, desktop-only workflows that assume fibre internet, CDE pricing that punishes mid-size practices, support tickets answered in office hours nine timezones away.</p>
+  <p>We were paying Autodesk Construction Cloud for seats we never used. We were sweating the FX spread on a $40/seat subscription every month. Our coordinators were screenshotting clashes into WhatsApp groups because the official tool didn't work without 4G. So we built the thing we wished existed.</p>
+
+  <h2>What we believe</h2>
+  <ul>
+    <li><strong>Flat per-firm pricing</strong> — not per seat. Software shouldn't tax you for being a bigger team.</li>
+    <li><strong>Offline-first is a design goal</strong>, not a "feature roadmap" item. The plant room doesn't have fibre.</li>
+    <li><strong>Local currency invoicing</strong> — UGX, KES, NGN. Your software bill shouldn't track the USD spot rate.</li>
+    <li><strong>ISO 19650 is a starting line</strong>, not a sales pitch. The templates ship pre-built.</li>
+    <li><strong>Audit trail is structural</strong>, not optional. Hash-chained writes from day one.</li>
+    <li><strong>Open standards win</strong> — IFC 4, BCF 2.1, COBie 2.4, IDS, bSDD. We integrate, we don't lock in.</li>
+  </ul>
+
+  <h2>The team</h2>
+  <p>Planscape is built by a small team of AEC practitioners and engineers based in Kampala. Architects, MEP engineers, BIM managers, and software developers who've spent careers delivering on the projects we now build software for.</p>
+  <p>We're not VC-funded and we're not trying to be. The product earns its keep — flat per-firm pricing, modest cloud bills, no growth-at-all-costs runway pressure. We answer support tickets in the same timezone you read them.</p>
+
+  <h2>Where we're going</h2>
+  <p>The pilot cohort runs through 2026. By end of 2026 we expect to support 40+ practices across East and West Africa across a mixed portfolio of healthcare, transport, education, and commercial work. Our 2027 roadmap focuses on:</p>
+  <ul>
+    <li>Nairobi edge replica for sub-100ms latency across East Africa</li>
+    <li>ArchiCAD + Tekla plugins (Revit is shipping, the IFC substrate is host-agnostic)</li>
+    <li>French-language UI for francophone West Africa</li>
+    <li>Mobile money payouts to contractors via the same Flutterwave rails we use for collection</li>
+  </ul>
+
+  <h2>How to reach us</h2>
+  <p>Email <a href="mailto:hello@planscape.app">hello@planscape.app</a> or <a href="https://wa.me/256700000000" target="_blank" rel="noopener">message us on WhatsApp</a>. We typically respond within 4 business hours (East Africa Time).</p>
+  <p>For procurement, partnership, or media enquiries: <a href="mailto:partners@planscape.app">partners@planscape.app</a>.</p>
+</section>
+
+<div class="cta-band">
+  <h2>Build with us.</h2>
+  <p>Start the 30-day free trial or book a demo call.</p>
+  <a href="/signup">Start free trial</a>
+</div>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/assets/footer.html
+++ b/marketing-site/assets/footer.html
@@ -1,0 +1,35 @@
+<!-- Shared footer reference — copy this block into each page <body>. -->
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms. Revit plugin, offline-first mobile, local currency invoicing.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">
+    © 2026 Planscape Ltd · Kampala, Uganda · All rights reserved
+  </div>
+</footer>

--- a/marketing-site/assets/footer.html
+++ b/marketing-site/assets/footer.html
@@ -5,7 +5,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms. Revit plugin, offline-first mobile, local currency invoicing.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -18,7 +18,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/assets/nav.html
+++ b/marketing-site/assets/nav.html
@@ -1,0 +1,15 @@
+<!-- Shared nav reference — copy this block into each page <body>.
+     Update active state by adding class="active" to the matching <a>. -->
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>

--- a/marketing-site/assets/site.css
+++ b/marketing-site/assets/site.css
@@ -1,0 +1,314 @@
+/* Planscape marketing site — shared styles.
+   Pattern: every page links this file; page-specific tweaks stay
+   inline in the page <style>. Keep this file under 12 KB. */
+
+:root {
+  --accent:#E8912D;
+  --accent-dark:#C77620;
+  --ink:#1c1f26;
+  --muted:#6c7280;
+  --bg:#fafbfc;
+  --card:#fff;
+  --line:#eceef3;
+  --code-bg:#f3f5f8;
+  --good:#16a34a;
+  --warn:#d97706;
+  --bad:#dc2626;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin:0;
+  font:16px/1.55 -apple-system,system-ui,Segoe UI,Roboto,sans-serif;
+  color:var(--ink);
+  background:var(--bg);
+}
+
+a { color: var(--accent); }
+a:hover { color: var(--accent-dark); }
+
+img { max-width: 100%; height: auto; }
+
+/* ---------- Nav ---------- */
+nav.site {
+  position:sticky; top:0; z-index:50;
+  background:rgba(250,251,252,0.92);
+  backdrop-filter:blur(8px);
+  border-bottom:1px solid var(--line);
+  padding:14px 24px;
+  display:flex; align-items:center; justify-content:space-between;
+}
+nav.site .brand { font-weight:700; font-size:18px; color:var(--ink); text-decoration:none; }
+nav.site .brand .dot { color: var(--accent); }
+nav.site .links a {
+  color:var(--ink); text-decoration:none;
+  margin:0 12px; font-size:14px;
+}
+nav.site .links a:hover { color: var(--accent); }
+nav.site .cta {
+  background:var(--accent); color:#fff;
+  padding:8px 14px; border-radius:8px;
+  text-decoration:none; font-weight:600; font-size:14px;
+}
+nav.site .cta:hover { background: var(--accent-dark); color:#fff; }
+nav.site .menu-toggle { display:none; background:none; border:0; font-size:24px; cursor:pointer; }
+@media (max-width:780px){
+  nav.site .links { display:none; position:absolute; top:60px; left:0; right:0; background:var(--card); border-bottom:1px solid var(--line); flex-direction:column; padding:8px 0; }
+  nav.site .links.open { display:flex; }
+  nav.site .links a { padding:12px 24px; margin:0; border-bottom:1px solid var(--line); }
+  nav.site .menu-toggle { display:block; }
+}
+
+/* ---------- Layout ---------- */
+section { max-width:1100px; margin:0 auto; padding:64px 24px; }
+section h2 { font-size:30px; margin:0 0 16px; letter-spacing:-0.01em; }
+section h3 { font-size:20px; margin:24px 0 8px; }
+section .lead { color:var(--muted); max-width:680px; margin:0 0 36px; font-size:17px; }
+
+.container-narrow { max-width: 760px; margin: 0 auto; padding: 48px 24px; }
+
+/* ---------- Hero ---------- */
+.hero {
+  padding:96px 24px 64px; text-align:center;
+  max-width:920px; margin:0 auto;
+}
+.hero h1 { font-size:48px; line-height:1.1; margin:0 0 16px; letter-spacing:-0.02em; }
+.hero .sub { color:var(--muted); font-size:18px; max-width:640px; margin:0 auto 32px; }
+.hero .cta-row a {
+  display:inline-block; padding:14px 22px;
+  border-radius:10px; text-decoration:none;
+  font-weight:600; margin:0 6px;
+}
+.hero .cta-row a.primary { background:var(--accent); color:#fff; }
+.hero .cta-row a.primary:hover { background: var(--accent-dark); }
+.hero .cta-row a.secondary { border:1px solid var(--ink); color:var(--ink); }
+.hero .cta-row a.secondary:hover { background: var(--ink); color:#fff; }
+@media (max-width:640px){
+  .hero { padding-top:48px; }
+  .hero h1 { font-size:32px; }
+  .hero .sub { font-size:16px; }
+  .hero .cta-row a { display:block; margin:8px auto; max-width:280px; }
+}
+
+/* Page header (less prominent than hero) */
+.page-header { padding:64px 24px 24px; max-width:920px; margin:0 auto; text-align:center; }
+.page-header h1 { font-size:38px; margin:0 0 12px; letter-spacing:-0.02em; }
+.page-header p { color:var(--muted); font-size:17px; max-width:580px; margin:0 auto; }
+
+/* ---------- Cards / grids ---------- */
+.grid-2 { display:grid; gap:24px; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); }
+.grid-3 { display:grid; gap:20px; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); }
+.grid-4 { display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+
+.card {
+  background:var(--card); border:1px solid var(--line);
+  border-radius:14px; padding:24px;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.card:hover { border-color: var(--accent); }
+.card .icon { font-size:32px; margin-bottom:10px; line-height:1; }
+.card h3 { margin:0 0 8px; font-size:17px; }
+.card p { margin:0; color:var(--muted); font-size:14px; }
+
+.card-link { text-decoration:none; color:inherit; display:block; }
+.card-link:hover { transform: translateY(-2px); }
+
+/* ---------- Tables ---------- */
+.tbl {
+  width:100%; border-collapse:collapse;
+  background:var(--card); border:1px solid var(--line);
+  border-radius:14px; overflow:hidden;
+}
+.tbl th, .tbl td {
+  padding:14px 18px; text-align:left;
+  border-bottom:1px solid var(--line); font-size:14px;
+}
+.tbl thead { background:#f3f5f8; }
+.tbl th { font-weight:600; }
+.tbl td.us { color:var(--accent); font-weight:600; }
+.tbl tr:last-child td { border-bottom: 0; }
+
+/* ---------- Pricing tiers ---------- */
+.pricing-grid {
+  display:grid; gap:16px;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  margin-top:32px;
+}
+.tier {
+  background:var(--card); border:1px solid var(--line);
+  border-radius:14px; padding:28px 24px;
+  display:flex; flex-direction:column;
+}
+.tier.highlight { border:2px solid var(--accent); position:relative; }
+.tier.highlight::before {
+  content:"Most popular";
+  position:absolute; top:-12px; left:50%; transform:translateX(-50%);
+  background:var(--accent); color:#fff;
+  padding:4px 12px; border-radius:999px;
+  font-size:12px; font-weight:600;
+}
+.tier h3 { margin:0 0 4px; font-size:20px; }
+.tier .price { font-size:36px; font-weight:700; margin:12px 0 0; }
+.tier .price .per { font-size:14px; color:var(--muted); font-weight:400; }
+.tier .desc { color:var(--muted); font-size:14px; margin:4px 0 16px; min-height:42px; }
+.tier ul { list-style:none; padding:0; margin:16px 0; flex:1; }
+.tier ul li { padding:8px 0; font-size:14px; border-bottom:1px solid var(--line); }
+.tier ul li:last-child { border-bottom:0; }
+.tier ul li::before { content:"✓ "; color:var(--good); font-weight:700; }
+.tier ul li.x::before { content:"✕ "; color:var(--muted); }
+.tier .cta {
+  display:block; text-align:center; padding:12px 16px;
+  background:var(--ink); color:#fff; border-radius:10px;
+  text-decoration:none; font-weight:600; margin-top:16px;
+}
+.tier.highlight .cta { background:var(--accent); }
+.tier .cta:hover { opacity:0.9; }
+
+/* ---------- CTAs ---------- */
+.cta-band {
+  text-align:center; background:var(--ink); color:#fff;
+  padding:64px 24px;
+}
+.cta-band h2 { margin:0 0 12px; color:#fff; font-size:30px; }
+.cta-band p { color:#a8b1c0; margin:0 0 24px; }
+.cta-band a {
+  display:inline-block; padding:14px 22px;
+  background:var(--accent); color:#fff;
+  text-decoration:none; border-radius:10px; font-weight:600;
+}
+.cta-band a:hover { background: var(--accent-dark); color:#fff; }
+
+/* ---------- Forms ---------- */
+.form-row {
+  display:flex; gap:8px; flex-wrap:wrap;
+  margin-top:24px; max-width:520px;
+}
+.form-row input, .form-row textarea, .form-row select {
+  flex:1; min-width:200px; padding:12px 14px;
+  border:1px solid var(--line); border-radius:10px;
+  font-size:15px; outline:none;
+  background:var(--card); color:var(--ink);
+  font-family: inherit;
+}
+.form-row input:focus, .form-row textarea:focus, .form-row select:focus {
+  border-color:var(--accent);
+}
+.form-row button {
+  padding:12px 20px; background:var(--accent); color:#fff;
+  border:none; border-radius:10px;
+  font-weight:600; font-size:15px; cursor:pointer; white-space:nowrap;
+}
+.form-row button:hover { background: var(--accent-dark); }
+.form-stack { display:flex; flex-direction:column; gap:12px; max-width:520px; }
+.form-stack label { font-size:14px; font-weight:600; }
+.form-stack textarea { min-height:120px; resize:vertical; }
+
+/* ---------- FAQ ---------- */
+.faq-list { max-width:720px; margin:0 auto; }
+.faq-item { border-bottom:1px solid var(--line); padding:20px 0; }
+.faq-item:last-child { border-bottom:0; }
+.faq-q {
+  font-weight:600; font-size:16px; cursor:pointer;
+  display:flex; justify-content:space-between; align-items:center;
+  gap:12px; list-style:none;
+}
+.faq-q::-webkit-details-marker { display:none; }
+.faq-q::after { content:"＋"; color:var(--accent); font-size:20px; flex-shrink:0; transition:transform 0.2s; }
+details[open] .faq-q::after { transform: rotate(45deg); }
+.faq-a { color:var(--muted); font-size:15px; padding:12px 0 4px; line-height:1.65; }
+.faq-a a { color: var(--accent); }
+
+/* ---------- Article (guides/tutorials) ---------- */
+article.doc {
+  max-width:760px; margin:0 auto; padding:48px 24px 64px;
+}
+article.doc .breadcrumb { font-size:13px; color:var(--muted); margin:0 0 16px; }
+article.doc .breadcrumb a { color:var(--muted); }
+article.doc .breadcrumb a:hover { color:var(--accent); }
+article.doc h1 { font-size:34px; margin:0 0 12px; letter-spacing:-0.02em; }
+article.doc .meta { color:var(--muted); font-size:13px; margin:0 0 32px; }
+article.doc h2 { font-size:24px; margin:36px 0 12px; padding-top:8px; }
+article.doc h3 { font-size:18px; margin:28px 0 8px; }
+article.doc p { margin:12px 0; }
+article.doc ul, article.doc ol { padding-left:24px; }
+article.doc li { margin:6px 0; }
+article.doc code {
+  background:var(--code-bg); padding:2px 6px;
+  border-radius:4px; font-size:13px;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+}
+article.doc pre {
+  background:var(--ink); color:#e8e8e8;
+  padding:16px 18px; border-radius:10px;
+  overflow-x:auto; font-size:13px; line-height:1.5;
+}
+article.doc pre code { background:transparent; padding:0; color:inherit; }
+article.doc blockquote {
+  border-left:4px solid var(--accent);
+  padding:8px 16px; margin:16px 0;
+  background:rgba(232,145,45,0.06); border-radius:0 8px 8px 0;
+  color:#34394a;
+}
+article.doc blockquote p:first-child { margin-top:0; }
+article.doc blockquote p:last-child { margin-bottom:0; }
+article.doc .callout {
+  border:1px solid var(--line); border-left:4px solid var(--accent);
+  background:rgba(232,145,45,0.04);
+  padding:14px 18px; border-radius:0 10px 10px 0; margin:18px 0;
+}
+article.doc .callout.warn { border-left-color: var(--warn); background:rgba(217,119,6,0.05); }
+article.doc .callout.danger { border-left-color: var(--bad); background:rgba(220,38,38,0.05); }
+article.doc .callout strong { display:block; margin-bottom:4px; }
+article.doc table { width:100%; border-collapse:collapse; margin:16px 0; }
+article.doc th, article.doc td { padding:10px 12px; border-bottom:1px solid var(--line); text-align:left; font-size:14px; }
+article.doc th { background:#f3f5f8; font-weight:600; }
+article.doc img { border-radius:10px; border:1px solid var(--line); margin:16px 0; }
+article.doc .next-prev {
+  display:flex; justify-content:space-between; gap:12px;
+  margin-top:48px; padding-top:24px; border-top:1px solid var(--line);
+}
+article.doc .next-prev a {
+  flex:1; padding:14px 16px; border:1px solid var(--line);
+  border-radius:10px; text-decoration:none; color:var(--ink);
+  font-size:14px;
+}
+article.doc .next-prev a:hover { border-color: var(--accent); }
+article.doc .next-prev a .lbl { display:block; font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:1px; margin-bottom:2px; }
+article.doc .next-prev a.next { text-align:right; }
+
+/* ---------- Footer ---------- */
+footer.site {
+  padding:48px 24px 32px; border-top:1px solid var(--line);
+  background: var(--card);
+}
+footer.site .footer-grid {
+  max-width:1100px; margin:0 auto;
+  display:grid; gap:32px;
+  grid-template-columns: 2fr repeat(3, 1fr);
+}
+@media (max-width:700px){ footer.site .footer-grid { grid-template-columns: 1fr 1fr; } }
+footer.site .col h4 { margin:0 0 12px; font-size:14px; color:var(--ink); }
+footer.site .col a { display:block; color:var(--muted); text-decoration:none; padding:4px 0; font-size:13px; }
+footer.site .col a:hover { color: var(--accent); }
+footer.site .col p { color:var(--muted); font-size:13px; margin:0 0 8px; max-width:280px; }
+footer.site .brand-row { font-weight:700; font-size:16px; color:var(--ink); margin-bottom:8px; }
+footer.site .brand-row .dot { color: var(--accent); }
+footer.site .legal {
+  max-width:1100px; margin:32px auto 0;
+  padding-top:24px; border-top:1px solid var(--line);
+  text-align:center; color:var(--muted); font-size:12px;
+}
+footer.site .legal a { color: var(--muted); margin: 0 8px; }
+
+/* ---------- Utility ---------- */
+.text-center { text-align:center; }
+.muted { color: var(--muted); }
+.chip {
+  display:inline-block; padding:4px 10px;
+  background:rgba(232,145,45,0.10); color:var(--accent);
+  border-radius:999px; font-size:12px; font-weight:600;
+  margin-right:6px;
+}
+.chip-muted { background:#eceef3; color:var(--muted); }
+.divider { border:0; border-top:1px solid var(--line); margin:32px 0; }

--- a/marketing-site/assets/template-guide.html
+++ b/marketing-site/assets/template-guide.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<!--
+  Planscape guide template — copy this file to /guides/<slug>.html
+  and replace the {{TOKEN}} placeholders. Keep article structure consistent.
+
+  Token list:
+    {{TITLE}}          Page <title> and <h1>
+    {{DESC}}           <meta description>
+    {{SLUG}}           URL slug, used in <link canonical>
+    {{READ_TIME}}      "8-minute read"
+    {{LEVEL}}          "Beginner" / "Intermediate" / "Advanced"
+    {{DATE}}           "2026-05-23"
+    {{INTRO}}          Opening 1–2 paragraphs
+    {{BODY}}           Markdown-equivalent HTML (h2/h3, p, ul, pre, table, .callout)
+    {{PREV_HREF}}      Previous link href
+    {{PREV_LABEL}}     Previous link title
+    {{NEXT_HREF}}      Next link href
+    {{NEXT_LABEL}}     Next link title
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{{TITLE}} — Planscape</title>
+<meta name="description" content="{{DESC}}">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/{{SLUG}}.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; {{TITLE}}</div>
+  <h1>{{TITLE}}</h1>
+  <div class="meta">📖 {{READ_TIME}} · {{LEVEL}} · Last updated {{DATE}}</div>
+
+  {{INTRO}}
+
+  {{BODY}}
+
+  <div class="next-prev">
+    <a href="{{PREV_HREF}}" class="prev">
+      <span class="lbl">← Previous</span>
+      {{PREV_LABEL}}
+    </a>
+    <a href="{{NEXT_HREF}}" class="next">
+      <span class="lbl">Next →</span>
+      {{NEXT_LABEL}}
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/assets/template-guide.html
+++ b/marketing-site/assets/template-guide.html
@@ -25,7 +25,7 @@
 <meta name="description" content="{{DESC}}">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/{{SLUG}}.html">
+<link rel="canonical" href="https://planscape.co/guides/{{SLUG}}.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -71,7 +71,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -84,7 +84,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/blog/2026-05-15-offline-first-mobile-bim.html
+++ b/marketing-site/blog/2026-05-15-offline-first-mobile-bim.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Building an offline-first mobile BIM tool — Planscape blog</title>
+<meta name="description" content="Five lessons from a year of building an offline-first mobile BIM tool. Conflict resolution, replay queues, why we chose SQLite over Realm.">
+<meta property="og:title" content="Building an offline-first mobile BIM tool">
+<meta property="og:type" content="article">
+<meta property="article:published_time" content="2026-05-15T08:00:00+03:00">
+<meta property="og:url" content="https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/" style="color:var(--accent)">Blog</a>
+    <a href="/about.html">About</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/blog/">Blog</a> &rsaquo; Building an offline-first mobile BIM tool</div>
+  <h1>Building an offline-first mobile BIM tool</h1>
+  <div class="meta">15 May 2026 · 11-minute read · By the Planscape team</div>
+
+  <p>Offline-first sounds simple. It isn't. After a year of building Planscape's mobile app for site teams in East Africa — places where the connection is the exception, not the rule — here's what we learned. This post is more technical than our usual writing; if you build mobile tools and you're tempted to say "we'll add offline later," please don't.</p>
+
+  <h2>The brief</h2>
+
+  <p>Our coordinators work on construction sites. Most of those sites have either no fibre at all, intermittent 4G in some areas and dead zones in others, or — in the worst case — a 24-hour total outage when the local mast goes down. They take photos, raise issues, scan QR tags on assets, navigate by GPS, and update issue statuses.</p>
+
+  <p>The brief was: every one of those actions must work when they're disconnected, must not lose data, and must sync seamlessly without manual intervention when connectivity returns. The user should never think about connectivity unless they choose to.</p>
+
+  <h2>Lesson 1: offline-first means designing the data layer first</h2>
+
+  <p>The mistake we made on the first prototype was building screens against the API directly, then adding a "cache layer" later. That works for read-heavy apps where stale data is acceptable. It doesn't work when the user expects to <em>write</em> while offline.</p>
+
+  <p>The right approach is to design the local database as the source of truth, and treat the server as an eventual-consistency replica. Every screen reads from local storage. Every action writes to local storage first and queues a sync job. The sync job hits the server when network state allows. Failed syncs retry with exponential backoff.</p>
+
+  <p>This inverts the usual mental model — and it forced us to rewrite about 40% of the original prototype. But it's the only model that gives the user the experience of "the app works regardless of connectivity".</p>
+
+  <h2>Lesson 2: SQLite > Realm for our case</h2>
+
+  <p>We started with Realm (now MongoDB Realm). Reactive, fast, lovely DX. But three things bit us:</p>
+
+  <ul>
+    <li><strong>Schema migration friction.</strong> Every backend schema change required a matching Realm migration. With a fast-moving server, we were managing migration scripts in two places.</li>
+    <li><strong>iOS/Android divergence on Hermes.</strong> Some Realm features behaved subtly differently across platforms, especially under low memory.</li>
+    <li><strong>Audit-trail incompatibility.</strong> We needed to write hash-chained records locally and have them verifiably append-only. Realm's transaction model didn't give us a clean way to do this without working around the abstraction.</li>
+  </ul>
+
+  <p>We migrated to plain SQLite with a hand-written schema, drizzle-style query builder, and a sync engine on top. More work to set up, less work to maintain in the long run. The audit-chain implementation became trivial — it's just an append-only table with a SHA-256 column.</p>
+
+  <p>For apps where the server is the source of truth and offline is "nice to have", Realm is great. For apps where the device is the source of truth for hours at a time and audit integrity matters, raw SQLite gave us cleaner control.</p>
+
+  <h2>Lesson 3: the replay queue is harder than you think</h2>
+
+  <p>Naive replay: collect pending writes, post them to the server in order, mark each as synced on success. This breaks in three ways:</p>
+
+  <h3>Write dependencies</h3>
+  <p>"Create issue, then add photo to issue, then add comment to issue" — three writes that have to land in order. If the first one fails (e.g. duplicate key from a previous partial sync), the second and third are orphaned.</p>
+  <p>We solved this by giving every local write a UUID generated client-side. The server treats UUIDs as idempotent — re-sending the same UUID is a no-op, not an error. This decouples "did the server receive this" from "did the server acknowledge this".</p>
+
+  <h3>Conflict resolution</h3>
+  <p>Two coordinators offline simultaneously, both change the same issue's status. When they come back online, whose write wins?</p>
+  <p>We adopted last-write-wins by timestamp — but with a twist: we surface the alternative in a conflict banner. The "loser" isn't silently overwritten. The user who got out-voted sees their change in a banner with "Override" and "Discard" options. In practice ~90% of conflicts are obvious (one user marked it Resolved before the other realised it was already fixed) and people pick the right option.</p>
+
+  <h3>Stale references</h3>
+  <p>You raise an issue offline, attached to element X. By the time you come back online, element X has been deleted in Revit. What happens?</p>
+  <p>We let the issue save (the photo and observation are still useful) but flag it as "orphaned — element no longer exists". The user can re-link to a current element or close the issue. We never silently drop user-generated data.</p>
+
+  <h2>Lesson 4: photos are not data</h2>
+
+  <p>Treat photos and voice notes as a different sync class to structured data. Specifically:</p>
+
+  <ul>
+    <li><strong>Structured data is small and fast.</strong> 1 KB JSON for an issue. Sync immediately on any connection.</li>
+    <li><strong>Photos are large and slow.</strong> 4 MB JPEG. Sync only on WiFi, or on a fast cellular connection, or when the user explicitly requests.</li>
+  </ul>
+
+  <p>We auto-detect connection quality (via a tiny ping on app startup) and queue photo uploads behind structured-data sync. If the user is on a slow connection, structured data lands first — the issue exists, just without its photo for the next hour. Coordinators value "the issue is on the server" much more than "the photo is uploaded right now".</p>
+
+  <p>The compression strategy matters too. We resize photos to 1080p before upload (originals stay on the device), and we generate a 400px thumbnail for the list view that uploads alongside the issue itself — so even before the original photo lands, teammates see the thumbnail.</p>
+
+  <h2>Lesson 5: pre-sync is the killer feature</h2>
+
+  <p>The single most useful UX intervention was making "pre-sync this project for offline use" a first-class one-button action. Users do it the night before a site visit, on WiFi at the office. The app downloads:</p>
+
+  <ul>
+    <li>The full issue list + photos at thumbnail resolution.</li>
+    <li>All "Site reference" documents (PDF drawings, RFIs, design notes).</li>
+    <li>The federated model's plan views at all visible levels.</li>
+    <li>Mapbox tiles for a 5km radius around the project pin.</li>
+  </ul>
+
+  <p>This takes 2–10 minutes on WiFi. Once done, the user can leave the office and work a full day offline without missing anything. We measured: before we had pre-sync as a button, ~30% of site visits had "I couldn't open X" friction. After: under 5%.</p>
+
+  <h2>What we still get wrong</h2>
+
+  <ul>
+    <li><strong>Push notifications when offline.</strong> If your phone has no signal, you don't get the push notification when an issue is assigned. The notification arrives when you reconnect — but by then the assignment may be hours old. Not a fix we have yet.</li>
+    <li><strong>Voice-note transcription.</strong> Transcription is server-side (Whisper). When offline, you can record a voice note but it won't be transcribed until you're back online. We've been asked for on-device Whisper; the model size and battery cost have stopped us so far.</li>
+    <li><strong>Real-time collaboration.</strong> SignalR is online-only. When two coordinators are both offline on the same project, they don't see each other's edits live — they replay when both reconnect. We don't think this can be solved without P2P sync, which is a lot of complexity for the value.</li>
+  </ul>
+
+  <h2>The principles that survived contact with reality</h2>
+
+  <ol>
+    <li><strong>Local DB is source of truth.</strong> Server is eventual.</li>
+    <li><strong>Every write gets a client-generated UUID.</strong> Idempotent server.</li>
+    <li><strong>Replay queue is durable.</strong> Survives app restart, OS kill, low memory.</li>
+    <li><strong>Surface conflicts; don't auto-resolve.</strong> Users handle ambiguity better than algorithms.</li>
+    <li><strong>Different sync classes for different data types.</strong> Structured first, media second.</li>
+    <li><strong>Pre-sync is a feature, not a setting.</strong> Make it a button on the project home.</li>
+  </ol>
+
+  <h2>Tech stack, for the curious</h2>
+
+  <ul>
+    <li>React Native + Expo (currently v52)</li>
+    <li>SQLite via expo-sqlite, custom thin query layer</li>
+    <li>TanStack Query for caching, with custom mutation middleware that writes to SQLite first</li>
+    <li>Background tasks via expo-background-fetch for sync retry</li>
+    <li>Mapbox GL Native for offline-capable maps</li>
+    <li>SignalR client (when online) for real-time push from other team members</li>
+    <li>Server: ASP.NET Core 8 + PostgreSQL + Redis + MinIO</li>
+  </ul>
+
+  <p>If you're building something similar and want to compare notes, drop us a line — <a href="mailto:engineering@planscape.app">engineering@planscape.app</a>. Always happy to talk shop.</p>
+
+  <div class="next-prev">
+    <a href="/blog/2026-05-20-iso-19650-in-east-africa.html" class="prev">
+      <span class="lbl">← Previous</span>
+      ISO 19650 in East Africa
+    </a>
+    <a href="/blog/" class="next">
+      <span class="lbl">Back to</span>
+      Blog index
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/blog/2026-05-15-offline-first-mobile-bim.html
+++ b/marketing-site/blog/2026-05-15-offline-first-mobile-bim.html
@@ -8,10 +8,10 @@
 <meta property="og:title" content="Building an offline-first mobile BIM tool">
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2026-05-15T08:00:00+03:00">
-<meta property="og:url" content="https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html">
+<meta property="og:url" content="https://planscape.co/blog/2026-05-15-offline-first-mobile-bim.html">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html">
+<link rel="canonical" href="https://planscape.co/blog/2026-05-15-offline-first-mobile-bim.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -138,7 +138,7 @@
     <li>Server: ASP.NET Core 8 + PostgreSQL + Redis + MinIO</li>
   </ul>
 
-  <p>If you're building something similar and want to compare notes, drop us a line — <a href="mailto:engineering@planscape.app">engineering@planscape.app</a>. Always happy to talk shop.</p>
+  <p>If you're building something similar and want to compare notes, drop us a line — <a href="mailto:engineering@planscape.co">engineering@planscape.co</a>. Always happy to talk shop.</p>
 
   <div class="next-prev">
     <a href="/blog/2026-05-20-iso-19650-in-east-africa.html" class="prev">
@@ -154,7 +154,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/blog/2026-05-20-iso-19650-in-east-africa.html
+++ b/marketing-site/blog/2026-05-20-iso-19650-in-east-africa.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ISO 19650 in East Africa — what actually applies — Planscape blog</title>
+<meta name="description" content="ISO 19650 was written with UK practice in mind. Here's what to adopt, what to adapt, and what to skip when delivering in East Africa.">
+<meta property="og:title" content="ISO 19650 in East Africa — what actually applies">
+<meta property="og:type" content="article">
+<meta property="article:published_time" content="2026-05-20T08:00:00+03:00">
+<meta property="og:url" content="https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/" style="color:var(--accent)">Blog</a>
+    <a href="/about.html">About</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/blog/">Blog</a> &rsaquo; ISO 19650 in East Africa</div>
+  <h1>ISO 19650 in East Africa — what actually applies</h1>
+  <div class="meta">20 May 2026 · 9-minute read · By the Planscape team</div>
+
+  <p>If you've worked on a UK-funded project in East Africa in the last five years, you've been asked for ISO 19650 compliance. If you've worked on a donor-funded project — World Bank, AfDB, EIB, USAID, DFI portfolio — the chances are even higher.</p>
+
+  <p>The standard is good. But it was written with UK practice in mind: the Building Regulations 2010 framework, the UK BIM Framework's interpretation, NHS Estates' adoption pattern, even the language ("appointing party" / "lead appointed party") was tuned to UK procurement law. Most of it transposes cleanly to East African work. Some of it doesn't. And a few of the "best practice" extensions that float around (UK BIM Framework Information Protocol, BS 8536, the PAS series remnants) will get you in awkward conversations with local authorities.</p>
+
+  <p>This is our running guide — what we tell our team and what we tell new clients. It's opinionated. We're happy to be argued out of any of it.</p>
+
+  <h2>The core that always applies</h2>
+
+  <p>These bits of ISO 19650 are universal. Adopt without modification:</p>
+
+  <ul>
+    <li><strong>The information management lifecycle (Part 1).</strong> Concept → delivery → operation. The diagram in §5.1 of ISO 19650-1 is correct regardless of jurisdiction.</li>
+    <li><strong>The roles (Part 2 §5.1).</strong> Appointing party / lead appointed party / appointed party / task team. The vocabulary maps cleanly to your client / lead consultant / sub-consultant structure in any jurisdiction.</li>
+    <li><strong>The CDE state machine.</strong> WIP → Shared → Published → Archived. Universal — this isn't even a UK concept; it's an information-management invariant.</li>
+    <li><strong>The file-naming convention (Part 2 Annex A).</strong> Project–Originator–Volume–Level–Type–Role–Number is sensible everywhere. The codes aren't sacred — but the structure is.</li>
+    <li><strong>The suitability codes (S0–S7).</strong> Universal.</li>
+    <li><strong>The revision schema (P / C / A).</strong> Universal.</li>
+    <li><strong>The audit-trail requirement (§5.6).</strong> Universal — and in our experience, the bit that earns its keep faster than any other when disputes arise.</li>
+  </ul>
+
+  <h2>The UK-specific bits to adapt</h2>
+
+  <p>These need translation for local practice:</p>
+
+  <h3>UK BIM Framework Information Protocol</h3>
+  <p>Annex A of the protocol assumes UK procurement: NEC contracts, JCT terms, references to UK CDM Regulations. The information requirements model is fine; the contract-clause integration won't survive a Ugandan or Kenyan procurement context. Use the IR structure, draft the contract clauses yourself with local counsel.</p>
+
+  <h3>The "OIR / AIR / EIR" cascade</h3>
+  <p>UK clients (especially NHS Estates) have well-developed OIRs and AIRs. Most East African clients don't. Telling a Ministry of Health that they need to issue an OIR before you can proceed will produce blank looks. Either draft the OIR/AIR yourself in consultation with the client team, or adopt a "presumed information needs" approach where you specify what you'll deliver and they sign it off.</p>
+
+  <h3>BS 1192:2007 references</h3>
+  <p>The earlier BS 1192 was the precursor to ISO 19650. Several UK guides still reference it. Where your project documents reference BS 1192 specifically, either swap the reference to ISO 19650-2 (which supersedes it) or, where the BS detail is more specific than ISO 19650, retain BS 1192 alongside.</p>
+
+  <h2>The bits that don't apply — and don't try to make them</h2>
+
+  <h3>BS 8536-1 / -2 ("Briefing for design and construction")</h3>
+  <p>UK-specific framework for the briefing process. Useful conceptual reading; not contractually applicable here. Don't pretend it is.</p>
+
+  <h3>UK government Soft Landings</h3>
+  <p>The handover-and-aftercare framework is UK-specific. The Soft Landings concept (better commissioning, better handover, post-occupancy evaluation) is universally good — but the formal framework references UK Government Construction Strategy 2025, BSRIA's specific guidance, and assumes a UK FM market structure. Borrow the ideas; don't try to formally adopt the framework.</p>
+
+  <h3>NEC4 BIM-specific clauses</h3>
+  <p>If your contract isn't NEC4 (and most East African public-sector contracts aren't), don't import the NEC4 BIM clauses verbatim. The intent is fine; the wording assumes NEC4 procedural language.</p>
+
+  <h2>What East African delivery adds</h2>
+
+  <p>Things ISO 19650 doesn't cover that you'll need:</p>
+
+  <h3>Donor-funded reporting requirements</h3>
+  <p>World Bank, AfDB, IFC, EIB — each has its own information reporting templates and frequencies. Your BIM Execution Plan should reference them explicitly. Most have an "environmental and social management framework" that requires geo-tagged photographic evidence of progress — fit naturally into the audit trail you've built for ISO 19650 anyway.</p>
+
+  <h3>Local building authority approvals</h3>
+  <p>Kampala City Authority, Nairobi County, Lagos State Physical Planning Permit Authority — each has its own drawing submission requirements. They typically want stamped PDFs, not IFC. Plan a workflow that produces both: your BIM-native deliverables for the design team, and authority-stamped PDFs from the same source.</p>
+
+  <h3>Multi-currency cost reporting</h3>
+  <p>Most large projects mix local-currency contracts with USD-denominated equipment imports. Your information requirements should call out which costs are reported in which currency, and what FX rate fix point applies. ISO 19650 is currency-agnostic; your BEP shouldn't be.</p>
+
+  <h3>French-language deliverables (for francophone West Africa)</h3>
+  <p>If you're working in francophone West Africa, you need bilingual document sets — French for the client, English for international consultants. ISO 19650 has French versions of the standard; the vocabulary table is in NF EN ISO 19650-1:2019.</p>
+
+  <h2>Compliance evidence — what we recommend</h2>
+
+  <p>When a donor auditor or sceptical client asks "show us your ISO 19650 compliance," these are the artefacts that pass without fuss:</p>
+
+  <ol>
+    <li><strong>Signed BEP</strong> with version history.</li>
+    <li><strong>MIDP</strong> with status against each deliverable.</li>
+    <li><strong>CDE state log</strong> — every file's transition history from WIP to Published.</li>
+    <li><strong>Suitability-coded deliverable register</strong> — S2 / S4 / S6 visible per file.</li>
+    <li><strong>Hash-chained audit log</strong> — proves no tampering. Run the chain-verify command live for the auditor; takes 5 seconds.</li>
+    <li><strong>Transmittal log</strong> — every Published deliverable, who it went to, when.</li>
+  </ol>
+
+  <p>If you can produce these six in a single export, you'll pass any ISO 19650 audit we've ever seen. Planscape does it as a one-click bundle — but the principle applies regardless of tool.</p>
+
+  <h2>Things we wish the standard said more clearly</h2>
+
+  <ul>
+    <li><strong>Naming for federation files.</strong> ISO 19650-2 Annex A is great for individual file naming but unclear about how to name the federation that combines them. We use <code>&lt;Project&gt;-&lt;Originator&gt;-ZZ-ZZ-FD-&lt;Discipline&gt;-&lt;Number&gt;</code> where <code>FD</code> = federation. Borrowed pragmatically from a UK firm's house style.</li>
+    <li><strong>Phase-handover vs project-handover.</strong> Multi-phase projects (e.g. four hospital wings delivered over three years) need clearer handover guidance than the standard gives. Plan it in the BEP.</li>
+    <li><strong>Sub-consultant TIDP relationships.</strong> When you have three layers of sub-consultancy (lead → primary sub → sub-sub-sub), the TIDP roll-up gets ambiguous. We map every actor explicitly in the BEP.</li>
+  </ul>
+
+  <h2>Closing</h2>
+
+  <p>ISO 19650 is the right baseline. It's worth the investment to learn it. But it isn't a tick-box and it isn't a UK-only thing — it's a structured way to manage information across the lifecycle, and most of it works fine for East African delivery.</p>
+
+  <p>The bits you adapt (OIR/AIR, contract clauses), the bits you replace (procurement-law references), and the bits you add (donor reporting, multi-currency, local authority workflows) all sit comfortably alongside the standard's core.</p>
+
+  <p>If you'd like to talk about ISO 19650 adoption on your project — happy to. Drop us a line at <a href="mailto:hello@planscape.app">hello@planscape.app</a>.</p>
+
+  <div class="next-prev">
+    <a href="/blog/2026-05-23-why-we-built-planscape.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Why we built Planscape
+    </a>
+    <a href="/blog/2026-05-15-offline-first-mobile-bim.html" class="next">
+      <span class="lbl">Next →</span>
+      Building an offline-first mobile BIM tool
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/blog/2026-05-20-iso-19650-in-east-africa.html
+++ b/marketing-site/blog/2026-05-20-iso-19650-in-east-africa.html
@@ -8,10 +8,10 @@
 <meta property="og:title" content="ISO 19650 in East Africa — what actually applies">
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2026-05-20T08:00:00+03:00">
-<meta property="og:url" content="https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html">
+<meta property="og:url" content="https://planscape.co/blog/2026-05-20-iso-19650-in-east-africa.html">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html">
+<link rel="canonical" href="https://planscape.co/blog/2026-05-20-iso-19650-in-east-africa.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -124,7 +124,7 @@
 
   <p>The bits you adapt (OIR/AIR, contract clauses), the bits you replace (procurement-law references), and the bits you add (donor reporting, multi-currency, local authority workflows) all sit comfortably alongside the standard's core.</p>
 
-  <p>If you'd like to talk about ISO 19650 adoption on your project — happy to. Drop us a line at <a href="mailto:hello@planscape.app">hello@planscape.app</a>.</p>
+  <p>If you'd like to talk about ISO 19650 adoption on your project — happy to. Drop us a line at <a href="mailto:hello@planscape.co">hello@planscape.co</a>.</p>
 
   <div class="next-prev">
     <a href="/blog/2026-05-23-why-we-built-planscape.html" class="prev">
@@ -140,7 +140,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/blog/2026-05-23-why-we-built-planscape.html
+++ b/marketing-site/blog/2026-05-23-why-we-built-planscape.html
@@ -10,10 +10,10 @@
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="2026-05-23T08:00:00+03:00">
 <meta property="article:author" content="Planscape team">
-<meta property="og:url" content="https://planscape.app/blog/2026-05-23-why-we-built-planscape.html">
+<meta property="og:url" content="https://planscape.co/blog/2026-05-23-why-we-built-planscape.html">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/blog/2026-05-23-why-we-built-planscape.html">
+<link rel="canonical" href="https://planscape.co/blog/2026-05-23-why-we-built-planscape.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -108,7 +108,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/blog/2026-05-23-why-we-built-planscape.html
+++ b/marketing-site/blog/2026-05-23-why-we-built-planscape.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Why we built Planscape — Planscape blog</title>
+<meta name="description" content="The frustrations that led us to build Planscape — and the principles we've stuck to since.">
+<meta property="og:title" content="Why we built Planscape">
+<meta property="og:description" content="Why a Kampala-based AEC firm built its own BIM coordination platform.">
+<meta property="og:type" content="article">
+<meta property="article:published_time" content="2026-05-23T08:00:00+03:00">
+<meta property="article:author" content="Planscape team">
+<meta property="og:url" content="https://planscape.app/blog/2026-05-23-why-we-built-planscape.html">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/blog/2026-05-23-why-we-built-planscape.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/" style="color:var(--accent)">Blog</a>
+    <a href="/about.html">About</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/blog/">Blog</a> &rsaquo; Why we built Planscape</div>
+  <h1>Why we built Planscape</h1>
+  <div class="meta">23 May 2026 · 6-minute read · By the Planscape team</div>
+
+  <p>The honest answer is: because what existed was the wrong shape for our work.</p>
+
+  <p>We're an AEC practice in Kampala. Healthcare projects mostly — district hospitals, mid-tier private clinics, the occasional teaching wing. ISO 19650 isn't optional for us. Donor-funded work demands it, public-sector clients increasingly ask for it, and frankly, projects run better when the information flow is structured.</p>
+
+  <p>Three years ago we standardised on Autodesk Construction Cloud. It worked, in the sense that we could deliver projects on it. But it cost us in three specific ways:</p>
+
+  <h2>1. We were paying for seats we never used</h2>
+
+  <p>ACC is licensed per user. That sounds simple until you remember the realities of a real practice: site coordinators come and go, sub-consultants get added for one project and stay licensed for two years, the intern from last year still has an active seat that nobody remembered to cancel.</p>
+
+  <p>The licence audit we did in December 2024 was depressing. Of 32 paid seats, 11 hadn't logged in for over 90 days. That's $440 a month — roughly $5,000 a year — on access nobody used.</p>
+
+  <p>Per-seat licensing isn't a bug in the pricing model. It's the point. But it punishes the exact thing healthy practices do: collaborate broadly, bring in specialists, give clients visibility. We wanted to pay for the project, not the headcount.</p>
+
+  <h2>2. The FX spread was a constant drag</h2>
+
+  <p>Software pricing tracks USD. East African currencies don't. Every month we were paying ~10% more than the headline number after the bank's FX spread and intermediary fees. Worse, when the dollar moved against us — as it did several times in 2024 — the bill quietly grew without anyone budgeting for it.</p>
+
+  <p>This is invisible to American or European buyers. The credit card hides it. For a Ugandan practice paying via international wire, the FX is line-item visible and it stings.</p>
+
+  <h2>3. The mobile experience was an afterthought</h2>
+
+  <p>Our coordinators don't sit at desks. They're on site. The site is a plant room. The plant room has no fibre, intermittent 4G, and concrete walls that absorb signal like a sponge.</p>
+
+  <p>The "official" mobile app required a signal for almost everything. When it failed — which was most of the time — coordinators reverted to WhatsApp groups. Photos of clashes. Voice notes describing snags. Screenshots of drawings with arrows drawn on them. It worked, in a way, but nothing got back into the model. The audit trail was a thread in WhatsApp.</p>
+
+  <p>We tried alternatives. Most of them treated mobile as a feature, not a foundation. Sync was synchronous. The model wouldn't load offline. The first thing a coordinator did after walking onto a site was discover they couldn't open the project.</p>
+
+  <h2>What we built instead</h2>
+
+  <p>The principles we wrote down at the start, and we've stuck to:</p>
+
+  <ul>
+    <li><strong>Flat per-firm pricing.</strong> One number per month covers the whole team. Inviting a colleague costs nothing extra. Inviting a client costs nothing at all.</li>
+    <li><strong>Offline-first as a design goal.</strong> Not a roadmap item. Every action a coordinator might take on site has to work without a signal and replay automatically. We bake this in at the data layer, not bolt it on at the UI.</li>
+    <li><strong>Local currency invoicing.</strong> UGX, KES, TZS, NGN — invoiced in your currency, processed via mobile money. No FX surprise.</li>
+    <li><strong>ISO 19650 pre-built.</strong> The standard ships ready-to-use. You shouldn't be reading the standard to use the tool.</li>
+    <li><strong>Audit trail by construction.</strong> Every write is hash-chained. Tampering breaks the chain. Court-admissible by default.</li>
+    <li><strong>Open standards everywhere.</strong> IFC 4, BCF 2.1, COBie 2.4, IDS, bSDD. We integrate; we don't lock in. Your data is yours and exports cleanly.</li>
+  </ul>
+
+  <h2>What we deliberately don't try to be</h2>
+
+  <p>We don't try to be the most feature-rich BIM platform on earth. ACC, Trimble Connect, Procore — they're huge surfaces with hundreds of features designed for thousands of customers across every sector. We respect that.</p>
+
+  <p>We're trying to be the right tool for a mid-size African practice delivering healthcare, education, transport, and commercial work to clients who care about ISO 19650 and increasingly about embodied carbon. That's a real, specific shape — and the existing tools fit it badly enough that building our own was a better answer than living with theirs.</p>
+
+  <p>We're not VC-funded. We're not chasing 10× growth. The pricing pays for the cloud bills and the small team, with some left over to keep the lights on through dry spells. If we're around in five years we'll consider that a win.</p>
+
+  <h2>Who Planscape is for</h2>
+
+  <p>If you're a mid-size AEC practice in East or West Africa, delivering on ISO 19650-shaped contracts, with site teams on phones and authors in Revit, and you've ever opened your software bill and winced — you're who we built this for.</p>
+
+  <p>The 30-day trial is free, takes no card, and covers the full Standard tier. Try it on a real project. If it doesn't fit, no hard feelings.</p>
+
+  <p style="margin-top:32px"><a href="/signup" style="display:inline-block;padding:14px 22px;background:var(--accent);color:#fff;text-decoration:none;border-radius:10px;font-weight:600">Start the free trial →</a></p>
+
+  <div class="next-prev">
+    <a href="/blog/" class="prev">
+      <span class="lbl">← Back to</span>
+      Blog index
+    </a>
+    <a href="/blog/2026-05-20-iso-19650-in-east-africa.html" class="next">
+      <span class="lbl">Next →</span>
+      ISO 19650 in East Africa
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/blog/index.html
+++ b/marketing-site/blog/index.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Blog — Planscape</title>
+<meta name="description" content="Notes from the Planscape team — BIM coordination, ISO 19650, African AEC delivery, product updates, engineering write-ups.">
+<meta property="og:title" content="Planscape blog">
+<meta property="og:url" content="https://planscape.app/blog/">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/blog/">
+<link rel="alternate" type="application/rss+xml" title="Planscape blog RSS" href="/blog/rss.xml">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.post-card {
+  display:flex; flex-direction:column;
+  background:var(--card); border:1px solid var(--line);
+  border-radius:14px; padding:24px;
+  text-decoration:none; color:inherit;
+  transition: border-color 0.15s, transform 0.1s;
+  margin-bottom:16px;
+}
+.post-card:hover { border-color:var(--accent); transform:translateY(-2px); }
+.post-card .pmeta { font-size:13px; color:var(--muted); margin-bottom:8px; }
+.post-card .pmeta .tag { display:inline-block; background:rgba(232,145,45,0.1); color:var(--accent); padding:2px 8px; border-radius:999px; font-weight:600; font-size:11px; margin-right:6px; }
+.post-card h2 { margin:0 0 8px; font-size:22px; color:var(--ink); }
+.post-card p { margin:0; color:var(--muted); font-size:15px; line-height:1.5; }
+.post-card .readmore { color:var(--accent); font-weight:600; font-size:14px; margin-top:12px; }
+.rss-strip {
+  background:var(--card); border:1px solid var(--line);
+  border-radius:10px; padding:14px 18px;
+  display:flex; justify-content:space-between; align-items:center;
+  font-size:14px; color:var(--muted);
+  margin:32px 0;
+  flex-wrap:wrap; gap:12px;
+}
+.rss-strip a { color:var(--accent); font-weight:600; }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/" style="color:var(--accent)">Blog</a>
+    <a href="/about.html">About</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<header class="page-header">
+  <h1>The Planscape blog</h1>
+  <p>Notes from the team on BIM coordination, ISO 19650 in the African delivery context, engineering write-ups, and product updates.</p>
+</header>
+
+<section style="padding-top:0;max-width:780px">
+
+  <div class="rss-strip">
+    <span>📡 Subscribe to the RSS feed</span>
+    <a href="/blog/rss.xml">/blog/rss.xml →</a>
+  </div>
+
+  <a href="/blog/2026-05-23-why-we-built-planscape.html" class="post-card">
+    <div class="pmeta">
+      <span class="tag">Founder note</span>
+      <span>23 May 2026 · 6-minute read · By the Planscape team</span>
+    </div>
+    <h2>Why we built Planscape</h2>
+    <p>We were paying for Autodesk Construction Cloud seats we never used, sweating the FX spread every month, and watching our coordinators screenshot clashes into WhatsApp groups because the official tool didn't work without 4G. So we built the thing we wished existed.</p>
+    <div class="readmore">Read more →</div>
+  </a>
+
+  <a href="/blog/2026-05-20-iso-19650-in-east-africa.html" class="post-card">
+    <div class="pmeta">
+      <span class="tag">ISO 19650</span>
+      <span>20 May 2026 · 9-minute read · By the Planscape team</span>
+    </div>
+    <h2>ISO 19650 in East Africa — what actually applies</h2>
+    <p>ISO 19650 was written with UK practice in mind. Most of it transposes cleanly to East African delivery — but some bits don't, and a few of the "best practice" guides from the UK BIM Framework will get you in trouble with local building authorities. Here's our running guide to what to adopt, what to adapt, and what to skip.</p>
+    <div class="readmore">Read more →</div>
+  </a>
+
+  <a href="/blog/2026-05-15-offline-first-mobile-bim.html" class="post-card">
+    <div class="pmeta">
+      <span class="tag">Engineering</span>
+      <span>15 May 2026 · 11-minute read · By the Planscape team</span>
+    </div>
+    <h2>Building an offline-first mobile BIM tool</h2>
+    <p>Five lessons from a year of building Planscape's mobile app for sites with no fibre, intermittent 4G, and the occasional total outage. Conflict resolution, replay queues, why we chose SQLite over Realm, and how the federated model loads on a 3-year-old Android.</p>
+    <div class="readmore">Read more →</div>
+  </a>
+
+  <hr class="divider">
+
+  <p class="text-center muted" style="font-size:14px">
+    Want to write a guest post? <a href="mailto:hello@planscape.app" style="color:var(--accent);font-weight:600">Pitch us</a>.
+  </p>
+</section>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/blog/index.html
+++ b/marketing-site/blog/index.html
@@ -6,10 +6,10 @@
 <title>Blog — Planscape</title>
 <meta name="description" content="Notes from the Planscape team — BIM coordination, ISO 19650, African AEC delivery, product updates, engineering write-ups.">
 <meta property="og:title" content="Planscape blog">
-<meta property="og:url" content="https://planscape.app/blog/">
+<meta property="og:url" content="https://planscape.co/blog/">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/blog/">
+<link rel="canonical" href="https://planscape.co/blog/">
 <link rel="alternate" type="application/rss+xml" title="Planscape blog RSS" href="/blog/rss.xml">
 <link rel="stylesheet" href="/assets/site.css">
 <style>
@@ -99,13 +99,13 @@
   <hr class="divider">
 
   <p class="text-center muted" style="font-size:14px">
-    Want to write a guest post? <a href="mailto:hello@planscape.app" style="color:var(--accent);font-weight:600">Pitch us</a>.
+    Want to write a guest post? <a href="mailto:hello@planscape.co" style="color:var(--accent);font-weight:600">Pitch us</a>.
   </p>
 </section>
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/blog/rss.xml
+++ b/marketing-site/blog/rss.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Planscape blog</title>
+    <link>https://planscape.app/blog/</link>
+    <atom:link href="https://planscape.app/blog/rss.xml" rel="self" type="application/rss+xml" />
+    <description>Notes from the Planscape team — BIM coordination, ISO 19650, African AEC delivery, product updates, engineering write-ups.</description>
+    <language>en-gb</language>
+    <copyright>© 2026 Planscape Ltd</copyright>
+    <managingEditor>hello@planscape.app (Planscape team)</managingEditor>
+    <webMaster>hello@planscape.app (Planscape team)</webMaster>
+    <lastBuildDate>Sat, 23 May 2026 08:00:00 +0300</lastBuildDate>
+    <image>
+      <url>https://planscape.app/images/og-card.png</url>
+      <title>Planscape blog</title>
+      <link>https://planscape.app/blog/</link>
+    </image>
+
+    <item>
+      <title>Why we built Planscape</title>
+      <link>https://planscape.app/blog/2026-05-23-why-we-built-planscape.html</link>
+      <guid isPermaLink="true">https://planscape.app/blog/2026-05-23-why-we-built-planscape.html</guid>
+      <pubDate>Sat, 23 May 2026 08:00:00 +0300</pubDate>
+      <author>hello@planscape.app (Planscape team)</author>
+      <category>Founder note</category>
+      <description>We were paying for Autodesk Construction Cloud seats we never used, sweating the FX spread every month, and watching our coordinators screenshot clashes into WhatsApp groups because the official tool didn't work without 4G. So we built the thing we wished existed.</description>
+    </item>
+
+    <item>
+      <title>ISO 19650 in East Africa — what actually applies</title>
+      <link>https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html</link>
+      <guid isPermaLink="true">https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html</guid>
+      <pubDate>Wed, 20 May 2026 08:00:00 +0300</pubDate>
+      <author>hello@planscape.app (Planscape team)</author>
+      <category>ISO 19650</category>
+      <description>ISO 19650 was written with UK practice in mind. Most of it transposes cleanly to East African delivery — but some bits don't, and a few of the "best practice" guides from the UK BIM Framework will get you in trouble with local building authorities. Here's our running guide to what to adopt, what to adapt, and what to skip.</description>
+    </item>
+
+    <item>
+      <title>Building an offline-first mobile BIM tool</title>
+      <link>https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html</link>
+      <guid isPermaLink="true">https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html</guid>
+      <pubDate>Fri, 15 May 2026 08:00:00 +0300</pubDate>
+      <author>hello@planscape.app (Planscape team)</author>
+      <category>Engineering</category>
+      <description>Five lessons from a year of building Planscape's mobile app for sites with no fibre, intermittent 4G, and the occasional total outage. Conflict resolution, replay queues, why we chose SQLite over Realm, and how the federated model loads on a 3-year-old Android.</description>
+    </item>
+
+  </channel>
+</rss>

--- a/marketing-site/blog/rss.xml
+++ b/marketing-site/blog/rss.xml
@@ -2,46 +2,46 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>Planscape blog</title>
-    <link>https://planscape.app/blog/</link>
-    <atom:link href="https://planscape.app/blog/rss.xml" rel="self" type="application/rss+xml" />
+    <link>https://planscape.co/blog/</link>
+    <atom:link href="https://planscape.co/blog/rss.xml" rel="self" type="application/rss+xml" />
     <description>Notes from the Planscape team — BIM coordination, ISO 19650, African AEC delivery, product updates, engineering write-ups.</description>
     <language>en-gb</language>
     <copyright>© 2026 Planscape Ltd</copyright>
-    <managingEditor>hello@planscape.app (Planscape team)</managingEditor>
-    <webMaster>hello@planscape.app (Planscape team)</webMaster>
+    <managingEditor>hello@planscape.co (Planscape team)</managingEditor>
+    <webMaster>hello@planscape.co (Planscape team)</webMaster>
     <lastBuildDate>Sat, 23 May 2026 08:00:00 +0300</lastBuildDate>
     <image>
-      <url>https://planscape.app/images/og-card.png</url>
+      <url>https://planscape.co/images/og-card.png</url>
       <title>Planscape blog</title>
-      <link>https://planscape.app/blog/</link>
+      <link>https://planscape.co/blog/</link>
     </image>
 
     <item>
       <title>Why we built Planscape</title>
-      <link>https://planscape.app/blog/2026-05-23-why-we-built-planscape.html</link>
-      <guid isPermaLink="true">https://planscape.app/blog/2026-05-23-why-we-built-planscape.html</guid>
+      <link>https://planscape.co/blog/2026-05-23-why-we-built-planscape.html</link>
+      <guid isPermaLink="true">https://planscape.co/blog/2026-05-23-why-we-built-planscape.html</guid>
       <pubDate>Sat, 23 May 2026 08:00:00 +0300</pubDate>
-      <author>hello@planscape.app (Planscape team)</author>
+      <author>hello@planscape.co (Planscape team)</author>
       <category>Founder note</category>
       <description>We were paying for Autodesk Construction Cloud seats we never used, sweating the FX spread every month, and watching our coordinators screenshot clashes into WhatsApp groups because the official tool didn't work without 4G. So we built the thing we wished existed.</description>
     </item>
 
     <item>
       <title>ISO 19650 in East Africa — what actually applies</title>
-      <link>https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html</link>
-      <guid isPermaLink="true">https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html</guid>
+      <link>https://planscape.co/blog/2026-05-20-iso-19650-in-east-africa.html</link>
+      <guid isPermaLink="true">https://planscape.co/blog/2026-05-20-iso-19650-in-east-africa.html</guid>
       <pubDate>Wed, 20 May 2026 08:00:00 +0300</pubDate>
-      <author>hello@planscape.app (Planscape team)</author>
+      <author>hello@planscape.co (Planscape team)</author>
       <category>ISO 19650</category>
       <description>ISO 19650 was written with UK practice in mind. Most of it transposes cleanly to East African delivery — but some bits don't, and a few of the "best practice" guides from the UK BIM Framework will get you in trouble with local building authorities. Here's our running guide to what to adopt, what to adapt, and what to skip.</description>
     </item>
 
     <item>
       <title>Building an offline-first mobile BIM tool</title>
-      <link>https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html</link>
-      <guid isPermaLink="true">https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html</guid>
+      <link>https://planscape.co/blog/2026-05-15-offline-first-mobile-bim.html</link>
+      <guid isPermaLink="true">https://planscape.co/blog/2026-05-15-offline-first-mobile-bim.html</guid>
       <pubDate>Fri, 15 May 2026 08:00:00 +0300</pubDate>
-      <author>hello@planscape.app (Planscape team)</author>
+      <author>hello@planscape.co (Planscape team)</author>
       <category>Engineering</category>
       <description>Five lessons from a year of building Planscape's mobile app for sites with no fibre, intermittent 4G, and the occasional total outage. Conflict resolution, replay queues, why we chose SQLite over Realm, and how the federated model loads on a 3-year-old Android.</description>
     </item>

--- a/marketing-site/contact.html
+++ b/marketing-site/contact.html
@@ -6,10 +6,10 @@
 <title>Contact — Planscape</title>
 <meta name="description" content="Get in touch with Planscape. Sales, support, demo bookings, enterprise enquiries. Based in Kampala — responses within 4 business hours.">
 <meta property="og:title" content="Contact — Planscape">
-<meta property="og:url" content="https://planscape.app/contact.html">
+<meta property="og:url" content="https://planscape.co/contact.html">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/contact.html">
+<link rel="canonical" href="https://planscape.co/contact.html">
 <link rel="stylesheet" href="/assets/site.css">
 <style>
 .contact-grid { display:grid; gap:32px; grid-template-columns:1.2fr 1fr; align-items:start; }
@@ -80,10 +80,10 @@
     <div style="display:flex;flex-direction:column;gap:16px">
       <div class="contact-card">
         <h3>📩 Email</h3>
-        <p><a href="mailto:hello@planscape.app">hello@planscape.app</a> — General</p>
-        <p><a href="mailto:support@planscape.app">support@planscape.app</a> — Customer support</p>
-        <p><a href="mailto:partners@planscape.app">partners@planscape.app</a> — Partnerships</p>
-        <p><a href="mailto:security@planscape.app">security@planscape.app</a> — Security disclosures</p>
+        <p><a href="mailto:hello@planscape.co">hello@planscape.co</a> — General</p>
+        <p><a href="mailto:support@planscape.co">support@planscape.co</a> — Customer support</p>
+        <p><a href="mailto:partners@planscape.co">partners@planscape.co</a> — Partnerships</p>
+        <p><a href="mailto:security@planscape.co">security@planscape.co</a> — Security disclosures</p>
       </div>
       <div class="contact-card" id="demo">
         <h3>📞 WhatsApp</h3>
@@ -109,15 +109,15 @@
   <div class="faq-list">
     <details class="faq-item">
       <summary class="faq-q">How do I report a security vulnerability?</summary>
-      <div class="faq-a">Email <a href="mailto:security@planscape.app">security@planscape.app</a>. Please don't open a public GitHub issue. We follow a 90-day coordinated disclosure policy and credit reporters in our security advisories (with your permission).</div>
+      <div class="faq-a">Email <a href="mailto:security@planscape.co">security@planscape.co</a>. Please don't open a public GitHub issue. We follow a 90-day coordinated disclosure policy and credit reporters in our security advisories (with your permission).</div>
     </details>
     <details class="faq-item">
       <summary class="faq-q">I'm a journalist — who do I talk to?</summary>
-      <div class="faq-a">Email <a href="mailto:press@planscape.app">press@planscape.app</a>. We respond same business day. We have a press kit with logos, screenshots, founder bios, and a one-page company summary on request.</div>
+      <div class="faq-a">Email <a href="mailto:press@planscape.co">press@planscape.co</a>. We respond same business day. We have a press kit with logos, screenshots, founder bios, and a one-page company summary on request.</div>
     </details>
     <details class="faq-item">
       <summary class="faq-q">Do you have a status page?</summary>
-      <div class="faq-a">Yes — <a href="https://status.planscape.app" target="_blank" rel="noopener">status.planscape.app</a>. Live API health, scheduled maintenance, post-incident reports.</div>
+      <div class="faq-a">Yes — <a href="https://status.planscape.co" target="_blank" rel="noopener">status.planscape.co</a>. Live API health, scheduled maintenance, post-incident reports.</div>
     </details>
     <details class="faq-item">
       <summary class="faq-q">Can I tour your office?</summary>
@@ -132,7 +132,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -145,7 +145,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">
@@ -169,7 +169,7 @@ function handleContact(e){
   new FormData(form).forEach(function(v,k){ data[k]=v; });
   btn.disabled = true;
   btn.textContent = 'Sending…';
-  fetch('https://api.planscape.app/marketing/contact', {
+  fetch('https://api.planscape.co/marketing/contact', {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
     body: JSON.stringify(data)
@@ -184,7 +184,7 @@ function handleContact(e){
     btn.disabled = false;
     btn.textContent = 'Send message';
     msg.style.color = '#dc2626';
-    msg.textContent = 'Something went wrong. Email us at hello@planscape.app instead.';
+    msg.textContent = 'Something went wrong. Email us at hello@planscape.co instead.';
   });
 }
 </script>

--- a/marketing-site/contact.html
+++ b/marketing-site/contact.html
@@ -31,6 +31,7 @@
     <a href="/pricing.html">Pricing</a>
     <a href="/guides/">Guides</a>
     <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/">Blog</a>
     <a href="/about.html">About</a>
     <a href="/contact.html" style="color:var(--accent)">Contact</a>
   </div>

--- a/marketing-site/contact.html
+++ b/marketing-site/contact.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Contact — Planscape</title>
+<meta name="description" content="Get in touch with Planscape. Sales, support, demo bookings, enterprise enquiries. Based in Kampala — responses within 4 business hours.">
+<meta property="og:title" content="Contact — Planscape">
+<meta property="og:url" content="https://planscape.app/contact.html">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/contact.html">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.contact-grid { display:grid; gap:32px; grid-template-columns:1.2fr 1fr; align-items:start; }
+@media (max-width:760px){ .contact-grid { grid-template-columns:1fr; } }
+.contact-card { background:var(--card); border:1px solid var(--line); border-radius:14px; padding:24px; }
+.contact-card h3 { margin:0 0 8px; font-size:17px; }
+.contact-card p { font-size:14px; color:var(--muted); margin:4px 0; }
+.contact-card a { color:var(--accent); font-weight:600; text-decoration:none; }
+#form-msg { margin-top:10px; font-size:13px; }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html" style="color:var(--accent)">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<header class="page-header">
+  <h1>Get in touch</h1>
+  <p>We typically respond within 4 business hours (East Africa Time). For urgent matters, use WhatsApp.</p>
+</header>
+
+<section>
+  <div class="contact-grid">
+    <form class="form-stack" id="contact-form" onsubmit="handleContact(event)">
+      <label>Your name
+        <input type="text" name="name" required style="width:100%;padding:10px 12px;border:1px solid var(--line);border-radius:8px;font-size:15px;margin-top:4px">
+      </label>
+      <label>Email
+        <input type="email" name="email" required style="width:100%;padding:10px 12px;border:1px solid var(--line);border-radius:8px;font-size:15px;margin-top:4px">
+      </label>
+      <label>Firm / company
+        <input type="text" name="firm" style="width:100%;padding:10px 12px;border:1px solid var(--line);border-radius:8px;font-size:15px;margin-top:4px">
+      </label>
+      <label>What can we help with?
+        <select name="topic" required style="width:100%;padding:10px 12px;border:1px solid var(--line);border-radius:8px;font-size:15px;margin-top:4px;background:var(--card)">
+          <option value="">— Choose one —</option>
+          <option value="demo">Book a demo</option>
+          <option value="trial">Question about the free trial</option>
+          <option value="pricing">Pricing or invoicing</option>
+          <option value="enterprise">Enterprise / self-host</option>
+          <option value="migration">Migration from another tool</option>
+          <option value="education">Education / non-profit discount</option>
+          <option value="partner">Partnership</option>
+          <option value="support">Support (existing customer)</option>
+          <option value="press">Press / media</option>
+          <option value="other">Other</option>
+        </select>
+      </label>
+      <label>Message
+        <textarea name="message" required placeholder="Tell us what you're working on, what you're stuck on, or what you'd like to see."></textarea>
+      </label>
+      <button type="submit" style="background:var(--accent);color:#fff;border:none;padding:12px 22px;border-radius:10px;font-weight:600;font-size:15px;cursor:pointer;align-self:flex-start">Send message</button>
+      <div id="form-msg"></div>
+    </form>
+
+    <div style="display:flex;flex-direction:column;gap:16px">
+      <div class="contact-card">
+        <h3>📩 Email</h3>
+        <p><a href="mailto:hello@planscape.app">hello@planscape.app</a> — General</p>
+        <p><a href="mailto:support@planscape.app">support@planscape.app</a> — Customer support</p>
+        <p><a href="mailto:partners@planscape.app">partners@planscape.app</a> — Partnerships</p>
+        <p><a href="mailto:security@planscape.app">security@planscape.app</a> — Security disclosures</p>
+      </div>
+      <div class="contact-card" id="demo">
+        <h3>📞 WhatsApp</h3>
+        <p>Fastest response — we read it on phones we always have on us.</p>
+        <p><a href="https://wa.me/256700000000?text=Hi%2C%20I%27d%20like%20to%20chat%20about%20Planscape" target="_blank" rel="noopener">+256 700 000 000</a></p>
+      </div>
+      <div class="contact-card" id="enterprise">
+        <h3>🏢 Office</h3>
+        <p>Plot 12, Industrial Area<br>Kampala, Uganda</p>
+        <p>Mon–Fri · 09:00–18:00 EAT</p>
+      </div>
+      <div class="contact-card">
+        <h3>📅 Book a 30-minute demo</h3>
+        <p>Walk through Planscape on your screen with one of our team. We'll show the bits that matter for your project mix.</p>
+        <p><a href="https://cal.com/planscape/demo" target="_blank" rel="noopener">Pick a time →</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="background:var(--card)">
+  <h2 class="text-center">Quick answers</h2>
+  <div class="faq-list">
+    <details class="faq-item">
+      <summary class="faq-q">How do I report a security vulnerability?</summary>
+      <div class="faq-a">Email <a href="mailto:security@planscape.app">security@planscape.app</a>. Please don't open a public GitHub issue. We follow a 90-day coordinated disclosure policy and credit reporters in our security advisories (with your permission).</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">I'm a journalist — who do I talk to?</summary>
+      <div class="faq-a">Email <a href="mailto:press@planscape.app">press@planscape.app</a>. We respond same business day. We have a press kit with logos, screenshots, founder bios, and a one-page company summary on request.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Do you have a status page?</summary>
+      <div class="faq-a">Yes — <a href="https://status.planscape.app" target="_blank" rel="noopener">status.planscape.app</a>. Live API health, scheduled maintenance, post-incident reports.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Can I tour your office?</summary>
+      <div class="faq-a">Yes — drop us a line. We're happy to host AEC firms, students, and partner organisations on weekday mornings. Bring a hard hat if you want to visit the projects we're delivering on.</div>
+    </details>
+  </div>
+</section>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+<script>
+function handleContact(e){
+  e.preventDefault();
+  var form = document.getElementById('contact-form');
+  var msg  = document.getElementById('form-msg');
+  var btn  = form.querySelector('button');
+  var data = {};
+  new FormData(form).forEach(function(v,k){ data[k]=v; });
+  btn.disabled = true;
+  btn.textContent = 'Sending…';
+  fetch('https://api.planscape.app/marketing/contact', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify(data)
+  })
+  .then(function(r){ return r.ok ? r.json() : Promise.reject(r.status); })
+  .then(function(){
+    form.style.display = 'none';
+    msg.style.color = '#16a34a';
+    msg.textContent = '✓ Thanks — we\'ll be in touch within 4 business hours.';
+  })
+  .catch(function(){
+    btn.disabled = false;
+    btn.textContent = 'Send message';
+    msg.style.color = '#dc2626';
+    msg.textContent = 'Something went wrong. Email us at hello@planscape.app instead.';
+  });
+}
+</script>
+
+</body>
+</html>

--- a/marketing-site/features.html
+++ b/marketing-site/features.html
@@ -1,0 +1,323 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Features — Planscape</title>
+<meta name="description" content="Every Planscape feature, grouped by who uses it: project leads, model authors, site coordinators, BIM managers.">
+<meta property="og:title" content="Features — Planscape">
+<meta property="og:description" content="Revit plugin, offline-first mobile, ISO 19650 templates, audit trail, GPS site mapping, photo capture, RFI/NCR workflows.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://planscape.app/features.html">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/features.html">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.feat-section { padding:48px 24px; }
+.feat-section:nth-child(odd of .feat-section) { background: var(--card); }
+.feat-section h2 { font-size:24px; margin:0 0 8px; }
+.feat-section .lead { margin-bottom:24px; }
+.feat-pill {
+  display:inline-block; background:rgba(232,145,45,0.10); color:var(--accent);
+  font-weight:600; font-size:12px; letter-spacing:1px; text-transform:uppercase;
+  padding:4px 10px; border-radius:999px; margin-bottom:8px;
+}
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html" style="color:var(--accent)">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<header class="page-header">
+  <h1>Features</h1>
+  <p>Every Planscape feature, grouped by who uses it. Click any item to jump to the matching guide or tutorial.</p>
+</header>
+
+<section>
+  <span class="feat-pill">For Model Authors</span>
+  <h2>Revit Plugin — STING Tools</h2>
+  <p class="lead">A single compiled .addin for Revit 2025 / 2026 / 2027. No per-seat license — included with every Planscape subscription.</p>
+  <div class="grid-3">
+    <div class="card">
+      <div class="icon">🏷️</div>
+      <h3>ISO 19650 auto-tagging</h3>
+      <p>One click tags every element with the 8-segment ISO 19650 identifier (DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ). Spatial auto-detect picks LOC + ZONE from rooms.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📐</div>
+      <h3>Drawing template manager</h3>
+      <p>90+ corporate drawing types · 22 view style packs · 289 AEC filters. One profile defines paper size, title block, view template, crop, annotation, sheet numbering.</p>
+    </div>
+    <div class="card">
+      <div class="icon">⚡</div>
+      <h3>763+ commands</h3>
+      <p>Auto-tagging, schedule generation, COBie export, model health audits, clash detection, BOQ generation, MEP sizing, healthcare validators.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🧪</div>
+      <h3>Healthcare pack</h3>
+      <p>HTM 02-01 medical gas verification, HTM 03-01 pressure regimes, NCRP 147 radiation shielding, anti-ligature audit, RDS room data sheets.</p>
+    </div>
+    <div class="card">
+      <div class="icon">⚙️</div>
+      <h3>MEP engineering</h3>
+      <p>BS 7671 cable sizing, IEC 60909 fault current, IEEE 1584 arc flash, BS EN 12056 drainage, ASHRAE block load + RTS, refrigerant pipe sizing.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📤</div>
+      <h3>One-click cloud sync</h3>
+      <p>Publish to the cloud CDE in a single click. No IFC export, no manual upload — the plugin pushes the diff.</p>
+    </div>
+  </div>
+  <p style="margin-top:24px"><a href="/guides/revit-plugin-setup.html">📖 Guide: Setting up the Revit plugin →</a></p>
+</section>
+
+<section style="background:var(--card)">
+  <span class="feat-pill">For Site Coordinators</span>
+  <h2>Mobile App — iOS &amp; Android</h2>
+  <p class="lead">Offline-first React Native app. The coordinator's tool of choice when there's no signal at the back of the plant room.</p>
+  <div class="grid-3">
+    <div class="card">
+      <div class="icon">🗺️</div>
+      <h3>GPS site map</h3>
+      <p>Mapbox-powered live site map centred on project coordinates. Live coordinator position, issue pins colour-coded by status, long-press to file a new issue.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📸</div>
+      <h3>Photo capture</h3>
+      <p>Camera + gallery. Auto-geotagged + auto-thumbnailed. Attach to issues, elements, or stand alone. Queues offline, replays when you're back on signal.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🎙️</div>
+      <h3>Voice notes</h3>
+      <p>For when typing on site doesn't work. Auto-transcribed via the server. Searchable across the project.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📲</div>
+      <h3>QR scan asset lookup</h3>
+      <p>Print STING tags as QR codes. Scan on site to pull the element's full tag history, photos, RFIs, commissioning log.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🔔</div>
+      <h3>Push notifications</h3>
+      <p>Issue assigned, comment added, status changed — pushed via Expo. Single endpoint covers iOS + Android.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🔄</div>
+      <h3>Real-time sync</h3>
+      <p>SignalR keeps your team's screens in sync. New issue raised on the coordinator's phone shows up on the project lead's laptop in &lt;1 second.</p>
+    </div>
+  </div>
+  <p style="margin-top:24px"><a href="/guides/mobile-onboarding.html">📖 Guide: Mobile app onboarding →</a></p>
+</section>
+
+<section>
+  <span class="feat-pill">For Project Leads</span>
+  <h2>ISO 19650 Workflow Engine</h2>
+  <p class="lead">Every document, every approval, every transmittal — auditable, automatable, repeatable.</p>
+  <div class="grid-3">
+    <div class="card">
+      <div class="icon">📋</div>
+      <h3>Pre-built templates</h3>
+      <p>Transmittals, RFIs, NCRs, BEPs, MIDPs, commissioning checklists, handover certificates. Edit in Word — token contract stays intact.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📨</div>
+      <h3>Transmittal orchestration</h3>
+      <p>Mint number → render docx → start workflow → push to CDE → notify recipients. One command, full audit trail.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🔁</div>
+      <h3>Deliverable lifecycle</h3>
+      <p>Issue → Re-issue → Publish → Supersede → Replace. Every state transition timestamped + hash-chained.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🎯</div>
+      <h3>20+ workflow presets</h3>
+      <p>Daily QA, weekly data drop, HTM 04-01 annual water audit, NFPA 110 generator test, MGPS verification, anti-ligature audit.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🗃️</div>
+      <h3>Hash-chained audit</h3>
+      <p>SHA-256 chain over every write — court-admissible by construction. Satisfies ISO 19650-2 §5.6.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📊</div>
+      <h3>Live compliance dashboard</h3>
+      <p>Per-discipline tag completeness, stale-element detection, missing-document RAG status. Refreshed on every save.</p>
+    </div>
+  </div>
+  <p style="margin-top:24px"><a href="/guides/iso-19650-workflow.html">📖 Guide: Running an ISO 19650 workflow →</a></p>
+</section>
+
+<section style="background:var(--card)">
+  <span class="feat-pill">For BIM Managers</span>
+  <h2>Coordination &amp; Quality</h2>
+  <p class="lead">The federated model is the source of truth — clashes, issues, and RFIs land back on the right element.</p>
+  <div class="grid-3">
+    <div class="card">
+      <div class="icon">💥</div>
+      <h3>Clash detection</h3>
+      <p>Full in-process clash kernel with AABB sweep + Möller–Trumbore SAT + OBB tree. Live re-detection on geometry change. BCF 2.1 round-trip.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🎯</div>
+      <h3>AI clash triage</h3>
+      <p>Prioritises by discipline pair + element size + resolution complexity. Suggests resolution strategies (raise tray, re-route pipe, offset duct).</p>
+    </div>
+    <div class="card">
+      <div class="icon">🏗️</div>
+      <h3>Federation walker</h3>
+      <p>Walks every linked model recursively. Cross-model validation, federated quantity take-off, federation health score.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📑</div>
+      <h3>COBie 2.4 export</h3>
+      <p>22 project-type presets covering NHS, private, commercial, education. 19 worksheets. Full tag integration.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🌱</div>
+      <h3>Embodied carbon</h3>
+      <p>RIBA-stage carbon tracking with EC3 integration hooks. Per-element, per-system, per-level breakdown.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📈</div>
+      <h3>Model health score</h3>
+      <p>12-metric composite score (0–100). Tag completeness, geometry quality, naming convention, file size, warning count, workset health.</p>
+    </div>
+  </div>
+  <p style="margin-top:24px"><a href="/guides/bim-coordination.html">📖 Guide: BIM coordination workflow →</a></p>
+</section>
+
+<section>
+  <span class="feat-pill">For Finance &amp; Operations</span>
+  <h2>Local Invoicing &amp; Multi-Tenancy</h2>
+  <p class="lead">Built for African delivery — local currencies, mobile money, multi-firm collaboration.</p>
+  <div class="grid-3">
+    <div class="card">
+      <div class="icon">💱</div>
+      <h3>9 currencies</h3>
+      <p>UGX · KES · TZS · RWF · NGN · ZAR via Flutterwave. USD · EUR · GBP via Stripe. Invoiced in your chosen currency — no FX spread.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📱</div>
+      <h3>Mobile money</h3>
+      <p>MTN Mobile Money, Airtel Money, M-Pesa, Tigo Pesa, Vodacom — all routed through Flutterwave's collection API.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🏢</div>
+      <h3>Multi-tenant</h3>
+      <p>One firm = one tenant. Cross-firm collaboration: invite a contractor as a project member without forcing them to buy a license.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🛡️</div>
+      <h3>Role-based access</h3>
+      <p>Owner · BIM Manager · Project Lead · Coordinator · Viewer · Client. Each role has explicit project-level permissions.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📊</div>
+      <h3>Usage dashboard</h3>
+      <p>Active users, project count, storage used, mobile sessions — visible to the firm owner so trial-to-paid is a no-surprise conversation.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🎁</div>
+      <h3>30-day free trial</h3>
+      <p>Full Standard tier features. No credit card required. Daily expiry job notifies your admin 7 / 3 / 1 days before end.</p>
+    </div>
+  </div>
+  <p style="margin-top:24px"><a href="/guides/billing-and-trials.html">📖 Guide: Billing &amp; trials →</a></p>
+</section>
+
+<section style="background:var(--card)">
+  <span class="feat-pill">For IT &amp; Compliance</span>
+  <h2>Platform &amp; Integration</h2>
+  <p class="lead">Standards-based, well-documented APIs and import/export paths into the rest of your AEC stack.</p>
+  <div class="grid-3">
+    <div class="card">
+      <div class="icon">🌐</div>
+      <h3>IFC 4 import/export</h3>
+      <p>Substrate-driven IFC layer with 52 enums, 5 Psets, 5 IDS files, bSDD publication plan. Host-agnostic — Revit + Bonsai + (planned) ArchiCAD.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📦</div>
+      <h3>BCF 2.1</h3>
+      <p>Full round-trip: import from Navisworks / Solibri / Trimble Connect. Export to any BCF-compatible tool. Comments, snapshots, viewpoints preserved.</p>
+    </div>
+    <div class="card">
+      <div class="icon">📊</div>
+      <h3>Excel round-trip</h3>
+      <p>Export every schedule to XLSX, edit, re-import. Conflict detection, audit trail, ClosedXML-styled output.</p>
+    </div>
+    <div class="card">
+      <div class="icon">☁️</div>
+      <h3>ACC + SharePoint sync</h3>
+      <p>Push deliverables to Autodesk Construction Cloud or SharePoint CDE. Delta-only sync — only changed files cross the wire.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🔐</div>
+      <h3>SSO + 2FA</h3>
+      <p>SAML 2.0 + OIDC for enterprise SSO. TOTP 2FA for individual accounts. Audit logs every login.</p>
+    </div>
+    <div class="card">
+      <div class="icon">🐳</div>
+      <h3>Self-host option</h3>
+      <p>Docker Compose ships with the Enterprise plan. ASP.NET Core 8 + PostgreSQL + Redis + MinIO. Run on your hardware, your jurisdiction.</p>
+    </div>
+  </div>
+  <p style="margin-top:24px"><a href="/guides/self-hosting.html">📖 Guide: Self-hosting Planscape →</a></p>
+</section>
+
+<div class="cta-band">
+  <h2>See it on your project.</h2>
+  <p>Start a 30-day free trial — full Standard tier features. No credit card required.</p>
+  <a href="/signup">Start now</a>
+</div>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/features.html
+++ b/marketing-site/features.html
@@ -35,6 +35,7 @@
     <a href="/pricing.html">Pricing</a>
     <a href="/guides/">Guides</a>
     <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/">Blog</a>
     <a href="/about.html">About</a>
     <a href="/contact.html">Contact</a>
   </div>

--- a/marketing-site/features.html
+++ b/marketing-site/features.html
@@ -8,10 +8,10 @@
 <meta property="og:title" content="Features — Planscape">
 <meta property="og:description" content="Revit plugin, offline-first mobile, ISO 19650 templates, audit trail, GPS site mapping, photo capture, RFI/NCR workflows.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://planscape.app/features.html">
+<meta property="og:url" content="https://planscape.co/features.html">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/features.html">
+<link rel="canonical" href="https://planscape.co/features.html">
 <link rel="stylesheet" href="/assets/site.css">
 <style>
 .feat-section { padding:48px 24px; }
@@ -293,7 +293,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -306,7 +306,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/guides/billing-and-trials.html
+++ b/marketing-site/guides/billing-and-trials.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Billing &amp; the free trial — Planscape</title>
+<meta name="description" content="How the 30-day free trial works, upgrading and downgrading, mobile money, exchange rates, invoices, refunds.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/billing-and-trials.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Billing &amp; the free trial</div>
+  <h1>Billing &amp; the free trial</h1>
+  <div class="meta">📖 8-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>Everything you need to know about paying for Planscape: how the trial works, switching plans, mobile money, how we handle exchange rates, invoices and tax compliance, and how to cancel.</p>
+
+  <h2>The 30-day free trial</h2>
+  <p>Every new tenant starts on a 30-day free trial with full Standard-tier features. No credit card needed at signup.</p>
+
+  <h3>What you get during the trial</h3>
+  <ul>
+    <li>Everything in the Standard plan (Plugin + Cloud CDE + Mobile + 50 GB storage + 10 projects + ACC sync + BCF round-trip).</li>
+    <li>Up to 10 users.</li>
+    <li>Email support (24-hour response).</li>
+  </ul>
+
+  <h3>What happens as the trial ends</h3>
+  <table>
+    <thead><tr><th>Day</th><th>What happens</th></tr></thead>
+    <tbody>
+      <tr><td>−7</td><td>Push notification + email reminder to tenant Owner</td></tr>
+      <tr><td>−3</td><td>Second reminder; in-app banner appears</td></tr>
+      <tr><td>−1</td><td>Final reminder; banner turns orange</td></tr>
+      <tr><td>0 (expiry)</td><td>If a plan has been chosen + paid → seamless transition. If not → tenant moves to read-only mode</td></tr>
+      <tr><td>+1 to +60</td><td>Read-only grace period: full data access, but no new projects, no new issues, no Revit plugin sync</td></tr>
+      <tr><td>+60</td><td>Data archived; export available on request for 12 months</td></tr>
+    </tbody>
+  </table>
+  <div class="callout">
+    <strong>Adding a payment method early</strong> means a seamless transition on day 31 — your subscription starts and you keep working. We charge on day 31, not day 1.
+  </div>
+
+  <h2>Choosing your plan</h2>
+  <p>Plans are documented on the <a href="/pricing.html">pricing page</a>. Quick decision matrix:</p>
+  <ul>
+    <li><strong>1 user, Revit plugin only</strong> → Plugin Only ($15/mo)</li>
+    <li><strong>Small practice, 2–5 users, ≤3 projects</strong> → Starter ($35/mo)</li>
+    <li><strong>Mid-size practice, 5–10 users, ≤10 projects</strong> → Standard ($65/mo)</li>
+    <li><strong>15+ users, unlimited projects, clash + carbon</strong> → Large ($90/mo)</li>
+    <li><strong>Self-host, SSO, custom integrations</strong> → Enterprise (contact us)</li>
+  </ul>
+
+  <h2>Paying — supported methods</h2>
+
+  <h3>Mobile money (recommended for East &amp; West Africa)</h3>
+  <ul>
+    <li>🇺🇬 Uganda — MTN Mobile Money, Airtel Money</li>
+    <li>🇰🇪 Kenya — M-Pesa, Airtel Money</li>
+    <li>🇹🇿 Tanzania — M-Pesa, Tigo Pesa, Airtel Money</li>
+    <li>🇷🇼 Rwanda — MTN MoMo</li>
+    <li>🇳🇬 Nigeria — Bank transfer, USSD</li>
+    <li>🇿🇦 South Africa — EFT, card</li>
+  </ul>
+  <p>All routed through Flutterwave. Setup once, auto-debit monthly. Confirmation comes via SMS and email.</p>
+
+  <h3>Card</h3>
+  <p>Visa / Mastercard via Stripe. Standard 3D Secure if your card requires it.</p>
+
+  <h3>Bank transfer (annual only)</h3>
+  <p>Pay annually, get an invoice, transfer to our bank. Setup time: about 24 hours after we receive your transfer confirmation.</p>
+
+  <h3>Crypto (Enterprise only)</h3>
+  <p>USDC, USDT, or BTC for donor-funded international work. Contact us for the wallet address and exchange-rate fix policy.</p>
+
+  <h2>How currency &amp; FX work</h2>
+  <p>You pick your billing currency at signup. Once chosen, prices are <strong>fixed in that currency</strong>. We don't pass on day-to-day FX volatility — you pay the same UGX figure each month regardless of what the dollar is doing.</p>
+  <p>We do, however, review FX rates quarterly and may adjust local-currency prices to track the underlying USD plan price. Any adjustment is announced 30 days in advance and never applies to your current billing cycle.</p>
+  <p>To change your billing currency: Tenant Dashboard → Billing → Currency. Change takes effect at the next billing cycle.</p>
+
+  <h2>Invoices &amp; tax</h2>
+  <p>Every payment generates a tax-compliant invoice in your billing currency. Invoices include:</p>
+  <ul>
+    <li>Your firm's legal name and billing address.</li>
+    <li>Your tax ID (e.g. Uganda TIN, Kenya KRA PIN, Nigerian TIN) — set in Settings → Billing.</li>
+    <li>Planscape's tax ID for your jurisdiction.</li>
+    <li>VAT / GST line items where applicable.</li>
+  </ul>
+  <p>Download from Tenant Dashboard → Billing → Invoices. We retain invoices for 7 years.</p>
+  <p>VAT registration status by country:</p>
+  <ul>
+    <li><strong>Uganda</strong> — VAT-registered, 18% added to local invoices.</li>
+    <li><strong>Kenya, Tanzania, Rwanda, Nigeria, South Africa</strong> — currently invoiced without local VAT under the digital-services exemption; you may need to self-account via reverse charge depending on your KRA / TRA / RRA / FIRS / SARS guidance.</li>
+    <li><strong>EU/UK</strong> — VAT MOSS registered, local VAT added.</li>
+    <li><strong>US</strong> — no sales tax (we're not US-resident).</li>
+  </ul>
+  <div class="callout warn">
+    <strong>This isn't tax advice.</strong> Consult your accountant for the right treatment in your jurisdiction.
+  </div>
+
+  <h2>Upgrading mid-cycle</h2>
+  <p>Upgrades take effect immediately. We pro-rate the new plan from the upgrade date:</p>
+  <ol>
+    <li>Calculate days remaining in the current cycle.</li>
+    <li>Refund proportional credit of the old plan.</li>
+    <li>Charge proportional cost of the new plan for the same period.</li>
+    <li>Apply the credit to that charge; you pay the difference.</li>
+  </ol>
+  <p>Example: 15 days into a Starter ($35/mo) cycle, upgrade to Standard ($65/mo). Old plan credit: $17.50. New plan pro-rated: $32.50. You're charged $15. Next month onwards, you pay $65 in full.</p>
+
+  <h2>Downgrading mid-cycle</h2>
+  <p>Downgrades take effect at the next billing cycle. You keep the higher plan until then; you don't get a refund for the unused portion. This protects you from losing access mid-month.</p>
+
+  <h2>Cancelling</h2>
+  <p>Tenant Dashboard → Billing → Cancel subscription. You're asked to confirm + give a reason (optional but appreciated).</p>
+  <p>Effects of cancellation:</p>
+  <ul>
+    <li>You keep full access until the end of your current billing cycle.</li>
+    <li>No auto-renew at the next cycle.</li>
+    <li>After cycle end, tenant moves to read-only mode for 60 days.</li>
+    <li>After 60 days, data is archived. Export available on request for 12 months.</li>
+    <li>After 12 months, data is permanently deleted (we keep cryptographic hashes for audit chain integrity but no readable data).</li>
+  </ul>
+
+  <h2>Refunds</h2>
+  <p>If you cancel within 30 days of your first paid invoice (i.e. within day 60 of your account), we refund 100% — no questions. Email <a href="mailto:hello@planscape.app">hello@planscape.app</a>.</p>
+  <p>After 30 days we don't pro-rate refunds for the current cycle. You can cancel any time and you'll keep access until end-of-cycle.</p>
+  <p>Annual plans: if you cancel partway through an annual cycle, we refund the unused months minus a 10% admin fee. So month 4 cancellation on a 12-month plan = refund of (8 months × monthly equivalent × 90%).</p>
+
+  <h2>Failed payments</h2>
+  <p>If a payment fails (insufficient funds, expired card, mobile money limit hit):</p>
+  <ul>
+    <li>We retry on day +3 and day +7.</li>
+    <li>You get an email after each failed attempt with instructions to fix.</li>
+    <li>After the second failed retry the tenant moves to read-only on day +14.</li>
+    <li>Update your payment method and trigger a manual retry from Billing → Pay now.</li>
+  </ul>
+
+  <h2>Educational &amp; non-profit discount</h2>
+  <p>Accredited universities, vocational training institutes, and registered non-profits get 50% off the Standard tier. Email <a href="mailto:hello@planscape.app">hello@planscape.app</a> with your accreditation documents (or non-profit certificate). Verification takes 1–3 business days.</p>
+
+  <h2>Anything else</h2>
+  <p>If your question isn't covered here, <a href="/contact.html">contact us</a> or check the <a href="/pricing.html#faq">pricing FAQ</a>.</p>
+
+  <div class="next-prev">
+    <a href="/guides/changing-currency.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Changing your billing currency
+    </a>
+    <a href="/guides/canceling.html" class="next">
+      <span class="lbl">Next →</span>
+      Cancelling &amp; exporting data
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/billing-and-trials.html
+++ b/marketing-site/guides/billing-and-trials.html
@@ -7,7 +7,7 @@
 <meta name="description" content="How the 30-day free trial works, upgrading and downgrading, mobile money, exchange rates, invoices, refunds.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/billing-and-trials.html">
+<link rel="canonical" href="https://planscape.co/guides/billing-and-trials.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -141,7 +141,7 @@
   </ul>
 
   <h2>Refunds</h2>
-  <p>If you cancel within 30 days of your first paid invoice (i.e. within day 60 of your account), we refund 100% — no questions. Email <a href="mailto:hello@planscape.app">hello@planscape.app</a>.</p>
+  <p>If you cancel within 30 days of your first paid invoice (i.e. within day 60 of your account), we refund 100% — no questions. Email <a href="mailto:hello@planscape.co">hello@planscape.co</a>.</p>
   <p>After 30 days we don't pro-rate refunds for the current cycle. You can cancel any time and you'll keep access until end-of-cycle.</p>
   <p>Annual plans: if you cancel partway through an annual cycle, we refund the unused months minus a 10% admin fee. So month 4 cancellation on a 12-month plan = refund of (8 months × monthly equivalent × 90%).</p>
 
@@ -155,7 +155,7 @@
   </ul>
 
   <h2>Educational &amp; non-profit discount</h2>
-  <p>Accredited universities, vocational training institutes, and registered non-profits get 50% off the Standard tier. Email <a href="mailto:hello@planscape.app">hello@planscape.app</a> with your accreditation documents (or non-profit certificate). Verification takes 1–3 business days.</p>
+  <p>Accredited universities, vocational training institutes, and registered non-profits get 50% off the Standard tier. Email <a href="mailto:hello@planscape.co">hello@planscape.co</a> with your accreditation documents (or non-profit certificate). Verification takes 1–3 business days.</p>
 
   <h2>Anything else</h2>
   <p>If your question isn't covered here, <a href="/contact.html">contact us</a> or check the <a href="/pricing.html#faq">pricing FAQ</a>.</p>
@@ -174,7 +174,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/guides/creating-first-project.html
+++ b/marketing-site/guides/creating-first-project.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Set up a Planscape project with metadata, GPS coordinates, ISO 19650 codes, and RIBA stages.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/creating-first-project.html">
+<link rel="canonical" href="https://planscape.co/guides/creating-first-project.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -150,7 +150,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/guides/creating-first-project.html
+++ b/marketing-site/guides/creating-first-project.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Creating your first project — Planscape</title>
+<meta name="description" content="Set up a Planscape project with metadata, GPS coordinates, ISO 19650 codes, and RIBA stages.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/creating-first-project.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Creating your first project</div>
+  <h1>Creating your first project</h1>
+  <div class="meta">📖 8-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>Creating a project is a 3-minute job if you have the basics to hand. This guide covers the fields, the decisions, and the small gotchas that save you grief later. By the end you'll have a configured project ready for the team to join.</p>
+
+  <h2>Before you start</h2>
+  <p>Have these to hand:</p>
+  <ul>
+    <li><strong>Project name</strong> — the human-readable name. Doesn't need to be unique across your tenant.</li>
+    <li><strong>Project code</strong> — 3–6 character identifier. Will appear in every document number for this project (e.g. <code>KIH</code> for "Kampala International Hospital"). Hard to change later — pick well.</li>
+    <li><strong>Client name</strong> — the appointing party.</li>
+    <li><strong>Site address</strong> — for GPS lookup. Approximate is fine; you can refine later.</li>
+    <li><strong>RIBA stage</strong> — current stage (1 to 7). If unsure: pre-design = Stage 1, planning = Stage 3, construction = Stage 5.</li>
+  </ul>
+
+  <h2>Step 1 — Click + New Project</h2>
+  <p>From the tenant dashboard or any other project, click <strong>+ New Project</strong> in the top-right.</p>
+
+  <h2>Step 2 — Project basics</h2>
+  <p>Fill these fields:</p>
+  <ul>
+    <li><strong>Project name</strong> — e.g. "Kampala International Hospital — Wing B".</li>
+    <li><strong>Project code</strong> — e.g. <code>KIH-WB</code>. Used in every document number.</li>
+    <li><strong>Description</strong> — optional 1–2 sentences for the team.</li>
+    <li><strong>Sector</strong> — Healthcare / Education / Commercial / Residential / Transport / Industrial / Other. Drives the default BEP template and COBie preset later.</li>
+    <li><strong>Client</strong> — the appointing party.</li>
+    <li><strong>Project value</strong> — optional. Used in dashboards.</li>
+    <li><strong>Start date / target completion</strong> — feeds the 4D scheduling tools.</li>
+  </ul>
+
+  <h2>Step 3 — GPS coordinates</h2>
+  <p>This is what powers the mobile GPS site map. Three input methods:</p>
+
+  <h3>Search by address</h3>
+  <p>Type the site address. We geocode it with Mapbox. Result usually within 50 m of correct.</p>
+
+  <h3>Drop a pin</h3>
+  <p>Click "Pick on map", pan to the site, click the exact location. Most accurate.</p>
+
+  <h3>Enter coordinates directly</h3>
+  <p>If your surveyor gave you exact lat/lng, paste them. Format: decimal degrees, comma-separated (e.g. <code>0.3136, 32.5811</code>).</p>
+
+  <div class="callout">
+    <strong>Why this matters:</strong> the mobile app centres on these coordinates and only caches a 5km radius of map tiles. Inaccurate coordinates = blank map on site.
+  </div>
+
+  <h2>Step 4 — ISO 19650 setup</h2>
+  <p>Quick choices that drive the whole project's file naming + workflow:</p>
+
+  <h3>Originator code</h3>
+  <p>Defaults to your tenant's originator code (set in tenant Settings). Override per-project if you're delivering for a JV or another firm.</p>
+
+  <h3>Volume code</h3>
+  <p>For most projects: <code>ZZ</code> (whole project). For multi-building or multi-zone work: <code>01</code>, <code>02</code>, etc.</p>
+
+  <h3>BEP template</h3>
+  <p>Pick from:</p>
+  <ul>
+    <li><strong>Standard</strong> — generic ISO 19650 BEP.</li>
+    <li><strong>UK Public Sector</strong> — adds IR cross-references.</li>
+    <li><strong>NHS / Healthcare</strong> — adds HBN / HTM document requirements.</li>
+    <li><strong>Donor-funded</strong> — adds DFI / IFC reporting fields.</li>
+    <li><strong>Blank</strong> — generate later from scratch.</li>
+  </ul>
+
+  <h3>Suitability schema</h3>
+  <p>Defaults to standard S0–S7. Override if your client uses a custom schema.</p>
+
+  <h3>Revision schema</h3>
+  <p>Defaults to P/C/A (pre-construction / construction / as-built). Custom options available for clients with bespoke schemes.</p>
+
+  <h2>Step 5 — RIBA stage &amp; phases</h2>
+  <p>Pick the current stage (1–7). Planscape pre-loads the Revit phase list to match (Existing, Demolition, New Construction, etc.) when the plugin first syncs.</p>
+  <p>You can add custom phases later for staged handovers (e.g. Phase 1 / Phase 2 of a multi-building site).</p>
+
+  <h2>Step 6 — Initial team members</h2>
+  <p>Optional at create-time. Pick from your tenant's existing users to add as project members. You'll be added as Project Lead automatically. See <a href="/guides/inviting-team.html">Inviting your team</a> for the full role model.</p>
+
+  <h2>Step 7 — Click Create</h2>
+  <p>You land on the project dashboard. Behind the scenes Planscape has:</p>
+  <ol>
+    <li>Created the project record in your tenant's database.</li>
+    <li>Created CDE containers (WIP / Shared / Published / Archived).</li>
+    <li>Generated an initial BEP (.docx) under Deliverables → BEP.</li>
+    <li>Created the project's Mapbox map config and pre-warmed tiles for the 5km radius.</li>
+    <li>Set up the audit log with a Genesis record.</li>
+    <li>Issued you a project-scoped email-to-issue address.</li>
+  </ol>
+
+  <h2>What to do next</h2>
+  <ul>
+    <li><strong>Invite your team</strong> — see <a href="/guides/inviting-team.html">Inviting your team</a></li>
+    <li><strong>Set up the ISO 19650 workflow</strong> — see <a href="/guides/iso-19650-workflow.html">ISO 19650 workflow setup</a></li>
+    <li><strong>Install the Revit plugin and sync the first model</strong> — see <a href="/guides/revit-plugin-setup.html">Installing the Revit plugin</a></li>
+    <li><strong>Build your MIDP</strong> — Project &rsaquo; Deliverables &rsaquo; MIDP view</li>
+  </ul>
+
+  <h2>Common mistakes</h2>
+  <ul>
+    <li><strong>Vague project code.</strong> "PROJ1" makes the next 10,000 document numbers harder to read. Use the project's actual initialism.</li>
+    <li><strong>Default GPS pin.</strong> The default GPS is Kampala. If you don't change it, every coordinator on site sees a blank map.</li>
+    <li><strong>Wrong sector pick.</strong> Drives BEP + COBie defaults. Healthcare project mis-set as "Commercial" misses the HTM/HBN preset.</li>
+    <li><strong>Skipping the BEP.</strong> Even a draft BEP is better than no BEP. The auto-generated one captures most of what auditors look for.</li>
+  </ul>
+
+  <h2>Cloning a project from a template</h2>
+  <p>Once you have a few projects on a similar pattern (e.g. you do 5 similar district hospitals a year), save one as a template: Project Settings → Save as template. Future projects can be cloned from it, inheriting CDE setup, BEP draft, team defaults, and MIDP skeleton.</p>
+
+  <div class="next-prev">
+    <a href="/guides/inviting-team.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Inviting your team
+    </a>
+    <a href="/guides/iso-19650-workflow.html" class="next">
+      <span class="lbl">Next →</span>
+      ISO 19650 workflow setup
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/getting-started.html
+++ b/marketing-site/guides/getting-started.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Sign up, set up your firm, create your first project, invite your team. 10-minute walkthrough.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/getting-started.html">
+<link rel="canonical" href="https://planscape.co/guides/getting-started.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -43,7 +43,7 @@
   </ul>
 
   <h2>Step 1 — Sign up</h2>
-  <p>Visit <a href="https://planscape.app/signup">planscape.app/signup</a>. You'll be asked for:</p>
+  <p>Visit <a href="https://planscape.co/signup">planscape.co/signup</a>. You'll be asked for:</p>
   <ol>
     <li><strong>Your firm's name</strong> — this becomes your tenant. It can be renamed later.</li>
     <li><strong>Your name, role, and email</strong> — you're the tenant owner. Your email becomes your login.</li>
@@ -129,7 +129,7 @@
   <h2>Step 6 — Install the mobile app</h2>
   <ol>
     <li>iOS: <a href="https://apps.apple.com/app/planscape" target="_blank" rel="noopener">App Store</a></li>
-    <li>Android: <a href="https://play.google.com/store/apps/details?id=com.planscape.app" target="_blank" rel="noopener">Play Store</a></li>
+    <li>Android: <a href="https://play.google.com/store/apps/details?id=com.planscape.co" target="_blank" rel="noopener">Play Store</a></li>
     <li>Open the app, sign in, choose your project.</li>
     <li>Tap <strong>Pre-sync</strong> to download the project for offline use — recommended before going to site.</li>
   </ol>
@@ -145,7 +145,7 @@
   </ul>
 
   <div class="callout">
-    <strong>Need help?</strong> WhatsApp <a href="https://wa.me/256700000000" target="_blank" rel="noopener">+256 700 000 000</a> or email <a href="mailto:hello@planscape.app">hello@planscape.app</a>. We typically reply within 4 business hours (East Africa Time).
+    <strong>Need help?</strong> WhatsApp <a href="https://wa.me/256700000000" target="_blank" rel="noopener">+256 700 000 000</a> or email <a href="mailto:hello@planscape.co">hello@planscape.co</a>. We typically reply within 4 business hours (East Africa Time).
   </div>
 
   <div class="next-prev">
@@ -166,7 +166,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -179,7 +179,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/guides/getting-started.html
+++ b/marketing-site/guides/getting-started.html
@@ -1,0 +1,197 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Getting started with Planscape</title>
+<meta name="description" content="Sign up, set up your firm, create your first project, invite your team. 10-minute walkthrough.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/getting-started.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Getting started</div>
+  <h1>Getting started with Planscape</h1>
+  <div class="meta">📖 10-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>Welcome. This guide walks you through everything you need to set up Planscape for your firm: signing up, configuring your tenant, creating your first project, and inviting your team. By the end you'll have a working project with the Revit plugin installed and a coordinator on the mobile app.</p>
+
+  <h2>What you'll need</h2>
+  <ul>
+    <li>An email address — yours, not a generic one. You're the tenant owner.</li>
+    <li>Your firm's legal name, billing address, and currency preference.</li>
+    <li>For the Revit plugin: a Windows machine running Revit 2025, 2026, or 2027.</li>
+    <li>For the mobile app: an iOS 16+ or Android 10+ phone.</li>
+    <li>Approximate GPS coordinates of your project site (we'll show you how to find them).</li>
+  </ul>
+
+  <h2>Step 1 — Sign up</h2>
+  <p>Visit <a href="https://planscape.app/signup">planscape.app/signup</a>. You'll be asked for:</p>
+  <ol>
+    <li><strong>Your firm's name</strong> — this becomes your tenant. It can be renamed later.</li>
+    <li><strong>Your name, role, and email</strong> — you're the tenant owner. Your email becomes your login.</li>
+    <li><strong>Country &amp; currency</strong> — pick the currency you'd like to be invoiced in.</li>
+    <li><strong>Password</strong> — minimum 12 characters. We don't enforce silly symbol-count rules, but we do block known-breached passwords.</li>
+  </ol>
+  <div class="callout">
+    <strong>No credit card required.</strong> Your 30-day free trial starts immediately. We'll only ask for a payment method when you're ready to upgrade.
+  </div>
+
+  <h2>Step 2 — Configure your tenant</h2>
+  <p>After signup you land on the tenant dashboard. Two things to do here:</p>
+  <h3>Upload your logo</h3>
+  <p>Settings → Branding. PNG or SVG, 400×400 minimum. This logo appears on every transmittal, RFI, and report your firm generates.</p>
+  <h3>Set your default ISO 19650 vocabulary</h3>
+  <p>Settings → Standards. Pick your default suitability codes, document type codes, and revision schemes. Most projects override these per-project, but having sensible defaults saves time.</p>
+  <div class="callout warn">
+    <strong>Heads up:</strong> Once a project is created with a particular code scheme, changing the tenant default won't retroactively change that project. Each project has its own copy.
+  </div>
+
+  <h2>Step 3 — Create your first project</h2>
+  <p>Click <strong>+ New Project</strong> on the dashboard. The form has three sections:</p>
+
+  <h3>Project metadata</h3>
+  <ul>
+    <li><strong>Project name</strong> — human-readable.</li>
+    <li><strong>Project code</strong> — short identifier (e.g. <code>KIH-2026</code>). Used in document numbers.</li>
+    <li><strong>Client name</strong> — the appointing party.</li>
+    <li><strong>Start &amp; target completion dates</strong> — used by the 4D scheduling tools later.</li>
+  </ul>
+
+  <h3>GPS coordinates</h3>
+  <p>This is what powers the mobile GPS site map. Two ways to set it:</p>
+  <ul>
+    <li><strong>Auto-detect from address</strong> — type the site address, we geocode it.</li>
+    <li><strong>Drop a pin</strong> — click "Pick on map" and click the site location on the world map.</li>
+  </ul>
+  <p>You can refine the coordinates later. The default zoom on the mobile map is set so that a 200m radius around your pin is visible.</p>
+
+  <h3>RIBA stage &amp; ISO 19650 context</h3>
+  <ul>
+    <li><strong>Current RIBA stage</strong> — drives drawing template defaults.</li>
+    <li><strong>BEP profile</strong> — pick from corporate templates or "blank".</li>
+    <li><strong>CDE state machine</strong> — defaults to <code>WIP → Shared → Published → Archived</code>.</li>
+  </ul>
+
+  <p>Click <strong>Create project</strong>. You're now in the project workspace.</p>
+
+  <h2>Step 4 — Invite your team</h2>
+  <p>Project &rsaquo; Team &rsaquo; <strong>+ Invite member</strong>. For each person:</p>
+  <table>
+    <thead><tr><th>Field</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td>Email</td><td>Their work email — they'll get an invite link.</td></tr>
+      <tr><td>Role</td><td>Owner, BIM Manager, Project Lead, Coordinator, Viewer, or Client.</td></tr>
+      <tr><td>External?</td><td>Tick for contractors / clients from other firms — they won't count against your user cap.</td></tr>
+    </tbody>
+  </table>
+
+  <p>Roles map to permissions as follows:</p>
+  <ul>
+    <li><strong>Owner</strong> — full access including billing.</li>
+    <li><strong>BIM Manager</strong> — full project access, no billing.</li>
+    <li><strong>Project Lead</strong> — manages deliverables, transmittals, RFIs.</li>
+    <li><strong>Coordinator</strong> — raises issues, captures site data, can't approve deliverables.</li>
+    <li><strong>Viewer</strong> — read-only.</li>
+    <li><strong>Client</strong> — read-only on Published documents; can comment on transmittals.</li>
+  </ul>
+  <p>Roles can be changed any time from the same screen.</p>
+
+  <h2>Step 5 — Install the Revit plugin</h2>
+  <p>Skip if no-one on your team uses Revit.</p>
+  <ol>
+    <li>From your project workspace: Tools &rsaquo; <strong>Download Revit plugin</strong>.</li>
+    <li>You'll get <code>StingTools.zip</code>. Unzip it.</li>
+    <li>Copy the contents (<code>StingTools.addin</code> + <code>StingTools.dll</code> + supporting files) to:<br>
+        <code>%APPDATA%\Autodesk\Revit\Addins\2026\</code></li>
+    <li>Start Revit. You'll see a new <strong>STING Tools</strong> tab on the ribbon, and a "Planscape" dockable panel on the right.</li>
+    <li>Click <strong>Sign in</strong> in the panel and use the same credentials as the web app.</li>
+  </ol>
+  <p>For the full Revit plugin walkthrough, see <a href="/guides/revit-plugin-setup.html">Installing the Revit plugin</a>.</p>
+
+  <h2>Step 6 — Install the mobile app</h2>
+  <ol>
+    <li>iOS: <a href="https://apps.apple.com/app/planscape" target="_blank" rel="noopener">App Store</a></li>
+    <li>Android: <a href="https://play.google.com/store/apps/details?id=com.planscape.app" target="_blank" rel="noopener">Play Store</a></li>
+    <li>Open the app, sign in, choose your project.</li>
+    <li>Tap <strong>Pre-sync</strong> to download the project for offline use — recommended before going to site.</li>
+  </ol>
+  <p>For the full mobile walkthrough, see <a href="/guides/mobile-onboarding.html">Mobile app onboarding</a>.</p>
+
+  <h2>What's next</h2>
+  <p>You're set up. Common next steps:</p>
+  <ul>
+    <li>Walk through <a href="/tutorials/raise-issue-from-mobile.html">Raising your first issue from mobile</a> (6 min).</li>
+    <li>Set up the <a href="/guides/iso-19650-workflow.html">ISO 19650 workflow</a> for your project (CDE codes, suitability, naming).</li>
+    <li>If you're migrating from Autodesk Construction Cloud, see <a href="/guides/acc-sync.html">ACC sync &amp; migration</a>.</li>
+    <li>If you want to self-host instead, see <a href="/guides/self-hosting.html">Self-hosting Planscape</a>.</li>
+  </ul>
+
+  <div class="callout">
+    <strong>Need help?</strong> WhatsApp <a href="https://wa.me/256700000000" target="_blank" rel="noopener">+256 700 000 000</a> or email <a href="mailto:hello@planscape.app">hello@planscape.app</a>. We typically reply within 4 business hours (East Africa Time).
+  </div>
+
+  <div class="next-prev">
+    <a href="/guides/" class="prev">
+      <span class="lbl">← All guides</span>
+      Guides index
+    </a>
+    <a href="/guides/revit-plugin-setup.html" class="next">
+      <span class="lbl">Next →</span>
+      Installing the Revit plugin
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/gps-site-map.html
+++ b/marketing-site/guides/gps-site-map.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Using the GPS site map — Planscape</title>
+<meta name="description" content="Centre the map on your project, drop pins, share live coordinator position, navigate to issues. Works offline.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/gps-site-map.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Using the GPS site map</div>
+  <h1>Using the GPS site map</h1>
+  <div class="meta">📖 7-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>The GPS site map is the second screen most coordinators open after the issue list. It plots every issue on a Mapbox map centred on your project, shows where you are right now, and lets you drop new pins with a long-press. This guide covers the basics, the offline behaviour, and the small features that make it useful on site.</p>
+
+  <h2>Opening the map</h2>
+  <p>Bottom tab bar &rsaquo; <strong>Map</strong>. The map loads centred on your project's GPS coordinates with all open issues plotted.</p>
+
+  <h2>Pin colours</h2>
+  <table>
+    <thead><tr><th>Pin colour</th><th>Status</th></tr></thead>
+    <tbody>
+      <tr><td>🔴 Red</td><td>Open issue</td></tr>
+      <tr><td>🟠 Amber</td><td>In-progress issue</td></tr>
+      <tr><td>🟢 Green</td><td>Resolved issue (last 7 days)</td></tr>
+      <tr><td>🔵 Blue (pulsing)</td><td>You — live GPS position</td></tr>
+    </tbody>
+  </table>
+  <p>Resolved-and-verified issues older than 7 days are hidden by default to reduce clutter. Toggle via Filter → "Show resolved older than 7d".</p>
+
+  <h2>Interacting with pins</h2>
+
+  <h3>Tap a pin</h3>
+  <p>Opens the issue summary bottom sheet: title, status, assignee, raised date, first photo thumbnail. Tap "View full issue" to open the detail screen.</p>
+
+  <h3>Long-press a pin</h3>
+  <p>Quick actions: Assign, Change status, Add comment, Get directions.</p>
+
+  <h3>Long-press anywhere on the map</h3>
+  <p>Opens the new-issue form with the tapped point's GPS coordinates pre-filled. Fastest way to raise an issue when you're not standing right at the location.</p>
+
+  <h2>Live position</h2>
+  <p>The blue pulsing dot is you. It updates every 5 seconds (or whenever you've moved &gt; 3m). Tap the blue compass-needle button in the bottom-right to centre the map on you.</p>
+  <p>The "Share live position with team" toggle (Map &rsaquo; Settings) makes your position visible to other project members. Useful during coordinated site walks.</p>
+
+  <h2>Search &amp; filter</h2>
+  <p>Top of the map screen has search + filter:</p>
+  <ul>
+    <li><strong>Search</strong> — finds issues by title or tag. Matching pins highlight, others fade.</li>
+    <li><strong>Filter</strong> — by type, priority, assignee, age. Persists across sessions.</li>
+  </ul>
+
+  <h2>Layers</h2>
+  <p>Top-right layers icon opens the layer panel:</p>
+  <ul>
+    <li><strong>Issues</strong> — toggle off to declutter when you just want the map.</li>
+    <li><strong>Site boundary</strong> — if you've drawn a boundary polygon under Project Settings → Site boundary.</li>
+    <li><strong>Workspaces / compounds</strong> — admin-defined sub-areas.</li>
+    <li><strong>Team positions</strong> — other coordinators' live positions if they've shared.</li>
+    <li><strong>Photo locations</strong> — every captured site photo plotted as a small camera icon.</li>
+  </ul>
+
+  <h2>Map styles</h2>
+  <p>Tap the map-style icon (stack-of-paper) to switch between:</p>
+  <ul>
+    <li><strong>Streets</strong> — default. Best for navigation.</li>
+    <li><strong>Satellite</strong> — best for seeing actual site features.</li>
+    <li><strong>Hybrid</strong> — satellite + street names.</li>
+    <li><strong>Dark</strong> — easier on the eyes in night-shift work.</li>
+  </ul>
+
+  <h2>Navigation to an issue</h2>
+  <p>Tap a pin → "Get directions". Opens your phone's default map app (Apple Maps / Google Maps) with the issue's GPS as destination.</p>
+
+  <h2>Offline behaviour</h2>
+  <p>Mapbox tiles within a 5km radius of your project pin are pre-cached when you first open the project. While offline:</p>
+  <ul>
+    <li>The map renders from the cache at all zoom levels.</li>
+    <li>Your live position keeps updating.</li>
+    <li>Pins for cached issues display correctly.</li>
+    <li>New pins (issues raised offline) appear as outlined-only markers until they sync.</li>
+    <li>Pan/zoom outside the cached area shows a grey grid with "Offline — tiles not cached".</li>
+  </ul>
+
+  <h2>Pre-syncing tiles</h2>
+  <p>If your project covers a larger area than 5km radius:</p>
+  <ol>
+    <li>Map &rsaquo; Settings &rsaquo; Tile cache &rsaquo; <strong>Extend cache</strong>.</li>
+    <li>Pan + zoom to define the area you need offline.</li>
+    <li>Tap "Cache this area" — downloads happen in the background.</li>
+  </ol>
+  <p>Each km² adds ~5 MB to your phone's storage. A typical 5×5km cache is ~125 MB.</p>
+
+  <h2>Battery considerations</h2>
+  <p>The map with live GPS uses ~10% of a modern phone's battery per hour. To reduce:</p>
+  <ul>
+    <li>Map &rsaquo; Settings &rsaquo; <strong>GPS accuracy: Balanced</strong> (drops accuracy from ±3m to ±10m, halves battery use).</li>
+    <li>Stop sharing live position when you don't need to.</li>
+    <li>Lower screen brightness — usually the bigger drain.</li>
+  </ul>
+
+  <h2>Privacy</h2>
+  <p>Your live position is only visible to other members of the same project, and only if you've turned on Share. Position history is not stored — once you stop sharing, the data is gone.</p>
+  <p>Photo geotags are visible to anyone with photo access. If you don't want photos geotagged, disable in Profile → Settings → Photos → "Geotag captures: Off".</p>
+
+  <h2>Common issues</h2>
+
+  <h3>"Map is blank / centred on Kampala"</h3>
+  <p>Your project's GPS coordinates haven't been set. Open the project on the web app → Settings → GPS coordinates → drop a pin or paste lat/lng.</p>
+
+  <h3>"My position keeps drifting"</h3>
+  <p>Indoor GPS is noisy. Step outside briefly to re-acquire signal. Indoors you can manually drop pins instead.</p>
+
+  <h3>"Tiles won't cache"</h3>
+  <p>You need to be online when you trigger pre-cache — the tiles download from Mapbox. Check your connection and try again. If you're on cellular and have data caps, do it on WiFi.</p>
+
+  <h3>"Issue pins are missing"</h3>
+  <p>Check the filter panel — you may have filters applied that hide them. Reset filters to default.</p>
+
+  <h2>What's next</h2>
+  <ul>
+    <li><a href="/guides/raising-issues.html">Raising and resolving issues</a></li>
+    <li><a href="/guides/photo-capture.html">Capturing site photos</a></li>
+    <li><a href="/tutorials/gps-site-map.html">Tutorial: Use the GPS site map</a></li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/guides/sharing-with-clients.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Sharing projects with clients
+    </a>
+    <a href="/guides/raising-issues.html" class="next">
+      <span class="lbl">Next →</span>
+      Raising and resolving issues
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/gps-site-map.html
+++ b/marketing-site/guides/gps-site-map.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Centre the map on your project, drop pins, share live coordinator position, navigate to issues. Works offline.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/gps-site-map.html">
+<link rel="canonical" href="https://planscape.co/guides/gps-site-map.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -158,7 +158,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/guides/index.html
+++ b/marketing-site/guides/index.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Guides — Planscape</title>
+<meta name="description" content="In-depth Planscape guides: setting up the Revit plugin, mobile onboarding, ISO 19650 workflows, BIM coordination, billing, self-hosting.">
+<meta property="og:title" content="Planscape guides">
+<meta property="og:url" content="https://planscape.app/guides/">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.guide-cat { margin-top:32px; }
+.guide-cat h2 { font-size:22px; margin:0 0 16px; padding-bottom:8px; border-bottom:1px solid var(--line); }
+.guide-list { display:grid; gap:12px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); }
+.guide-row {
+  display:block; padding:14px 16px;
+  background:var(--card); border:1px solid var(--line); border-radius:10px;
+  text-decoration:none; color:inherit;
+  transition: border-color 0.15s, transform 0.1s;
+}
+.guide-row:hover { border-color:var(--accent); }
+.guide-row .ttl { font-weight:600; font-size:15px; margin-bottom:4px; color:var(--ink); }
+.guide-row .sub { font-size:13px; color:var(--muted); }
+.guide-row .badge { display:inline-block; padding:2px 8px; background:rgba(232,145,45,0.10); color:var(--accent); border-radius:999px; font-size:11px; font-weight:600; margin-right:6px; }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<header class="page-header">
+  <h1>Guides</h1>
+  <p>Deep-dive guides that walk you through Planscape concept by concept. New to the platform? Start with <a href="/guides/getting-started.html">Getting started</a>.</p>
+</header>
+
+<section style="padding-top:0">
+  <div class="guide-cat">
+    <h2>🚀 Getting started</h2>
+    <div class="guide-list">
+      <a href="/guides/getting-started.html" class="guide-row">
+        <div class="ttl"><span class="badge">START HERE</span> Getting started with Planscape</div>
+        <div class="sub">Create your tenant, invite your team, set up your first project. 10-minute read.</div>
+      </a>
+      <a href="/guides/revit-plugin-setup.html" class="guide-row">
+        <div class="ttl">Installing the Revit plugin</div>
+        <div class="sub">Download, install, license-bind. Works on Revit 2025 / 2026 / 2027.</div>
+      </a>
+      <a href="/guides/mobile-onboarding.html" class="guide-row">
+        <div class="ttl">Mobile app onboarding</div>
+        <div class="sub">Install from the App Store / Play, log in, sync your first project.</div>
+      </a>
+      <a href="/guides/inviting-team.html" class="guide-row">
+        <div class="ttl">Inviting your team</div>
+        <div class="sub">Roles, permissions, external clients, removing users.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>🏗️ Project setup</h2>
+    <div class="guide-list">
+      <a href="/guides/creating-first-project.html" class="guide-row">
+        <div class="ttl">Creating your first project</div>
+        <div class="sub">Project metadata, GPS coordinates, ISO 19650 vocabulary, RIBA stages.</div>
+      </a>
+      <a href="/guides/iso-19650-workflow.html" class="guide-row">
+        <div class="ttl">ISO 19650 workflow setup</div>
+        <div class="sub">BEP, MIDP, naming conventions, suitability codes, CDE container model.</div>
+      </a>
+      <a href="/guides/sharing-with-clients.html" class="guide-row">
+        <div class="ttl">Sharing projects with clients</div>
+        <div class="sub">External members, viewer-only access, transmittal recipients, secure links.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>📱 Site coordination</h2>
+    <div class="guide-list">
+      <a href="/guides/gps-site-map.html" class="guide-row">
+        <div class="ttl">Using the GPS site map</div>
+        <div class="sub">Centre the map on your project, drop pins, share live location with the team.</div>
+      </a>
+      <a href="/guides/raising-issues.html" class="guide-row">
+        <div class="ttl">Raising and resolving issues</div>
+        <div class="sub">RFIs, NCRs, snag lists, assignment, status workflow, comment threads.</div>
+      </a>
+      <a href="/guides/photo-capture.html" class="guide-row">
+        <div class="ttl">Capturing site photos</div>
+        <div class="sub">Camera + gallery, geotagging, attaching to elements, offline queueing.</div>
+      </a>
+      <a href="/guides/offline-mode.html" class="guide-row">
+        <div class="ttl">Working offline</div>
+        <div class="sub">What syncs, what doesn't, how the replay queue handles conflicts.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>🧊 Revit plugin</h2>
+    <div class="guide-list">
+      <a href="/guides/auto-tagging.html" class="guide-row">
+        <div class="ttl">ISO 19650 auto-tagging</div>
+        <div class="sub">Tag 30,000 elements in &lt;1s. Configure discipline / system / product codes per project.</div>
+      </a>
+      <a href="/guides/drawing-templates.html" class="guide-row">
+        <div class="ttl">Drawing Template Manager</div>
+        <div class="sub">90 drawing types, 22 view style packs, healthcare/MEP/architectural profiles.</div>
+      </a>
+      <a href="/guides/clash-detection.html" class="guide-row">
+        <div class="ttl">Clash detection workflow</div>
+        <div class="sub">Run clash, triage by priority, push to BCF, resolve in source model, re-check.</div>
+      </a>
+      <a href="/guides/cobie-export.html" class="guide-row">
+        <div class="ttl">COBie 2.4 export</div>
+        <div class="sub">22 project-type presets, 19 worksheets, validation, handover packaging.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>🏥 Healthcare pack</h2>
+    <div class="guide-list">
+      <a href="/guides/healthcare-overview.html" class="guide-row">
+        <div class="ttl">Healthcare pack overview</div>
+        <div class="sub">HTM / HBN / FGI / NFPA 99 / NCRP 147 — what's covered, what to set up.</div>
+      </a>
+      <a href="/guides/mgas-verification.html" class="guide-row">
+        <div class="ttl">Medical gas (HTM 02-01)</div>
+        <div class="sub">12-step verification log, manifold sizing, terminal unit count, alarm panels.</div>
+      </a>
+      <a href="/guides/pressure-regimes.html" class="guide-row">
+        <div class="ttl">Pressure regimes (HTM 03-01)</div>
+        <div class="sub">Pressure cascade audit, isolation cubicles, positive/negative room mapping.</div>
+      </a>
+      <a href="/guides/anti-ligature.html" class="guide-row">
+        <div class="ttl">Anti-ligature audit</div>
+        <div class="sub">Mental-health fittings audit, observation lines, compliance matrix.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>💳 Billing &amp; account</h2>
+    <div class="guide-list">
+      <a href="/guides/billing-and-trials.html" class="guide-row">
+        <div class="ttl">Billing &amp; the free trial</div>
+        <div class="sub">30-day trial, upgrading, downgrading, mobile money, FX, invoices.</div>
+      </a>
+      <a href="/guides/changing-currency.html" class="guide-row">
+        <div class="ttl">Changing your billing currency</div>
+        <div class="sub">9 currencies supported, how exchange rates work, cycle alignment.</div>
+      </a>
+      <a href="/guides/canceling.html" class="guide-row">
+        <div class="ttl">Cancelling &amp; exporting data</div>
+        <div class="sub">How to cancel, what we keep, how to export everything.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>🛠️ Admin &amp; IT</h2>
+    <div class="guide-list">
+      <a href="/guides/sso.html" class="guide-row">
+        <div class="ttl">Setting up SSO</div>
+        <div class="sub">SAML 2.0 + OIDC. Azure AD, Google Workspace, Okta walk-throughs.</div>
+      </a>
+      <a href="/guides/2fa.html" class="guide-row">
+        <div class="ttl">Two-factor authentication</div>
+        <div class="sub">Enable TOTP per user, enforce 2FA per tenant, recovery codes.</div>
+      </a>
+      <a href="/guides/audit-logs.html" class="guide-row">
+        <div class="ttl">Audit logs &amp; hash chain</div>
+        <div class="sub">What gets logged, how to verify the chain, exporting for compliance.</div>
+      </a>
+      <a href="/guides/self-hosting.html" class="guide-row">
+        <div class="ttl">Self-hosting Planscape</div>
+        <div class="sub">Docker Compose, hardware requirements, backup, monitoring, upgrades.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>🔌 Integrations</h2>
+    <div class="guide-list">
+      <a href="/guides/acc-sync.html" class="guide-row">
+        <div class="ttl">Autodesk Construction Cloud sync</div>
+        <div class="sub">Connect ACC, scope what syncs, conflict handling, migration from ACC.</div>
+      </a>
+      <a href="/guides/sharepoint.html" class="guide-row">
+        <div class="ttl">SharePoint integration</div>
+        <div class="sub">Deliverable export to SharePoint CDE folders. M365 tenant binding.</div>
+      </a>
+      <a href="/guides/bcf-roundtrip.html" class="guide-row">
+        <div class="ttl">BCF 2.1 round-trip</div>
+        <div class="sub">Import from Navisworks / Solibri / BIM Track. Export to any BCF tool.</div>
+      </a>
+      <a href="/guides/excel-roundtrip.html" class="guide-row">
+        <div class="ttl">Excel bidirectional sync</div>
+        <div class="sub">Export schedule, edit in Excel, re-import, conflict resolution.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<div class="cta-band">
+  <h2>Looking for a hands-on walkthrough?</h2>
+  <p>Tutorials show you exactly how to use each feature, step by step.</p>
+  <a href="/tutorials/">Browse tutorials</a>
+</div>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/index.html
+++ b/marketing-site/guides/index.html
@@ -6,10 +6,10 @@
 <title>Guides — Planscape</title>
 <meta name="description" content="In-depth Planscape guides: setting up the Revit plugin, mobile onboarding, ISO 19650 workflows, BIM coordination, billing, self-hosting.">
 <meta property="og:title" content="Planscape guides">
-<meta property="og:url" content="https://planscape.app/guides/">
+<meta property="og:url" content="https://planscape.co/guides/">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/">
+<link rel="canonical" href="https://planscape.co/guides/">
 <link rel="stylesheet" href="/assets/site.css">
 <style>
 .guide-cat { margin-top:32px; }
@@ -230,7 +230,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -243,7 +243,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/guides/inviting-team.html
+++ b/marketing-site/guides/inviting-team.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Roles, permissions, external clients, removing users. Set up your team in 5 minutes.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/inviting-team.html">
+<link rel="canonical" href="https://planscape.co/guides/inviting-team.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -117,7 +117,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/guides/inviting-team.html
+++ b/marketing-site/guides/inviting-team.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Inviting your team — Planscape</title>
+<meta name="description" content="Roles, permissions, external clients, removing users. Set up your team in 5 minutes.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/inviting-team.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Inviting your team</div>
+  <h1>Inviting your team</h1>
+  <div class="meta">📖 6-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>Planscape uses two levels of access: tenant-level (your whole firm) and project-level (per-project membership). Users can belong to your tenant but only have access to specific projects. External users — clients and contractors from other firms — can be added to a project without being part of your tenant.</p>
+
+  <h2>The role model in 60 seconds</h2>
+  <table>
+    <thead><tr><th>Role</th><th>Scope</th><th>What they can do</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Owner</strong></td><td>Tenant</td><td>Everything, including billing &amp; tenant settings</td></tr>
+      <tr><td><strong>Admin</strong></td><td>Tenant</td><td>Everything except billing</td></tr>
+      <tr><td><strong>BIM Manager</strong></td><td>Tenant</td><td>Create projects, manage standards, manage all projects they're added to</td></tr>
+      <tr><td><strong>Project Lead</strong></td><td>Project</td><td>Manage deliverables, approve transmittals, assign issues</td></tr>
+      <tr><td><strong>Coordinator</strong></td><td>Project</td><td>Raise issues, capture site data, edit (but not approve) deliverables</td></tr>
+      <tr><td><strong>Viewer</strong></td><td>Project</td><td>Read-only access to project data</td></tr>
+      <tr><td><strong>Client</strong></td><td>Project (external)</td><td>Read-only on Published documents; comment on transmittals</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Step 1 — Invite tenant users</h2>
+  <p>Tenant Dashboard &rsaquo; Team &rsaquo; <strong>+ Invite user</strong>.</p>
+  <p>For each user enter:</p>
+  <ul>
+    <li><strong>Email</strong> — they'll get an invite link with a 7-day expiry.</li>
+    <li><strong>Tenant role</strong> — Admin / BIM Manager / Member.</li>
+    <li><strong>Projects to add to</strong> — optional. You can add them to projects later.</li>
+  </ul>
+  <div class="callout">
+    <strong>Heads up:</strong> Inviting a tenant user counts against your plan's user cap immediately, even before they accept the invite. If you hit the cap, an upgrade prompt appears. Cancel pending invites to free up a slot.
+  </div>
+
+  <h2>Step 2 — Add users to a project</h2>
+  <p>Open the project &rsaquo; Team tab &rsaquo; <strong>+ Add member</strong>.</p>
+  <p>Two paths:</p>
+  <h3>Internal user (already in your tenant)</h3>
+  <p>Pick from a dropdown. Assign a project role (Project Lead / Coordinator / Viewer). They get an in-app notification, no invite email needed.</p>
+  <h3>External user (different firm or no Planscape account)</h3>
+  <p>Type their email. Pick Viewer or Client role. They'll get an invite to create a free external account — they don't count against your user cap and they don't get access to anything else in your tenant.</p>
+
+  <h2>Common permission scenarios</h2>
+
+  <h3>"Our MEP sub-consultants need to mark up issues on a shared model"</h3>
+  <p>Add them as <strong>External &rsaquo; Coordinator</strong>. They can raise and update issues but can't change project settings, approve deliverables, or see other projects in your tenant.</p>
+
+  <h3>"The client wants visibility on transmittals only"</h3>
+  <p>Add them as <strong>External &rsaquo; Client</strong>. They see Published documents and can comment on transmittals routed to them. They don't see WIP work or internal RFIs.</p>
+
+  <h3>"The contractor wants their site team on the mobile app"</h3>
+  <p>Add each site coordinator as <strong>External &rsaquo; Coordinator</strong>. They get full mobile-app access to that project — issues, photos, voice notes, QR-scan — without seeing your other projects.</p>
+
+  <h3>"A BIM consultant needs to set up project standards"</h3>
+  <p>Add them as <strong>External &rsaquo; Project Lead</strong>. They can manage the BEP, naming conventions, and view templates on that one project. They can't see anything else in your tenant.</p>
+
+  <h2>Changing someone's role</h2>
+  <p>Project Team tab → click the role badge next to their name → pick the new role. Changes are immediate; the affected user sees a brief banner next time they refresh.</p>
+  <p>To promote/demote at the tenant level (e.g. make someone an Admin), use the Tenant Dashboard Team tab instead.</p>
+
+  <h2>Removing a user</h2>
+
+  <h3>From a project</h3>
+  <p>Project Team tab → row context menu → <strong>Remove from project</strong>. Their access ends immediately. Their past contributions (issues raised, photos uploaded, comments) remain, attributed to them.</p>
+
+  <h3>From the tenant</h3>
+  <p>Tenant Dashboard Team tab → row context menu → <strong>Deactivate</strong>. The user is signed out of all sessions, their projects lose them, and their seat frees up. You can reactivate within 90 days — after that, the account is permanently removed.</p>
+  <div class="callout warn">
+    <strong>Don't delete the original Owner.</strong> Every tenant needs at least one Owner. If you want to leave, transfer ownership first (Settings → Transfer ownership).
+  </div>
+
+  <h2>Single sign-on (SSO)</h2>
+  <p>On the Large + Enterprise plans you can require SSO for all tenant users. Configure once in Settings → Security → SSO, choose your IdP (Azure AD / Google Workspace / Okta), map IdP groups to Planscape roles, and switch on enforcement. External users (Clients, Contractors) keep using email/password login since their identity sits in your tenant boundary.</p>
+  <p>See <a href="/guides/sso.html">Setting up SSO</a> for the per-IdP walk-through.</p>
+
+  <h2>Audit trail</h2>
+  <p>Every invite, role change, and removal is logged in the tenant audit log with the actor, target, and timestamp. Tenant Dashboard → Audit log to view; export to CSV from there.</p>
+
+  <div class="next-prev">
+    <a href="/guides/mobile-onboarding.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Mobile app onboarding
+    </a>
+    <a href="/guides/creating-first-project.html" class="next">
+      <span class="lbl">Next →</span>
+      Creating your first project
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/iso-19650-workflow.html
+++ b/marketing-site/guides/iso-19650-workflow.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Set up BEP, MIDP, naming conventions, suitability codes, and the CDE state machine for an ISO 19650-compliant project.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/iso-19650-workflow.html">
+<link rel="canonical" href="https://planscape.co/guides/iso-19650-workflow.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -132,7 +132,7 @@ KIH-PLNS-ZZ-XX-DR-M-0042.pdf</code></pre>
 
   <h2>Step 7 — Verify the audit trail is on</h2>
   <p>Audit trail is on by default. To verify: Settings &rsaquo; Audit &rsaquo; <strong>Verify chain</strong>. Planscape walks every record in the project's audit log, checks each SHA-256 hash against the previous record, and reports the chain length and verification result.</p>
-  <p>A broken chain means tampering. Don't ignore it — contact <a href="mailto:support@planscape.app">support@planscape.app</a> immediately. We haven't yet seen a real-world break, but the verification mechanism is what makes the audit trail court-admissible.</p>
+  <p>A broken chain means tampering. Don't ignore it — contact <a href="mailto:support@planscape.co">support@planscape.co</a> immediately. We haven't yet seen a real-world break, but the verification mechanism is what makes the audit trail court-admissible.</p>
 
   <h2>Day-to-day workflow once set up</h2>
   <ol>
@@ -166,7 +166,7 @@ KIH-PLNS-ZZ-XX-DR-M-0042.pdf</code></pre>
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/guides/iso-19650-workflow.html
+++ b/marketing-site/guides/iso-19650-workflow.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ISO 19650 workflow setup — Planscape</title>
+<meta name="description" content="Set up BEP, MIDP, naming conventions, suitability codes, and the CDE state machine for an ISO 19650-compliant project.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/iso-19650-workflow.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; ISO 19650 workflow setup</div>
+  <h1>ISO 19650 workflow setup</h1>
+  <div class="meta">📖 14-minute read · Intermediate · Last updated 2026-05-23</div>
+
+  <p>ISO 19650 is the international standard for managing information across the asset lifecycle. Planscape ships ISO 19650 conventions pre-built — naming, suitability, CDE containers, transmittal forms, audit trail. This guide shows you how to configure them for your project so that on day one you're generating information that satisfies the standard.</p>
+
+  <div class="callout">
+    <strong>You don't need to read ISO 19650-1 and -2 to follow this guide.</strong> But if you want the source: <a href="https://www.iso.org/standard/68078.html" target="_blank" rel="noopener">ISO 19650-1:2018</a> (concepts) and <a href="https://www.iso.org/standard/68080.html" target="_blank" rel="noopener">ISO 19650-2:2018</a> (delivery phase).
+  </div>
+
+  <h2>The four pillars Planscape configures for you</h2>
+  <ol>
+    <li><strong>Naming convention</strong> — every file and document gets an ISO 19650 name.</li>
+    <li><strong>CDE state machine</strong> — WIP → Shared → Published → Archived.</li>
+    <li><strong>Suitability &amp; revision codes</strong> — S0–S7 and P/A revisions.</li>
+    <li><strong>Audit trail</strong> — hash-chained log over every state change.</li>
+  </ol>
+
+  <h2>Step 1 — Project metadata</h2>
+  <p>Open the project &rsaquo; Settings &rsaquo; ISO 19650. Fill in the codes that go into every filename:</p>
+  <table>
+    <thead><tr><th>Code</th><th>Example</th><th>Source</th></tr></thead>
+    <tbody>
+      <tr><td>Project code</td><td>KIH</td><td>You — 3–6 chars</td></tr>
+      <tr><td>Originator code</td><td>PLNS</td><td>Your firm — 3–4 chars</td></tr>
+      <tr><td>Volume / system</td><td>ZZ (whole project), 01 (zone 1)</td><td>Per project — usually ZZ to start</td></tr>
+      <tr><td>Level</td><td>ZZ, 00, 01, 02, …</td><td>Per file</td></tr>
+      <tr><td>Type</td><td>M3 (model), DR (drawing), SP (specification)</td><td>Per file</td></tr>
+      <tr><td>Role</td><td>A (architectural), M (mechanical), …</td><td>Per file</td></tr>
+      <tr><td>Number</td><td>0001</td><td>Auto — sequential</td></tr>
+    </tbody>
+  </table>
+  <p>A complete file name then looks like:</p>
+  <pre><code>KIH-PLNS-ZZ-00-M3-A-0001.rvt
+KIH-PLNS-ZZ-XX-DR-M-0042.pdf</code></pre>
+
+  <h2>Step 2 — Configure the CDE state machine</h2>
+  <p>Every file in Planscape lives in one of four containers:</p>
+  <table>
+    <thead><tr><th>Container</th><th>Who can write</th><th>Who can read</th><th>Use for</th></tr></thead>
+    <tbody>
+      <tr><td><strong>WIP</strong></td><td>Author</td><td>Author + tenant</td><td>Daily work</td></tr>
+      <tr><td><strong>Shared</strong></td><td>Author (publish)</td><td>All project members</td><td>Coordination across disciplines</td></tr>
+      <tr><td><strong>Published</strong></td><td>Project Lead (approve)</td><td>All members + external clients</td><td>Contract-grade information</td></tr>
+      <tr><td><strong>Archived</strong></td><td>System (auto)</td><td>Read-only by all</td><td>Historical record</td></tr>
+    </tbody>
+  </table>
+
+  <p>Settings → CDE state machine. Defaults are correct for most projects. You can:</p>
+  <ul>
+    <li>Require a second approver before promoting to Published.</li>
+    <li>Force a suitability change on each container transition.</li>
+    <li>Auto-archive Published files after N days from project completion.</li>
+  </ul>
+
+  <h2>Step 3 — Suitability codes</h2>
+  <p>The S codes mark what an information container is fit for:</p>
+  <table>
+    <thead><tr><th>Code</th><th>Meaning</th><th>Typical CDE container</th></tr></thead>
+    <tbody>
+      <tr><td>S0</td><td>Initial status / WIP</td><td>WIP</td></tr>
+      <tr><td>S1</td><td>Suitable for coordination</td><td>Shared</td></tr>
+      <tr><td>S2</td><td>Suitable for information</td><td>Shared</td></tr>
+      <tr><td>S3</td><td>Suitable for internal review &amp; comment</td><td>Shared</td></tr>
+      <tr><td>S4</td><td>Suitable for stage approval</td><td>Published</td></tr>
+      <tr><td>S5</td><td>Suitable for PIM authorization</td><td>Published</td></tr>
+      <tr><td>S6</td><td>Suitable for AIM authorization</td><td>Published</td></tr>
+      <tr><td>S7</td><td>Suitable for asset operation</td><td>Published</td></tr>
+    </tbody>
+  </table>
+  <p>The default mapping (S1/S2 → Shared, S4–S7 → Published) is the standard interpretation. Customize per project in Settings.</p>
+
+  <h2>Step 4 — Revision codes</h2>
+  <p>Planscape uses the P (pre-construction) and C (construction) revision scheme:</p>
+  <ul>
+    <li><code>P01, P02, P03…</code> — pre-construction revisions</li>
+    <li><code>P01.01, P01.02</code> — minor revisions within a major</li>
+    <li><code>C01, C02, …</code> — construction-issue revisions</li>
+    <li><code>A01, A02, …</code> — as-built revisions (after handover)</li>
+  </ul>
+  <p>Auto-increment is enabled by default — re-issuing a deliverable bumps the revision code without you typing it.</p>
+
+  <h2>Step 5 — Build the BEP</h2>
+  <p>Project &rsaquo; Documents &rsaquo; <strong>+ Generate BEP</strong>. Pick a template:</p>
+  <ul>
+    <li><strong>Standard</strong> — generic ISO 19650 BEP.</li>
+    <li><strong>UK Public Sector</strong> — includes IR (Information Requirements) cross-references.</li>
+    <li><strong>NHS / Healthcare</strong> — adds HBN/HTM document requirements.</li>
+    <li><strong>Donor-funded</strong> — adds DFI/IFC reporting fields.</li>
+  </ul>
+  <p>The BEP is rendered as a .docx with all your project metadata pre-filled. Edit in Word, re-upload as a deliverable.</p>
+
+  <h2>Step 6 — Build the MIDP</h2>
+  <p>The Master Information Delivery Plan lists every deliverable, its responsible party, and its target date.</p>
+  <p>Project &rsaquo; Deliverables &rsaquo; <strong>MIDP view</strong>. Add deliverables one of three ways:</p>
+  <ul>
+    <li><strong>From a template</strong> — pick from 8 industry templates (Hospital, Airport, Office, etc.) — adds 30–80 deliverables in one click.</li>
+    <li><strong>From Excel</strong> — paste a delivery schedule, Planscape parses columns and creates deliverables.</li>
+    <li><strong>Manually</strong> — one row at a time.</li>
+  </ul>
+
+  <p>Each deliverable carries: number, name, type, responsible party, suitability target, milestone, and dependencies. The MIDP view also shows RAG status (on-track / at-risk / late).</p>
+
+  <h2>Step 7 — Verify the audit trail is on</h2>
+  <p>Audit trail is on by default. To verify: Settings &rsaquo; Audit &rsaquo; <strong>Verify chain</strong>. Planscape walks every record in the project's audit log, checks each SHA-256 hash against the previous record, and reports the chain length and verification result.</p>
+  <p>A broken chain means tampering. Don't ignore it — contact <a href="mailto:support@planscape.app">support@planscape.app</a> immediately. We haven't yet seen a real-world break, but the verification mechanism is what makes the audit trail court-admissible.</p>
+
+  <h2>Day-to-day workflow once set up</h2>
+  <ol>
+    <li><strong>Author</strong> works in Revit / Word / Excel, syncs to WIP via the plugin or upload.</li>
+    <li>When ready to share with the team, the author <strong>Publishes to Shared</strong> with a suitability code (S1 / S2 / S3).</li>
+    <li>Other disciplines coordinate in Shared. RFIs and NCRs raised against specific elements.</li>
+    <li>When ready for client review, the Project Lead <strong>Promotes to Published</strong> at a stage-gate suitability (S4 / S5).</li>
+    <li>A <strong>Transmittal</strong> is issued to client recipients listing every Published deliverable in that batch.</li>
+    <li>Each step is automatically logged in the audit trail.</li>
+  </ol>
+
+  <h2>Common mistakes</h2>
+  <ul>
+    <li><strong>Skipping the MIDP.</strong> Without it you can't show progress against plan. Even a rough first version is better than none.</li>
+    <li><strong>Using suitability codes inconsistently.</strong> Pick a convention (S2 for general info, S3 for review) and stick to it across the project.</li>
+    <li><strong>Approving your own work to Published.</strong> Even if your role allows it, route via a separate Project Lead. The audit trail benefits enormously from a second signature.</li>
+    <li><strong>Never running the chain verification.</strong> Do it monthly. It takes 5 seconds and proves the audit trail isn't compromised.</li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/guides/creating-first-project.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Creating your first project
+    </a>
+    <a href="/guides/sharing-with-clients.html" class="next">
+      <span class="lbl">Next →</span>
+      Sharing projects with clients
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/mobile-onboarding.html
+++ b/marketing-site/guides/mobile-onboarding.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Mobile app onboarding — Planscape</title>
+<meta name="description" content="Install the Planscape mobile app, sign in, sync your first project, prepare for offline use on site.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/mobile-onboarding.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Mobile app onboarding</div>
+  <h1>Mobile app onboarding</h1>
+  <div class="meta">📖 8-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>The Planscape mobile app is offline-first by design. This guide walks you through installation, sign-in, project sync, and the pre-site preparation that lets you work a full day without signal and have everything replay automatically when you're back in range.</p>
+
+  <h2>Supported devices</h2>
+  <table>
+    <thead><tr><th>Platform</th><th>Minimum version</th><th>Recommended</th></tr></thead>
+    <tbody>
+      <tr><td>iOS</td><td>iOS 16 (iPhone XR or later)</td><td>iPhone 13 or later · 128 GB</td></tr>
+      <tr><td>Android</td><td>Android 10 / API 29</td><td>Android 12+ · 6 GB RAM · 128 GB</td></tr>
+    </tbody>
+  </table>
+  <p>The app is ~85 MB on first install. Each cached project adds 50–500 MB depending on how many photos and model views you pre-sync.</p>
+
+  <h2>Step 1 — Install</h2>
+  <ul>
+    <li><strong>iOS:</strong> <a href="https://apps.apple.com/app/planscape" target="_blank" rel="noopener">App Store — search "Planscape BIM"</a></li>
+    <li><strong>Android:</strong> <a href="https://play.google.com/store/apps/details?id=com.planscape.app" target="_blank" rel="noopener">Play Store — search "Planscape BIM"</a></li>
+  </ul>
+  <p>If you're a beta tester, use the TestFlight / Play Internal Testing link sent to your email instead.</p>
+
+  <h2>Step 2 — First launch &amp; permissions</h2>
+  <p>The app asks for four permissions on first run. All are optional, but you'll need them for the core workflows:</p>
+  <table>
+    <thead><tr><th>Permission</th><th>What it's used for</th><th>If denied</th></tr></thead>
+    <tbody>
+      <tr><td>📷 Camera</td><td>Capture site photos, scan QR codes</td><td>Can still upload from gallery</td></tr>
+      <tr><td>📍 Location</td><td>GPS site map, geotagging photos</td><td>Map shows project pin only, no live position</td></tr>
+      <tr><td>🖼️ Photos</td><td>Pick existing photos from your gallery</td><td>Camera-only photo capture</td></tr>
+      <tr><td>🔔 Notifications</td><td>Issue assignments, comments, trial reminders</td><td>You'll miss real-time updates</td></tr>
+    </tbody>
+  </table>
+  <p>You can change any of these later in your phone's Settings → Planscape.</p>
+
+  <h2>Step 3 — Sign in</h2>
+  <p>Enter the email and password you used for the web app. If your firm has SSO enabled, tap <strong>Sign in with SSO</strong> and you'll be redirected to your identity provider (Azure AD, Google Workspace, Okta).</p>
+  <p>After login, the app fetches your project list and shows the project picker. Tap any project to open it.</p>
+
+  <h2>Step 4 — Pre-sync before going to site</h2>
+  <p>This is the step most people skip and then regret. Pre-syncing downloads everything you'll need to work offline:</p>
+  <ul>
+    <li>The full issue list and all photos.</li>
+    <li>The current document register and all PDFs marked "Site reference".</li>
+    <li>The federated model's plan views at all visible levels.</li>
+    <li>The Mapbox tile cache for a 5 km radius around your project pin.</li>
+  </ul>
+  <p>To pre-sync: open the project, tap the cloud icon in the top right, choose <strong>Full pre-sync</strong>. On a normal 4G connection this takes 2–10 minutes depending on project size. Do it from the office, not the site.</p>
+
+  <div class="callout">
+    <strong>Tip:</strong> The app caches the last 30 days of activity by default. If you only visit a project once a quarter, run a fresh pre-sync the night before.
+  </div>
+
+  <h2>Step 5 — Test offline mode</h2>
+  <p>While you're still at the office, do a quick offline test:</p>
+  <ol>
+    <li>Put your phone in airplane mode.</li>
+    <li>Open the Planscape app.</li>
+    <li>Open your project.</li>
+    <li>Tap <strong>+ New issue</strong>, fill it in, attach a photo, save.</li>
+    <li>You should see a yellow chip on the issue: <strong>"Queued — will sync when online"</strong>.</li>
+    <li>Turn airplane mode off. Within 10–30 seconds the chip should go away and the issue is synced.</li>
+  </ol>
+  <p>If that worked, you're ready for a site visit with confidence.</p>
+
+  <h2>Working a day on site</h2>
+  <h3>The status indicator</h3>
+  <p>The top-right of every screen has a connection indicator:</p>
+  <ul>
+    <li>🟢 <strong>Online</strong> — connected, all features available.</li>
+    <li>🟡 <strong>Queued (N)</strong> — offline; N changes waiting to sync.</li>
+    <li>🔴 <strong>Sync failed</strong> — tap to see why and retry.</li>
+  </ul>
+
+  <h3>What works offline</h3>
+  <ul>
+    <li>Browsing issues, documents, the federated model.</li>
+    <li>Raising new issues with photos and voice notes.</li>
+    <li>Commenting on existing issues.</li>
+    <li>Changing issue status (open → in progress → resolved).</li>
+    <li>The GPS site map (using cached Mapbox tiles).</li>
+    <li>QR scanning an asset (offline lookup hits the local cache).</li>
+  </ul>
+
+  <h3>What needs a connection</h3>
+  <ul>
+    <li>Real-time comment notifications from teammates.</li>
+    <li>Initial document download (use pre-sync to avoid this).</li>
+    <li>Voice-note transcription (the audio file syncs offline; the transcript is generated server-side).</li>
+    <li>Push notifications from teammates.</li>
+  </ul>
+
+  <h3>Conflict handling</h3>
+  <p>When the queue replays, two situations can produce conflicts:</p>
+  <ul>
+    <li><strong>You and a teammate both change the same issue status.</strong> Last-write-wins by timestamp. The app shows a conflict banner on the issue with the alternative value so you can decide.</li>
+    <li><strong>You raised an issue against an element that was deleted in Revit.</strong> The issue still saves but is flagged as "orphaned" — you can re-link it to another element or close it.</li>
+  </ul>
+
+  <h2>Push notifications</h2>
+  <p>You'll get a push notification when:</p>
+  <ul>
+    <li>An issue is assigned to you.</li>
+    <li>Someone comments on an issue you created or are assigned to.</li>
+    <li>A document you authored gets approved or rejected.</li>
+    <li>Your firm's trial is about to expire (7 / 3 / 1 days before).</li>
+  </ul>
+  <p>Tapping a notification opens the relevant screen directly — issue detail, document approval queue, billing page.</p>
+
+  <p>Configure which notification types you want: Profile → Settings → Notifications.</p>
+
+  <h2>Battery &amp; data usage</h2>
+  <p>A typical day on site (8 hours, GPS on, 50 photos, 20 issues raised) uses roughly:</p>
+  <ul>
+    <li><strong>Battery:</strong> 25–40% of a modern phone. Bring a power bank if you'll be out all day.</li>
+    <li><strong>Data:</strong> 15–50 MB when syncing the queue. Pre-syncing the night before reduces this to almost nothing.</li>
+  </ul>
+
+  <h2>Troubleshooting</h2>
+
+  <h3>App won't open / crashes on launch</h3>
+  <p>Most common cause: corrupted cache. Profile → Settings → Storage → <strong>Clear cache</strong>. You'll need to log in and pre-sync again.</p>
+
+  <h3>"Stuck queue" — items won't sync</h3>
+  <ul>
+    <li>Check the status indicator. If it's red, tap it and read the error.</li>
+    <li>Most often: an issue references an element ID that no longer exists. Open the issue, re-attach to a current element, save again.</li>
+    <li>If everything else fails: Profile → Diagnostics → <strong>Export queue</strong> and email it to <a href="mailto:support@planscape.app">support@planscape.app</a>. We'll force-replay server-side.</li>
+  </ul>
+
+  <h3>GPS keeps drifting</h3>
+  <p>Indoor GPS is inherently noisy. Go outdoors briefly to re-acquire signal, or use the manual pin-drop instead of "use my location".</p>
+
+  <h3>Photos take ages to upload</h3>
+  <ul>
+    <li>Photos are 12 MP by default — large. We compress to 80% JPEG, but a 50-photo batch is still ~200 MB.</li>
+    <li>The app auto-pauses uploads on slow connections. Force them to upload now: Profile → Sync → <strong>Resume uploads</strong>.</li>
+    <li>To reduce upload size: Profile → Settings → Photos → <strong>Upload quality: Standard</strong> (drops to 1080p).</li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/guides/revit-plugin-setup.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Installing the Revit plugin
+    </a>
+    <a href="/guides/inviting-team.html" class="next">
+      <span class="lbl">Next →</span>
+      Inviting your team
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/mobile-onboarding.html
+++ b/marketing-site/guides/mobile-onboarding.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Install the Planscape mobile app, sign in, sync your first project, prepare for offline use on site.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/mobile-onboarding.html">
+<link rel="canonical" href="https://planscape.co/guides/mobile-onboarding.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -46,7 +46,7 @@
   <h2>Step 1 — Install</h2>
   <ul>
     <li><strong>iOS:</strong> <a href="https://apps.apple.com/app/planscape" target="_blank" rel="noopener">App Store — search "Planscape BIM"</a></li>
-    <li><strong>Android:</strong> <a href="https://play.google.com/store/apps/details?id=com.planscape.app" target="_blank" rel="noopener">Play Store — search "Planscape BIM"</a></li>
+    <li><strong>Android:</strong> <a href="https://play.google.com/store/apps/details?id=com.planscape.co" target="_blank" rel="noopener">Play Store — search "Planscape BIM"</a></li>
   </ul>
   <p>If you're a beta tester, use the TestFlight / Play Internal Testing link sent to your email instead.</p>
 
@@ -155,7 +155,7 @@
   <ul>
     <li>Check the status indicator. If it's red, tap it and read the error.</li>
     <li>Most often: an issue references an element ID that no longer exists. Open the issue, re-attach to a current element, save again.</li>
-    <li>If everything else fails: Profile → Diagnostics → <strong>Export queue</strong> and email it to <a href="mailto:support@planscape.app">support@planscape.app</a>. We'll force-replay server-side.</li>
+    <li>If everything else fails: Profile → Diagnostics → <strong>Export queue</strong> and email it to <a href="mailto:support@planscape.co">support@planscape.co</a>. We'll force-replay server-side.</li>
   </ul>
 
   <h3>GPS keeps drifting</h3>
@@ -186,7 +186,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -199,7 +199,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/guides/raising-issues.html
+++ b/marketing-site/guides/raising-issues.html
@@ -7,7 +7,7 @@
 <meta name="description" content="The full issue workflow: RFIs, NCRs, snag lists, assignment, status transitions, comment threads, BCF round-trip.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/raising-issues.html">
+<link rel="canonical" href="https://planscape.co/guides/raising-issues.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -195,7 +195,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/guides/raising-issues.html
+++ b/marketing-site/guides/raising-issues.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Raising and resolving issues — Planscape</title>
+<meta name="description" content="The full issue workflow: RFIs, NCRs, snag lists, assignment, status transitions, comment threads, BCF round-trip.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/raising-issues.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Raising and resolving issues</div>
+  <h1>Raising and resolving issues</h1>
+  <div class="meta">📖 9-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>Issues are the spine of project coordination on Planscape. Every observation, RFI, NCR, and snag flows through the same issue system — same fields, same status machine, same audit trail. This guide covers the full lifecycle from raised to verified.</p>
+
+  <h2>Issue types</h2>
+  <table>
+    <thead><tr><th>Type</th><th>Use for</th><th>Default priority</th><th>Default workflow</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Quality</strong></td><td>Defects, snag list, finishing issues</td><td>Medium</td><td>open → in-progress → resolved → verified</td></tr>
+      <tr><td><strong>Safety</strong></td><td>Site hazards, near-misses, PPE failures</td><td>High</td><td>open → in-progress → resolved → verified</td></tr>
+      <tr><td><strong>Coordination</strong></td><td>Clashes, sequencing problems, missing info</td><td>Medium</td><td>open → in-progress → resolved → verified</td></tr>
+      <tr><td><strong>RFI</strong></td><td>Question to the designer / specifier</td><td>Medium</td><td>open → answered → closed</td></tr>
+      <tr><td><strong>NCR</strong></td><td>Non-conformance against spec/standard</td><td>High</td><td>open → in-progress → resolved → verified → closed</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Where issues can be raised</h2>
+  <ul>
+    <li><strong>Mobile app</strong> — on site, with photo + GPS + voice. See <a href="/tutorials/raise-issue-from-mobile.html">tutorial</a>.</li>
+    <li><strong>Web app</strong> — Project &rsaquo; Issues &rsaquo; <strong>+ New issue</strong>.</li>
+    <li><strong>Revit plugin</strong> — right-click any element → "Raise issue". Element link auto-set.</li>
+    <li><strong>Email-to-issue</strong> — every project has a magic email address; emails sent to it become issues with attachments preserved.</li>
+    <li><strong>BCF import</strong> — Project &rsaquo; Issues &rsaquo; Import → drop a BCF 2.1 file from Navisworks / Solibri / BIM Track. Each topic becomes an issue.</li>
+  </ul>
+
+  <h2>The fields that matter</h2>
+  <p>The form has many fields but only a few make-or-break the workflow:</p>
+  <ul>
+    <li><strong>Title</strong> — short, specific. "Fire damper FD-103 installed back-to-front" beats "damper issue".</li>
+    <li><strong>Type</strong> — picks the workflow. Get this right at raise-time; changing later is allowed but messy.</li>
+    <li><strong>Priority</strong> — drives sort order in dashboards. Critical = response within 24h, High = 72h, Medium = 7d, Low = 30d.</li>
+    <li><strong>Linked element</strong> — Revit ElementUniqueId. Without this the issue is "floating" and harder to action. Use QR scan or the element picker.</li>
+    <li><strong>Assignee</strong> — who's on the hook. One person, not a team. Re-assign as the issue moves through phases.</li>
+    <li><strong>Due date</strong> — optional but useful. Triggers SLA breach alerts when missed.</li>
+  </ul>
+
+  <h2>The status machine</h2>
+  <p>Default workflow for Quality / Safety / Coordination / NCR:</p>
+
+  <pre><code>open ──&gt; in-progress ──&gt; resolved ──&gt; verified ──&gt; closed
+                              │
+                              └──&gt; reopened (back to in-progress)</code></pre>
+
+  <ul>
+    <li><strong>open</strong> — raised, awaiting action.</li>
+    <li><strong>in-progress</strong> — assignee acknowledged, working on it.</li>
+    <li><strong>resolved</strong> — assignee says it's done.</li>
+    <li><strong>verified</strong> — raiser (or QA) confirms it's actually fixed.</li>
+    <li><strong>closed</strong> — admin-locked; can't be edited.</li>
+  </ul>
+
+  <p>RFI workflow is simpler: <code>open → answered → closed</code>.</p>
+
+  <p>Status transitions are gated by role:</p>
+  <ul>
+    <li>open → in-progress: assignee only</li>
+    <li>in-progress → resolved: assignee only</li>
+    <li>resolved → verified: raiser, QA role, or Project Lead</li>
+    <li>verified → closed: Project Lead</li>
+    <li>* → reopened: anyone, with a comment explaining why</li>
+  </ul>
+
+  <h2>Comment threads</h2>
+  <p>Every issue has a comment thread. Comments are markdown — you can use <code>**bold**</code>, <code>`code`</code>, lists, and inline image embeds. Tagging a user with <code>@firstname</code> sends them a push notification.</p>
+  <p>Comments are append-only — you can't edit or delete them. If you make a mistake, post a correction. This protects the audit trail.</p>
+
+  <h2>Attachments &amp; photos</h2>
+  <p>Up to 10 photos and 5 voice notes per issue. Additional documents (PDFs, drawings, RFIs) can be attached as well, up to 50 MB each.</p>
+  <p>Photos taken in the mobile app are automatically:</p>
+  <ul>
+    <li>Compressed (80% JPEG, 1080p by default).</li>
+    <li>Thumbnailed (400px wide for fast list-view loading).</li>
+    <li>Geotagged with capture coordinates.</li>
+    <li>Timestamped with capture time + upload time.</li>
+  </ul>
+
+  <h2>Tracking &amp; reporting</h2>
+  <p>Project &rsaquo; Issues &rsaquo; <strong>Dashboard</strong> shows:</p>
+  <ul>
+    <li>Open issues by type and priority.</li>
+    <li>SLA breach count (issues past their due date).</li>
+    <li>Median time-to-resolve, broken down by assignee.</li>
+    <li>Aging buckets (0–7d, 7–30d, 30–60d, 60+).</li>
+    <li>Trend lines for the last 30 days.</li>
+  </ul>
+  <p>Export to CSV or PDF for client reporting.</p>
+
+  <h2>BCF round-trip</h2>
+  <p>For coordination work with consultants on a different platform:</p>
+  <ol>
+    <li>Project &rsaquo; Issues &rsaquo; Export → BCF 2.1.</li>
+    <li>Filter (open coordination issues only, for example).</li>
+    <li>You get a <code>.bcfzip</code> file with topics, comments, viewpoints, and snapshots.</li>
+    <li>Consultant imports into Navisworks / Solibri / etc., resolves issues, exports back.</li>
+    <li>Import the modified .bcfzip back into Planscape. Status changes are applied automatically; conflicts surface for review.</li>
+  </ol>
+
+  <h2>Pushing issues to the Revit author</h2>
+  <p>When the author opens the Revit project with the Planscape plugin, the dock panel shows a count of open issues linked to elements in the active view. Clicking the count opens a side panel listing each issue with its photo, comments, and a "Zoom to element" button that re-centres the Revit view on the affected element.</p>
+
+  <h2>Bulk actions</h2>
+  <p>From the issue list view, select multiple issues (checkbox or shift-click) and choose:</p>
+  <ul>
+    <li>Bulk assign (re-route 20 snags to a new contractor)</li>
+    <li>Bulk close (after a verification round)</li>
+    <li>Bulk export to BCF</li>
+    <li>Bulk add comment (useful for batch status updates)</li>
+  </ul>
+
+  <h2>Issue templates</h2>
+  <p>For recurring issue types (e.g. "missing fire collar"), create a template under Settings → Issue templates. Templates pre-fill type, priority, assignee, and a draft description. Coordinators just adjust the linked element and submit.</p>
+
+  <h2>Common patterns</h2>
+
+  <h3>Daily snag walk</h3>
+  <ol>
+    <li>Coordinator walks the site with the mobile app.</li>
+    <li>Each defect → photo + drop pin + Quality issue type.</li>
+    <li>Auto-assigns to the relevant trade based on location + element category.</li>
+    <li>Trade lead gets push notification, schedules fix.</li>
+    <li>Coordinator re-visits next day, verifies fix, marks Verified.</li>
+  </ol>
+
+  <h3>RFI to designer</h3>
+  <ol>
+    <li>Site team raises RFI from mobile, attached to the affected element.</li>
+    <li>Project Lead reviews + routes to the right designer.</li>
+    <li>Designer answers in-thread (markdown supported).</li>
+    <li>If a drawing revision is needed, designer attaches the revised drawing as a Deliverable, links to RFI.</li>
+    <li>Project Lead marks RFI Closed.</li>
+  </ol>
+
+  <h3>NCR / non-conformance</h3>
+  <ol>
+    <li>QA raises NCR with linked element + photo + spec reference.</li>
+    <li>Auto-assigned to contractor responsible.</li>
+    <li>Contractor proposes corrective action in-thread.</li>
+    <li>QA approves the corrective action (or asks for alternative).</li>
+    <li>Contractor implements; marks Resolved.</li>
+    <li>QA re-inspects, marks Verified.</li>
+    <li>Project Lead closes NCR after Verified.</li>
+  </ol>
+
+  <h2>Common mistakes</h2>
+  <ul>
+    <li><strong>Generic titles.</strong> "Issue with HVAC" doesn't tell anyone what's wrong. Be specific.</li>
+    <li><strong>Floating issues</strong> (no linked element). Hard to triage and easy to forget. Always link.</li>
+    <li><strong>Assigning to "the team"</strong>. Assign to a person. Re-assign as ownership moves.</li>
+    <li><strong>Skipping the verify step.</strong> Resolved ≠ fixed. Make the raiser confirm.</li>
+    <li><strong>Closing without comments.</strong> Future-you will want to know why this was closed. Leave a note.</li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/guides/gps-site-map.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Using the GPS site map
+    </a>
+    <a href="/guides/photo-capture.html" class="next">
+      <span class="lbl">Next →</span>
+      Capturing site photos
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/revit-plugin-setup.html
+++ b/marketing-site/guides/revit-plugin-setup.html
@@ -1,0 +1,205 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Installing the Revit plugin — Planscape</title>
+<meta name="description" content="Download, install, and license-bind the Planscape Revit plugin. Works on Revit 2025 / 2026 / 2027.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/revit-plugin-setup.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Installing the Revit plugin</div>
+  <h1>Installing the Revit plugin</h1>
+  <div class="meta">📖 7-minute read · Beginner · Last updated 2026-05-23</div>
+
+  <p>The Planscape Revit plugin (STING Tools) gives your model authors 763+ commands for ISO 19650 tagging, drawing production, MEP engineering, healthcare validation, and one-click cloud sync. This guide walks through downloading, installing, and licence-binding the plugin on a single machine.</p>
+
+  <h2>System requirements</h2>
+  <table>
+    <thead><tr><th>Component</th><th>Requirement</th></tr></thead>
+    <tbody>
+      <tr><td>OS</td><td>Windows 10 (build 1909+) or Windows 11</td></tr>
+      <tr><td>Revit</td><td>2025, 2026, or 2027 — any flavour (Architecture / MEP / Structure)</td></tr>
+      <tr><td>.NET runtime</td><td>.NET 8 desktop runtime (auto-installed if missing)</td></tr>
+      <tr><td>RAM</td><td>8 GB minimum, 16 GB recommended for federations &gt; 1 GB</td></tr>
+      <tr><td>Disk</td><td>500 MB for the plugin + cache, plus your model footprint</td></tr>
+      <tr><td>Network</td><td>HTTPS outbound to <code>api.planscape.app</code> on port 443</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Step 1 — Download the plugin</h2>
+  <p>Sign in to the web app at <a href="https://planscape.app/">planscape.app</a>. From any project workspace, open <strong>Tools &rsaquo; Download Revit plugin</strong>.</p>
+  <p>You get a single ZIP file: <code>StingTools.zip</code> (around 45 MB). It contains:</p>
+  <ul>
+    <li><code>StingTools.addin</code> — the Revit manifest</li>
+    <li><code>StingTools.dll</code> — the compiled plugin</li>
+    <li><code>Newtonsoft.Json.dll</code>, <code>ClosedXML.dll</code>, <code>MiniWord.dll</code>, <code>Lucene.Net.dll</code> — supporting libraries</li>
+    <li><code>data/</code> — 72 runtime data files (parameter registry, drawing types, AEC filters, healthcare data, ISO symbols)</li>
+  </ul>
+
+  <h2>Step 2 — Install</h2>
+  <p>Two installation modes:</p>
+
+  <h3>Option A — Per-user (recommended)</h3>
+  <p>Only installs for your Windows account. No admin rights needed.</p>
+  <ol>
+    <li>Press <code>Win + R</code>, type <code>%APPDATA%\Autodesk\Revit\Addins\</code>, Enter.</li>
+    <li>You'll see folders for each Revit version (2025, 2026, 2027). Open the one you use.</li>
+    <li>If the folder doesn't exist, create it.</li>
+    <li>Unzip <code>StingTools.zip</code> and copy ALL contents into that folder.</li>
+  </ol>
+
+  <h3>Option B — All users on this machine</h3>
+  <p>Needs admin rights. Useful for shared workstations.</p>
+  <ol>
+    <li>Open <code>C:\ProgramData\Autodesk\Revit\Addins\</code></li>
+    <li>Same as above — unzip into the matching year folder.</li>
+  </ol>
+
+  <div class="callout warn">
+    <strong>Don't mix.</strong> If you install to both per-user and ProgramData folders, Revit loads the addin twice and the plugin will fail to start. Pick one.
+  </div>
+
+  <h2>Step 3 — Start Revit &amp; sign in</h2>
+  <p>Launch Revit. You'll see:</p>
+  <ul>
+    <li>A new <strong>STING Tools</strong> tab on the Revit ribbon (Select / Docs / Tags / Organise / Temp panels).</li>
+    <li>A new dockable panel on the right edge — the main UI, with 9 tabs.</li>
+  </ul>
+  <p>If you don't see them: <a href="#troubleshooting">see Troubleshooting</a> below.</p>
+
+  <p>In the dockable panel, click the <strong>Sign in</strong> button at the bottom-left. Use the same email + password as the web app. You'll be asked which firm to bind to (if you're a member of more than one), and which project to open.</p>
+
+  <div class="callout">
+    <strong>Offline sign-in.</strong> Once you've signed in once, the plugin caches a refresh token good for 30 days. You can launch Revit and use most commands offline; only cloud-sync commands require a live connection.
+  </div>
+
+  <h2>Step 4 — First-run setup</h2>
+  <p>The plugin asks you to confirm a handful of project-level settings on first run:</p>
+  <ol>
+    <li><strong>Load shared parameters?</strong> &nbsp;Yes — binds the 2,555 STING shared parameters into the project. Takes about 30 seconds.</li>
+    <li><strong>Apply ISO 19650 view templates?</strong> &nbsp;Yes if this is a new project; No if you've already set up templates.</li>
+    <li><strong>Run compliance scan?</strong> &nbsp;Yes — surfaces any orphaned elements, missing tags, or non-compliant naming up front.</li>
+  </ol>
+
+  <p>The status bar at the bottom of the panel shows your compliance % as a quick RAG indicator. New projects typically start around 20% and climb as you tag.</p>
+
+  <h2>Step 5 — Quick smoke test</h2>
+  <p>Confirm the plugin is working by running a read-only command:</p>
+  <ol>
+    <li>Open any Revit project (a sample if you don't have one handy).</li>
+    <li>In the STING dockable panel, go to the <strong>SELECT</strong> tab.</li>
+    <li>Click <strong>Lighting Fixtures</strong>.</li>
+    <li>You should see selection statistics: count of lighting fixtures in the active view.</li>
+  </ol>
+  <p>If that works, the plugin is installed correctly.</p>
+
+  <h2>Updating the plugin</h2>
+  <p>We ship updates monthly. The plugin checks for updates on Revit startup and shows a banner when one is available.</p>
+  <p>To update manually:</p>
+  <ol>
+    <li>Close Revit.</li>
+    <li>Download a fresh <code>StingTools.zip</code> from your project workspace.</li>
+    <li>Replace the contents of your addins folder (delete old DLLs first).</li>
+    <li>Re-launch Revit.</li>
+  </ol>
+  <p>Settings, sign-in tokens, and project caches are preserved across updates — they live in <code>%LOCALAPPDATA%\Planscape\</code>, separate from the addin folder.</p>
+
+  <h2 id="troubleshooting">Troubleshooting</h2>
+
+  <h3>I don't see the STING Tools tab on the ribbon</h3>
+  <ul>
+    <li>Check the addin folder — is <code>StingTools.addin</code> actually there? (Files starting with a dot are sometimes hidden.)</li>
+    <li>Open <code>StingTools.addin</code> in a text editor. The <code>&lt;Assembly&gt;</code> path should match where the DLL actually lives.</li>
+    <li>Check <code>%LOCALAPPDATA%\Planscape\StingTools.log</code> for startup errors.</li>
+  </ul>
+
+  <h3>Revit shows a security warning on startup</h3>
+  <p>Revit checks the digital signature of each addin. Our DLL is signed by Planscape Ltd — click "Always Load". If you see "Publisher: Unknown", you probably have a corrupted download — re-download from your project workspace.</p>
+
+  <h3>The dockable panel won't show</h3>
+  <p>Revit hides docked panels by default. Click <strong>View &rsaquo; User Interface &rsaquo; STING Tools Panel</strong> to show it, or use the ribbon "Toggle Panel" button.</p>
+
+  <h3>I get "Cannot connect to api.planscape.app"</h3>
+  <ul>
+    <li>Most likely cause: your network blocks outbound HTTPS on a corporate firewall. Ask IT to whitelist <code>api.planscape.app</code> on port 443.</li>
+    <li>The plugin works offline for most commands. Cloud-sync commands will queue until you're online.</li>
+  </ul>
+
+  <h3>The plugin is slow on a large model</h3>
+  <p>Some commands (BatchTag on a 30k-element model, full clash detection on a federation) are CPU-bound and will use all your cores. Close other heavy Revit operations while running them. If you regularly work with federations over 1 GB, 32 GB RAM and an NVMe SSD make a real difference.</p>
+
+  <h2>Uninstalling</h2>
+  <ol>
+    <li>Close Revit.</li>
+    <li>Delete the addin folder contents (your year folder under <code>%APPDATA%\Autodesk\Revit\Addins\</code>).</li>
+    <li>Optionally delete <code>%LOCALAPPDATA%\Planscape\</code> to remove cached tokens and settings.</li>
+  </ol>
+  <p>Your cloud data is untouched — you can sign in from another machine any time.</p>
+
+  <div class="next-prev">
+    <a href="/guides/getting-started.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Getting started
+    </a>
+    <a href="/guides/mobile-onboarding.html" class="next">
+      <span class="lbl">Next →</span>
+      Mobile app onboarding
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/revit-plugin-setup.html
+++ b/marketing-site/guides/revit-plugin-setup.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Download, install, and license-bind the Planscape Revit plugin. Works on Revit 2025 / 2026 / 2027.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/revit-plugin-setup.html">
+<link rel="canonical" href="https://planscape.co/guides/revit-plugin-setup.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -42,12 +42,12 @@
       <tr><td>.NET runtime</td><td>.NET 8 desktop runtime (auto-installed if missing)</td></tr>
       <tr><td>RAM</td><td>8 GB minimum, 16 GB recommended for federations &gt; 1 GB</td></tr>
       <tr><td>Disk</td><td>500 MB for the plugin + cache, plus your model footprint</td></tr>
-      <tr><td>Network</td><td>HTTPS outbound to <code>api.planscape.app</code> on port 443</td></tr>
+      <tr><td>Network</td><td>HTTPS outbound to <code>api.planscape.co</code> on port 443</td></tr>
     </tbody>
   </table>
 
   <h2>Step 1 — Download the plugin</h2>
-  <p>Sign in to the web app at <a href="https://planscape.app/">planscape.app</a>. From any project workspace, open <strong>Tools &rsaquo; Download Revit plugin</strong>.</p>
+  <p>Sign in to the web app at <a href="https://planscape.co/">planscape.co</a>. From any project workspace, open <strong>Tools &rsaquo; Download Revit plugin</strong>.</p>
   <p>You get a single ZIP file: <code>StingTools.zip</code> (around 45 MB). It contains:</p>
   <ul>
     <li><code>StingTools.addin</code> — the Revit manifest</li>
@@ -139,9 +139,9 @@
   <h3>The dockable panel won't show</h3>
   <p>Revit hides docked panels by default. Click <strong>View &rsaquo; User Interface &rsaquo; STING Tools Panel</strong> to show it, or use the ribbon "Toggle Panel" button.</p>
 
-  <h3>I get "Cannot connect to api.planscape.app"</h3>
+  <h3>I get "Cannot connect to api.planscape.co"</h3>
   <ul>
-    <li>Most likely cause: your network blocks outbound HTTPS on a corporate firewall. Ask IT to whitelist <code>api.planscape.app</code> on port 443.</li>
+    <li>Most likely cause: your network blocks outbound HTTPS on a corporate firewall. Ask IT to whitelist <code>api.planscape.co</code> on port 443.</li>
     <li>The plugin works offline for most commands. Cloud-sync commands will queue until you're online.</li>
   </ul>
 
@@ -174,7 +174,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -187,7 +187,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/guides/self-hosting.html
+++ b/marketing-site/guides/self-hosting.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Run Planscape on your own infrastructure. Docker Compose, hardware requirements, SSL, backup, monitoring, upgrades.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/guides/self-hosting.html">
+<link rel="canonical" href="https://planscape.co/guides/self-hosting.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -62,7 +62,7 @@
   </ul>
 
   <h2>Step 1 — Get the Compose bundle</h2>
-  <p>Email <a href="mailto:onboarding@planscape.app">onboarding@planscape.app</a> with your Enterprise account ID. You'll get a private link to <code>planscape-selfhost-v&lt;version&gt;.tar.gz</code> with:</p>
+  <p>Email <a href="mailto:onboarding@planscape.co">onboarding@planscape.co</a> with your Enterprise account ID. You'll get a private link to <code>planscape-selfhost-v&lt;version&gt;.tar.gz</code> with:</p>
   <ul>
     <li><code>docker-compose.yml</code></li>
     <li><code>.env.example</code></li>
@@ -225,7 +225,7 @@ curl https://planscape.yourfirm.co.ug/health</code></pre>
 
   <h2>Getting help</h2>
   <p>Enterprise support hours: 24×5 (Mon–Fri) with 1-hour response SLA. Out of hours: best-effort via WhatsApp.</p>
-  <p>Channel: <a href="mailto:enterprise@planscape.app">enterprise@planscape.app</a> + a dedicated Slack Connect channel set up at onboarding.</p>
+  <p>Channel: <a href="mailto:enterprise@planscape.co">enterprise@planscape.co</a> + a dedicated Slack Connect channel set up at onboarding.</p>
 
   <div class="next-prev">
     <a href="/guides/audit-logs.html" class="prev">
@@ -241,7 +241,7 @@ curl https://planscape.yourfirm.co.ug/health</code></pre>
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/guides/self-hosting.html
+++ b/marketing-site/guides/self-hosting.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Self-hosting Planscape — Planscape</title>
+<meta name="description" content="Run Planscape on your own infrastructure. Docker Compose, hardware requirements, SSL, backup, monitoring, upgrades.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/guides/self-hosting.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Self-hosting Planscape</div>
+  <h1>Self-hosting Planscape</h1>
+  <div class="meta">📖 18-minute read · Advanced · Last updated 2026-05-23</div>
+
+  <p>Self-hosting Planscape gives you data residency in your country, integration with your existing identity provider, and full control over backups and disaster recovery. It's included in the Enterprise plan and ships as a Docker Compose configuration. This guide walks you through deploying, hardening, and maintaining a self-hosted instance.</p>
+
+  <div class="callout warn">
+    <strong>Self-hosting is for IT teams.</strong> If your firm doesn't have someone comfortable with Linux, Docker, PostgreSQL, and HTTPS certificates, the cloud-hosted plan is the right choice. We don't provide remote-hands setup as part of self-hosting; the Enterprise plan includes consulting hours but you supply the infrastructure access.
+  </div>
+
+  <h2>Hardware requirements</h2>
+  <table>
+    <thead><tr><th>Profile</th><th>Users</th><th>vCPU</th><th>RAM</th><th>Storage</th></tr></thead>
+    <tbody>
+      <tr><td>Small (single firm)</td><td>≤25</td><td>4</td><td>8 GB</td><td>200 GB SSD</td></tr>
+      <tr><td>Medium (multi-firm)</td><td>≤100</td><td>8</td><td>16 GB</td><td>500 GB NVMe</td></tr>
+      <tr><td>Large</td><td>≤500</td><td>16</td><td>32 GB</td><td>2 TB NVMe + 4 TB cold</td></tr>
+      <tr><td>Enterprise</td><td>≥500</td><td>HA cluster</td><td>—</td><td>Discuss with us</td></tr>
+    </tbody>
+  </table>
+  <p>OS: Ubuntu Server 22.04 LTS or 24.04 LTS. Other Linuxes work but we test against Ubuntu.</p>
+
+  <h2>The component stack</h2>
+  <p>Self-hosted Planscape runs the same code as our cloud. The Compose stack contains:</p>
+  <ul>
+    <li><strong>API</strong> — ASP.NET Core 8 (Planscape.API)</li>
+    <li><strong>Hangfire</strong> — background worker (Planscape.Worker)</li>
+    <li><strong>SignalR</strong> — real-time hubs (within API)</li>
+    <li><strong>PostgreSQL 16</strong> — primary database</li>
+    <li><strong>Redis 7</strong> — cache + SignalR backplane</li>
+    <li><strong>MinIO</strong> — S3-compatible object store for photos / model files / documents</li>
+    <li><strong>Caddy</strong> — reverse proxy + automatic HTTPS via Let's Encrypt</li>
+  </ul>
+
+  <h2>Step 1 — Get the Compose bundle</h2>
+  <p>Email <a href="mailto:onboarding@planscape.app">onboarding@planscape.app</a> with your Enterprise account ID. You'll get a private link to <code>planscape-selfhost-v&lt;version&gt;.tar.gz</code> with:</p>
+  <ul>
+    <li><code>docker-compose.yml</code></li>
+    <li><code>.env.example</code></li>
+    <li><code>caddy/Caddyfile</code></li>
+    <li><code>scripts/backup.sh</code>, <code>scripts/restore.sh</code></li>
+    <li><code>README.md</code></li>
+  </ul>
+
+  <h2>Step 2 — Prepare your host</h2>
+  <pre><code># Install Docker + Compose
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Verify
+docker --version
+docker compose version</code></pre>
+
+  <p>Open ports:</p>
+  <ul>
+    <li><strong>80 + 443</strong> — Caddy (HTTP redirect + HTTPS)</li>
+    <li><strong>22</strong> — SSH (your existing access)</li>
+  </ul>
+  <p>Block everything else at the firewall. The internal services (Postgres, Redis, MinIO) bind to the Docker network only.</p>
+
+  <h2>Step 3 — Configure environment</h2>
+  <p>Copy <code>.env.example</code> to <code>.env</code> and fill in:</p>
+  <pre><code># Required
+DOMAIN=planscape.yourfirm.co.ug
+ADMIN_EMAIL=admin@yourfirm.co.ug
+POSTGRES_PASSWORD=&lt;long-random&gt;
+REDIS_PASSWORD=&lt;long-random&gt;
+MINIO_ROOT_PASSWORD=&lt;long-random&gt;
+JWT_SECRET=&lt;64-char-random&gt;
+LICENSE_KEY=&lt;from-onboarding-email&gt;
+
+# Optional
+SMTP_HOST=smtp.brevo.com
+SMTP_PORT=587
+SMTP_USER=...
+SMTP_PASS=...
+SMTP_FROM=planscape@yourfirm.co.ug
+
+# Mobile push (optional — leave blank to disable)
+EXPO_ACCESS_TOKEN=
+
+# Backup target (recommended)
+S3_BACKUP_ENDPOINT=https://...
+S3_BACKUP_BUCKET=planscape-backups
+S3_BACKUP_KEY=...
+S3_BACKUP_SECRET=...</code></pre>
+
+  <div class="callout warn">
+    <strong>Generate random secrets properly.</strong> Use <code>openssl rand -base64 48</code> for each. Don't reuse the example values.
+  </div>
+
+  <h2>Step 4 — DNS</h2>
+  <p>Point your chosen domain at the host's public IP:</p>
+  <pre><code>A   planscape.yourfirm.co.ug   → 1.2.3.4</code></pre>
+  <p>Caddy fetches a Let's Encrypt certificate the first time it starts. The DNS A record must resolve before you start the stack or the cert acquisition will fail.</p>
+
+  <h2>Step 5 — Start the stack</h2>
+  <pre><code>docker compose up -d
+docker compose logs -f api  # watch startup</code></pre>
+
+  <p>First boot does these things in order:</p>
+  <ol>
+    <li>Postgres starts and initialises an empty database.</li>
+    <li>API runs <code>dotnet ef database update</code> applying all schema migrations.</li>
+    <li>API seeds the default tenant + an initial admin user.</li>
+    <li>MinIO buckets are created (<code>planscape-photos</code>, <code>planscape-models</code>, <code>planscape-docs</code>).</li>
+    <li>Hangfire schedules the recurring jobs (trial expiry, backups).</li>
+    <li>Caddy acquires HTTPS certificate.</li>
+  </ol>
+
+  <p>Open <code>https://planscape.yourfirm.co.ug</code> and log in with the admin credentials emailed to you when the bundle was generated. Change the password immediately.</p>
+
+  <h2>Step 6 — Configure backup</h2>
+  <p>The default <code>scripts/backup.sh</code> dumps Postgres, snapshots the MinIO buckets, and uploads both to your S3-compatible target.</p>
+  <p>Add a cron entry:</p>
+  <pre><code>0 2 * * * /opt/planscape/scripts/backup.sh &gt;&gt; /var/log/planscape-backup.log 2&gt;&amp;1</code></pre>
+
+  <p>For point-in-time recovery, enable WAL archiving on Postgres (see the bundle README). Without WAL, you can restore to last-night's backup only.</p>
+
+  <h2>Step 7 — Configure SSO (optional)</h2>
+  <p>Self-hosted Planscape supports SAML 2.0 + OIDC out of the box. From the admin dashboard: Settings → SSO. Walk-throughs:</p>
+  <ul>
+    <li><a href="/guides/sso-azure-ad.html">Azure AD / Entra ID</a></li>
+    <li><a href="/guides/sso-google-workspace.html">Google Workspace</a></li>
+    <li><a href="/guides/sso-okta.html">Okta</a></li>
+  </ul>
+
+  <h2>Day-to-day operations</h2>
+
+  <h3>Health check</h3>
+  <pre><code>curl https://planscape.yourfirm.co.ug/health
+# Expected: {"status":"healthy","version":"v2.1.4","db":"up","redis":"up","minio":"up"}</code></pre>
+
+  <h3>Logs</h3>
+  <pre><code>docker compose logs --tail=200 -f api
+docker compose logs --tail=200 -f worker</code></pre>
+  <p>Logs are structured JSON. Ship them to Loki / Elastic / Datadog with your log shipper of choice.</p>
+
+  <h3>Restart a service</h3>
+  <pre><code>docker compose restart api</code></pre>
+
+  <h3>Database access</h3>
+  <pre><code>docker compose exec db psql -U planscape -d planscape</code></pre>
+
+  <h2>Upgrading</h2>
+  <p>We release updates monthly. To upgrade:</p>
+  <pre><code># Backup first
+./scripts/backup.sh
+
+# Pull new images
+docker compose pull
+
+# Apply
+docker compose up -d
+
+# Verify migrations applied + health
+docker compose logs api | grep "Migrations applied"
+curl https://planscape.yourfirm.co.ug/health</code></pre>
+
+  <p>Major version upgrades (e.g. v2.x to v3.x) may require a migration script — we send release notes with each Enterprise newsletter.</p>
+
+  <h2>Monitoring</h2>
+  <p>The API exposes Prometheus metrics on <code>/metrics</code> (internal port 8080). Useful starting metrics:</p>
+  <ul>
+    <li><code>planscape_active_users</code> — concurrent users</li>
+    <li><code>planscape_db_connection_pool_utilization</code> — DB pool pressure</li>
+    <li><code>planscape_hangfire_pending_jobs</code> — background job queue depth</li>
+    <li><code>planscape_storage_bytes_used</code> — MinIO consumption</li>
+  </ul>
+  <p>Sample Grafana dashboard JSON is in the bundle (<code>monitoring/grafana-planscape.json</code>).</p>
+
+  <h2>Hardening checklist</h2>
+  <ul>
+    <li>Firewall closes everything except 80/443/22</li>
+    <li>SSH keys only (password auth disabled)</li>
+    <li>Postgres / Redis / MinIO never exposed to the public network</li>
+    <li>All <code>.env</code> secrets are unique random strings</li>
+    <li>Backups run nightly and are stored off-host</li>
+    <li>Caddy auto-renews certs every 60 days (default behaviour)</li>
+    <li>OS unattended-upgrades enabled for security patches</li>
+    <li>Database password rotation policy in place</li>
+    <li>Admin accounts require 2FA (enforced in Settings → Security)</li>
+  </ul>
+
+  <h2>Migrating from cloud to self-hosted</h2>
+  <p>If you've been on the cloud plan and want to bring data on-prem:</p>
+  <ol>
+    <li>Tell us 14 days in advance — we schedule an export window.</li>
+    <li>We generate an export bundle (Postgres dump + MinIO archive + audit log).</li>
+    <li>We ship the bundle to your team via encrypted transfer.</li>
+    <li>Stand up the self-host stack with an empty database.</li>
+    <li>Run <code>./scripts/restore.sh planscape-export.tar.gz</code>.</li>
+    <li>Verify; switch DNS for your users; we revoke the cloud instance after a 30-day quarantine.</li>
+  </ol>
+
+  <h2>Getting help</h2>
+  <p>Enterprise support hours: 24×5 (Mon–Fri) with 1-hour response SLA. Out of hours: best-effort via WhatsApp.</p>
+  <p>Channel: <a href="mailto:enterprise@planscape.app">enterprise@planscape.app</a> + a dedicated Slack Connect channel set up at onboarding.</p>
+
+  <div class="next-prev">
+    <a href="/guides/audit-logs.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Audit logs &amp; hash chain
+    </a>
+    <a href="/guides/" class="next">
+      <span class="lbl">Next →</span>
+      All guides
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -21,107 +21,66 @@
 <link rel="icon" type="image/png" href="/images/favicon-32.png" sizes="32x32">
 <link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
 <link rel="canonical" href="https://planscape.app/">
-<!-- Phase 169 — Mapbox GL JS for the Africa project location map.
-     Replace PLANSCAPE_MAPBOX_TOKEN inside the bottom <script> with a
-     real public token from mapbox.com (free tier — no credit card). -->
+<link rel="stylesheet" href="/assets/site.css">
 <link rel="preconnect" href="https://api.mapbox.com">
 <link rel="preconnect" href="https://client.crisp.chat">
 <link href='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css' rel='stylesheet' />
 <script src='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js'></script>
 <style>
-:root{--accent:#E8912D;--ink:#1c1f26;--muted:#6c7280;--bg:#fafbfc;--card:#fff;--line:#eceef3}
-*{box-sizing:border-box}
-body{margin:0;font:16px/1.55 -apple-system,system-ui,Segoe UI,Roboto,sans-serif;color:var(--ink);background:var(--bg)}
-nav{position:sticky;top:0;z-index:10;background:rgba(250,251,252,0.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line);padding:14px 24px;display:flex;align-items:center;justify-content:space-between}
-nav .brand{font-weight:700;font-size:18px}
-nav .brand .dot{color:var(--accent)}
-nav .links a{color:var(--ink);text-decoration:none;margin:0 14px;font-size:14px}
-nav .cta{background:var(--accent);color:#fff;padding:8px 14px;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px}
-.hero{padding:96px 24px 64px;text-align:center;max-width:920px;margin:0 auto}
-.hero h1{font-size:48px;line-height:1.1;margin:0 0 16px;letter-spacing:-0.02em}
-.hero .sub{color:var(--muted);font-size:18px;max-width:640px;margin:0 auto 32px}
-.hero .cta-row a{display:inline-block;padding:14px 22px;border-radius:10px;text-decoration:none;font-weight:600;margin:0 6px}
-.hero .cta-row a.primary{background:var(--accent);color:#fff}
-.hero .cta-row a.secondary{border:1px solid var(--ink);color:var(--ink)}
-.hero .price-strip{margin-top:32px;color:var(--muted);font-size:14px}
-.hero .price-strip strong{color:var(--ink);font-weight:600}
-section{max-width:1100px;margin:0 auto;padding:64px 24px}
-section h2{font-size:30px;margin:0 0 16px;letter-spacing:-0.01em}
-section .lead{color:var(--muted);max-width:640px;margin:0 0 36px}
-.grid-3{display:grid;gap:20px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
-.feat{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:24px}
-.feat .icon{font-size:32px;margin-bottom:10px}
-.feat h3{margin:0 0 6px;font-size:17px}
-.feat p{margin:0;color:var(--muted);font-size:14px}
-.compare{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:14px;overflow:hidden}
-.compare th,.compare td{padding:14px 18px;text-align:left;border-bottom:1px solid var(--line);font-size:14px}
-.compare thead{background:#f3f5f8}
-.compare th{font-weight:600}
-.compare td.us{color:var(--accent);font-weight:600}
-.testimonial{background:linear-gradient(135deg,rgba(232,145,45,0.08),rgba(232,145,45,0.02));border-radius:14px;padding:32px;margin:24px 0;font-size:16px}
-.testimonial .quote{font-style:italic;color:#34394a}
-.testimonial .who{margin-top:12px;color:var(--muted);font-size:13px}
-.cta-band{text-align:center;background:var(--ink);color:#fff;padding:64px 24px}
-.cta-band h2{margin:0 0 12px;color:#fff;font-size:30px}
-.cta-band p{color:#a8b1c0;margin:0 0 24px}
-.cta-band a{display:inline-block;padding:14px 22px;background:var(--accent);color:#fff;text-decoration:none;border-radius:10px;font-weight:600}
-footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;border-top:1px solid var(--line)}
-@media (max-width:640px){.hero h1{font-size:32px}.hero .sub{font-size:16px}}
+/* Page-specific styles for the landing page */
+.price-strip { margin-top:32px; color:var(--muted); font-size:14px; }
+.price-strip strong { color:var(--ink); font-weight:600; }
 
-/* Phase 169 — Africa section + Mapbox map */
-#africa{background:#FEFAF6}
-#africa .africa-grid{display:grid;gap:48px;grid-template-columns:1fr 1fr;align-items:center}
-@media (max-width:880px){#africa .africa-grid{grid-template-columns:1fr}}
-#africa .eyebrow{font-size:12px;text-transform:uppercase;letter-spacing:2px;color:var(--accent);font-weight:600;margin:0 0 8px}
-#africa h2{font-size:32px;line-height:1.15;margin:0 0 16px;color:var(--ink)}
-#africa p{color:var(--muted);font-size:16px;margin:0 0 12px;max-width:520px}
-#africa-map{width:100%;height:420px;border-radius:16px;overflow:hidden;border:1px solid rgba(232,145,45,0.3);box-shadow:0 20px 60px rgba(0,0,0,0.15)}
-.africa-stats{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
-.africa-stats .stat-chip{background:rgba(232,145,45,0.10);color:var(--accent);border-radius:999px;padding:4px 12px;font-size:13px;font-weight:600;display:inline-flex;align-items:center;gap:6px}
-.mapboxgl-popup-content{background:#1A1F5E !important;color:#fff !important;border-radius:12px !important;padding:16px !important;min-width:240px !important;border:1px solid rgba(255,255,255,0.1) !important;box-shadow:0 8px 32px rgba(0,0,0,0.4) !important}
-.mapboxgl-popup-tip{border-top-color:#1A1F5E !important;border-bottom-color:#1A1F5E !important}
-.mapboxgl-popup-close-button{color:rgba(255,255,255,0.6) !important;padding:4px 8px !important}
-.popup-card h4{margin:0 0 4px;font-size:15px;color:#fff;font-weight:700}
-.popup-card .loc{font-size:12px;color:rgba(255,255,255,0.65);margin-bottom:8px}
-.popup-card .row{display:flex;justify-content:space-between;font-size:12px;margin:4px 0;color:rgba(255,255,255,0.85)}
-.popup-card .row .ind-active{color:#FF6B35;font-weight:600}
-.popup-card .row .ind-completed{color:#22C55E;font-weight:600}
-.popup-card hr{border:0;border-top:1px solid rgba(255,255,255,0.12);margin:10px 0}
-.popup-card .demo-link{display:inline-block;color:#FF6B35;font-weight:600;font-size:13px;text-decoration:none}
-.popup-card .demo-link:hover{text-decoration:underline}
-.map-marker-mkt{position:relative;width:14px;height:14px;border-radius:50%;border:2px solid #fff;box-shadow:0 1px 4px rgba(0,0,0,0.4);cursor:pointer}
-.map-marker-mkt.active{background:#FF6B35}
-.map-marker-mkt.completed{background:#22C55E}
-.map-marker-mkt::after{content:"";position:absolute;inset:-2px;border-radius:50%;background:inherit;opacity:0.35;animation:mkt-pulse 2s ease-out infinite;z-index:-1}
-@keyframes mkt-pulse{0%{transform:scale(1);opacity:0.5}80%{transform:scale(2.6);opacity:0}100%{transform:scale(2.6);opacity:0}}
+.testimonial {
+  background:linear-gradient(135deg,rgba(232,145,45,0.08),rgba(232,145,45,0.02));
+  border-radius:14px; padding:32px; margin:24px 0; font-size:16px;
+}
+.testimonial .quote { font-style:italic; color:#34394a; }
+.testimonial .who { margin-top:12px; color:var(--muted); font-size:13px; }
+
+/* Africa section */
+#africa { background:#FEFAF6; }
+#africa .africa-grid { display:grid; gap:48px; grid-template-columns:1fr 1fr; align-items:center; }
+@media (max-width:880px){ #africa .africa-grid{ grid-template-columns:1fr; } }
+#africa .eyebrow { font-size:12px; text-transform:uppercase; letter-spacing:2px; color:var(--accent); font-weight:600; margin:0 0 8px; }
+#africa h2 { font-size:32px; line-height:1.15; margin:0 0 16px; color:var(--ink); }
+#africa p { color:var(--muted); font-size:16px; margin:0 0 12px; max-width:520px; }
+#africa-map { width:100%; height:420px; border-radius:16px; overflow:hidden; border:1px solid rgba(232,145,45,0.3); box-shadow:0 20px 60px rgba(0,0,0,0.15); }
+.africa-stats { display:flex; flex-wrap:wrap; gap:8px; margin-top:12px; }
+.africa-stats .stat-chip { background:rgba(232,145,45,0.10); color:var(--accent); border-radius:999px; padding:4px 12px; font-size:13px; font-weight:600; display:inline-flex; align-items:center; gap:6px; }
+.mapboxgl-popup-content { background:#1A1F5E !important; color:#fff !important; border-radius:12px !important; padding:16px !important; min-width:240px !important; border:1px solid rgba(255,255,255,0.1) !important; box-shadow:0 8px 32px rgba(0,0,0,0.4) !important; }
+.mapboxgl-popup-tip { border-top-color:#1A1F5E !important; border-bottom-color:#1A1F5E !important; }
+.mapboxgl-popup-close-button { color:rgba(255,255,255,0.6) !important; padding:4px 8px !important; }
+.popup-card h4 { margin:0 0 4px; font-size:15px; color:#fff; font-weight:700; }
+.popup-card .loc { font-size:12px; color:rgba(255,255,255,0.65); margin-bottom:8px; }
+.popup-card .row { display:flex; justify-content:space-between; font-size:12px; margin:4px 0; color:rgba(255,255,255,0.85); }
+.popup-card .row .ind-active { color:#FF6B35; font-weight:600; }
+.popup-card .row .ind-completed { color:#22C55E; font-weight:600; }
+.popup-card hr { border:0; border-top:1px solid rgba(255,255,255,0.12); margin:10px 0; }
+.popup-card .demo-link { display:inline-block; color:#FF6B35; font-weight:600; font-size:13px; text-decoration:none; }
+.popup-card .demo-link:hover { text-decoration:underline; }
+.map-marker-mkt { position:relative; width:14px; height:14px; border-radius:50%; border:2px solid #fff; box-shadow:0 1px 4px rgba(0,0,0,0.4); cursor:pointer; }
+.map-marker-mkt.active { background:#FF6B35; }
+.map-marker-mkt.completed { background:#22C55E; }
+.map-marker-mkt::after { content:""; position:absolute; inset:-2px; border-radius:50%; background:inherit; opacity:0.35; animation:mkt-pulse 2s ease-out infinite; z-index:-1; }
+@keyframes mkt-pulse { 0%{transform:scale(1);opacity:0.5} 80%{transform:scale(2.6);opacity:0} 100%{transform:scale(2.6);opacity:0} }
 
 /* How it works */
-.how-steps{display:grid;gap:0;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));position:relative}
-.how-step{text-align:center;padding:32px 24px}
-.how-step .num{width:52px;height:52px;border-radius:50%;background:var(--accent);color:#fff;font-size:20px;font-weight:700;display:flex;align-items:center;justify-content:center;margin:0 auto 16px}
-.how-step h3{margin:0 0 8px;font-size:17px}
-.how-step p{margin:0;color:var(--muted);font-size:14px}
-.how-connector{display:none}
-@media (min-width:641px){.how-connector{display:block;position:absolute;top:68px;left:calc(33.33% - 12px);width:calc(33.33% + 24px);height:2px;background:linear-gradient(90deg,var(--accent),rgba(232,145,45,0.3));pointer-events:none}}
+.how-steps { display:grid; gap:0; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); position:relative; }
+.how-step { text-align:center; padding:32px 24px; }
+.how-step .num { width:52px; height:52px; border-radius:50%; background:var(--accent); color:#fff; font-size:20px; font-weight:700; display:flex; align-items:center; justify-content:center; margin:0 auto 16px; }
+.how-step h3 { margin:0 0 8px; font-size:17px; }
+.how-step p { margin:0; color:var(--muted); font-size:14px; }
 
-/* Demo form */
-.demo-form{display:flex;gap:8px;flex-wrap:wrap;margin-top:24px;max-width:480px}
-.demo-form input[type=email]{flex:1;min-width:200px;padding:12px 14px;border:1px solid var(--line);border-radius:10px;font-size:15px;outline:none;background:var(--card);color:var(--ink)}
-.demo-form input[type=email]:focus{border-color:var(--accent)}
-.demo-form button{padding:12px 20px;background:var(--accent);color:#fff;border:none;border-radius:10px;font-weight:600;font-size:15px;cursor:pointer;white-space:nowrap}
-.demo-form button:hover{opacity:0.9}
-#demo-msg{margin-top:10px;font-size:13px;color:var(--muted)}
+/* Demo form (legacy compat) */
+.demo-form { display:flex; gap:8px; flex-wrap:wrap; margin-top:24px; max-width:480px; }
+.demo-form input[type=email] { flex:1; min-width:200px; padding:12px 14px; border:1px solid var(--line); border-radius:10px; font-size:15px; outline:none; background:var(--card); color:var(--ink); }
+.demo-form input[type=email]:focus { border-color:var(--accent); }
+.demo-form button { padding:12px 20px; background:var(--accent); color:#fff; border:none; border-radius:10px; font-weight:600; font-size:15px; cursor:pointer; white-space:nowrap; }
+.demo-form button:hover { opacity:0.9; }
+#demo-msg { margin-top:10px; font-size:13px; color:var(--muted); }
 
-/* FAQ */
-#faq{background:var(--bg)}
-.faq-list{max-width:720px;margin:0 auto}
-.faq-item{border-bottom:1px solid var(--line);padding:20px 0}
-.faq-item:last-child{border-bottom:none}
-.faq-q{font-weight:600;font-size:16px;cursor:pointer;display:flex;justify-content:space-between;align-items:center;gap:12px;list-style:none}
-.faq-q::after{content:"＋";color:var(--accent);font-size:20px;flex-shrink:0;transition:transform 0.2s}
-details[open] .faq-q::after{transform:rotate(45deg)}
-.faq-a{color:var(--muted);font-size:15px;padding:12px 0 4px;line-height:1.65}
-.faq-a a{color:var(--accent)}
+#faq { background:var(--bg); }
 </style>
 <script type="application/ld+json">
 {
@@ -154,13 +113,7 @@ details[open] .faq-q::after{transform:rotate(45deg)}
       "offers": {
         "@type": "Offer",
         "price": "15",
-        "priceCurrency": "USD",
-        "priceSpecification": {
-          "@type": "UnitPriceSpecification",
-          "price": "15",
-          "priceCurrency": "USD",
-          "unitText": "MONTH"
-        }
+        "priceCurrency": "USD"
       },
       "publisher": { "@id": "https://planscape.app/#org" }
     }
@@ -170,15 +123,16 @@ details[open] .faq-q::after{transform:rotate(45deg)}
 </head>
 <body>
 
-<nav>
-  <div class="brand">Plan<span class="dot">·</span>scape</div>
-  <div class="links">
-    <a href="#features">Features</a>
-    <a href="#how-it-works">How it works</a>
-    <a href="#compare">Compare</a>
-    <a href="/api/pricing/html">Pricing</a>
-    <a href="/docs/">Docs</a>
-    <a href="https://wa.me/256700000000?text=Hi%2C%20I%27d%20like%20to%20learn%20more%20about%20Planscape" class="links" target="_blank" rel="noopener" title="Chat on WhatsApp" style="color:var(--muted);font-size:18px;margin:0 8px;text-decoration:none">💬</a>
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
   </div>
   <a href="/signup" class="cta">Start free trial</a>
 </nav>
@@ -187,7 +141,7 @@ details[open] .faq-q::after{transform:rotate(45deg)}
   <h1>BIM coordination built for East African firms.</h1>
   <p class="sub">Revit plugin for authors, offline-first mobile for site coordinators, ISO 19650 templates pre-built. Invoiced in shillings, not dollars.</p>
   <div class="cta-row">
-    <a href="/signup" class="primary">Start 30-day trial</a>
+    <a href="/signup" class="primary">Start 30-day free trial</a>
     <a href="#demo" class="secondary">Watch 90-second demo</a>
   </div>
   <p style="margin:12px 0 0;font-size:13px;color:var(--muted)">No credit card required · Cancel any time</p>
@@ -200,19 +154,20 @@ details[open] .faq-q::after{transform:rotate(45deg)}
   <h2>Everything you need, nothing you don't</h2>
   <p class="lead">Built around the workflow ISO 19650 actually demands — and the connectivity East African sites actually have.</p>
   <div class="grid-3">
-    <div class="feat"><div class="icon">🧊</div><h3>Revit plugin included</h3><p>Tag, sync, publish models direct from Revit. No separate license, no extra seat cost.</p></div>
-    <div class="feat"><div class="icon">📱</div><h3>Offline-first mobile</h3><p>Coordinators work on site without signal. Photos, voice notes, pins queue and replay automatically.</p></div>
-    <div class="feat"><div class="icon">📋</div><h3>ISO 19650 templates</h3><p>Transmittals, RFIs, NCRs, BEPs, MIDPs — pre-built and ready to issue from day one.</p></div>
-    <div class="feat"><div class="icon">🌍</div><h3>Local invoicing</h3><p>UGX, KES, TZS, RWF, NGN, ZAR via Flutterwave. USD/EUR/GBP via Stripe. You pick.</p></div>
-    <div class="feat"><div class="icon">🔐</div><h3>Audit-grade trail</h3><p>Tamper-evident hash chain over every write. Court-admissible by construction.</p></div>
-    <div class="feat"><div class="icon">⚡</div><h3>Fast where it matters</h3><p>30k-element model save in &lt;1s. 200MB federation loads on a 3G phone.</p></div>
+    <div class="card"><div class="icon">🧊</div><h3>Revit plugin included</h3><p>Tag, sync, publish models direct from Revit. No separate license, no extra seat cost.</p></div>
+    <div class="card"><div class="icon">📱</div><h3>Offline-first mobile</h3><p>Coordinators work on site without signal. Photos, voice notes, pins queue and replay automatically.</p></div>
+    <div class="card"><div class="icon">📋</div><h3>ISO 19650 templates</h3><p>Transmittals, RFIs, NCRs, BEPs, MIDPs — pre-built and ready to issue from day one.</p></div>
+    <div class="card"><div class="icon">🌍</div><h3>Local invoicing</h3><p>UGX, KES, TZS, RWF, NGN, ZAR via Flutterwave. USD/EUR/GBP via Stripe. You pick.</p></div>
+    <div class="card"><div class="icon">🔐</div><h3>Audit-grade trail</h3><p>Tamper-evident hash chain over every write. Court-admissible by construction.</p></div>
+    <div class="card"><div class="icon">⚡</div><h3>Fast where it matters</h3><p>30k-element model save in &lt;1s. 200MB federation loads on a 3G phone.</p></div>
   </div>
+  <p style="text-align:center;margin-top:32px"><a href="/features.html" style="font-weight:600">See the full feature list →</a></p>
 </section>
 
 <section id="how-it-works">
   <h2>From model to site in three steps</h2>
   <p class="lead">Planscape fits the workflow your team already uses — it doesn't replace it.</p>
-  <div class="how-steps" style="position:relative">
+  <div class="how-steps">
     <div class="how-step">
       <div class="num">1</div>
       <h3>Author in Revit</h3>
@@ -234,7 +189,7 @@ details[open] .faq-q::after{transform:rotate(45deg)}
 <section id="compare">
   <h2>How we stack up</h2>
   <p class="lead">Flat per-firm pricing — add people without paying more per seat. We don't try to be the most feature-rich BIM platform on earth — we try to be the right one for a mid-size East African practice.</p>
-  <table class="compare">
+  <table class="tbl">
     <thead><tr><th>Tool</th><th>Pricing model</th><th>Offline mobile</th><th>Local invoicing</th></tr></thead>
     <tbody>
       <tr><td class="us">Planscape Large (20 users)</td><td class="us">$90/firm — $4.50/user</td><td class="us">Yes</td><td class="us">Yes (UGX/KES/TZS/…)</td></tr>
@@ -303,7 +258,7 @@ details[open] .faq-q::after{transform:rotate(45deg)}
     </details>
     <details class="faq-item">
       <summary class="faq-q">Can I migrate from Autodesk Construction Cloud?</summary>
-      <div class="faq-a">Yes. We provide a BCF 2.1 import for issues and a document importer for CDE-structured file sets. Your Revit models come across as-is — the Planscape plugin reads the same .rvt files. Book a migration call with our team and we'll scope the move for your project count and data volume.</div>
+      <div class="faq-a">Yes. We provide a BCF 2.1 import for issues and a document importer for CDE-structured file sets. Your Revit models come across as-is — the Planscape plugin reads the same .rvt files. <a href="/contact.html#demo">Book a migration call</a> and we'll scope the move for your project count and data volume.</div>
     </details>
     <details class="faq-item">
       <summary class="faq-q">Is the data stored in Africa?</summary>
@@ -315,7 +270,7 @@ details[open] .faq-q::after{transform:rotate(45deg)}
     </details>
     <details class="faq-item">
       <summary class="faq-q">Can we self-host Planscape on our own servers?</summary>
-      <div class="faq-a">Yes — the server stack (ASP.NET Core 8 + PostgreSQL + Redis + MinIO) ships as a Docker Compose configuration. Self-host is included in the Enterprise plan. See the <a href="/docs/ops/self-host">self-hosting guide</a> for requirements and a step-by-step deployment walkthrough.</div>
+      <div class="faq-a">Yes — the server stack (ASP.NET Core 8 + PostgreSQL + Redis + MinIO) ships as a Docker Compose configuration. Self-host is included in the Enterprise plan. See the <a href="/guides/self-hosting.html">self-hosting guide</a> for requirements and a step-by-step deployment walkthrough.</div>
     </details>
   </div>
 </section>
@@ -326,18 +281,41 @@ details[open] .faq-q::after{transform:rotate(45deg)}
   <a href="/signup">Start now</a>
 </div>
 
-<footer>
-  © 2026 Planscape Ltd · Kampala, Uganda · <a href="mailto:hello@planscape.app">hello@planscape.app</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms. Revit plugin, offline-first mobile, local currency invoicing.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">
+    © 2026 Planscape Ltd · Kampala, Uganda · All rights reserved
+  </div>
 </footer>
 
-<!--
-  S4.6 — Crisp chat widget on the marketing site only. Mobile + web
-  app embed a smaller mailto-based help button (see
-  Planscape/src/components/HelpButton.tsx) to keep the bundle small.
-  Replace CRISP_WEBSITE_ID at deploy time with the real id; absent
-  the id the widget silently no-ops, which is what we want during
-  pre-launch.
--->
 <script>
 function handleDemoForm(e) {
   e.preventDefault();
@@ -367,12 +345,6 @@ function handleDemoForm(e) {
 }
 </script>
 
-<!--
-  Phase 169 — Africa project location map. Hardcoded demo pins; no API
-  call. Replace PLANSCAPE_MAPBOX_TOKEN below with a real public Mapbox
-  token (free account, no credit card). Without a real token the script
-  silently no-ops and the section still renders the headline + chips.
--->
 <script type="text/javascript">
 (function(){
   var MAPBOX_TOKEN = "PLANSCAPE_MAPBOX_TOKEN";
@@ -397,7 +369,6 @@ function handleDemoForm(e) {
     interactive: true,
     attributionControl: false,
   });
-  // Don't hijack page scroll; user must click in to enable zoom.
   map.scrollZoom.disable();
   map.on("click", function(){ map.scrollZoom.enable(); });
 
@@ -426,11 +397,10 @@ function handleDemoForm(e) {
         '<div class="row"><span>Status</span><span class="' + indClass + '">' + dot + ' ' + esc(p.status) + '</span></div>' +
         '<div class="row"><span>Compliance</span><span>' + p.compliance + '%</span></div>' +
         '<hr>' +
-        '<a href="#pricing" class="demo-link">Request a Demo →</a>' +
+        '<a href="/contact.html#demo" class="demo-link">Request a Demo →</a>' +
       '</div>';
 
-    var popup = new mapboxgl.Popup({ offset: 18, closeButton: true })
-      .setHTML(html);
+    var popup = new mapboxgl.Popup({ offset: 18, closeButton: true }).setHTML(html);
 
     new mapboxgl.Marker({ element: el })
       .setLngLat([p.lng, p.lat])

--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -8,19 +8,19 @@
 <meta property="og:title" content="Planscape — BIM coordination for East African firms">
 <meta property="og:description" content="Revit plugin from $15/firm/month. Add cloud sync + mobile from $35/firm/month. ISO 19650 templates pre-built. Invoiced in your local currency.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://planscape.app/">
-<meta property="og:image" content="https://planscape.app/images/og-card.png">
+<meta property="og:url" content="https://planscape.co/">
+<meta property="og:image" content="https://planscape.co/images/og-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Planscape — BIM coordination for East African firms">
 <meta name="twitter:description" content="Revit plugin from $15/mo · cloud platform from $35/mo · ISO 19650 templates · invoiced in UGX/KES/TZS.">
-<meta name="twitter:image" content="https://planscape.app/images/og-card.png">
+<meta name="twitter:image" content="https://planscape.co/images/og-card.png">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
 <link rel="icon" type="image/png" href="/images/favicon-32.png" sizes="32x32">
 <link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
-<link rel="canonical" href="https://planscape.app/">
+<link rel="canonical" href="https://planscape.co/">
 <link rel="stylesheet" href="/assets/site.css">
 <link rel="preconnect" href="https://api.mapbox.com">
 <link rel="preconnect" href="https://client.crisp.chat">
@@ -88,13 +88,13 @@
   "@graph": [
     {
       "@type": "Organization",
-      "@id": "https://planscape.app/#org",
+      "@id": "https://planscape.co/#org",
       "name": "Planscape Ltd",
-      "url": "https://planscape.app",
-      "logo": "https://planscape.app/images/og-card.png",
+      "url": "https://planscape.co",
+      "logo": "https://planscape.co/images/og-card.png",
       "contactPoint": {
         "@type": "ContactPoint",
-        "email": "hello@planscape.app",
+        "email": "hello@planscape.co",
         "contactType": "customer support"
       },
       "address": {
@@ -105,7 +105,7 @@
     },
     {
       "@type": "SoftwareApplication",
-      "@id": "https://planscape.app/#app",
+      "@id": "https://planscape.co/#app",
       "name": "Planscape",
       "applicationCategory": "BusinessApplication",
       "operatingSystem": "Windows, iOS, Android",
@@ -115,7 +115,7 @@
         "price": "15",
         "priceCurrency": "USD"
       },
-      "publisher": { "@id": "https://planscape.app/#org" }
+      "publisher": { "@id": "https://planscape.co/#org" }
     }
   ]
 }
@@ -288,7 +288,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms. Revit plugin, offline-first mobile, local currency invoicing.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -301,7 +301,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">
@@ -326,7 +326,7 @@ function handleDemoForm(e) {
   var btn   = form.querySelector('button');
   btn.disabled = true;
   btn.textContent = 'Sending…';
-  fetch('https://api.planscape.app/marketing/demo-request', {
+  fetch('https://api.planscape.co/marketing/demo-request', {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
     body: JSON.stringify({ email: email, source: 'marketing-site' })
@@ -341,7 +341,7 @@ function handleDemoForm(e) {
     btn.disabled = false;
     btn.textContent = 'Send me the demo';
     msg.style.color = '#dc2626';
-    msg.textContent = 'Something went wrong. Email us at hello@planscape.app instead.';
+    msg.textContent = 'Something went wrong. Email us at hello@planscape.co instead.';
   });
 }
 </script>

--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -131,6 +131,7 @@
     <a href="/pricing.html">Pricing</a>
     <a href="/guides/">Guides</a>
     <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/">Blog</a>
     <a href="/about.html">About</a>
     <a href="/contact.html">Contact</a>
   </div>

--- a/marketing-site/pricing.html
+++ b/marketing-site/pricing.html
@@ -34,6 +34,7 @@
     <a href="/pricing.html" style="color:var(--accent)">Pricing</a>
     <a href="/guides/">Guides</a>
     <a href="/tutorials/">Tutorials</a>
+    <a href="/blog/">Blog</a>
     <a href="/about.html">About</a>
     <a href="/contact.html">Contact</a>
   </div>

--- a/marketing-site/pricing.html
+++ b/marketing-site/pricing.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Pricing — Planscape</title>
+<meta name="description" content="Flat per-firm pricing. Free 30-day trial. Starter $35/mo, Standard $65/mo, Large $90/mo, Enterprise custom. Invoiced in your local currency.">
+<meta property="og:title" content="Pricing — Planscape">
+<meta property="og:description" content="Flat per-firm pricing — add users without paying per seat. From $35/mo. Local currency invoicing for East &amp; West Africa.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://planscape.app/pricing.html">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/pricing.html">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.toggle-row { display:flex; justify-content:center; gap:8px; margin:24px 0 8px; flex-wrap:wrap; }
+.toggle-row button {
+  background:var(--card); border:1px solid var(--line);
+  padding:8px 16px; border-radius:999px; cursor:pointer;
+  font-size:13px; font-weight:600; color:var(--muted);
+}
+.toggle-row button.active { background:var(--ink); color:#fff; border-color:var(--ink); }
+.save-badge { color:var(--good); font-size:13px; font-weight:600; }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html" style="color:var(--accent)">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<header class="page-header">
+  <h1>Simple, predictable pricing</h1>
+  <p>One flat price per firm — not per seat. Invite the whole team. Pay in your local currency.</p>
+</header>
+
+<section style="padding-top:0">
+  <div class="toggle-row">
+    <button class="active" onclick="setBilling('month')" id="btn-month">Monthly</button>
+    <button onclick="setBilling('year')" id="btn-year">Annual <span class="save-badge">Save 20%</span></button>
+  </div>
+  <p class="text-center muted" style="font-size:13px;margin-bottom:0">All plans include the Revit plugin · 30-day free trial · no credit card required</p>
+
+  <div class="pricing-grid">
+    <div class="tier">
+      <h3>Plugin Only</h3>
+      <p class="desc">Just the Revit plugin. No cloud sync, no mobile app.</p>
+      <div class="price">$<span data-m="15" data-y="12">15</span><span class="per">/firm/mo</span></div>
+      <ul>
+        <li>Revit 2025 / 2026 / 2027 plugin</li>
+        <li>763+ commands</li>
+        <li>ISO 19650 auto-tagging</li>
+        <li>Drawing template manager</li>
+        <li>Healthcare + MEP packs</li>
+        <li class="x">No cloud CDE</li>
+        <li class="x">No mobile app</li>
+        <li class="x">Email support only</li>
+      </ul>
+      <a href="/signup?plan=plugin" class="cta">Start trial</a>
+    </div>
+
+    <div class="tier">
+      <h3>Starter</h3>
+      <p class="desc">Plugin + cloud CDE + mobile. For solo practices and small teams.</p>
+      <div class="price">$<span data-m="35" data-y="28">35</span><span class="per">/firm/mo</span></div>
+      <ul>
+        <li>Everything in Plugin Only</li>
+        <li>Up to 5 users</li>
+        <li>3 active projects</li>
+        <li>Cloud CDE (10 GB storage)</li>
+        <li>Offline-first mobile app</li>
+        <li>GPS site map</li>
+        <li>Photo capture + voice notes</li>
+        <li>Email + WhatsApp support</li>
+      </ul>
+      <a href="/signup?plan=starter" class="cta">Start trial</a>
+    </div>
+
+    <div class="tier highlight">
+      <h3>Standard</h3>
+      <p class="desc">For mid-size practices delivering on multiple projects in parallel.</p>
+      <div class="price">$<span data-m="65" data-y="52">65</span><span class="per">/firm/mo</span></div>
+      <ul>
+        <li>Everything in Starter</li>
+        <li>Up to 10 users</li>
+        <li>10 active projects</li>
+        <li>50 GB storage</li>
+        <li>ACC + SharePoint sync</li>
+        <li>BCF round-trip</li>
+        <li>Excel bidirectional sync</li>
+        <li>Priority support (4h response)</li>
+      </ul>
+      <a href="/signup?plan=standard" class="cta">Start trial</a>
+    </div>
+
+    <div class="tier">
+      <h3>Large</h3>
+      <p class="desc">For practices with 15+ coordinators and an active portfolio.</p>
+      <div class="price">$<span data-m="90" data-y="72">90</span><span class="per">/firm/mo</span></div>
+      <ul>
+        <li>Everything in Standard</li>
+        <li>Up to 20 users</li>
+        <li>Unlimited projects</li>
+        <li>200 GB storage</li>
+        <li>4D / 5D scheduling</li>
+        <li>Embodied carbon tracking</li>
+        <li>Clash detection</li>
+        <li>SSO + 2FA</li>
+      </ul>
+      <a href="/signup?plan=large" class="cta">Start trial</a>
+    </div>
+  </div>
+
+  <div class="pricing-grid" style="grid-template-columns:1fr;margin-top:24px">
+    <div class="tier">
+      <h3>Enterprise</h3>
+      <p class="desc">For large practices, contractors, and public-sector clients with custom needs.</p>
+      <div class="price">Custom<span class="per"> &nbsp;contact us</span></div>
+      <div class="grid-3" style="margin-top:16px">
+        <ul style="border:0;padding:0;margin:0">
+          <li>Everything in Large</li>
+          <li>Unlimited users</li>
+          <li>Unlimited storage</li>
+        </ul>
+        <ul style="border:0;padding:0;margin:0">
+          <li>Self-host option (Docker Compose)</li>
+          <li>Dedicated EU or Africa region</li>
+          <li>Single-tenant database</li>
+        </ul>
+        <ul style="border:0;padding:0;margin:0">
+          <li>Custom integrations</li>
+          <li>1-hour SLA · phone support</li>
+          <li>Onboarding + training included</li>
+        </ul>
+      </div>
+      <a href="/contact.html#enterprise" class="cta" style="background:var(--ink);margin-top:24px;max-width:240px">Talk to us</a>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2 class="text-center">Compare plans</h2>
+  <p class="lead text-center" style="margin:0 auto 24px">Every limit explained side-by-side.</p>
+  <div style="overflow-x:auto">
+  <table class="tbl">
+    <thead>
+      <tr><th>Feature</th><th>Plugin</th><th>Starter</th><th>Standard</th><th>Large</th><th>Enterprise</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Revit plugin (2025/26/27)</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+      <tr><td>Cloud CDE</td><td>—</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+      <tr><td>Mobile app (iOS + Android)</td><td>—</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+      <tr><td>Users</td><td>1</td><td>5</td><td>10</td><td>20</td><td>Unlimited</td></tr>
+      <tr><td>Active projects</td><td>—</td><td>3</td><td>10</td><td>Unlimited</td><td>Unlimited</td></tr>
+      <tr><td>Storage</td><td>—</td><td>10 GB</td><td>50 GB</td><td>200 GB</td><td>Unlimited</td></tr>
+      <tr><td>GPS site map</td><td>—</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+      <tr><td>Photo capture + voice notes</td><td>—</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+      <tr><td>ACC + SharePoint sync</td><td>—</td><td>—</td><td>✓</td><td>✓</td><td>✓</td></tr>
+      <tr><td>BCF 2.1 round-trip</td><td>—</td><td>—</td><td>✓</td><td>✓</td><td>✓</td></tr>
+      <tr><td>4D / 5D scheduling</td><td>—</td><td>—</td><td>—</td><td>✓</td><td>✓</td></tr>
+      <tr><td>Clash detection</td><td>—</td><td>—</td><td>—</td><td>✓</td><td>✓</td></tr>
+      <tr><td>Embodied carbon tracking</td><td>—</td><td>—</td><td>—</td><td>✓</td><td>✓</td></tr>
+      <tr><td>SSO + 2FA</td><td>—</td><td>—</td><td>—</td><td>✓</td><td>✓</td></tr>
+      <tr><td>Self-host option</td><td>—</td><td>—</td><td>—</td><td>—</td><td>✓</td></tr>
+      <tr><td>Support SLA</td><td>Email · 48h</td><td>Email · 24h</td><td>Email · 4h</td><td>Email · 4h</td><td>Phone · 1h</td></tr>
+    </tbody>
+  </table>
+  </div>
+</section>
+
+<section style="background:var(--card)">
+  <h2 class="text-center">Pay in your local currency</h2>
+  <p class="lead text-center" style="margin:0 auto 24px">9 currencies supported. Choose at signup; change in your billing settings.</p>
+  <div class="grid-4">
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇺🇬 UGX</div><p>Ugandan Shilling · MTN Mobile Money · Airtel Money</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇰🇪 KES</div><p>Kenyan Shilling · M-Pesa · Airtel Money</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇹🇿 TZS</div><p>Tanzanian Shilling · M-Pesa · Tigo Pesa · Airtel Money</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇷🇼 RWF</div><p>Rwandan Franc · MTN MoMo</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇳🇬 NGN</div><p>Nigerian Naira · Bank transfer · Card</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇿🇦 ZAR</div><p>South African Rand · EFT · Card</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇺🇸 USD</div><p>US Dollar · Stripe card</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇪🇺 EUR</div><p>Euro · Stripe SEPA + card</p></div>
+  </div>
+  <p class="text-center muted" style="font-size:13px;margin-top:16px">GBP also supported via Stripe. Bitcoin / USDC on request for international donor-funded work.</p>
+</section>
+
+<section>
+  <h2 class="text-center">Frequently asked questions</h2>
+  <div class="faq-list">
+    <details class="faq-item">
+      <summary class="faq-q">What does "per firm" actually mean?</summary>
+      <div class="faq-a">One price covers your whole firm regardless of how many users you have, up to the plan's user cap. So Standard at $65/mo covers up to 10 users in your firm — invite the whole team without worrying about per-seat math. When you hit the cap, upgrade or remove inactive users.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Can my clients access projects?</summary>
+      <div class="faq-a">Yes — clients and contractors join as external project members without buying a separate license. They get role-restricted access to the project you've invited them to (typically Viewer or Client role). They don't count against your user cap as long as their firm doesn't also need to author models.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">What happens at the end of the 30-day trial?</summary>
+      <div class="faq-a">If you've added a payment method, your subscription starts on day 31 at the plan you chose at signup. If you haven't, your account moves to read-only mode — you keep access to all your data but can't create new projects, raise new issues, or sync the Revit plugin. We give you 60 days to either upgrade or export your data before it's archived.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Can I switch plans mid-cycle?</summary>
+      <div class="faq-a">Yes — upgrades take effect immediately and we pro-rate the new plan from the upgrade date. Downgrades take effect at the next billing cycle so you don't lose access mid-month.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Is there an annual discount?</summary>
+      <div class="faq-a">Yes — pay annually and save 20% on any plan. Toggle the annual / monthly switch at the top of this page to see the discounted rate.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Do you offer educational or non-profit pricing?</summary>
+      <div class="faq-a">Yes. Accredited universities, vocational training institutes, and registered non-profits get 50% off the Standard tier. <a href="/contact.html">Contact us</a> with your accreditation details.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Can I self-host instead of using your cloud?</summary>
+      <div class="faq-a">Yes — self-host ships with the Enterprise plan. The server stack (ASP.NET Core 8 + PostgreSQL + Redis + MinIO) deploys via Docker Compose. We provide the configuration, you provide the hardware. See the <a href="/guides/self-hosting.html">self-hosting guide</a> for the deployment walkthrough and hardware requirements.</div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">What's your refund policy?</summary>
+      <div class="faq-a">If you cancel within 30 days of your first paid invoice, we refund 100% — no questions. After that we don't pro-rate refunds for the current billing cycle, but you can cancel at any time and you'll keep access until the end of the cycle you've paid for.</div>
+    </details>
+  </div>
+</section>
+
+<div class="cta-band">
+  <h2>Try it free for 30 days.</h2>
+  <p>Full Standard tier features. No credit card. Cancel any time.</p>
+  <a href="/signup">Start now</a>
+</div>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+<script>
+function setBilling(mode) {
+  var prices = document.querySelectorAll('.price span[data-m]');
+  prices.forEach(function(p){
+    p.textContent = mode === 'year' ? p.getAttribute('data-y') : p.getAttribute('data-m');
+  });
+  document.getElementById('btn-month').classList.toggle('active', mode==='month');
+  document.getElementById('btn-year').classList.toggle('active', mode==='year');
+}
+</script>
+
+</body>
+</html>

--- a/marketing-site/pricing.html
+++ b/marketing-site/pricing.html
@@ -8,10 +8,10 @@
 <meta property="og:title" content="Pricing — Planscape">
 <meta property="og:description" content="Flat per-firm pricing — add users without paying per seat. From $35/mo. Local currency invoicing for East &amp; West Africa.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://planscape.app/pricing.html">
+<meta property="og:url" content="https://planscape.co/pricing.html">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/pricing.html">
+<link rel="canonical" href="https://planscape.co/pricing.html">
 <link rel="stylesheet" href="/assets/site.css">
 <style>
 .toggle-row { display:flex; justify-content:center; gap:8px; margin:24px 0 8px; flex-wrap:wrap; }
@@ -246,7 +246,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -259,7 +259,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/privacy.html
+++ b/marketing-site/privacy.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy Policy — Planscape</title>
 <meta name="description" content="How Planscape collects, uses, and protects your personal and project data — written for Uganda's DPPA 2019 and GDPR.">
-<link rel="canonical" href="https://planscape.app/privacy">
+<link rel="canonical" href="https://planscape.co/privacy">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
 <link rel="icon" type="image/png" href="/images/favicon-32.png" sizes="32x32">
@@ -112,7 +112,7 @@ footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;bor
     <li><strong>Objection</strong> to processing based on legitimate interests; you can opt out of analytics anytime.</li>
     <li><strong>Withdrawal of consent</strong> for marketing emails.</li>
   </ul>
-  <p>To exercise any of these rights, email <a href="mailto:privacy@planscape.app">privacy@planscape.app</a>. We respond within 30 days. If you're not satisfied with our response you can complain to the Personal Data Protection Office of Uganda (PDPO) or, if you're an EU data subject, your local supervisory authority.</p>
+  <p>To exercise any of these rights, email <a href="mailto:privacy@planscape.co">privacy@planscape.co</a>. We respond within 30 days. If you're not satisfied with our response you can complain to the Personal Data Protection Office of Uganda (PDPO) or, if you're an EU data subject, your local supervisory authority.</p>
 
   <h2>8. Cookies</h2>
   <p>We use a small number of cookies:</p>
@@ -127,8 +127,8 @@ footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;bor
   <p>Our primary data region is EU (Frankfurt, Germany). When you sign up from Uganda or elsewhere outside the EU, your data is transferred to and stored in the EU. This transfer is covered by EU-standard contractual clauses (SCCs) between Planscape Ltd and our infrastructure providers, satisfying both DPPA 2019 §38 and GDPR Article 46. If you require in-country data residency, ask about our self-host option which lets you run Planscape on your own infrastructure.</p>
 
   <h2>10. Contact</h2>
-  <p>Privacy questions: <a href="mailto:privacy@planscape.app">privacy@planscape.app</a><br>
-  General questions: <a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+  <p>Privacy questions: <a href="mailto:privacy@planscape.co">privacy@planscape.co</a><br>
+  General questions: <a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
   <p>We commit to acknowledge any privacy enquiry within 5 working days and to provide a substantive response within 30 days.</p>
 
   <h2>11. Changes to this policy</h2>
@@ -136,7 +136,7 @@ footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;bor
 </div>
 
 <footer>
-  © 2026 Planscape Ltd · Kampala, Uganda · <a href="mailto:hello@planscape.app">hello@planscape.app</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>
+  © 2026 Planscape Ltd · Kampala, Uganda · <a href="mailto:hello@planscape.co">hello@planscape.co</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>
 </footer>
 
 </body>

--- a/marketing-site/robots.txt
+++ b/marketing-site/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /api/
+Disallow: /assets/template-*
+
 Sitemap: https://planscape.app/sitemap.xml

--- a/marketing-site/robots.txt
+++ b/marketing-site/robots.txt
@@ -3,4 +3,4 @@ Allow: /
 Disallow: /api/
 Disallow: /assets/template-*
 
-Sitemap: https://planscape.app/sitemap.xml
+Sitemap: https://planscape.co/sitemap.xml

--- a/marketing-site/sitemap.xml
+++ b/marketing-site/sitemap.xml
@@ -1,27 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://planscape.app/</loc>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://planscape.app/privacy</loc>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://planscape.app/terms</loc>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://docs.planscape.app/</loc>
-    <lastmod>2026-05-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
+  <!-- Top-level pages -->
+  <url><loc>https://planscape.app/</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://planscape.app/features.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://planscape.app/pricing.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://planscape.app/about.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://planscape.app/contact.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://planscape.app/privacy.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://planscape.app/terms.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
+
+  <!-- Guides hub -->
+  <url><loc>https://planscape.app/guides/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://planscape.app/guides/getting-started.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/revit-plugin-setup.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/mobile-onboarding.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+
+  <!-- Tutorials hub -->
+  <url><loc>https://planscape.app/tutorials/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://planscape.app/tutorials/raise-issue-from-mobile.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+
+  <!-- Developer docs -->
+  <url><loc>https://docs.planscape.app/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/marketing-site/sitemap.xml
+++ b/marketing-site/sitemap.xml
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <!-- Top-level pages -->
-  <url><loc>https://planscape.app/</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>1.0</priority></url>
-  <url><loc>https://planscape.app/features.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://planscape.app/pricing.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://planscape.app/about.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
-  <url><loc>https://planscape.app/contact.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
-  <url><loc>https://planscape.app/privacy.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
-  <url><loc>https://planscape.app/terms.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://planscape.co/</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://planscape.co/features.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://planscape.co/pricing.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://planscape.co/about.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://planscape.co/contact.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://planscape.co/privacy.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
+  <url><loc>https://planscape.co/terms.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
 
   <!-- Guides hub + articles -->
-  <url><loc>https://planscape.app/guides/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://planscape.app/guides/getting-started.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/revit-plugin-setup.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/mobile-onboarding.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/inviting-team.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/creating-first-project.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/iso-19650-workflow.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/billing-and-trials.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/self-hosting.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/raising-issues.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/guides/gps-site-map.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://planscape.co/guides/getting-started.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/revit-plugin-setup.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/mobile-onboarding.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/inviting-team.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/creating-first-project.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/iso-19650-workflow.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/billing-and-trials.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/self-hosting.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/raising-issues.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/guides/gps-site-map.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
 
   <!-- Tutorials hub + walkthroughs -->
-  <url><loc>https://planscape.app/tutorials/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://planscape.app/tutorials/create-first-project.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://planscape.app/tutorials/install-mobile-app.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://planscape.app/tutorials/install-revit-plugin.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://planscape.app/tutorials/raise-issue-from-mobile.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://planscape.app/tutorials/capture-site-photos.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/tutorials/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://planscape.co/tutorials/create-first-project.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/tutorials/install-mobile-app.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/tutorials/install-revit-plugin.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/tutorials/raise-issue-from-mobile.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/tutorials/capture-site-photos.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
 
   <!-- Blog -->
-  <url><loc>https://planscape.app/blog/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://planscape.app/blog/2026-05-23-why-we-built-planscape.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html</loc><lastmod>2026-05-20</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html</loc><lastmod>2026-05-15</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/blog/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.co/blog/2026-05-23-why-we-built-planscape.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/blog/2026-05-20-iso-19650-in-east-africa.html</loc><lastmod>2026-05-20</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.co/blog/2026-05-15-offline-first-mobile-bim.html</loc><lastmod>2026-05-15</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
 
   <!-- Developer docs -->
-  <url><loc>https://docs.planscape.app/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.planscape.co/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/marketing-site/sitemap.xml
+++ b/marketing-site/sitemap.xml
@@ -9,15 +9,32 @@
   <url><loc>https://planscape.app/privacy.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
   <url><loc>https://planscape.app/terms.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.3</priority></url>
 
-  <!-- Guides hub -->
+  <!-- Guides hub + articles -->
   <url><loc>https://planscape.app/guides/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://planscape.app/guides/getting-started.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://planscape.app/guides/revit-plugin-setup.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://planscape.app/guides/mobile-onboarding.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/inviting-team.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/creating-first-project.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/iso-19650-workflow.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/billing-and-trials.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/self-hosting.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/raising-issues.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/guides/gps-site-map.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
 
-  <!-- Tutorials hub -->
+  <!-- Tutorials hub + walkthroughs -->
   <url><loc>https://planscape.app/tutorials/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://planscape.app/tutorials/create-first-project.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.app/tutorials/install-mobile-app.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.app/tutorials/install-revit-plugin.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://planscape.app/tutorials/raise-issue-from-mobile.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.app/tutorials/capture-site-photos.html</loc><lastmod>2026-05-23</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+
+  <!-- Blog -->
+  <url><loc>https://planscape.app/blog/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://planscape.app/blog/2026-05-23-why-we-built-planscape.html</loc><lastmod>2026-05-23</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.app/blog/2026-05-20-iso-19650-in-east-africa.html</loc><lastmod>2026-05-20</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://planscape.app/blog/2026-05-15-offline-first-mobile-bim.html</loc><lastmod>2026-05-15</lastmod><changefreq>yearly</changefreq><priority>0.6</priority></url>
 
   <!-- Developer docs -->
   <url><loc>https://docs.planscape.app/</loc><lastmod>2026-05-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>

--- a/marketing-site/terms.html
+++ b/marketing-site/terms.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Terms of Service — Planscape</title>
 <meta name="description" content="The terms governing your use of the Planscape platform — Revit plugin, mobile app, and cloud service.">
-<link rel="canonical" href="https://planscape.app/terms">
+<link rel="canonical" href="https://planscape.co/terms">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
 <link rel="icon" type="image/png" href="/images/favicon-32.png" sizes="32x32">
@@ -91,7 +91,7 @@ footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;bor
 
   <h2>8. Uptime and support</h2>
   <p>We use commercially reasonable efforts to keep the service available 24/7. We do not offer a contractual uptime SLA on the Studio plan; we target but do not contractually commit to 99.5% monthly uptime on Practice and Network. The Enterprise plan includes a contractual SLA — typically 99.9% — set out in the Enterprise order form.</p>
-  <p>Support is provided by email (<a href="mailto:hello@planscape.app">hello@planscape.app</a>) and via the in-app chat widget during East African business hours (Mon–Fri 09:00–18:00 EAT, public holidays excepted). Enterprise customers receive priority support with a contractual response time.</p>
+  <p>Support is provided by email (<a href="mailto:hello@planscape.co">hello@planscape.co</a>) and via the in-app chat widget during East African business hours (Mon–Fri 09:00–18:00 EAT, public holidays excepted). Enterprise customers receive priority support with a contractual response time.</p>
 
   <h2>9. Limitation of liability</h2>
   <p>To the fullest extent permitted by law, Planscape's total aggregate liability arising out of or relating to these Terms or your use of the service is capped at the total subscription fees paid by you in the 12 months immediately preceding the event giving rise to the claim. We are not liable for indirect, incidental, consequential, special, or punitive damages — including lost profits, lost data (where data loss arises despite our reasonable security measures), or business interruption — even if we have been advised of the possibility of such damages.</p>
@@ -107,12 +107,12 @@ footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;bor
   <p>We may update these Terms from time to time. For material changes — anything that meaningfully affects your rights or obligations — we will give all account holders at least 30 days notice by email and by banner notice in the dashboard. Continued use of the service after the effective date of the new Terms constitutes acceptance. If you do not accept the new Terms you may cancel your account before they take effect, and we will refund any unused pre-paid fees on a pro-rata basis.</p>
 
   <h2>13. Contact</h2>
-  <p>Legal correspondence: <a href="mailto:legal@planscape.app">legal@planscape.app</a><br>
-  General enquiries: <a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+  <p>Legal correspondence: <a href="mailto:legal@planscape.co">legal@planscape.co</a><br>
+  General enquiries: <a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
 </div>
 
 <footer>
-  © 2026 Planscape Ltd · Kampala, Uganda · <a href="mailto:hello@planscape.app">hello@planscape.app</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>
+  © 2026 Planscape Ltd · Kampala, Uganda · <a href="mailto:hello@planscape.co">hello@planscape.co</a> · <a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>
 </footer>
 
 </body>

--- a/marketing-site/tutorials/capture-site-photos.html
+++ b/marketing-site/tutorials/capture-site-photos.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Use the camera, attach photos to issues / elements / site progress, add captions. 5-minute walkthrough.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/tutorials/capture-site-photos.html">
+<link rel="canonical" href="https://planscape.co/tutorials/capture-site-photos.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -151,7 +151,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/tutorials/capture-site-photos.html
+++ b/marketing-site/tutorials/capture-site-photos.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Capture &amp; tag site photos — Planscape tutorial</title>
+<meta name="description" content="Use the camera, attach photos to issues / elements / site progress, add captions. 5-minute walkthrough.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/tutorials/capture-site-photos.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/" style="color:var(--accent)">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/tutorials/">Tutorials</a> &rsaquo; Capture &amp; tag site photos</div>
+  <h1>Capture &amp; tag site photos</h1>
+  <div class="meta">⏱️ 5 minutes · Beginner · Works offline · Last updated 2026-05-23</div>
+
+  <p>Site photos are the most-used artefact on construction projects. This tutorial covers the three ways to capture them in Planscape, how to attach them to the right thing, and how the auto-geotag / auto-thumbnail / auto-compress pipeline works behind the scenes.</p>
+
+  <h2>Three capture flows</h2>
+
+  <h3>Flow 1 — Standalone site photo</h3>
+  <p>For documenting progress without tying to a specific issue or element.</p>
+  <ol>
+    <li>Bottom tab bar → <strong>Photos</strong>.</li>
+    <li>Tap the floating camera button (bottom right).</li>
+    <li>Take the photo. The viewfinder shows your current GPS coordinates at the top so you can confirm.</li>
+    <li>Tap the checkmark to use it.</li>
+    <li>Add an optional caption ("Pour 4 of Level 2 slab, southeast corner").</li>
+    <li>Tap Save.</li>
+  </ol>
+  <p>The photo lands in the project's photo stream, geotagged, timestamped, and visible to all project members.</p>
+
+  <h3>Flow 2 — Attached to an issue</h3>
+  <p>For evidence supporting a defect, RFI, or NCR. See <a href="/tutorials/raise-issue-from-mobile.html">Raise an issue from your phone</a> for the full flow — the photo capture step is the same as above but the photo gets attached to the issue you're creating.</p>
+
+  <h3>Flow 3 — Attached to a specific element</h3>
+  <p>For commissioning records, asset photos, before/after pairs on a specific piece of equipment.</p>
+  <ol>
+    <li>Bottom tab bar → <strong>Map</strong> (or open an element via QR scan).</li>
+    <li>Tap the element in the 2D view, or scan its QR tag.</li>
+    <li>Element detail panel opens. Scroll to "Photos" section.</li>
+    <li>Tap <strong>+ Add photo</strong>.</li>
+    <li>Camera opens with the element name pre-filled in the caption prompt.</li>
+    <li>Take, confirm, save.</li>
+  </ol>
+  <p>The photo is now part of that element's permanent record. Anyone viewing that element later sees the photo.</p>
+
+  <h2>Picking from your gallery</h2>
+  <p>Every photo flow has a "From gallery" option alongside "Take photo". Useful for:</p>
+  <ul>
+    <li>Photos you took with the phone's stock camera before opening Planscape.</li>
+    <li>Photos from a DSLR you've airdropped to your phone.</li>
+    <li>Screenshots, diagrams, sketches.</li>
+  </ul>
+  <p>Gallery photos still get geotagged if the original photo had GPS metadata. If they don't, the location is recorded as "Unknown".</p>
+
+  <h2>What happens to each photo</h2>
+  <p>When you tap Save, Planscape does this in roughly 1 second on a typical photo:</p>
+  <ol>
+    <li>Saves the original (usually 4 MB JPEG, 12 MP) to local storage.</li>
+    <li>Generates a 400px-wide thumbnail for fast list-view loading.</li>
+    <li>Stamps the file with GPS coordinates, capture time, and your user ID.</li>
+    <li>If online: uploads original + thumbnail to the server in the background. You see "Synced" on the photo card within ~10 seconds.</li>
+    <li>If offline: queues for upload. You see "Queued (N)" in the status indicator.</li>
+  </ol>
+
+  <h2>Configuring quality / size</h2>
+  <p>Profile → Settings → Photos:</p>
+  <ul>
+    <li><strong>Quality: High</strong> (default, 12 MP, ~4 MB)</li>
+    <li><strong>Quality: Standard</strong> (1080p, ~1 MB) — recommended on slow networks or limited data plans</li>
+    <li><strong>Quality: Low</strong> (720p, ~400 KB) — fine for snag-list photos where size matters more than detail</li>
+  </ul>
+  <p>The thumbnail is always 400px regardless of quality setting — affects only the original.</p>
+
+  <h2>Viewing photos</h2>
+  <p>The Photos tab lists every project photo in reverse chronological order. Each card shows:</p>
+  <ul>
+    <li>Thumbnail</li>
+    <li>Caption (first 2 lines)</li>
+    <li>Capture time + author</li>
+    <li>Linked entity (issue / element / standalone)</li>
+    <li>Sync status chip if not yet uploaded</li>
+  </ul>
+  <p>Tap a thumbnail to open the full-screen viewer with pinch-zoom, swipe-between-photos, share, and "Show on map" actions.</p>
+
+  <h2>The map view of photos</h2>
+  <p>Map → Layers → enable <strong>Photo locations</strong>. Every photo appears as a small camera icon at the GPS coordinates of capture. Tap an icon to preview, tap again to open full screen.</p>
+  <p>Useful for spatial debugging: "where was that crack we photographed last week?" — open the map, find the camera icon, tap to confirm.</p>
+
+  <h2>Captions worth writing</h2>
+  <p>A caption you'll thank yourself for in three months:</p>
+  <ul>
+    <li>What's in the frame ("Pour 4, southeast corner of Level 2 slab")</li>
+    <li>Which way the camera is pointing if not obvious ("looking south")</li>
+    <li>Reference dimension or measurement if relevant ("strip width 60 mm")</li>
+    <li>Crew or witness name for sign-off photos ("witnessed by J. Otieno")</li>
+  </ul>
+  <p>Voice-to-text is faster than typing on site — tap the microphone icon in the caption field.</p>
+
+  <h2>Privacy &amp; storage</h2>
+  <p>Photos taken in the app are NOT saved to your phone's camera roll by default. This avoids leaking client work into your personal photo backup.</p>
+  <p>To save a copy to your camera roll: open the photo in the full-screen viewer → share → "Save to camera roll". You can also enable auto-save under Profile → Settings → Photos → "Save copies to camera roll: On".</p>
+  <p>Storage usage on your phone: Profile → Settings → Storage. Tap "Free up space" to delete locally-cached originals (thumbnails stay). The originals are safe on the server and re-download on demand.</p>
+
+  <hr class="divider">
+
+  <h2>Common mistakes</h2>
+  <ul>
+    <li><strong>Blurry photos.</strong> The viewfinder shows a green outline when focus is locked. Wait for it before tapping shutter.</li>
+    <li><strong>No caption.</strong> "Photo 4719" tells you nothing in 6 months. Write a sentence.</li>
+    <li><strong>Forgetting to attach.</strong> Standalone photos are fine for progress monitoring but for defects/elements, always use the right capture flow so the photo joins the right record.</li>
+    <li><strong>High-quality on slow network.</strong> Drop to Standard quality before a site visit if your data plan is limited.</li>
+  </ul>
+
+  <h2>What's next</h2>
+  <ul>
+    <li><a href="/tutorials/raise-issue-from-mobile.html">Raise an issue from your phone</a></li>
+    <li><a href="/tutorials/qr-scan.html">QR-scan an asset on site</a></li>
+    <li><a href="/guides/photo-capture.html">Photo capture guide</a> for deeper detail</li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/tutorials/raise-issue-from-mobile.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Raise an issue from your phone
+    </a>
+    <a href="/tutorials/gps-site-map.html" class="next">
+      <span class="lbl">Next →</span>
+      Use the GPS site map
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/tutorials/create-first-project.html
+++ b/marketing-site/tutorials/create-first-project.html
@@ -7,7 +7,7 @@
 <meta name="description" content="From signup to a working project with team members, GPS coordinates, and ISO 19650 metadata. 8-minute walkthrough.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/tutorials/create-first-project.html">
+<link rel="canonical" href="https://planscape.co/tutorials/create-first-project.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -34,7 +34,7 @@
   <p>You've signed up, you're staring at an empty tenant dashboard. This tutorial walks you through creating a project end-to-end with realistic example data, so by the end you have a working playground to explore the rest of Planscape.</p>
 
   <div class="callout">
-    <strong>Before you start:</strong> sign up at <a href="https://planscape.app/signup">planscape.app/signup</a> if you haven't already. Free, no credit card.
+    <strong>Before you start:</strong> sign up at <a href="https://planscape.co/signup">planscape.co/signup</a> if you haven't already. Free, no credit card.
   </div>
 
   <h2>What you'll build</h2>
@@ -162,7 +162,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/tutorials/create-first-project.html
+++ b/marketing-site/tutorials/create-first-project.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Create your first project — Planscape tutorial</title>
+<meta name="description" content="From signup to a working project with team members, GPS coordinates, and ISO 19650 metadata. 8-minute walkthrough.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/tutorials/create-first-project.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/" style="color:var(--accent)">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/tutorials/">Tutorials</a> &rsaquo; Create your first project</div>
+  <h1>Create your first project</h1>
+  <div class="meta">⏱️ 8 minutes · Beginner · Last updated 2026-05-23</div>
+
+  <p>You've signed up, you're staring at an empty tenant dashboard. This tutorial walks you through creating a project end-to-end with realistic example data, so by the end you have a working playground to explore the rest of Planscape.</p>
+
+  <div class="callout">
+    <strong>Before you start:</strong> sign up at <a href="https://planscape.app/signup">planscape.app/signup</a> if you haven't already. Free, no credit card.
+  </div>
+
+  <h2>What you'll build</h2>
+  <ul>
+    <li>A project called "Demo Hospital — Wing A"</li>
+    <li>Centred on Kampala, Uganda (you can change this to your real site later)</li>
+    <li>With ISO 19650 codes configured</li>
+    <li>With a draft BEP auto-generated</li>
+    <li>With at least one teammate invited</li>
+  </ul>
+
+  <hr class="divider">
+
+  <h2>Step 1 — Open the new project form</h2>
+  <p>From the tenant dashboard, find the orange <strong>+ New project</strong> button at the top right. Click it. The new-project form opens.</p>
+
+  <h2>Step 2 — Fill the basics</h2>
+  <p>Use these example values (or your real project data):</p>
+  <table>
+    <thead><tr><th>Field</th><th>Example value</th></tr></thead>
+    <tbody>
+      <tr><td>Project name</td><td>Demo Hospital — Wing A</td></tr>
+      <tr><td>Project code</td><td><code>DH-WA</code></td></tr>
+      <tr><td>Sector</td><td>Healthcare</td></tr>
+      <tr><td>Client</td><td>Demo Client Ministry</td></tr>
+      <tr><td>Description</td><td>50-bed wing including paediatrics, maternity, and outpatient.</td></tr>
+      <tr><td>Project value</td><td>$8,400,000</td></tr>
+      <tr><td>Start date</td><td>Today</td></tr>
+      <tr><td>Target completion</td><td>18 months from today</td></tr>
+    </tbody>
+  </table>
+  <p>The "Sector: Healthcare" choice will switch the BEP template default to the NHS / Healthcare variant — you'll see that change reflected in the BEP section below.</p>
+
+  <h2>Step 3 — Drop the GPS pin</h2>
+  <p>Scroll to the GPS section. Three input methods are offered — for this tutorial, use <strong>Pick on map</strong>.</p>
+  <ol>
+    <li>Click "Pick on map".</li>
+    <li>The map opens centred on the world view.</li>
+    <li>Search for "Kampala" in the search box.</li>
+    <li>Click anywhere in Kampala to drop the pin.</li>
+    <li>Click <strong>Use this location</strong>.</li>
+  </ol>
+  <p>The coordinates field auto-fills (something close to <code>0.3136, 32.5811</code>).</p>
+
+  <h2>Step 4 — ISO 19650 setup</h2>
+  <p>Scroll to the ISO 19650 section. Set:</p>
+  <ul>
+    <li><strong>Originator code</strong> — leave as the default (your tenant's code).</li>
+    <li><strong>Volume code</strong> — <code>ZZ</code>.</li>
+    <li><strong>BEP template</strong> — already auto-set to "NHS / Healthcare" because you picked Healthcare as sector. Keep it.</li>
+    <li><strong>Suitability schema</strong> — default S0–S7.</li>
+    <li><strong>Revision schema</strong> — default P/C/A.</li>
+  </ul>
+
+  <h2>Step 5 — RIBA stage</h2>
+  <p>Pick <strong>Stage 4 — Technical Design</strong>. This is a sensible default for any project in active design.</p>
+
+  <h2>Step 6 — Invite a teammate</h2>
+  <p>Scroll to the Initial team section. Click <strong>+ Add member</strong>.</p>
+  <p>For this tutorial, invite yourself at a second email address so you can see how the invite looks. Or invite a colleague — anyone you trust to receive a test invite.</p>
+  <p>Set their role to <strong>Coordinator</strong>. Click <strong>Add</strong>.</p>
+
+  <h2>Step 7 — Create</h2>
+  <p>Hit the orange <strong>Create project</strong> button at the bottom of the form.</p>
+  <p>You'll land on the project dashboard within a couple of seconds.</p>
+
+  <h2>Step 8 — Look around</h2>
+  <p>The project dashboard has these sections — give each one a click to see what's there:</p>
+  <ul>
+    <li><strong>Overview</strong> — RAG status, recent activity, key dates.</li>
+    <li><strong>Issues</strong> — empty (you haven't raised any yet).</li>
+    <li><strong>Documents</strong> — already contains the auto-generated BEP draft as a .docx.</li>
+    <li><strong>Deliverables</strong> — MIDP view. Empty; you can add deliverables here later.</li>
+    <li><strong>Team</strong> — you + the colleague you invited.</li>
+    <li><strong>Settings</strong> — all the project metadata you just configured.</li>
+  </ul>
+
+  <h2>Step 9 — Download &amp; review the auto-generated BEP</h2>
+  <p>Documents tab → <code>BEP Draft v0.1</code> → Download. Open in Word. You'll see a full BEP with:</p>
+  <ul>
+    <li>Project metadata pre-filled (name, code, client, dates).</li>
+    <li>ISO 19650 file-naming convention with your codes baked in.</li>
+    <li>CDE state-machine diagram.</li>
+    <li>NHS-specific sections (HBN cross-references, HTM compliance matrix) because you picked Healthcare.</li>
+    <li>Placeholder sections for your project team to fill in (information requirements, exchange points, etc.).</li>
+  </ul>
+
+  <h2>Step 10 — Customise the BEP and re-upload</h2>
+  <p>Edit the .docx in Word — fill in any of the placeholder sections. Save. Back in Planscape: Documents → BEP → <strong>Upload new version</strong>. Your edit is preserved as v0.2 alongside the auto-generated v0.1.</p>
+
+  <hr class="divider">
+
+  <h2>What you've achieved</h2>
+  <ul>
+    <li>A configured project with ISO 19650 metadata.</li>
+    <li>A geocoded site location ready for mobile use.</li>
+    <li>A team member invited.</li>
+    <li>A draft BEP ready to refine.</li>
+    <li>A working playground to explore the rest of Planscape.</li>
+  </ul>
+
+  <h2>What's next</h2>
+  <ul>
+    <li><a href="/tutorials/install-mobile-app.html">Install the mobile app</a> and sync this project (5 min)</li>
+    <li><a href="/tutorials/raise-issue-from-mobile.html">Raise your first issue from mobile</a> (6 min)</li>
+    <li><a href="/tutorials/install-revit-plugin.html">Install the Revit plugin</a> (7 min)</li>
+    <li><a href="/guides/iso-19650-workflow.html">Read the ISO 19650 workflow guide</a> to understand what's happening under the hood</li>
+  </ul>
+
+  <div class="callout">
+    <strong>Don't want to keep this demo project?</strong> Project Settings → Archive project. Or rename it and use it as your real project — entirely up to you.
+  </div>
+
+  <div class="next-prev">
+    <a href="/tutorials/install-mobile-app.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Install &amp; log into the mobile app
+    </a>
+    <a href="/tutorials/invite-team.html" class="next">
+      <span class="lbl">Next →</span>
+      Invite your team
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/tutorials/index.html
+++ b/marketing-site/tutorials/index.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Tutorials — Planscape</title>
+<meta name="description" content="Hands-on Planscape tutorials with screenshots and step-by-step instructions. Tag elements, capture photos, raise issues, sync to ACC.">
+<meta property="og:title" content="Planscape tutorials">
+<meta property="og:url" content="https://planscape.app/tutorials/">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/tutorials/">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.tut-grid { display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); }
+.tut-card {
+  background:var(--card); border:1px solid var(--line); border-radius:14px;
+  padding:0; overflow:hidden; text-decoration:none; color:inherit;
+  display:flex; flex-direction:column;
+  transition: border-color 0.15s, transform 0.1s;
+}
+.tut-card:hover { border-color:var(--accent); }
+.tut-card .thumb { aspect-ratio:16/9; background:linear-gradient(135deg,rgba(232,145,45,0.15),rgba(232,145,45,0.04)); display:flex;align-items:center;justify-content:center; font-size:48px; }
+.tut-card .body { padding:16px 18px; }
+.tut-card h3 { margin:0 0 6px; font-size:16px; line-height:1.3; }
+.tut-card .meta { font-size:12px; color:var(--muted); margin-bottom:6px; }
+.tut-card p { margin:0; font-size:13px; color:var(--muted); line-height:1.5; }
+.tut-card .tag { display:inline-block; padding:2px 8px; background:rgba(232,145,45,0.10); color:var(--accent); border-radius:999px; font-size:11px; font-weight:600; margin-right:6px; }
+.section-h { font-size:22px; margin:48px 0 16px; padding-bottom:8px; border-bottom:1px solid var(--line); }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/" style="color:var(--accent)">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<header class="page-header">
+  <h1>Tutorials</h1>
+  <p>Step-by-step walkthroughs with screenshots. Each tutorial takes ~5–15 minutes and you'll end up with a working result.</p>
+</header>
+
+<section style="padding-top:0">
+
+  <h2 class="section-h">🚀 Beginner — start here</h2>
+  <div class="tut-grid">
+    <a href="/tutorials/create-first-project.html" class="tut-card">
+      <div class="thumb">🏗️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">8 min</span> Beginner</div>
+        <h3>Create your first project</h3>
+        <p>From signup to a configured project with team members, GPS coordinates, and the right ISO 19650 metadata.</p>
+      </div>
+    </a>
+    <a href="/tutorials/install-mobile-app.html" class="tut-card">
+      <div class="thumb">📱</div>
+      <div class="body">
+        <div class="meta"><span class="tag">5 min</span> Beginner</div>
+        <h3>Install &amp; log into the mobile app</h3>
+        <p>Download from the App Store / Play Store, log in with your firm credentials, sync your first project.</p>
+      </div>
+    </a>
+    <a href="/tutorials/install-revit-plugin.html" class="tut-card">
+      <div class="thumb">🧊</div>
+      <div class="body">
+        <div class="meta"><span class="tag">7 min</span> Beginner</div>
+        <h3>Install the Revit plugin</h3>
+        <p>Download the .addin, drop it in the right folder, license-bind on first launch. Works on Revit 2025/26/27.</p>
+      </div>
+    </a>
+    <a href="/tutorials/invite-team.html" class="tut-card">
+      <div class="thumb">👥</div>
+      <div class="body">
+        <div class="meta"><span class="tag">4 min</span> Beginner</div>
+        <h3>Invite your team</h3>
+        <p>Add coordinators, assign roles, set per-project permissions. Includes inviting external clients.</p>
+      </div>
+    </a>
+  </div>
+
+  <h2 class="section-h">📱 Site coordination — mobile</h2>
+  <div class="tut-grid">
+    <a href="/tutorials/raise-issue-from-mobile.html" class="tut-card">
+      <div class="thumb">⚠️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">6 min</span> Beginner</div>
+        <h3>Raise an issue from your phone</h3>
+        <p>Spot a problem on site, snap a photo, drop a pin, assign to a coordinator. Works offline.</p>
+      </div>
+    </a>
+    <a href="/tutorials/capture-site-photos.html" class="tut-card">
+      <div class="thumb">📸</div>
+      <div class="body">
+        <div class="meta"><span class="tag">5 min</span> Beginner</div>
+        <h3>Capture &amp; tag site photos</h3>
+        <p>Use the camera in the app, attach photos to issues / elements / general site progress, add captions.</p>
+      </div>
+    </a>
+    <a href="/tutorials/gps-site-map.html" class="tut-card">
+      <div class="thumb">🗺️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">7 min</span> Beginner</div>
+        <h3>Use the GPS site map</h3>
+        <p>Pan to your project, drop pins, share your live location, navigate to a specific issue.</p>
+      </div>
+    </a>
+    <a href="/tutorials/voice-notes.html" class="tut-card">
+      <div class="thumb">🎙️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">4 min</span> Beginner</div>
+        <h3>Record &amp; transcribe voice notes</h3>
+        <p>When typing on site doesn't work. Records in any language, transcribed when back on signal.</p>
+      </div>
+    </a>
+    <a href="/tutorials/qr-scan.html" class="tut-card">
+      <div class="thumb">📲</div>
+      <div class="body">
+        <div class="meta"><span class="tag">6 min</span> Intermediate</div>
+        <h3>QR-scan an asset on site</h3>
+        <p>Pull the full tag history, attached photos, commissioning log, and RFIs for any printed STING tag.</p>
+      </div>
+    </a>
+    <a href="/tutorials/working-offline.html" class="tut-card">
+      <div class="thumb">📵</div>
+      <div class="body">
+        <div class="meta"><span class="tag">8 min</span> Intermediate</div>
+        <h3>Working a full day offline</h3>
+        <p>Pre-sync your project, work all day off-signal, replay everything when you're back in range.</p>
+      </div>
+    </a>
+  </div>
+
+  <h2 class="section-h">🧊 Revit plugin</h2>
+  <div class="tut-grid">
+    <a href="/tutorials/tag-elements-in-revit.html" class="tut-card">
+      <div class="thumb">🏷️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">10 min</span> Intermediate</div>
+        <h3>Tag elements in Revit (ISO 19650)</h3>
+        <p>Configure discipline / system / product codes, auto-detect from rooms, run BatchTag on 30k elements.</p>
+      </div>
+    </a>
+    <a href="/tutorials/sync-revit-to-cloud.html" class="tut-card">
+      <div class="thumb">☁️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">5 min</span> Intermediate</div>
+        <h3>Sync your Revit model to the cloud</h3>
+        <p>One-click publish. Diff-only upload. Resolve conflicts when two authors edit the same workset.</p>
+      </div>
+    </a>
+    <a href="/tutorials/run-clash-detection.html" class="tut-card">
+      <div class="thumb">💥</div>
+      <div class="body">
+        <div class="meta"><span class="tag">12 min</span> Intermediate</div>
+        <h3>Run clash detection</h3>
+        <p>Configure the matrix, run on a federated model, triage by priority, push to BCF, fix the source.</p>
+      </div>
+    </a>
+    <a href="/tutorials/export-cobie.html" class="tut-card">
+      <div class="thumb">📑</div>
+      <div class="body">
+        <div class="meta"><span class="tag">15 min</span> Advanced</div>
+        <h3>Export a full COBie 2.4 handover</h3>
+        <p>Pick a project-type preset, validate the model, generate 19 worksheets, package with O&amp;M documents.</p>
+      </div>
+    </a>
+    <a href="/tutorials/create-drawing-set.html" class="tut-card">
+      <div class="thumb">📐</div>
+      <div class="body">
+        <div class="meta"><span class="tag">10 min</span> Intermediate</div>
+        <h3>Create a drawing set</h3>
+        <p>Use Drawing Type profiles to produce A1 plans + A3 details + schedules with consistent title blocks.</p>
+      </div>
+    </a>
+  </div>
+
+  <h2 class="section-h">📋 ISO 19650 workflows</h2>
+  <div class="tut-grid">
+    <a href="/tutorials/issue-transmittal.html" class="tut-card">
+      <div class="thumb">📨</div>
+      <div class="body">
+        <div class="meta"><span class="tag">8 min</span> Intermediate</div>
+        <h3>Issue a transmittal</h3>
+        <p>Mint a number, select deliverables, render the B06 .docx, push to the CDE, notify recipients.</p>
+      </div>
+    </a>
+    <a href="/tutorials/raise-rfi.html" class="tut-card">
+      <div class="thumb">❓</div>
+      <div class="body">
+        <div class="meta"><span class="tag">6 min</span> Beginner</div>
+        <h3>Raise an RFI</h3>
+        <p>From mobile or web. Attach photos, route to the right reviewer, track to closeout.</p>
+      </div>
+    </a>
+    <a href="/tutorials/weekly-data-drop.html" class="tut-card">
+      <div class="thumb">📦</div>
+      <div class="body">
+        <div class="meta"><span class="tag">12 min</span> Advanced</div>
+        <h3>Run the weekly data drop</h3>
+        <p>Use the 10-step workflow preset to issue a compliant ISO 19650 weekly data drop in one click.</p>
+      </div>
+    </a>
+    <a href="/tutorials/handover-pack.html" class="tut-card">
+      <div class="thumb">📤</div>
+      <div class="body">
+        <div class="meta"><span class="tag">20 min</span> Advanced</div>
+        <h3>Build a project handover pack</h3>
+        <p>Asset register, COBie, O&amp;M manuals, spare-part schedule, commissioning certificates — auto-assembled.</p>
+      </div>
+    </a>
+  </div>
+
+  <h2 class="section-h">🏥 Healthcare workflows</h2>
+  <div class="tut-grid">
+    <a href="/tutorials/mgas-verification.html" class="tut-card">
+      <div class="thumb">⚕️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">15 min</span> Advanced</div>
+        <h3>Run an MGPS verification (HTM 02-01)</h3>
+        <p>12-step NFPA 99 §5.1.12 verification log, witness sign-off, audit-grade record.</p>
+      </div>
+    </a>
+    <a href="/tutorials/pressure-audit.html" class="tut-card">
+      <div class="thumb">💨</div>
+      <div class="body">
+        <div class="meta"><span class="tag">12 min</span> Advanced</div>
+        <h3>Pressure regime audit (HTM 03-01)</h3>
+        <p>Map positive / negative / neutral pressure rooms, identify isolation cubicle violations.</p>
+      </div>
+    </a>
+    <a href="/tutorials/rds-issue.html" class="tut-card">
+      <div class="thumb">🏥</div>
+      <div class="body">
+        <div class="meta"><span class="tag">10 min</span> Intermediate</div>
+        <h3>Issue Room Data Sheets</h3>
+        <p>Per-room RDS .docx with all clinical parameters, signed off by the QE before issue.</p>
+      </div>
+    </a>
+  </div>
+
+  <h2 class="section-h">💳 Account &amp; admin</h2>
+  <div class="tut-grid">
+    <a href="/tutorials/upgrade-plan.html" class="tut-card">
+      <div class="thumb">⬆️</div>
+      <div class="body">
+        <div class="meta"><span class="tag">3 min</span> Beginner</div>
+        <h3>Upgrade your subscription</h3>
+        <p>From trial to paid, or Standard to Large. Pro-rating, payment methods, invoice.</p>
+      </div>
+    </a>
+    <a href="/tutorials/setup-mobile-money.html" class="tut-card">
+      <div class="thumb">💰</div>
+      <div class="body">
+        <div class="meta"><span class="tag">5 min</span> Beginner</div>
+        <h3>Pay with mobile money</h3>
+        <p>MTN MoMo, Airtel Money, M-Pesa. Setup once, auto-renew monthly.</p>
+      </div>
+    </a>
+    <a href="/tutorials/export-data.html" class="tut-card">
+      <div class="thumb">💾</div>
+      <div class="body">
+        <div class="meta"><span class="tag">6 min</span> Intermediate</div>
+        <h3>Export all your data</h3>
+        <p>Full project export: models, documents, issues, photos, audit log. ZIP per project.</p>
+      </div>
+    </a>
+    <a href="/tutorials/enable-sso.html" class="tut-card">
+      <div class="thumb">🔐</div>
+      <div class="body">
+        <div class="meta"><span class="tag">15 min</span> Advanced</div>
+        <h3>Enable SSO (Azure AD)</h3>
+        <p>SAML 2.0 setup with Microsoft Entra ID. Provisioning, role mapping, MFA enforcement.</p>
+      </div>
+    </a>
+  </div>
+
+</section>
+
+<div class="cta-band">
+  <h2>Need something we haven't covered?</h2>
+  <p>Tell us what you'd like a tutorial on — we write them based on what you ask for.</p>
+  <a href="/contact.html">Request a tutorial</a>
+</div>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/tutorials/index.html
+++ b/marketing-site/tutorials/index.html
@@ -6,10 +6,10 @@
 <title>Tutorials — Planscape</title>
 <meta name="description" content="Hands-on Planscape tutorials with screenshots and step-by-step instructions. Tag elements, capture photos, raise issues, sync to ACC.">
 <meta property="og:title" content="Planscape tutorials">
-<meta property="og:url" content="https://planscape.app/tutorials/">
+<meta property="og:url" content="https://planscape.co/tutorials/">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/tutorials/">
+<link rel="canonical" href="https://planscape.co/tutorials/">
 <link rel="stylesheet" href="/assets/site.css">
 <style>
 .tut-grid { display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); }
@@ -298,7 +298,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -311,7 +311,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/tutorials/install-mobile-app.html
+++ b/marketing-site/tutorials/install-mobile-app.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Install &amp; log into the mobile app — Planscape tutorial</title>
+<meta name="description" content="Install Planscape on iOS or Android, log in, sync your first project. 5-minute walkthrough.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/tutorials/install-mobile-app.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/" style="color:var(--accent)">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/tutorials/">Tutorials</a> &rsaquo; Install &amp; log into the mobile app</div>
+  <h1>Install &amp; log into the mobile app</h1>
+  <div class="meta">⏱️ 5 minutes · Beginner · Last updated 2026-05-23</div>
+
+  <p>Five minutes from "no app" to "logged in with your first project synced for offline use". This tutorial covers both iOS and Android.</p>
+
+  <h2>Step 1 — Download</h2>
+  <p>On your phone:</p>
+  <ul>
+    <li><strong>iOS:</strong> <a href="https://apps.apple.com/app/planscape" target="_blank" rel="noopener">App Store</a> (search "Planscape BIM")</li>
+    <li><strong>Android:</strong> <a href="https://play.google.com/store/apps/details?id=com.planscape.app" target="_blank" rel="noopener">Play Store</a> (search "Planscape BIM")</li>
+  </ul>
+  <p>The app is around 85 MB. On a decent connection the download takes a couple of minutes.</p>
+
+  <h2>Step 2 — First launch</h2>
+  <p>Open the app. You'll see a brief 3-screen intro carousel — swipe through or tap Skip.</p>
+
+  <h2>Step 3 — Grant permissions</h2>
+  <p>The app asks for four permissions. For this tutorial, allow all four (you can revoke later):</p>
+  <ul>
+    <li>📷 <strong>Camera</strong> — for site photos and QR scanning</li>
+    <li>📍 <strong>Location</strong> — for the GPS site map ("Allow While Using App" is fine)</li>
+    <li>🖼️ <strong>Photos</strong> — to attach existing photos</li>
+    <li>🔔 <strong>Notifications</strong> — for issue assignments and comments</li>
+  </ul>
+
+  <h2>Step 4 — Sign in</h2>
+  <p>Enter the email and password you used for the web app. Tap <strong>Sign in</strong>.</p>
+  <p>If your firm uses SSO, tap <strong>Sign in with SSO</strong> instead — you'll be redirected to your identity provider.</p>
+  <div class="callout">
+    <strong>Tip:</strong> The app remembers your login. Subsequent launches go straight to the project picker. You only need to re-authenticate every 30 days (or when you sign out).
+  </div>
+
+  <h2>Step 5 — Pick a project</h2>
+  <p>The project picker appears. For this tutorial, pick the project you created in <a href="/tutorials/create-first-project.html">Create your first project</a>. If you don't have one yet, do that first.</p>
+
+  <h2>Step 6 — Pre-sync</h2>
+  <p>You land on the project home screen. Top-right corner has a cloud icon. Tap it → <strong>Full pre-sync</strong>.</p>
+  <p>You'll see a progress bar with three phases:</p>
+  <ol>
+    <li><strong>Metadata</strong> — issue list, team list, document register (~5 seconds).</li>
+    <li><strong>Documents</strong> — PDFs marked "Site reference" (variable; depends on count and size).</li>
+    <li><strong>Map tiles</strong> — Mapbox tiles for 5km radius around project pin (~30 seconds on 4G).</li>
+  </ol>
+  <p>On a normal 4G connection the whole pre-sync takes 2–10 minutes depending on project size. For a fresh demo project it's well under a minute.</p>
+
+  <h2>Step 7 — Verify it works offline</h2>
+  <p>Quick offline test:</p>
+  <ol>
+    <li>Put your phone in airplane mode.</li>
+    <li>Switch back to Planscape.</li>
+    <li>Tap the <strong>Map</strong> tab — the map should still render with the project pin visible.</li>
+    <li>Tap the <strong>Issues</strong> tab — the list shows (currently empty, that's fine).</li>
+    <li>Tap <strong>+ New issue</strong>, fill in a quick title ("Test offline"), tap Save.</li>
+    <li>You should see a small yellow chip: <strong>"Queued — will sync when online"</strong>.</li>
+    <li>Turn airplane mode off. Within 10–30 seconds the chip disappears and the issue is on the server.</li>
+  </ol>
+  <p>If all of that worked, you're ready for a real site visit.</p>
+
+  <h2>Step 8 — Explore the bottom tab bar</h2>
+  <p>Five tabs, left to right:</p>
+  <ul>
+    <li><strong>🏠 Home</strong> — project summary + quick actions</li>
+    <li><strong>📋 Issues</strong> — issue list, raise new issue</li>
+    <li><strong>🗺️ Map</strong> — GPS site map with pins</li>
+    <li><strong>📄 Docs</strong> — document register, view PDFs</li>
+    <li><strong>👤 Profile</strong> — settings, sign-out, switch project</li>
+  </ul>
+
+  <hr class="divider">
+
+  <h2>What you've achieved</h2>
+  <ul>
+    <li>App installed on your phone.</li>
+    <li>Signed in with your firm credentials.</li>
+    <li>A project pre-synced for offline use.</li>
+    <li>Confirmed offline mode works end-to-end.</li>
+  </ul>
+
+  <h2>What's next</h2>
+  <ul>
+    <li>Try <a href="/tutorials/raise-issue-from-mobile.html">raising an issue from your phone</a> (6 min)</li>
+    <li>Try <a href="/tutorials/gps-site-map.html">using the GPS site map</a> (7 min)</li>
+    <li>Try <a href="/tutorials/capture-site-photos.html">capturing site photos</a> (5 min)</li>
+    <li>Read the <a href="/guides/mobile-onboarding.html">mobile onboarding guide</a> for the full feature tour</li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/tutorials/create-first-project.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Create your first project
+    </a>
+    <a href="/tutorials/install-revit-plugin.html" class="next">
+      <span class="lbl">Next →</span>
+      Install the Revit plugin
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/tutorials/install-mobile-app.html
+++ b/marketing-site/tutorials/install-mobile-app.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Install Planscape on iOS or Android, log in, sync your first project. 5-minute walkthrough.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/tutorials/install-mobile-app.html">
+<link rel="canonical" href="https://planscape.co/tutorials/install-mobile-app.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -37,7 +37,7 @@
   <p>On your phone:</p>
   <ul>
     <li><strong>iOS:</strong> <a href="https://apps.apple.com/app/planscape" target="_blank" rel="noopener">App Store</a> (search "Planscape BIM")</li>
-    <li><strong>Android:</strong> <a href="https://play.google.com/store/apps/details?id=com.planscape.app" target="_blank" rel="noopener">Play Store</a> (search "Planscape BIM")</li>
+    <li><strong>Android:</strong> <a href="https://play.google.com/store/apps/details?id=com.planscape.co" target="_blank" rel="noopener">Play Store</a> (search "Planscape BIM")</li>
   </ul>
   <p>The app is around 85 MB. On a decent connection the download takes a couple of minutes.</p>
 
@@ -128,7 +128,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/tutorials/install-revit-plugin.html
+++ b/marketing-site/tutorials/install-revit-plugin.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Install the Revit plugin — Planscape tutorial</title>
+<meta name="description" content="Download, install, license-bind the Planscape Revit plugin on Revit 2025/26/27. 7-minute walkthrough.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/tutorials/install-revit-plugin.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/" style="color:var(--accent)">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/tutorials/">Tutorials</a> &rsaquo; Install the Revit plugin</div>
+  <h1>Install the Revit plugin</h1>
+  <div class="meta">⏱️ 7 minutes · Beginner · Last updated 2026-05-23</div>
+
+  <p>The Planscape Revit plugin (STING Tools) brings 763+ commands to your Revit ribbon and dockable panel. This tutorial walks through downloading, installing, and signing in on a single workstation.</p>
+
+  <div class="callout">
+    <strong>Before you start:</strong>
+    <ul>
+      <li>Windows 10 or 11 with Revit 2025, 2026, or 2027 installed.</li>
+      <li>A Planscape account (free trial works).</li>
+      <li>Admin rights on your machine — only needed if you choose "all users" install.</li>
+    </ul>
+  </div>
+
+  <h2>Step 1 — Download the plugin</h2>
+  <ol>
+    <li>Go to <a href="https://planscape.app/">planscape.app</a> and sign in.</li>
+    <li>Open any project workspace.</li>
+    <li>Click <strong>Tools → Download Revit plugin</strong>.</li>
+    <li>You get <code>StingTools.zip</code> (about 45 MB).</li>
+  </ol>
+
+  <h2>Step 2 — Pick a Revit version folder</h2>
+  <p>On your Windows machine, press <code>Win + R</code> to open the Run dialog. Paste this path and hit Enter:</p>
+  <pre><code>%APPDATA%\Autodesk\Revit\Addins\</code></pre>
+  <p>You'll see folders for each Revit version installed (2025, 2026, 2027). Open the one matching your Revit. If the folder doesn't exist, create it.</p>
+  <div class="callout">
+    <strong>Pick one Revit version per machine.</strong> If you have multiple Revit versions and want the plugin in all of them, copy the files into each folder separately.
+  </div>
+
+  <h2>Step 3 — Extract the ZIP</h2>
+  <ol>
+    <li>Open the downloaded <code>StingTools.zip</code>.</li>
+    <li>Select all contents (Ctrl+A).</li>
+    <li>Copy / drag everything into the Addins folder you opened in Step 2.</li>
+  </ol>
+  <p>The folder should now contain:</p>
+  <ul>
+    <li><code>StingTools.addin</code></li>
+    <li><code>StingTools.dll</code></li>
+    <li><code>Newtonsoft.Json.dll</code> + a few other supporting DLLs</li>
+    <li><code>data/</code> subdirectory with 72 runtime data files</li>
+  </ul>
+
+  <h2>Step 4 — Start Revit</h2>
+  <p>Launch Revit. Wait for it to fully load (open the home screen at minimum). You should see:</p>
+  <ul>
+    <li>A new <strong>STING Tools</strong> tab on the Revit ribbon</li>
+    <li>A dockable panel on the right side called "Planscape"</li>
+  </ul>
+  <p>If you don't see them, see the troubleshooting section at the bottom.</p>
+
+  <h2>Step 5 — Allow the addin (first run only)</h2>
+  <p>Revit checks the digital signature of each addin and asks you to confirm on first load:</p>
+  <ol>
+    <li>You'll see a dialog: "Planscape Ltd — Always Load / Load Once / Do Not Load".</li>
+    <li>Click <strong>Always Load</strong>.</li>
+  </ol>
+  <p>Subsequent Revit launches load the plugin without asking.</p>
+
+  <h2>Step 6 — Sign in</h2>
+  <ol>
+    <li>In the dockable panel, click the <strong>Sign in</strong> button at the bottom-left.</li>
+    <li>Enter your Planscape email + password.</li>
+    <li>If you're a member of multiple firms, pick the firm to bind to.</li>
+    <li>Pick the project you want to work on.</li>
+  </ol>
+  <p>The panel header changes to show your name, the project, and a green "Connected" status.</p>
+
+  <h2>Step 7 — Run the smoke test</h2>
+  <p>Confirm the plugin actually does something:</p>
+  <ol>
+    <li>Open any Revit project (a sample if you don't have one).</li>
+    <li>In the dockable panel, click the <strong>SELECT</strong> tab.</li>
+    <li>Click <strong>Lighting Fixtures</strong>.</li>
+    <li>You should see a count of lighting fixtures in the active view (or "0 found" if there aren't any).</li>
+  </ol>
+  <p>If that works, the plugin is correctly installed.</p>
+
+  <h2>Step 8 — Optional first-run setup</h2>
+  <p>The plugin offers to do project-level setup the first time you open a project on a logged-in account:</p>
+  <ul>
+    <li><strong>Load shared parameters?</strong> — Yes, on new projects. Binds the 2,555 STING shared parameters. ~30 seconds.</li>
+    <li><strong>Apply ISO 19650 view templates?</strong> — Yes on a brand new project; No if you've set them up manually.</li>
+    <li><strong>Run compliance scan?</strong> — Yes. Surfaces orphaned elements or non-compliant naming up front.</li>
+  </ul>
+  <p>You can skip these and run them later from the SETUP tab.</p>
+
+  <hr class="divider">
+
+  <h2>Troubleshooting</h2>
+
+  <h3>I don't see the STING Tools tab</h3>
+  <ol>
+    <li>Is <code>StingTools.addin</code> actually in the Addins folder? Files starting with a dot can be hidden — switch on "show hidden files" in Explorer.</li>
+    <li>Open <code>StingTools.addin</code> in Notepad. The <code>&lt;Assembly&gt;</code> element should point to a file that exists in the same folder.</li>
+    <li>Check the log: <code>%LOCALAPPDATA%\Planscape\StingTools.log</code> — last few lines usually explain.</li>
+  </ol>
+
+  <h3>"Cannot connect to api.planscape.app"</h3>
+  <ul>
+    <li>Most common cause: your corporate firewall blocks outbound HTTPS.</li>
+    <li>Ask IT to allow outbound 443 to <code>api.planscape.app</code>.</li>
+    <li>You can still use most non-sync commands offline.</li>
+  </ul>
+
+  <h3>The dockable panel won't appear</h3>
+  <p>Revit hides docked panels by default. From the Revit menu:</p>
+  <pre><code>View → User Interface → STING Tools Panel</code></pre>
+
+  <h3>"This addin is not signed by a trusted publisher"</h3>
+  <p>Revit's security policy is strict. Click <strong>Always Load</strong> — we sign every release with a code-signing certificate from Planscape Ltd. If "Publisher: Unknown" instead of "Publisher: Planscape Ltd", you probably have a corrupted download. Re-download from your project workspace.</p>
+
+  <hr class="divider">
+
+  <h2>What's next</h2>
+  <ul>
+    <li><a href="/tutorials/tag-elements-in-revit.html">Tag elements in Revit (ISO 19650)</a> (10 min)</li>
+    <li><a href="/tutorials/sync-revit-to-cloud.html">Sync your Revit model to the cloud</a> (5 min)</li>
+    <li><a href="/tutorials/run-clash-detection.html">Run clash detection</a> (12 min)</li>
+    <li><a href="/guides/revit-plugin-setup.html">Read the full Revit plugin guide</a></li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/tutorials/install-mobile-app.html" class="prev">
+      <span class="lbl">← Previous</span>
+      Install &amp; log into the mobile app
+    </a>
+    <a href="/tutorials/tag-elements-in-revit.html" class="next">
+      <span class="lbl">Next →</span>
+      Tag elements in Revit
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
+    <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
+    <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/tutorials/install-revit-plugin.html
+++ b/marketing-site/tutorials/install-revit-plugin.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Download, install, license-bind the Planscape Revit plugin on Revit 2025/26/27. 7-minute walkthrough.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/tutorials/install-revit-plugin.html">
+<link rel="canonical" href="https://planscape.co/tutorials/install-revit-plugin.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -44,7 +44,7 @@
 
   <h2>Step 1 — Download the plugin</h2>
   <ol>
-    <li>Go to <a href="https://planscape.app/">planscape.app</a> and sign in.</li>
+    <li>Go to <a href="https://planscape.co/">planscape.co</a> and sign in.</li>
     <li>Open any project workspace.</li>
     <li>Click <strong>Tools → Download Revit plugin</strong>.</li>
     <li>You get <code>StingTools.zip</code> (about 45 MB).</li>
@@ -127,10 +127,10 @@
     <li>Check the log: <code>%LOCALAPPDATA%\Planscape\StingTools.log</code> — last few lines usually explain.</li>
   </ol>
 
-  <h3>"Cannot connect to api.planscape.app"</h3>
+  <h3>"Cannot connect to api.planscape.co"</h3>
   <ul>
     <li>Most common cause: your corporate firewall blocks outbound HTTPS.</li>
-    <li>Ask IT to allow outbound 443 to <code>api.planscape.app</code>.</li>
+    <li>Ask IT to allow outbound 443 to <code>api.planscape.co</code>.</li>
     <li>You can still use most non-sync commands offline.</li>
   </ul>
 
@@ -165,7 +165,7 @@
 
 <footer class="site">
   <div class="footer-grid">
-    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p></div>
+    <div class="col"><div class="brand-row">Plan<span class="dot">·</span>scape</div><p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p><p>📍 Kampala, Uganda</p><p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p></div>
     <div class="col"><h4>Product</h4><a href="/features.html">Features</a><a href="/pricing.html">Pricing</a><a href="/signup">Start trial</a><a href="/contact.html#demo">Book a demo</a></div>
     <div class="col"><h4>Learn</h4><a href="/guides/">Guides</a><a href="/tutorials/">Tutorials</a><a href="/blog/">Blog</a><a href="/contact.html">Contact support</a></div>
     <div class="col"><h4>Company</h4><a href="/about.html">About</a><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a><a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a></div>

--- a/marketing-site/tutorials/raise-issue-from-mobile.html
+++ b/marketing-site/tutorials/raise-issue-from-mobile.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Raise an issue from your phone — Planscape tutorial</title>
+<meta name="description" content="Step-by-step tutorial: spot a problem on site, capture a photo, drop a GPS pin, assign to a coordinator. Works offline.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.app/tutorials/raise-issue-from-mobile.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/tutorials/" style="color:var(--accent)">Tutorials</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/tutorials/">Tutorials</a> &rsaquo; Raise an issue from your phone</div>
+  <h1>Raise an issue from your phone</h1>
+  <div class="meta">⏱️ 6 minutes · Beginner · Works offline · Last updated 2026-05-23</div>
+
+  <p>You're walking the site and spot a fire damper installed back-to-front. This tutorial shows you how to capture the problem, attach a photo, drop a GPS pin, and route the issue to the right person — all from your phone, even if you have no signal.</p>
+
+  <div class="callout">
+    <strong>Before you start:</strong> you need the Planscape mobile app installed and signed in, with at least one project on your account. See <a href="/guides/mobile-onboarding.html">Mobile app onboarding</a> if you haven't done that yet.
+  </div>
+
+  <h2>What you'll build</h2>
+  <p>By the end of this tutorial you'll have:</p>
+  <ul>
+    <li>A new issue with a photo, GPS coordinates, and a clear title</li>
+    <li>The issue assigned to a specific coordinator</li>
+    <li>The issue tagged against an element from your federated model</li>
+    <li>A working understanding of the offline queue</li>
+  </ul>
+
+  <hr class="divider">
+
+  <h2>Step 1 — Open the project</h2>
+  <p>Launch the app. If you're already signed in, the project picker shows. Tap the project you're on site for.</p>
+  <p>If this is your first visit, the app may prompt you to pre-sync. Tap <strong>Skip for now</strong> — you can still raise issues without pre-syncing.</p>
+
+  <h2>Step 2 — Start a new issue</h2>
+  <p>You have three ways to start a new issue. Pick whichever matches your situation:</p>
+
+  <h3>From the issue list</h3>
+  <p>Bottom tab bar → <strong>Issues</strong> → tap the orange <strong>+</strong> button in the bottom right.</p>
+
+  <h3>From the GPS site map</h3>
+  <p>Bottom tab bar → <strong>Map</strong> → long-press anywhere on the map. The new-issue form opens with the tapped point's GPS coordinates pre-filled.</p>
+
+  <h3>From the camera</h3>
+  <p>Quick-action: hold the floating camera button on the home screen for 1 second. Takes a photo and goes straight to the new-issue form with the photo attached.</p>
+
+  <div class="callout">
+    <strong>Tip:</strong> If you're standing right where the problem is, the GPS-pin route is fastest — coordinates are already set.
+  </div>
+
+  <h2>Step 3 — Fill in the issue</h2>
+  <p>The new-issue form has these fields:</p>
+
+  <table>
+    <thead><tr><th>Field</th><th>What to enter</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Title</strong></td><td>One line. "Fire damper FD-103 installed back-to-front"</td></tr>
+      <tr><td><strong>Type</strong></td><td>Quality / Safety / Coordination / RFI / NCR. Tap to pick.</td></tr>
+      <tr><td><strong>Priority</strong></td><td>Low / Medium / High / Critical</td></tr>
+      <tr><td><strong>Description</strong></td><td>Free-text. Voice-to-text icon if typing on site is awkward.</td></tr>
+      <tr><td><strong>Location</strong></td><td>Auto-filled if you used the GPS-pin route. Otherwise tap "Use my location".</td></tr>
+      <tr><td><strong>Linked element</strong></td><td>Optional. Tap "Link element" → QR-scan the asset, or pick from a list.</td></tr>
+      <tr><td><strong>Assignee</strong></td><td>Tap to pick from the project's team list.</td></tr>
+      <tr><td><strong>Due date</strong></td><td>Optional.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Step 4 — Attach a photo</h2>
+  <p>Tap the <strong>+ Add photo</strong> button. You get three options:</p>
+  <ul>
+    <li><strong>Take photo</strong> — opens the camera. Capture, tap the checkmark to use.</li>
+    <li><strong>From gallery</strong> — pick existing photos from your phone.</li>
+    <li><strong>Record voice note</strong> — useful for context that's faster to speak than type.</li>
+  </ul>
+  <p>You can attach up to 10 photos and 5 voice notes per issue. Photos are automatically thumbnailed and geotagged.</p>
+
+  <div class="callout warn">
+    <strong>Privacy note:</strong> Photos taken inside the app are not saved to your phone's camera roll unless you explicitly tap "Save to camera roll" in the photo viewer. This avoids leaking client work into your personal photo backup.
+  </div>
+
+  <h2>Step 5 — Link to an element (optional but recommended)</h2>
+  <p>Tying an issue to a specific element in the federated model is what makes it actionable for the BIM author. Three ways to link:</p>
+
+  <h3>QR scan</h3>
+  <p>Tap <strong>Link element → Scan QR</strong>. Point your camera at a printed STING tag on the asset. The element loads automatically with its full tag history.</p>
+
+  <h3>Pick from view</h3>
+  <p>Tap <strong>Link element → From map view</strong>. The 2D plan view of your current level opens. Tap the element you want to link.</p>
+
+  <h3>Search by tag</h3>
+  <p>Tap <strong>Link element → Search tag</strong>. Type any segment of the ISO 19650 tag (e.g. <code>HVAC-FD-0103</code>). Matching elements appear.</p>
+
+  <h2>Step 6 — Assign &amp; save</h2>
+  <p>Tap <strong>Assignee → pick a teammate</strong>. They'll get a push notification (when they're next online).</p>
+  <p>Hit <strong>Save</strong>. If you're online, the issue posts and you see "✓ Issue raised" briefly. If you're offline, you see "Queued — will sync when online" instead.</p>
+
+  <h2>Step 7 — Verify it synced</h2>
+  <p>Back on the issue list, your new issue appears at the top. If you're offline, it shows a small yellow chip with the queue count.</p>
+  <p>The status indicator at the top right of the screen tells you the queue state:</p>
+  <ul>
+    <li>🟢 <strong>Online</strong> — everything is synced.</li>
+    <li>🟡 <strong>Queued (N)</strong> — N items waiting; will sync automatically when connected.</li>
+    <li>🔴 <strong>Sync failed</strong> — something's wrong; tap for details.</li>
+  </ul>
+
+  <hr class="divider">
+
+  <h2>What happened behind the scenes</h2>
+  <p>For the curious — here's what the app did:</p>
+  <ol>
+    <li>Saved the issue to the local SQLite database with a status of <code>pending</code>.</li>
+    <li>Saved photos and voice notes to local storage with a foreign key to the issue.</li>
+    <li>If online: posted <code>POST /api/projects/{projectId}/issues</code> with the issue body, then uploaded each photo to <code>POST /api/projects/{projectId}/photos</code> (multipart). Marked all as <code>synced</code>.</li>
+    <li>If offline: kept everything <code>pending</code>; a background task retries when network state changes.</li>
+    <li>Once synced server-side, SignalR broadcast the new issue to all connected project members — they get a push notification within a few seconds.</li>
+  </ol>
+
+  <h2>Common mistakes</h2>
+  <ul>
+    <li><strong>Forgetting to set priority.</strong> Defaults to Medium. Critical issues should be flagged explicitly so they appear in the daily standup.</li>
+    <li><strong>Not linking to an element.</strong> Floating issues are hard to triage. Link to the element you're complaining about whenever possible.</li>
+    <li><strong>Generic titles.</strong> "Issue with damper" is less useful than "FD-103 installed back-to-front, blade direction reversed". The author needs to know what's wrong without opening the photos.</li>
+    <li><strong>Assigning to no-one.</strong> Unassigned issues sit in the project queue and may be missed. Even "Project Lead" is better than no-one.</li>
+  </ul>
+
+  <h2>What's next?</h2>
+  <ul>
+    <li>Try <a href="/tutorials/qr-scan.html">QR-scanning an asset</a> to learn the fastest way to link issues to elements.</li>
+    <li>Try <a href="/tutorials/working-offline.html">Working a full day offline</a> to confirm your queue handles a real site visit.</li>
+    <li>Read the <a href="/guides/raising-issues.html">issue workflow guide</a> for the full lifecycle (open → in-progress → resolved → verified).</li>
+  </ul>
+
+  <div class="next-prev">
+    <a href="/tutorials/" class="prev">
+      <span class="lbl">← All tutorials</span>
+      Tutorials index
+    </a>
+    <a href="/tutorials/capture-site-photos.html" class="next">
+      <span class="lbl">Next →</span>
+      Capture &amp; tag site photos
+    </a>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/tutorials/">Tutorials</a>
+      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/tutorials/raise-issue-from-mobile.html
+++ b/marketing-site/tutorials/raise-issue-from-mobile.html
@@ -7,7 +7,7 @@
 <meta name="description" content="Step-by-step tutorial: spot a problem on site, capture a photo, drop a GPS pin, assign to a coordinator. Works offline.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-<link rel="canonical" href="https://planscape.app/tutorials/raise-issue-from-mobile.html">
+<link rel="canonical" href="https://planscape.co/tutorials/raise-issue-from-mobile.html">
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -168,7 +168,7 @@
       <div class="brand-row">Plan<span class="dot">·</span>scape</div>
       <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
       <p>📍 Kampala, Uganda</p>
-      <p><a href="mailto:hello@planscape.app">hello@planscape.app</a></p>
+      <p><a href="mailto:hello@planscape.co">hello@planscape.co</a></p>
     </div>
     <div class="col">
       <h4>Product</h4>
@@ -181,7 +181,7 @@
       <h4>Learn</h4>
       <a href="/guides/">Guides</a>
       <a href="/tutorials/">Tutorials</a>
-      <a href="https://docs.planscape.app/">Developer docs</a>
+      <a href="https://docs.planscape.co/">Developer docs</a>
       <a href="/contact.html">Contact support</a>
     </div>
     <div class="col">

--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -18,7 +18,7 @@ compatibility_date = "2026-05-01"
 # Environment variables — replace placeholders before deploy, or set in the dashboard
 # (Pages → Settings → Environment variables) which is safer for secrets.
 [vars]
-SITE_URL = "https://planscape.app"
+SITE_URL = "https://planscape.co"
 
 # Per-environment overrides
 [env.preview]

--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -1,0 +1,28 @@
+# Cloudflare Pages config for Wrangler CLI.
+# Used by: wrangler pages deploy ./marketing-site --project-name=planscape-marketing
+#
+# Pages settings (build command, output dir) live in the Cloudflare dashboard
+# under: Pages → planscape-marketing → Settings → Builds & deployments.
+# Recommended dashboard settings:
+#   Production branch: main
+#   Build command:     (empty — static site, no build step)
+#   Build output dir:  marketing-site
+#   Root directory:    /
+#
+# This file controls deploy-time options.
+
+name = "planscape-marketing"
+pages_build_output_dir = "."
+compatibility_date = "2026-05-01"
+
+# Environment variables — replace placeholders before deploy, or set in the dashboard
+# (Pages → Settings → Environment variables) which is safer for secrets.
+[vars]
+SITE_URL = "https://planscape.app"
+
+# Per-environment overrides
+[env.preview]
+name = "planscape-marketing-preview"
+
+[env.production]
+name = "planscape-marketing"


### PR DESCRIPTION
Merges unmerged branch `claude/fervent-knuth-ofJXy` into `main`.

Switches the marketing-site domain from planscape.app to planscape.co (40 files). Group B.

Opened as part of branch-cleanup triage to preserve work before branch deletion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5aGwxY9iznAn6LU1Y1hff)_