### PR TITLE
Planscape web: fix BCC→/app/, dashboard freeze, viewer pipeline + add live meetings & site-photos in web

### DIFF
--- a/Planscape.Server/docker/.env.template
+++ b/Planscape.Server/docker/.env.template
@@ -42,8 +42,21 @@ CONVERTER_TOKEN=
 CONVERTER_API_BEARER=
 
 # ── Model converter (S5.2 / Phase: 3D viewing review) ───────────────────
+# Turns uploaded IFC into GLB so the 3D viewer can render it. GLB/glTF
+# uploads (incl. the Revit plugin's "Export 3D view to GLB") never need
+# this. To enable IFC auto-conversion:
+#   1) Set MODEL_CONVERTER_PROVIDER=ifcconvert  (below)
+#   2) Set IFCCONVERT_URL to an IfcOpenShell IfcConvert linux64 zip, e.g.
+#      https://github.com/IfcOpenShell/IfcOpenShell/releases/download/blenderbim-<ver>/IfcConvert-<ver>-linux64.zip
+#   3) Rebuild so the binary is baked in:  docker compose build api worker
+#   4) docker compose up -d
+# ModelDerivativeJob (already scheduled) then converts IFC→GLB every ~10 min,
+# swaps the model's StoragePath to the GLB and flips Format=Glb — the viewer
+# picks it up automatically. RVT-from-non-Revit needs the 'aps' provider.
 # Provider: 'null' (default off) | 'ifcconvert' | 'aps'
 MODEL_CONVERTER_PROVIDER=null
+# IfcConvert (IfcOpenShell) download URL for the build. 'skip' = don't install.
+IFCCONVERT_URL=skip
 MODEL_THUMBNAIL_PROVIDER=gltf-bounds
 APS_CLIENT_ID=
 APS_CLIENT_SECRET=

--- a/Planscape.Server/docker/docker-compose.yml
+++ b/Planscape.Server/docker/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     build:
       context: ../..
       dockerfile: Planscape.Server/docker/Dockerfile
+      args:
+        # IFC→GLB viewer derivatives: set IFCCONVERT_URL in .env to an
+        # IfcOpenShell IfcConvert linux64 zip URL to bake the binary in,
+        # then set MODEL_CONVERTER_PROVIDER=ifcconvert. Default "skip"
+        # leaves the converter off (uploads must already be GLB/glTF).
+        IFCCONVERT_URL: ${IFCCONVERT_URL:-skip}
     ports:
       - "5000:8080"
     environment:
@@ -157,6 +163,10 @@ services:
     build:
       context: ../..
       dockerfile: Planscape.Server/docker/Dockerfile
+      args:
+        # The worker runs Hangfire jobs incl. ModelDerivativeJob (IFC→GLB),
+        # so it needs the same IfcConvert binary as the api. See api.build.
+        IFCCONVERT_URL: ${IFCCONVERT_URL:-skip}
     environment:
       # Worker shares the same Program.cs as the api, so it needs the same
       # env to wire DI / DbContext / Redis. Without Redis__Connection the

--- a/Planscape.Server/docker/docker-compose.yml
+++ b/Planscape.Server/docker/docker-compose.yml
@@ -36,8 +36,13 @@ services:
       - ClamAv__Host=${CLAMAV_HOST:-clamav}
       - ClamAv__Port=${CLAMAV_PORT:-3310}
     depends_on:
-      pgbouncer:
-        condition: service_started
+      # NB: pgbouncer is intentionally NOT listed here. It lives behind the
+      # optional `pool` profile (see below), and Compose rejects the whole
+      # project ("depends on undefined service pgbouncer") if an active
+      # service depends on a profile-gated one that isn't enabled. The api
+      # connects to Host=postgres directly (see ConnectionStrings above);
+      # when you opt into pooling with `--profile pool`, repoint the
+      # connection string Host to `pgbouncer` as well.
       postgres:
         condition: service_healthy
       redis:

--- a/Planscape.Server/src/Planscape.API/wwwroot/app/index.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/app/index.html
@@ -29,6 +29,7 @@
   <a href="#workflows"     class="nav-link"        data-view="workflows">Workflows</a>
   <a href="#warnings"      class="nav-link"        data-view="warnings">Warnings</a>
   <a href="#models"        class="nav-link"        data-view="models">3D models</a>
+  <a href="#photos"        class="nav-link"        data-view="photos">Site photos</a>
   <a href="#schedule"      class="nav-link"        data-view="schedule">Schedule</a>
   <a href="#cost"          class="nav-link"        data-view="cost">Cost</a>
   <!-- Phase 152 — admin section -->

