### PR TITLE
fix(boq): Z-21 — apply waste% on the BOQ legacy take-off fallback path

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <!-- Pure-logic test project. Does NOT reference Revit API or WPF. Instead,
+         links the pure-logic .cs files from the main StingTools project via
+         <Compile Include>, avoiding the need for Revit DLLs on the test host.
+         Mirrors StingTools.Tags.Tests / StingTools.Clash.Tests. -->
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The unit under test. WasteFactor has zero Autodesk.Revit.* dependencies,
+         so it compiles cleanly against net8.0 with no shims. -->
+    <Compile Include="..\StingTools\BOQ\WasteFactor.cs" Link="BOQ\WasteFactor.cs" />
+  </ItemGroup>
+
+</Project>

--- a/StingTools.Boq.Tests/WasteFactorTests.cs
+++ b/StingTools.Boq.Tests/WasteFactorTests.cs
@@ -1,0 +1,64 @@
+using StingTools.BOQ;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Z-21 — locks in that the BOQ legacy-fallback path applies a wastage
+    // allowance to measured material quantities (it applied 0% before — audit
+    // §6.3). WasteFactor is the pure helper DeriveQuantity's fallback now calls.
+    public class WasteFactorTests
+    {
+        [Theory]
+        [InlineData("m²")]
+        [InlineData("m2")]
+        [InlineData("sqm")]
+        [InlineData("m³")]
+        [InlineData("m3")]
+        [InlineData("cum")]
+        [InlineData("m")]
+        [InlineData("kg")]
+        [InlineData("tonne")]
+        [InlineData("tonnes")]
+        public void Apply_GrossesUpMeasuredUnits(string unit)
+        {
+            // 100 units @ 5% waste => 105.
+            Assert.Equal(105.0, WasteFactor.Apply(100.0, unit, 5.0), 6);
+            Assert.True(WasteFactor.AppliesTo(unit));
+        }
+
+        [Theory]
+        [InlineData("each")]
+        [InlineData("item")]
+        [InlineData("nr")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Apply_LeavesCountedAndUnknownUnitsUntouched(string unit)
+        {
+            // You do not waste 5% of a pump.
+            Assert.Equal(100.0, WasteFactor.Apply(100.0, unit, 5.0), 6);
+            Assert.False(WasteFactor.AppliesTo(unit));
+        }
+
+        [Fact]
+        public void Apply_IsCaseAndWhitespaceInsensitive()
+        {
+            Assert.Equal(110.0, WasteFactor.Apply(100.0, " M3 ", 10.0), 6);
+        }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(-5.0)]
+        [InlineData(double.NaN)]
+        public void Apply_NonPositiveWasteNeverReducesQuantity(double wastePct)
+        {
+            Assert.Equal(100.0, WasteFactor.Apply(100.0, "m3", wastePct), 6);
+        }
+
+        [Fact]
+        public void Apply_DefaultFivePercentMatchesFallbackKnob()
+        {
+            // COST_DEFAULT_WASTE_PCT default is 5.0 in BOQCostManager.
+            Assert.Equal(52.5, WasteFactor.Apply(50.0, "m3", 5.0), 6);
+        }
+    }
+}

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -375,9 +375,18 @@ namespace StingTools.BOQ
             }
             catch (Exception ex) { StingLog.Warn($"DeriveQuantity rule lookup: {ex.Message}"); }
 
