### PR TITLE
fix(geofence): bare-array boundary always failed closed (every in-bounds point 403'd)

### DIFF
--- a/Planscape.Server/src/Planscape.Infrastructure/Services/GeofenceValidationService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/GeofenceValidationService.cs
@@ -42,20 +42,29 @@ public class GeofenceValidationService : IGeofenceValidationService
             using var doc = JsonDocument.Parse(geoJson);
             var root = doc.RootElement;
 
-            // Support both bare coordinate arrays and GeoJSON Polygon
+            // Support both a bare coordinate ring (`[[lon,lat],…]`, what the
+            // project seed + ProjectSettings store) and a GeoJSON Polygon
+            // (`{ "type":"Polygon", "coordinates":[[[lon,lat],…]] }`).
+            //
+            // BUGFIX: JsonElement.TryGetProperty THROWS InvalidOperationException
+            // when called on anything other than an Object. The old code called
+            // it FIRST, so a bare-array boundary threw, was caught below, and
+            // failed closed — i.e. geofence ALWAYS denied (every in-bounds point
+            // 403'd) for the array format. Branch on ValueKind first.
             JsonElement coordinates;
-            if (root.TryGetProperty("coordinates", out var coords))
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                coordinates = root; // bare outer ring
+            }
+            else if (root.ValueKind == JsonValueKind.Object
+                     && root.TryGetProperty("coordinates", out var coords))
             {
                 if (coords.ValueKind != JsonValueKind.Array || coords.GetArrayLength() == 0)
                 {
                     _logger.LogWarning("Geofence boundary has empty coordinates — failing closed");
                     return false;
                 }
-                coordinates = coords[0]; // outer ring of Polygon
-            }
-            else if (root.ValueKind == JsonValueKind.Array)
-            {
-                coordinates = root;
+                coordinates = coords[0]; // outer ring of the GeoJSON Polygon
             }
             else
             {


### PR DESCRIPTION
## Root cause (not a cache)
Instrumented the live read: the geofence read the **correct** boundary and **correct** coords yet returned `inside=False` — because `IsInsideBoundary` called `root.TryGetProperty("coordinates")` **first**, and `JsonElement.TryGetProperty` **throws** `InvalidOperationException` on a JSON **Array**. Project boundaries are stored as a **bare ring** `[[lon,lat],…]` (seed + ProjectSettings), so the throw was caught by the fail-closed handler → geofence denied **every** point → every in-bounds GPS create 403'd. The `else if (ValueKind == Array)` branch was never reached.

## Fix
Branch on `root.ValueKind` first: an Array is the bare ring; only call `TryGetProperty` when the root is an Object (GeoJSON `{type:Polygon, coordinates:…}`).

## Proven (live, real Postgres — NHW-2026 London box)
```
in-bounds  (lng -0.126,  lat 51.506)  -> 201   (was 403)
in-bounds  (lng -0.1275, lat 51.5048) -> 201
out-bounds (Kampala 32.58, 0.347)     -> 403   (still correctly denied)
```

Server builds + boots clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)