--- a/Planscape.Server/src/Planscape.API/wwwroot/css/dashboard.css
+++ b/Planscape.Server/src/Planscape.API/wwwroot/css/dashboard.css
@@ -511,3 +511,15 @@ tr:hover td { background: #fafafa; }
 .photo-sub { color:#6b7280; font-size:11px; margin-top:2px; }
 .photo-sub a { color:#3a7de8; text-decoration:none; }
 .photo-meta .badge { background:#eceff5; border-radius:8px; padding:1px 6px; font-size:10px; }
+
+/* Site photos — toolbar + capture form */
+.photo-toolbar { display:flex; gap:14px; align-items:center; margin-bottom:14px; flex-wrap:wrap; }
+.photo-toolbar label { font-size:12px; color:#555; display:flex; gap:6px; align-items:center; }
+.photo-toolbar select { padding:4px 6px; }
+.photo-capture { padding:14px; max-width:440px; margin-bottom:14px; display:flex; flex-direction:column; gap:8px; }
+.photo-capture .field { display:flex; flex-direction:column; gap:3px; }
+.photo-capture .field label { font-size:12px; color:#555; }
+.photo-capture input[type=text], .photo-capture select { padding:5px 7px; }
+.photo-capture .capture-row { display:flex; gap:10px; flex-wrap:wrap; }
+.photo-capture .capture-row label { display:flex; flex-direction:column; gap:3px; font-size:12px; color:#555; }
+.photo-capture .capture-gps { font-size:12px; color:#555; display:flex; gap:6px; align-items:center; }

--- a/Planscape.Server/src/Planscape.API/wwwroot/css/dashboard.css
+++ b/Planscape.Server/src/Planscape.API/wwwroot/css/dashboard.css
@@ -499,3 +499,15 @@ tr:hover td { background: #fafafa; }
 }
 @keyframes toastIn  { from { transform: translateY(20px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
 @keyframes toastOut { to   { transform: translateY(20px); opacity: 0; } }
+
+/* Site photos gallery (dashboard "Site photos" view) */
+.photo-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(220px,1fr)); gap:14px; }
+.photo-card { padding:0; overflow:hidden; }
+.photo-thumb { aspect-ratio:4/3; background:#eef0f4; display:flex; align-items:center; justify-content:center; }
+.photo-thumb img { width:100%; height:100%; object-fit:cover; cursor:zoom-in; display:block; }
+.photo-spinner, .photo-err { color:#8a8f99; font-size:12px; }
+.photo-meta { padding:8px 10px; }
+.photo-cap { font-weight:600; font-size:13px; }
+.photo-sub { color:#6b7280; font-size:11px; margin-top:2px; }
+.photo-sub a { color:#3a7de8; text-decoration:none; }
+.photo-meta .badge { background:#eceff5; border-radius:8px; padding:1px 6px; font-size:10px; }

--- a/Planscape.Server/src/Planscape.API/wwwroot/js/dashboard.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/js/dashboard.js
@@ -1344,15 +1344,128 @@
   // auth-gated, so a bare <img src> can't carry the Bearer token; each tile
   // lazy-fetches the file as a blob on scroll-into-view and swaps in an
   // object URL (the same pattern the coordination viewer uses for models).
+  const PHOTO_REASONS = ["Reference", "Progress", "Defect", "Safety", "QA", "Handover"];
+
   async function renderPhotos(main) {
-    const data = await api(`/api/projects/${state.projectId}/photos?pageSize=60`);
-    const items = (data && data.items) || [];
     main.innerHTML = `
       <h1>Site photos</h1>
-      ${items.length === 0
-        ? `<div class="empty">No photos yet. Capture site photos from the Planscape mobile app.</div>`
-        : `<div class="photo-grid">${items.map(photoCard).join("")}</div>`}`;
-    lazyLoadPhotos(main);
+      <div class="photo-toolbar">
+        <label>Album
+          <select id="photoAlbum"><option value="">All photos</option></select>
+        </label>
+        <button id="photoUploadBtn" class="btn-primary">＋ Upload photo</button>
+      </div>
+      <div id="photoUploadMount"></div>
+      <div id="photoGrid"><div class="empty">Loading…</div></div>`;
+
+    // Album dropdown (non-blocking).
+    api(`/api/projects/${state.projectId}/photo-albums`).then(albums => {
+      const list = Array.isArray(albums) ? albums : (albums && albums.items) || [];
+      const sel = document.getElementById("photoAlbum");
+      if (!sel) return;
+      list.forEach(a => {
+        const o = document.createElement("option");
+        o.value = a.id;
+        o.textContent = `${a.name}${a.photoCount != null ? " (" + a.photoCount + ")" : ""}`;
+        sel.appendChild(o);
+      });
+      sel.onchange = () => loadPhotoGrid(sel.value);
+    }).catch(() => {});
+
+    document.getElementById("photoUploadBtn").onclick = () => openCaptureForm();
+    await loadPhotoGrid("");
+  }
+
+  // Render the grid for "all photos" (albumId empty) or a single album.
+  async function loadPhotoGrid(albumId) {
+    const grid = document.getElementById("photoGrid");
+    if (!grid) return;
+    grid.innerHTML = `<div class="empty">Loading…</div>`;
+    try {
+      let items;
+      if (albumId) {
+        const a = await api(`/api/projects/${state.projectId}/photo-albums/${albumId}`);
+        items = (a && a.photos) || [];
+      } else {
+        const data = await api(`/api/projects/${state.projectId}/photos?pageSize=60`);
+        items = (data && data.items) || [];
+      }
+      grid.innerHTML = items.length === 0
+        ? `<div class="empty">No photos here yet. Capture from the mobile app or use “Upload photo”.</div>`
+        : `<div class="photo-grid">${items.map(photoCard).join("")}</div>`;
+      lazyLoadPhotos(grid);
+    } catch (e) {
+      grid.innerHTML = `<div class="empty">Could not load photos: ${esc(String(e))}</div>`;
+    }
+  }
+
+  // Capture-from-web: multipart POST to /photos/capture (the same endpoint
+  // the mobile app uses). Best-effort browser geolocation tags lat/long.
+  function openCaptureForm() {
+    const mount = document.getElementById("photoUploadMount");
+    if (!mount) return;
+    mount.innerHTML = `
+      <div class="card photo-capture">
+        <div class="field"><label>Photo</label><input type="file" id="capFile" accept="image/*" capture="environment" /></div>
+        <div class="field"><label>Caption</label><input type="text" id="capCaption" placeholder="What does this show?" /></div>
+        <div class="capture-row">
+          <label>Reason<select id="capReason">${PHOTO_REASONS.map(r => `<option>${r}</option>`).join("")}</select></label>
+          <label>Level<input type="text" id="capLevel" placeholder="L02" /></label>
+          <label>Zone<input type="text" id="capZone" placeholder="Z01" /></label>
+        </div>
+        <label class="capture-gps"><input type="checkbox" id="capGps" checked /> Tag GPS location</label>
+        <div class="actions">
+          <button class="btn-cancel" id="capCancel">Cancel</button>
+          <button class="btn-primary" id="capSubmit">Upload</button>
+        </div>
+        <p id="capStatus" class="error"></p>
+      </div>`;
+    document.getElementById("capCancel").onclick = () => { mount.innerHTML = ""; };
+    document.getElementById("capSubmit").onclick = submitCapture;
+  }
+
+  async function submitCapture() {
+    const fileEl = document.getElementById("capFile");
+    const status = document.getElementById("capStatus");
+    const btn = document.getElementById("capSubmit");
+    status.textContent = "";
+    const file = fileEl && fileEl.files && fileEl.files[0];
+    if (!file) { status.textContent = "Pick an image first."; return; }
+    btn.disabled = true; btn.textContent = "Uploading…";
+    try {
+      const fd = new FormData();
+      fd.append("File", file, file.name);
+      fd.append("Reason", document.getElementById("capReason").value || "Reference");
+      const cap = document.getElementById("capCaption").value.trim(); if (cap) fd.append("Caption", cap);
+      const lvl = document.getElementById("capLevel").value.trim();   if (lvl) fd.append("LevelCode", lvl);
+      const zone = document.getElementById("capZone").value.trim();   if (zone) fd.append("ZoneCode", zone);
+      fd.append("Source", "web");
+      if (document.getElementById("capGps").checked) {
+        const pos = await getGeo().catch(() => null);
+        if (pos) { fd.append("Latitude", String(pos.lat)); fd.append("Longitude", String(pos.lng)); if (pos.acc) fd.append("AccuracyM", String(pos.acc)); }
+      }
+      const res = await fetch(`/api/projects/${state.projectId}/photos/capture`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer " + getToken() }, // no Content-Type — browser sets the multipart boundary
+        body: fd,
+      });
+      if (!res.ok) throw new Error("HTTP " + res.status + " " + await res.text());
+      document.getElementById("photoUploadMount").innerHTML = "";
+      const sel = document.getElementById("photoAlbum");
+      await loadPhotoGrid(sel ? sel.value : "");
+    } catch (e) {
+      btn.disabled = false; btn.textContent = "Upload";
+      status.textContent = "Upload failed — check permissions and try again.";
+    }
+  }
+
+  function getGeo() {
+    return new Promise((resolve, reject) => {
+      if (!navigator.geolocation) return reject();
+      navigator.geolocation.getCurrentPosition(
+        p => resolve({ lat: p.coords.latitude, lng: p.coords.longitude, acc: p.coords.accuracy }),
+        reject, { enableHighAccuracy: true, timeout: 8000 });
+    });
   }
 
   function photoCard(p) {

--- a/Planscape.Server/src/Planscape.API/wwwroot/js/dashboard.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/js/dashboard.js
@@ -285,7 +285,7 @@
   // deep-link only (no nav button).
   const KNOWN_VIEWS = new Set([
     "overview", "issues", "documents", "transmittals", "meetings", "workflows",
-    "warnings", "models", "schedule", "cost", "tenant-keywords",
+    "warnings", "models", "photos", "schedule", "cost", "tenant-keywords",
     "tenant-bim-manager-roles", "project-dashboard",
   ]);
 
@@ -428,6 +428,7 @@
         case "workflows":    await renderList(main, `Workflow runs`, `/api/projects/${state.projectId}/workflows/history`, workflowColumns); break;
         case "warnings":     await renderList(main, `Warnings`, `/api/projects/${state.projectId}/warnings/trend`, warningColumns); break;
         case "models":       await renderModels(main); break;
+        case "photos":       await renderPhotos(main); break;
         case "schedule":     await renderList(main, `Schedule`, `/api/projects/${state.projectId}/schedule`, scheduleColumns); break;
         case "cost":         await renderCost(main); break;
         // Phase 152 — admin: tenant keyword extensions for the
@@ -1337,6 +1338,68 @@
     main.querySelectorAll('[data-action="delete"]').forEach(b => {
       b.onclick = () => openDeleteModelModal(main, { id: b.dataset.id, name: b.dataset.name });
     });
+  }
+
+  // Site photos — gallery over the existing /photos API. Photo bytes are
+  // auth-gated, so a bare <img src> can't carry the Bearer token; each tile
+  // lazy-fetches the file as a blob on scroll-into-view and swaps in an
+  // object URL (the same pattern the coordination viewer uses for models).
+  async function renderPhotos(main) {
+    const data = await api(`/api/projects/${state.projectId}/photos?pageSize=60`);
+    const items = (data && data.items) || [];
+    main.innerHTML = `
+      <h1>Site photos</h1>
+      ${items.length === 0
+        ? `<div class="empty">No photos yet. Capture site photos from the Planscape mobile app.</div>`
+        : `<div class="photo-grid">${items.map(photoCard).join("")}</div>`}`;
+    lazyLoadPhotos(main);
+  }
+
+  function photoCard(p) {
+    const when = fmtDate(p.capturedAt);
+    const where = [p.levelCode, p.zoneCode].filter(Boolean).join(" · ");
+    const gps = (p.latitude != null && p.longitude != null)
+      ? `<a href="https://maps.google.com/?q=${p.latitude},${p.longitude}" target="_blank" rel="noopener">📍 ${Number(p.latitude).toFixed(5)}, ${Number(p.longitude).toFixed(5)}</a>`
+      : "";
+    const aud = p.audience ? `<span class="badge">${esc(p.audience)}</span>` : "";
+    return `
+      <div class="card photo-card">
+        <div class="photo-thumb" data-photo-id="${esc(p.id)}"><div class="photo-spinner">Loading…</div></div>
+        <div class="photo-meta">
+          <div class="photo-cap">${esc(p.caption || "(no caption)")}</div>
+          <div class="photo-sub">${esc(when)}${where ? " · " + esc(where) : ""} ${aud}</div>
+          ${gps ? `<div class="photo-sub">${gps}</div>` : ""}
+        </div>
+      </div>`;
+  }
+
+  function lazyLoadPhotos(main) {
+    const tiles = Array.from(main.querySelectorAll(".photo-thumb[data-photo-id]"));
+    if (tiles.length === 0) return;
+    const load = async (tile) => {
+      const id = tile.getAttribute("data-photo-id");
+      if (!id) return;
+      tile.removeAttribute("data-photo-id"); // handled once
+      try {
+        const res = await fetch(`/api/projects/${state.projectId}/photos/${id}/file`,
+          { headers: { Authorization: "Bearer " + getToken() } });
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        const obj = URL.createObjectURL(await res.blob());
+        const img = document.createElement("img");
+        img.src = obj; img.alt = ""; img.onclick = () => window.open(obj, "_blank");
+        tile.innerHTML = ""; tile.appendChild(img);
+      } catch (e) {
+        tile.innerHTML = `<div class="photo-err">⚠ unavailable</div>`;
+      }
+    };
+    if ("IntersectionObserver" in window) {
+      const io = new IntersectionObserver((entries) => {
+        entries.forEach(en => { if (en.isIntersecting) { io.unobserve(en.target); load(en.target); } });
+      }, { rootMargin: "200px" });
+      tiles.forEach(t => io.observe(t));
+    } else {
+      tiles.forEach(load);
+    }
   }
 
   // Wrong-model rescue: the Revit plugin SHA-256-dedups uploads, so a

--- a/Planscape.Server/src/Planscape.API/wwwroot/js/dashboard.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/js/dashboard.js
@@ -59,7 +59,9 @@
         res = await fetch(path, Object.assign({}, options, { headers }));
       } else {
         showLogin();
-        throw new Error("unauthenticated");
+        const e = new Error("unauthenticated");
+        e.unauthenticated = true;
+        throw e;
       }
     }
     if (!res.ok) throw new Error("HTTP " + res.status + " " + await res.text());
@@ -84,6 +86,8 @@
 
   function showLogin() {
     document.getElementById("loginOverlay").classList.remove("hidden");
+    const chip = document.getElementById("userChip");
+    if (chip) chip.textContent = "Not signed in";
   }
   function hideLogin() {
     document.getElementById("loginOverlay").classList.add("hidden");
@@ -271,25 +275,52 @@
 
   // ── Boot + router ─────────────────────────────────────────────────────
 
-  async function boot() {
-    document.getElementById("userChip").textContent = localStorage.getItem(USER_KEY) || "";
-    // Phase 169 — pull public runtime config (Mapbox token) before any
-    // view tries to render the map.
-    await loadPublicConfig();
-    try {
-      state.projects = await api("/api/projects");
-    } catch { return; /* showLogin already invoked */ }
-    const picker = document.getElementById("projectPicker");
-    picker.innerHTML = state.projects
-      .map(p => `<option value="${p.id}">${esc(p.name)} (${esc(p.code)})</option>`)
-      .join("");
-    state.projectId = state.projects[0]?.id || null;
-    picker.addEventListener("change", () => { state.projectId = picker.value; Hub.join(state.projectId); render(); });
+  // Wire the persistent chrome (chip, nav links) exactly once. This MUST run
+  // before any network call so the sidebar buttons are always live — even
+  // when the API is unreachable. Previously these handlers were attached
+  // only *after* a successful /api/projects fetch, so a server that was down
+  // (or returned 5xx) left every nav link dead and the chip frozen on
+  // "Signing in…".
+  // Views that can appear in the URL hash. project-dashboard is reachable by
+  // deep-link only (no nav button).
+  const KNOWN_VIEWS = new Set([
+    "overview", "issues", "documents", "transmittals", "meetings", "workflows",
+    "warnings", "models", "schedule", "cost", "tenant-keywords",
+    "tenant-bim-manager-roles", "project-dashboard",
+  ]);
 
-    // P1-C — open the realtime connection once we have a project context.
-    // Fire-and-forget: rendering must not wait on the SignalR CDN load.
-    Hub.start();
+  // Parse a hash like "#models?project=GUID" into { view, project }.
+  function parseHash() {
+    const h = (location.hash || "").replace(/^#/, "");
+    const [viewPart, queryPart] = h.split("?");
+    const params = new URLSearchParams(queryPart || "");
+    return { view: viewPart || "", project: params.get("project") };
+  }
 
+  // Sync state + active nav link from the URL hash. Called on boot and on
+  // every hashchange so deep-links (incl. the Revit BCC "Open Web Dashboard"
+  // button) land on the right view/project instead of always Overview.
+  function applyHashRoute() {
+    const { view, project } = parseHash();
+    if (project && state.projects.some(p => String(p.id) === String(project))) {
+      state.projectId = project;
+      const picker = document.getElementById("projectPicker");
+      if (picker) picker.value = project;
+    }
+    if (view && KNOWN_VIEWS.has(view)) {
+      state.view = view;
+      document.querySelectorAll(".nav-link").forEach(l => {
+        l.classList.toggle("active", l.dataset.view === view);
+      });
+    }
+  }
+
+  let chromeWired = false;
+  function wireChrome() {
+    if (chromeWired) return;
+    chromeWired = true;
+    const chip = document.getElementById("userChip");
+    if (chip) chip.textContent = localStorage.getItem(USER_KEY) || "Signed in";
     document.querySelectorAll(".nav-link").forEach(link => {
       link.addEventListener("click", (ev) => {
         ev.preventDefault();
@@ -299,6 +330,65 @@
         render();
       });
     });
+    window.addEventListener("hashchange", () => { applyHashRoute(); render(); });
+  }
+
+  // Shown when the API can't be reached (server down, wrong port, CORS,
+  // 5xx). Keeps the chrome alive and gives the user a way back in instead
+  // of a silent freeze.
+  function renderServerUnreachable(err) {
+    const chip = document.getElementById("userChip");
+    if (chip) chip.textContent = "Offline";
+    const main = document.getElementById("main");
+    if (!main) return;
+    main.innerHTML = `
+      <div class="greeting-strip">
+        <div>
+          <h2>Can't reach the Planscape server</h2>
+          <div class="summary">The dashboard loaded, but the API at
+            <code>${esc(location.origin)}/api</code> didn't respond. Make sure the
+            Planscape server is running (e.g. <code>docker compose up -d</code> in
+            <code>Planscape.Server/docker</code>), then retry.</div>
+          <div class="summary" style="margin-top:6px;opacity:.7">${esc(String(err && err.message || err || ""))}</div>
+        </div>
+        <div class="actions">
+          <button id="btnRetryBoot" class="btn-primary">↻ Retry</button>
+          <button id="btnReLogin" class="ghost">Sign in again</button>
+        </div>
+      </div>`;
+    const retry = document.getElementById("btnRetryBoot");
+    if (retry) retry.onclick = () => { state.projectId = null; boot().catch(() => {}); };
+    const relog = document.getElementById("btnReLogin");
+    if (relog) relog.onclick = () => { clearTokens(); showLogin(); };
+  }
+
+  async function boot() {
+    wireChrome();
+    // Phase 169 — pull public runtime config (Mapbox token) before any
+    // view tries to render the map. Non-fatal on its own.
+    await loadPublicConfig();
+    try {
+      state.projects = await api("/api/projects");
+    } catch (e) {
+      // 401 path already invoked showLogin() inside api(); anything else is a
+      // server-reachability problem — show it instead of freezing.
+      if (!(e && e.unauthenticated)) renderServerUnreachable(e);
+      return;
+    }
+    const picker = document.getElementById("projectPicker");
+    picker.innerHTML = state.projects
+      .map(p => `<option value="${p.id}">${esc(p.name)} (${esc(p.code)})</option>`)
+      .join("");
+    state.projectId = state.projects[0]?.id || null;
+    picker.onchange = () => { state.projectId = picker.value; Hub.join(state.projectId); render(); };
+
+    // Honour any deep-link in the URL hash (view + project) before first paint.
+    applyHashRoute();
+
+    // P1-C — open the realtime connection once we have a project context.
+    // Fire-and-forget: rendering must not wait on the SignalR CDN load.
+    Hub.start();
+
     render();
   }
 
@@ -1219,7 +1309,7 @@
   }
 
   async function renderModels(main) {
-    const rows = await api(`/api/projects/${state.projectId}/models`);
+    const rows = (await api(`/api/projects/${state.projectId}/models`)) || [];
     main.innerHTML = `
       <h1>3D models</h1>
       ${rows.length === 0 ? `<div class="empty">No models published yet. Use the Revit plugin's "Publish Model to Planscape" command.</div>` : ""}

--- a/Planscape.Server/src/Planscape.API/wwwroot/meeting-sync.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/meeting-sync.js
@@ -36,8 +36,10 @@
 
   var state = {
     conn: null,
-    following: true,        // followers track the presenter's camera
-    applyingRemote: false,  // feedback-loop guard
+    following: true,         // followers track the presenter's camera
+    applyingRemote: false,   // camera feedback-loop guard
+    applyingRemoteHi: false, // highlight feedback-loop guard
+    applyingRemoteSec: false,// section feedback-loop guard
     lastSentAt: 0,
     participants: new Map(), // connectionId → { displayName }
   };
@@ -96,16 +98,21 @@
     conn.on("OverlayChanged", function (profile) {
       try { window.STING_VIEWER.applyOverlay && window.STING_VIEWER.applyOverlay(profile); } catch (e) {}
     });
-    // Received-but-not-yet-applied hooks (fast-follow): expose for later wiring.
-    conn.on("SectionChanged", function (msg) { window.dispatchEvent(new CustomEvent("sting:remoteSection", { detail: msg && msg.section })); });
-    conn.on("HighlightChanged", function (msg) { window.dispatchEvent(new CustomEvent("sting:remoteHighlight", { detail: msg && msg.guids })); });
+    conn.on("SectionChanged", function (msg) {
+      applyRemoteSection(msg && msg.section);
+      window.dispatchEvent(new CustomEvent("sting:remoteSection", { detail: msg && msg.section }));
+    });
+    conn.on("HighlightChanged", function (msg) {
+      applyRemoteHighlight(msg && msg.guids);
+      window.dispatchEvent(new CustomEvent("sting:remoteHighlight", { detail: msg && msg.guids }));
+    });
     conn.on("RoomChanged", function (st) { window.dispatchEvent(new CustomEvent("sting:roomChanged", { detail: st })); });
 
     conn.onreconnected(function () { conn.invoke("JoinSession", sessionId, displayName).catch(noop); });
 
     conn.start()
       .then(function () { return conn.invoke("JoinSession", sessionId, displayName); })
-      .then(function () { wireCameraBroadcast(); setStatus("live"); })
+      .then(function () { wireCameraBroadcast(); wireSelectionAndSection(); setStatus("live"); })
       .catch(function (e) { console.warn("[meeting] connect failed", e); setStatus("offline"); });
 
     window.addEventListener("beforeunload", function () {
@@ -154,6 +161,68 @@
     // Release the guard after the controls 'end'/'change' has flushed.
     setTimeout(function () { state.applyingRemote = false; }, 0);
   }
+
+  // ── outbound: selection (highlight) + section plane ───────────────────
+  // Non-invasive: we wrap the viewer's existing outbound event bus
+  // (bridge.send) and the one section setter, rather than editing the
+  // 4k-line coordination viewer. coordination-viewer.js also wraps
+  // bridge.send; we chain on top of whatever's there.
+  function wireSelectionAndSection() {
+    var V = window.STING_VIEWER;
+    try {
+      if (V && V.bridge && typeof V.bridge.send === "function" && !V.bridge.__meetingWrapped) {
+        var orig = V.bridge.send.bind(V.bridge);
+        V.bridge.send = function (type, payload) {
+          try {
+            if (!state.applyingRemoteHi && state.conn && (type === "pick" || type === "pinTap")) {
+              var guid = payload && (payload.guid || (payload.meta && payload.meta.guid));
+              if (guid) state.conn.invoke("BroadcastHighlight", sessionId, [guid]).catch(noop);
+            }
+          } catch (e) {}
+          return orig(type, payload);
+        };
+        V.bridge.__meetingWrapped = true;
+      }
+    } catch (e) {}
+    try {
+      var ext = window.STING_VIEWER_EXTRAS;
+      if (ext && typeof ext.setSectionPlane === "function" && !ext.__meetingWrapped) {
+        var origSec = ext.setSectionPlane.bind(ext);
+        ext.setSectionPlane = function (plane) {
+          var r = origSec(plane);
+          try {
+            if (!state.applyingRemoteSec && state.conn)
+              state.conn.invoke("BroadcastSection", sessionId, { plane: plane }).catch(noop);
+          } catch (e) {}
+          return r;
+        };
+        ext.__meetingWrapped = true;
+      }
+    } catch (e) {}
+  }
+
+  function applyRemoteHighlight(guids) {
+    state.applyingRemoteHi = true;
+    try {
+      if (guids && guids.length) postCmd({ type: "selectAndZoom", payload: { guid: guids[0] } });
+      else postCmd({ type: "clearHighlight" });
+    } catch (e) {}
+    setTimeout(function () { state.applyingRemoteHi = false; }, 60);
+  }
+
+  function applyRemoteSection(section) {
+    var ext = window.STING_VIEWER_EXTRAS;
+    if (!ext || typeof ext.setSectionPlane !== "function") return;
+    var plane = section && (section.plane || section);
+    if (!plane) return;
+    state.applyingRemoteSec = true;
+    try { ext.setSectionPlane(plane); } catch (e) {}
+    setTimeout(function () { state.applyingRemoteSec = false; }, 0);
+  }
+
+  // Drive the viewer engine via its window 'message' command channel
+  // (viewer.html: window.addEventListener('message', e => handleCommand(JSON.parse(e.data)))).
+  function postCmd(cmd) { try { window.postMessage(JSON.stringify(cmd), "*"); } catch (e) {} }
 
   // ── presence UI (small corner panel) ──────────────────────────────────
   function buildPresenceUI() {
@@ -234,6 +303,10 @@
     set following(v) { state.following = !!v; var f = document.getElementById("meetingFollow"); if (f) f.checked = !!v; },
     serializeCamera: serializeCamera,
     applyRemoteCamera: applyRemoteCamera,
+    applyRemoteHighlight: applyRemoteHighlight,
+    applyRemoteSection: applyRemoteSection,
+    broadcastHighlight: function (guids) { if (state.conn) state.conn.invoke("BroadcastHighlight", sessionId, guids || []).catch(noop); },
+    broadcastSection: function (section) { if (state.conn) state.conn.invoke("BroadcastSection", sessionId, section || {}).catch(noop); },
     sessionId: sessionId,
   };
 })();

--- a/Planscape.Server/src/Planscape.API/wwwroot/meeting-sync.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/meeting-sync.js
@@ -1,0 +1,239 @@
+/* meeting-sync.js — live synced 3D meetings client.
+ *
+ * The server half has always existed (MeetingHub at /hubs/meeting +
+ * MeetingRoomController), but no client ever connected to it, so the
+ * realtime co-presence feature was dark. This is that client.
+ *
+ * Activation is OPT-IN via the URL: it only does anything when the viewer
+ * is opened with `?meeting=<sessionId>` (a MeetingSession GUID). Without
+ * it the script is a complete no-op — zero risk to the standalone viewer.
+ *
+ *   /viewer.html?project=<pid>&model=<mid>&meeting=<sessionId>
+ *
+ * What it syncs (v1): live camera ("follow the presenter") + participant
+ * presence + K3 overlay pushes. Section/highlight broadcasts are received
+ * and exposed as hooks for a fast-follow; camera-follow is the 80% feature.
+ *
+ * Contract (see MeetingHub.cs):
+ *   invoke: JoinSession(sessionId, name) · LeaveSession(sessionId)
+ *           BroadcastCamera(sessionId, camera) · BroadcastOverlay(...) · …
+ *   on:     ParticipantJoined/Left · CameraMoved({camera}) · OverlayChanged(profile)
+ *           SectionChanged({section}) · HighlightChanged({guids}) · RoomChanged(state)
+ */
+(function () {
+  "use strict";
+
+  var params = new URLSearchParams(location.search);
+  var sessionId = params.get("meeting") || params.get("session") || "";
+  var projectId = params.get("project") || "";
+  if (!sessionId) return; // not a meeting — stay inert.
+
+  var TOKEN_KEY = "planscape_token";
+  var USER_KEY  = "planscape_user";
+  var apiBase   = (params.get("api") || "").replace(/\/$/, ""); // same-origin when blank
+  var token     = (function () { try { return localStorage.getItem(TOKEN_KEY) || ""; } catch (e) { return ""; } })();
+  var displayName = (function () { try { return (localStorage.getItem(USER_KEY) || "Guest").split("@")[0]; } catch (e) { return "Guest"; } })();
+
+  var state = {
+    conn: null,
+    following: true,        // followers track the presenter's camera
+    applyingRemote: false,  // feedback-loop guard
+    lastSentAt: 0,
+    participants: new Map(), // connectionId → { displayName }
+  };
+
+  // ── wait for both the viewer API and the SignalR lib (shim loads it async)
+  function ready(cb, tries) {
+    tries = tries || 0;
+    var V = window.STING_VIEWER;
+    if (V && V.camera && V.controls && window.signalR) return cb();
+    if (tries > 200) { console.warn("[meeting] STING_VIEWER / signalR never became ready"); return; }
+    setTimeout(function () { ready(cb, tries + 1); }, 100);
+  }
+
+  ready(start);
+
+  function start() {
+    buildPresenceUI();
+    // Best-effort REST join so the hub's OwnsSessionAsync guard passes
+    // (adds the participant row). Non-fatal if it 403s — the hub will
+    // simply not add us to the group and we degrade to view-only.
+    restJoin().finally(connect);
+  }
+
+  function restJoin() {
+    if (!projectId) return Promise.resolve();
+    var url = apiBase + "/api/projects/" + projectId + "/meeting-sessions/" + sessionId + "/join";
+    return fetch(url, {
+      method: "POST",
+      headers: token ? { "Authorization": "Bearer " + token, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      body: JSON.stringify({ displayName: displayName }),
+    }).catch(function () { /* non-fatal */ });
+  }
+
+  function connect() {
+    var SR = window.signalR;
+    var hubUrl = apiBase + "/hubs/meeting";
+    var conn = new SR.HubConnectionBuilder()
+      .withUrl(hubUrl, { accessTokenFactory: function () { return token; } })
+      .withAutomaticReconnect()
+      .build();
+    state.conn = conn;
+
+    conn.on("ParticipantJoined", function (p) {
+      if (p && p.connectionId) state.participants.set(p.connectionId, { displayName: p.displayName || "Guest" });
+      renderPresence();
+      toast((p && p.displayName ? p.displayName : "Someone") + " joined");
+    });
+    conn.on("ParticipantLeft", function (p) {
+      if (p && p.connectionId) state.participants.delete(p.connectionId);
+      renderPresence();
+    });
+    conn.on("CameraMoved", function (msg) {
+      if (!state.following) return;
+      applyRemoteCamera(msg && msg.camera);
+    });
+    conn.on("OverlayChanged", function (profile) {
+      try { window.STING_VIEWER.applyOverlay && window.STING_VIEWER.applyOverlay(profile); } catch (e) {}
+    });
+    // Received-but-not-yet-applied hooks (fast-follow): expose for later wiring.
+    conn.on("SectionChanged", function (msg) { window.dispatchEvent(new CustomEvent("sting:remoteSection", { detail: msg && msg.section })); });
+    conn.on("HighlightChanged", function (msg) { window.dispatchEvent(new CustomEvent("sting:remoteHighlight", { detail: msg && msg.guids })); });
+    conn.on("RoomChanged", function (st) { window.dispatchEvent(new CustomEvent("sting:roomChanged", { detail: st })); });
+
+    conn.onreconnected(function () { conn.invoke("JoinSession", sessionId, displayName).catch(noop); });
+
+    conn.start()
+      .then(function () { return conn.invoke("JoinSession", sessionId, displayName); })
+      .then(function () { wireCameraBroadcast(); setStatus("live"); })
+      .catch(function (e) { console.warn("[meeting] connect failed", e); setStatus("offline"); });
+
+    window.addEventListener("beforeunload", function () {
+      try { conn.invoke("LeaveSession", sessionId); } catch (e) {}
+    });
+  }
+
+  // ── outbound: broadcast our camera when the user finishes a move ───────
+  function wireCameraBroadcast() {
+    var controls = window.STING_VIEWER.controls;
+    if (!controls || !controls.addEventListener) return;
+    var onMove = throttle(function () {
+      if (state.applyingRemote) return;          // don't echo a remote move
+      if (!state.conn) return;
+      var cam = serializeCamera();
+      if (!cam) return;
+      state.conn.invoke("BroadcastCamera", sessionId, cam).catch(noop);
+    }, 100);
+    // OrbitControls fires 'end' on interaction finish, 'change' continuously.
+    controls.addEventListener("end", onMove);
+  }
+
+  function serializeCamera() {
+    var V = window.STING_VIEWER;
+    var c = V.camera, ctl = V.controls;
+    if (!c || !ctl) return null;
+    return {
+      p: c.position.toArray(),
+      t: ctl.target.toArray(),
+      q: c.quaternion ? c.quaternion.toArray() : null,
+    };
+  }
+
+  function applyRemoteCamera(cam) {
+    if (!cam) return;
+    var V = window.STING_VIEWER;
+    var c = V.camera, ctl = V.controls;
+    if (!c || !ctl) return;
+    state.applyingRemote = true;
+    try {
+      if (cam.p) c.position.fromArray(cam.p);
+      if (cam.q && c.quaternion) c.quaternion.fromArray(cam.q);
+      if (cam.t) ctl.target.fromArray(cam.t);
+      ctl.update && ctl.update();
+    } catch (e) { /* ignore */ }
+    // Release the guard after the controls 'end'/'change' has flushed.
+    setTimeout(function () { state.applyingRemote = false; }, 0);
+  }
+
+  // ── presence UI (small corner panel) ──────────────────────────────────
+  function buildPresenceUI() {
+    if (document.getElementById("meetingPanel")) return;
+    var panel = document.createElement("div");
+    panel.id = "meetingPanel";
+    panel.style.cssText = [
+      "position:absolute", "top:8px", "right:184px", "z-index:12",
+      "background:rgba(0,0,0,0.66)", "color:#fff", "padding:8px 10px",
+      "border-radius:6px", "font:12px -apple-system,Segoe UI,Roboto,sans-serif",
+      "max-width:220px", "backdrop-filter:blur(4px)",
+    ].join(";");
+    panel.innerHTML =
+      '<div style="display:flex;align-items:center;gap:6px;margin-bottom:6px">' +
+        '<span id="meetingDot" style="width:8px;height:8px;border-radius:50%;background:#e8a13a"></span>' +
+        '<strong>Live meeting</strong>' +
+      '</div>' +
+      '<label style="display:flex;align-items:center;gap:6px;cursor:pointer;margin-bottom:6px">' +
+        '<input type="checkbox" id="meetingFollow" checked> Follow presenter' +
+      '</label>' +
+      '<div id="meetingParticipants" style="display:flex;flex-wrap:wrap;gap:4px"></div>';
+    (document.getElementById("viewer-canvas") ? document.body : document.body).appendChild(panel);
+    var f = document.getElementById("meetingFollow");
+    if (f) f.addEventListener("change", function () { state.following = f.checked; });
+    renderPresence();
+  }
+
+  function renderPresence() {
+    var host = document.getElementById("meetingParticipants");
+    if (!host) return;
+    host.innerHTML = "";
+    var me = document.createElement("span");
+    me.textContent = displayName + " (you)";
+    me.style.cssText = chipCss("#3a7de8");
+    host.appendChild(me);
+    state.participants.forEach(function (p) {
+      var s = document.createElement("span");
+      s.textContent = p.displayName;
+      s.style.cssText = chipCss(colorFor(p.displayName));
+      host.appendChild(s);
+    });
+  }
+
+  function setStatus(s) {
+    var dot = document.getElementById("meetingDot");
+    if (dot) dot.style.background = s === "live" ? "#37c272" : (s === "offline" ? "#d05050" : "#e8a13a");
+  }
+
+  // ── small helpers ──────────────────────────────────────────────────────
+  function chipCss(bg) {
+    return "background:" + bg + ";padding:2px 7px;border-radius:10px;font-size:11px;white-space:nowrap";
+  }
+  function colorFor(name) {
+    var h = 0; for (var i = 0; i < (name || "").length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+    return "hsl(" + (h % 360) + ",55%,42%)";
+  }
+  function throttle(fn, ms) {
+    var last = 0, timer = null;
+    return function () {
+      var now = Date.now(), wait = ms - (now - last);
+      if (wait <= 0) { last = now; fn(); }
+      else if (!timer) { timer = setTimeout(function () { last = Date.now(); timer = null; fn(); }, wait); }
+    };
+  }
+  function toast(msg) {
+    var t = document.createElement("div");
+    t.textContent = msg;
+    t.style.cssText = "position:absolute;bottom:64px;left:50%;transform:translateX(-50%);z-index:13;" +
+      "background:rgba(0,0,0,0.8);color:#fff;padding:6px 12px;border-radius:4px;font:12px sans-serif";
+    document.body.appendChild(t);
+    setTimeout(function () { t.remove(); }, 2500);
+  }
+  function noop() {}
+
+  // Expose a tiny API for tests / future wiring.
+  window.STING_MEETING = {
+    get following() { return state.following; },
+    set following(v) { state.following = !!v; var f = document.getElementById("meetingFollow"); if (f) f.checked = !!v; },
+    serializeCamera: serializeCamera,
+    applyRemoteCamera: applyRemoteCamera,
+    sessionId: sessionId,
+  };
+})();

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -1443,5 +1443,10 @@ THREE.ColorManagement.enabled = false;
 
 <!-- Coordination layer — panels, API, clash + issue management. -->
 <script defer src="./coordination-viewer.js"></script>
+
+<!-- Live synced meetings — opt-in via ?meeting=<sessionId>. Connects to
+     /hubs/meeting for camera-follow + participant presence + overlay sync.
+     Complete no-op when the meeting param is absent. -->
+<script defer src="./meeting-sync.js"></script>
 </body>
 </html>

--- a/StingTools/BIMManager/PlanscapeServerClient.CrossHost.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.CrossHost.cs
@@ -1,3 +1,4 @@
+#nullable enable
 // PlanscapeServerClient — read-only dashboard + cross-host identity getters.
 //
 // Three thin GETs the BIM Coordination Center renders:

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -2819,7 +2819,13 @@ namespace StingTools.BIMManager
                 if (string.IsNullOrWhiteSpace(url))
                     url = "https://planscape-api.onrender.com";
 
-                string dashboardUrl = url.TrimEnd('/') + "/dashboard";
+                // /app/ is the real coordinator SPA; deep-link to the active
+                // project's models when one is connected. (The old "/dashboard"
+                // path is not a served route.)
+                string dashboardUrl = url.TrimEnd('/') + "/app/";
+                var client = PlanscapeServerClient.Instance;
+                if (client != null && client.IsConnected && client.CurrentProjectId != Guid.Empty)
+                    dashboardUrl += $"#models?project={client.CurrentProjectId}";
                 Process.Start(new ProcessStartInfo(dashboardUrl) { UseShellExecute = true })?.Dispose();
                 StingLog.Info($"Planscape: opened dashboard {dashboardUrl}");
                 return Result.Succeeded;

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -364,11 +364,14 @@ namespace StingTools.BIMManager
                 CommonButtons = TaskDialogCommonButtons.Cancel,
             };
             dlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
-                "Export current 3D view to GLB",
-                "Uses the built-in STING glTF exporter. Active view must be a 3D view.");
+                "Export current 3D view to GLB  (recommended)",
+                "Uses the built-in STING glTF exporter. Active view must be a 3D view. " +
+                "Produces a file the web/mobile viewer renders directly — no server conversion needed.");
             dlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink2,
-                "Pick an existing file (.glb / .gltf / .ifc / .obj / .fbx)",
-                "Use a file produced by APS, SimLab, rvt2gltf, Dynamo, etc.");
+                "Pick an existing file (.glb / .gltf / .ifc)",
+                "GLB/glTF render directly. IFC is auto-converted to GLB on the server " +
+                "(requires the Planscape converter to be enabled). OBJ/FBX are NOT supported — " +
+                "the viewer can't render them and there is no converter, so they're excluded.");
             var r = dlg.Show();
             if (r == TaskDialogResult.CommandLink1) return ExportActiveView(doc);
             if (r == TaskDialogResult.CommandLink2) return PromptForModelFile();
@@ -411,7 +414,12 @@ namespace StingTools.BIMManager
             var dlg = new OpenFileDialog
             {
                 Title = "Select 3D model to publish",
-                Filter = "3D models (*.glb;*.gltf;*.ifc;*.obj;*.fbx)|*.glb;*.gltf;*.ifc;*.obj;*.fbx|All files (*.*)|*.*",
+                // Only formats the platform can actually display: GLB/glTF render
+                // directly in the web/mobile viewer; IFC is auto-converted to GLB
+                // server-side by ModelDerivativeJob. OBJ/FBX are intentionally
+                // excluded — there is no converter for them, so publishing one
+                // produces a model that opens to an empty viewer.
+                Filter = "Viewable 3D models (*.glb;*.gltf;*.ifc)|*.glb;*.gltf;*.ifc|All files (*.*)|*.*",
                 CheckFileExists = true,
                 CheckPathExists = true,
             };

--- a/StingTools/Core/WarningsManager.cs
+++ b/StingTools/Core/WarningsManager.cs
@@ -4732,12 +4732,21 @@ namespace StingTools.Core
                     {
                         try
                         {
-                            string url = BIMManager.PlanscapeServerClient.Instance.ServerUrl;
-                            if (string.IsNullOrEmpty(url))
+                            var client = BIMManager.PlanscapeServerClient.Instance;
+                            string baseUrl = client.ServerUrl;
+                            if (string.IsNullOrEmpty(baseUrl))
                             {
                                 TaskDialog.Show("STING — Planscape", "Connect to the Planscape server first.");
                                 return;
                             }
+                            // Open the real coordinator SPA at /app/ — the full
+                            // sidebar dashboard (Issues / Documents / Transmittals /
+                            // Warnings / 3D models) — not the marketing landing page
+                            // served at the server root. Deep-link straight to the
+                            // active project's models when one is connected.
+                            string url = baseUrl.TrimEnd('/') + "/app/";
+                            if (client.IsConnected && client.CurrentProjectId != Guid.Empty)
+                                url += $"#models?project={client.CurrentProjectId}";
                             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                                 { FileName = url, UseShellExecute = true })?.Dispose();
                         }

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -8954,10 +8954,16 @@ namespace StingTools.UI
             {
                 baseUrl = "http://localhost:5000";
             }
-            string url = baseUrl.TrimEnd('/') + "/index.html";
+            // Open the real coordinator SPA (/app/) — the full sidebar
+            // dashboard with Issues / Documents / Transmittals / Warnings /
+            // 3D models — rather than the marketing landing page at
+            // /index.html. The SPA reads location.hash to pick the active
+            // view, so deep-link straight to a project's models when a
+            // project is active on the client.
+            string url = baseUrl.TrimEnd('/') + "/app/";
             if (client.IsConnected && client.CurrentProjectId != Guid.Empty)
             {
-                url += $"#project-dashboard?project={client.CurrentProjectId}";
+                url += $"#models?project={client.CurrentProjectId}";
             }
             try
             {


### PR DESCRIPTION
## Summary

Makes the Planscape web platform actually work end-to-end from the Revit BCC, then adds two previously-dark features (live synced meetings, site photos in the web). Started from a user report — "BCC opens the old boring page, buttons are lifeless, the 3D viewer opens empty" — and worked outward through a cross-surface alignment pass.

## Fixes

| # | Problem | Fix |
|---|---|---|
| `fdf6d5a` | `/app/` dashboard froze on "Signing in…" with dead nav buttons when the API was unreachable (`boot()` wired nav only *after* a successful fetch; non-401 errors were swallowed) | Wire chrome before the API call; show login on 401, a recoverable "server unreachable" panel otherwise; add URL-hash routing so deep-links land on the right view |
| `7437f6f` | `docker compose up -d` failed: `api` depended on the profile-gated `pgbouncer` service | Drop the spurious dependency (api connects to `postgres` directly); documented the `pool` profile |
| `18600c2` | 6 × CS8632 warnings | `#nullable enable` on `PlanscapeServerClient.CrossHost.cs` to match its sibling partials |
| `11f769f` + (in `WarningsManager`/`PlanscapeOpenWebCommand`) | BCC "Open Web Dashboard" opened the marketing `index.html` (and a non-existent `/dashboard`) | All three open-web code paths now open the real SPA at `/app/` with a project deep-link |
| `8a47a38` | **Empty 3D viewer after publishing** — the publish picker accepted `.obj/.fbx`, which nothing can render or convert | Narrow the picker to `.glb/.gltf/.ifc`; "Export 3D view to GLB" (already built) marked recommended; enable the already-built server IFC→GLB pipeline from `.env` (`IFCCONVERT_URL` build-arg passthrough + `MODEL_CONVERTER_PROVIDER=ifcconvert`) |

## Features

- **Live synced meetings** (`11c4260` + `7fdc96b`) — new `meeting-sync.js`, the missing client for the already-built `/hubs/meeting`. The server was emitting co-presence to nobody. Opt-in via `?meeting=<sessionId>` (fully inert otherwise): camera-follow, participant presence + Follow toggle, overlay sync, **and** element-highlight + section-plane sync — all feedback-guarded, wired non-invasively around the existing viewer event bus.
- **Site photos in the web** (`88d7a70` + `d6f4d17`) — new "Site photos" view in `/app/` over the existing `/photos` API: responsive gallery (caption / date / level-zone / audience / GPS link, auth-blob lazy-loaded thumbnails), an **album filter**, and **capture-from-web** (multipart upload to the same `/photos/capture` endpoint the mobile app uses, with optional browser geolocation).

## Verification

All web JS is runtime-verified in **headless Chromium against mocked APIs**:

- Dashboard boot/login/deep-link **10/10** · Meetings base **9/9** · Meetings section/highlight **7/7** · Photos gallery **6/6** · Photos album+capture **7/7**.
- Compose validated with `docker compose config` (default + `--profile pool` + converter-enabled).

**Caveats (please confirm on the running stack):**
1. No `dotnet`/Revit/full-stack in the dev sandbox — the **C# plugin** changes (`PublishModelCommand`, the three open-web paths, the nullable fix) and the **converter enablement** are verified by inspection + compose-parse only. Build the plugin + run the stack to confirm.
2. **Live meetings** end-to-end needs the real SignalR server + a `MeetingSession` + two clients; the harness proves the client speaks the hub contract, not the round trip.
3. **Capture-from-web** is verified to POST the correct multipart; the real `/photos/capture` also enforces project membership + image validation + redaction.

## How to test

- **Backend:** `cd Planscape.Server/docker && cp .env.template .env` → set `JWT_KEY` → `docker compose up -d`. Sign in at `/app/` with `admin@planscape.demo` / `admin123`.
- **Viewer:** Revit → Publish Model → "Export 3D view to GLB". For IFC: set `MODEL_CONVERTER_PROVIDER=ifcconvert` + `IFCCONVERT_URL=…`, `docker compose build api worker`, `up -d`.
- **Site photos:** `/app/` → Site photos (web JS is bind-mounted; hard-refresh, no rebuild).
- **Live meeting:** open the viewer with `?meeting=<sessionId>` (create via `POST /api/projects/{id}/meeting-sessions`); two participants on the same session → camera/section/highlight follow.

Companion read-only audit (`docs/PLANSCAPE_ALIGNMENT_AUDIT.md`, authored separately) catalogs further cross-surface mismatches not addressed here (e.g. mobile token-field + realtime-hub blockers).

https://claude.ai/code/session_01WgVp8yGCyTvnzXC4RNsno6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgVp8yGCyTvnzXC4RNsno6)_