-            // Legacy fallback — preserved verbatim for back-compat.
+            // Legacy fallback — preserved verbatim for back-compat, except
+            // Z-21: a wastage allowance is now applied to genuinely-measured
+            // quantities so the fallback path stops under-quantifying (audit
+            // §6.3 — waste was previously applied only on the TakeoffRule path).
+            // Source: project-config knob COST_DEFAULT_WASTE_PCT (default 5%);
+            // applied via WasteFactor.Apply only to measured material units —
+            // never to "each"/"item" counts or the 1.0 "couldn't-measure"
+            // placeholders. Elements that match a TakeoffRule never reach here
+            // (the rule's own WastePercent governs them), so no double-count.
             try
             {
+                double wastePct = TagConfig.GetConfigDouble("COST_DEFAULT_WASTE_PCT", 5.0);
                 switch ((unit ?? "").ToLowerInvariant())
                 {
                     case "m²":
@@ -385,29 +394,29 @@ namespace StingTools.BOQ
                     case "sqm":
                         Parameter areaP = el.get_Parameter(BuiltInParameter.HOST_AREA_COMPUTED);
                         if (areaP != null && areaP.HasValue)
-                            return areaP.AsDouble() * 0.092903; // ft² → m²
+                            return WasteFactor.Apply(areaP.AsDouble() * 0.092903, unit, wastePct); // ft² → m²
                         return 1.0;
                     case "m³":
                     case "m3":
                     case "cum":
                         Parameter volP = el.get_Parameter(BuiltInParameter.HOST_VOLUME_COMPUTED);
                         if (volP != null && volP.HasValue)
-                            return volP.AsDouble() * 0.0283168; // ft³ → m³
+                            return WasteFactor.Apply(volP.AsDouble() * 0.0283168, unit, wastePct); // ft³ → m³
                         return 1.0;
                     case "m":
                         if (el.Location is LocationCurve lc)
-                            return lc.Curve.Length * 0.3048; // ft → m
+                            return WasteFactor.Apply(lc.Curve.Length * 0.3048, unit, wastePct); // ft → m
                         Parameter lenP = el.LookupParameter("Length")
                             ?? el.get_Parameter(BuiltInParameter.CURVE_ELEM_LENGTH);
                         if (lenP != null && lenP.HasValue)
-                            return lenP.AsDouble() * 0.3048;
+                            return WasteFactor.Apply(lenP.AsDouble() * 0.3048, unit, wastePct);
                         return 1.0;
                     case "kg":
                     case "tonne":
                     case "tonnes":
                         Parameter massP = el.LookupParameter("Weight") ?? el.LookupParameter("Mass");
                         if (massP != null && massP.HasValue)
-                            return massP.AsDouble();
+                            return WasteFactor.Apply(massP.AsDouble(), unit, wastePct);
                         return 1.0;
                     default:
                         return 1.0;

--- a/StingTools/BOQ/WasteFactor.cs
+++ b/StingTools/BOQ/WasteFactor.cs
@@ -1,0 +1,60 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  WasteFactor.cs — pure wastage-allowance arithmetic for BOQ take-off.
+//
+//  Extracted so the legacy-fallback path in BOQCostManager.DeriveQuantity can
+//  apply the same `qty *= 1 + waste%` step the data-driven TakeoffRule path
+//  already applies (TakeoffRule.WastePercent). Before Z-21 the fallback path
+//  applied 0% waste, under-quantifying every element that did not match a
+//  take-off rule (audit §6.3).
+//
+//  Zero Autodesk.Revit.* dependencies on purpose — this file is linked into
+//  the pure-logic test project (StingTools.Boq.Tests) the same way SeqAssigner
+//  is linked into StingTools.Tags.Tests, so the waste arithmetic is unit-tested
+//  without a Revit host.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+
+namespace StingTools.BOQ
+{
+    public static class WasteFactor
+    {
+        /// <summary>
+        /// True for measured material quantities (area / volume / length /
+        /// mass) where a cutting/lapping/offcut allowance is physically
+        /// meaningful. False for counted items ("each" / "item") and unknown
+        /// units — you do not waste 5% of a pump.
+        /// </summary>
+        public static bool AppliesTo(string unit)
+        {
+            switch ((unit ?? "").Trim().ToLowerInvariant())
+            {
+                case "m²":
+                case "m2":
+                case "sqm":
+                case "m³":
+                case "m3":
+                case "cum":
+                case "m":
+                case "kg":
+                case "tonne":
+                case "tonnes":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns <paramref name="rawQuantity"/> grossed up by
+        /// <paramref name="wastePercent"/> when the unit is a measured material
+        /// quantity; otherwise returns it unchanged. Negative / NaN waste is
+        /// treated as 0 so a mis-keyed config knob can never reduce a quantity.
+        /// </summary>
+        public static double Apply(double rawQuantity, string unit, double wastePercent)
+        {
+            if (!AppliesTo(unit)) return rawQuantity;
+            if (double.IsNaN(wastePercent) || wastePercent <= 0) return rawQuantity;
+            return rawQuantity * (1.0 + wastePercent / 100.0);
+        }
+    }
+}


### PR DESCRIPTION
Closes **Z-21** from `docs/PHASE_Z_NUMERIC_AUDIT.md` §6.3.

The TakeoffRule path in `BOQCostManager.DeriveQuantity` correctly applied `q *= 1 + Waste%`; the **legacy fallback path** returned raw converted quantities (0% waste). Elements routed through the fallback were silently under-quantified on every BOQ export.

## What changed

- Extracted **`WasteFactor.Apply(qty, unit, wastePct)`** as a pure dependency-free helper (no Revit/.NET-host coupling — lives in a separable assembly so it can be unit-tested without a Revit instance)
- Fallback paths for **m², m, m³, kg/tonne** now route through it
- "Couldn't-measure" `return 1.0` placeholders + each/item unit branches **deliberately stay at 0%** (you don't waste 5% of a pump)
- **TakeoffRule path (lines 370–371) untouched** — no regression risk on the rule-matched path
- **Waste% source: `COST_DEFAULT_WASTE_PCT` config knob** (default 5%, project-overridable via `project_config.json`) — same `TagConfig.GetConfigDouble` mechanism the BOQ already uses for prelims / contingency / overhead
- `MATERIAL_LOOKUP.csv` untouched
- No double-count: rule-matched elements never reach this fallback

## Tests added

**First PR in the Phase Z numeric series to add tests.** New `StingTools.Boq.Tests` project mirroring the existing `StingTools.Tags.Tests` pattern — links the dependency-free `WasteFactor.cs`, no Revit host.

20 test cases, all passing:
- Waste grosses up all measured units (`m²`/`m2`/`sqm`/`m³`/`m3`/`cum`/`m`/`kg`/`tonne`/`tonnes`)
- Each / item / unknown / null units left untouched
- Case- and whitespace-insensitive
- Never reduces a quantity on `0` / negative / `NaN` waste

## Build

`dotnet build StingTools/StingTools.csproj` → **0 warnings, 0 errors**.
`dotnet test StingTools.Boq.Tests` → **20 / 20 passing**.

## Out of scope (tracked as Z-21b)

Elements carrying an explicit `StingCostRateOverride.WastePercent` get waste applied to the **rate** (`RateProviders.cs:89`). After this PR they will also get waste applied to the **quantity** via the legacy fallback. A 5% rate-override + 5% quantity-waste compounds to ~10.25% on line cost. That override path is rare/explicit and orthogonal; dedup is a separate follow-up PR — Z-21b in `docs/UI_CLEANUP_CAMPAIGN.md` §11.

## Files

- `StingTools/BOQ/BOQCostManager.cs` — fallback paths route through `WasteFactor.Apply`
- `StingTools/Boq/WasteFactor.cs` — new pure helper
- `StingTools.Boq.Tests/` — new test project (csproj + tests)

4 files changed, +166 / −6.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5aGwxY9iznAn6LU1Y1hff)_