### PR TITLE
fix(ci): set up Docker Buildx for GHA cache export

### DIFF
--- a/.github/workflows/planscape-server.yml
+++ b/.github/workflows/planscape-server.yml
@@ -92,6 +92,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Buildx with the docker-container driver is REQUIRED for GHA cache export
+      # (cache-to: type=gha). Without it the default 'docker' driver is used and
+      # the build fails: "Cache export is not supported for the docker driver."
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Fixes the pre-existing Docker Build & Push failure on main (Cache export not supported for the docker driver) by adding docker/setup-buildx-action. Unrelated to branch code; part of getting main fully green for the consolidation. Job is push-to-main only so it is verified on main after merge.