### PR TITLE
fix(ci): docker build context = repo root

### DIFF
--- a/.github/workflows/planscape-server.yml
+++ b/.github/workflows/planscape-server.yml
@@ -117,7 +117,12 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: Planscape.Server
+          # Context = repo root: the Dockerfile COPYs repo-root paths
+          # (Planscape/assets/viewer/, Planscape.Server/src/**, COPY . .) and is
+          # documented "Build context is the STINGTOOLS repo root" (matches
+          # docker-compose's context: ../..). 'Planscape.Server' was wrong and
+          # made every COPY fail "not found".
+          context: .
           file: Planscape.Server/docker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
The `Build and push Docker image` step used `context: Planscape.Server`, but the Dockerfile COPYs **repo-root-relative** paths:
- `COPY Planscape/assets/viewer/...`
- `COPY Planscape.Server/src/**`
- `COPY . .`

With the wrong context every `COPY` failed `not found`. Setting `context: .` (matching docker-compose's `context: ../..`) fixes the build.

## Validation
CI is the gate — watching the **Docker Build & Push** check on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)