### PR TITLE
feat(viewer): meetings entry point, desktop webcam capture, working 3D markup

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -544,9 +544,18 @@
       bindMenu('#btnMarkup', '#menuMarkup', {
         '#mkScreenshot': () => takeScreenshot(),
         '#mkShare':      () => shareCurrentView(),
-        '#mkText':  () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'text'  } }); toast('Markup: click to place text'); },
-        '#mkArrow': () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'arrow' } }); toast('Markup: drag to draw arrow'); },
-        '#mkDraw':  () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'draw'  } }); toast('Markup: drag to draw freehand'); }
+        '#mkText':    () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'text'    } }); toast('Markup: click a surface to place text'); },
+        '#mkArrow':   () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'arrow'   } }); toast('Markup: drag from tail to head'); },
+        '#mkDraw':    () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'draw'    } }); toast('Markup: drag to draw freehand'); },
+        '#mkCloud':   () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'cloud'   } }); toast('Markup: drag a box for a revision cloud'); },
+        '#mkDim':     () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'dim'     } }); toast('Markup: click two points for a dimension'); },
+        '#mkCallout': () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'callout' } }); toast('Markup: click a point, then a label spot'); },
+        '#mkClear':   () => { handleHostCommand({ type: 'clearMarkup' }); toast('Markups cleared'); },
+      });
+      bindMenu('#btnMeet', '#menuMeet', {
+        '#meetStart': () => startMeeting(),
+        '#meetJoin':  () => joinMeeting(),
+        '#meetCopy':  () => copyMeetingLink(),
       });
 
       $('#btnClashes').addEventListener('click', () => switchBottomTab('clashes'));
@@ -671,6 +680,57 @@
         const it = $(sel, menu);
         if (it) it.addEventListener('click', () => { menu.classList.remove('open'); items[sel](); });
       }
+    }
+
+    // ── Live meetings entry point ─────────────────────────────────────────────
+    // The realtime co-presence client (meeting-sync.js) is URL-driven: it only
+    // activates with ?meeting=<sessionId>. These controls CREATE a session via
+    // the existing API, copy a shareable join link, and reload into it so the
+    // client connects (camera-follow + presence + overlay co-presence).
+    function meetingJoinUrl(sessionId) {
+      const u = new URL(location.href);
+      u.searchParams.set('meeting', sessionId);
+      if (projectId) u.searchParams.set('project', projectId);
+      if (modelId) u.searchParams.set('model', modelId);
+      return u.toString();
+    }
+    function copyToClipboard(text) {
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) { navigator.clipboard.writeText(text); return; }
+      } catch (_) {}
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+        document.body.appendChild(ta); ta.select();
+        document.execCommand('copy'); ta.remove();
+      } catch (_) {}
+    }
+    async function startMeeting() {
+      if (!projectId) return toast('No project — cannot start a meeting', 'warn');
+      const displayName = (() => { try { return (localStorage.getItem('planscape_user') || 'Host').split('@')[0]; } catch (_) { return 'Host'; } })();
+      const resp = await api(`/api/projects/${projectId}/meeting-sessions`, {
+        method: 'POST',
+        body: JSON.stringify({ modelId: modelId || null, displayName, surface: 'web' }),
+      });
+      const id = resp && (resp.id || resp.Id);
+      if (!id) return toast('Could not start meeting (check sign-in)', 'error');
+      const link = meetingJoinUrl(id);
+      copyToClipboard(link);
+      toast('Meeting started — join link copied. Opening session…');
+      logHistory && logHistory('Started a live meeting');
+      // Reload this tab INTO the meeting so meeting-sync.js activates.
+      setTimeout(() => { location.href = link; }, 700);
+    }
+    function joinMeeting() {
+      const id = (prompt('Paste the meeting session ID to join:') || '').trim();
+      if (!id) return;
+      location.href = meetingJoinUrl(id);
+    }
+    function copyMeetingLink() {
+      const cur = new URLSearchParams(location.search).get('meeting');
+      if (!cur) return toast('Not in a meeting yet — Start one first', 'warn');
+      copyToClipboard(meetingJoinUrl(cur));
+      toast('Join link copied to clipboard');
     }
     document.addEventListener('click', () => $$('.menu.open').forEach(m => m.classList.remove('open')));
 
@@ -3439,6 +3499,10 @@
     // block has run.)
     let pendingPhotoFile = null;             // staged file in capture modal
     let pendingPhotoObjectUrl = null;        // preview url to revoke on close
+    let pcStream = null;                     // active getUserMedia webcam stream
+    function stopWebcam() {
+      if (pcStream) { try { pcStream.getTracks().forEach(t => t.stop()); } catch (_) {} pcStream = null; }
+    }
 
     // ── API helpers — match the existing loadIssues / loadClashes pattern ──
     async function loadSitePhotos(filters = {}) {
@@ -3820,6 +3884,7 @@
     function closePhotoCaptureModal() {
       const modal = $('#photoCaptureModal');
       if (!modal) return;
+      stopWebcam();   // release the camera if a live preview was open
       modal.classList.remove('open');
       pendingPhotoFile = null;
       if (pendingPhotoObjectUrl) { try { URL.revokeObjectURL(pendingPhotoObjectUrl); } catch (_) {} pendingPhotoObjectUrl = null; }
@@ -3857,6 +3922,50 @@
       }
       pickBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); input.click(); });
       input.addEventListener('change', () => { stagePhoto(input.files?.[0]); input.value = ''; });
+
+      // Desktop webcam capture (getUserMedia). Falls back to the file picker
+      // when there's no camera or permission is denied. Mobile keeps its
+      // native camera via the file input's capture="environment".
+      const webcamBtn = $('#pcWebcamBtn');
+      function snapFromVideo(video) {
+        const w = video.videoWidth || 1280, h = video.videoHeight || 720;
+        const canvas = document.createElement('canvas');
+        canvas.width = w; canvas.height = h;
+        canvas.getContext('2d').drawImage(video, 0, 0, w, h);
+        canvas.toBlob((blob) => {
+          stopWebcam();
+          if (!blob) { toast('Could not capture frame', 'error'); $('#pcPreview').innerHTML = ''; return; }
+          const file = new File([blob], 'webcam-' + Date.now() + '.jpg', { type: 'image/jpeg' });
+          stagePhoto(file);          // same path as a picked file
+        }, 'image/jpeg', 0.92);
+      }
+      async function startWebcamCapture() {
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+          toast('Webcam not available — opening file picker', 'warn');
+          return input.click();
+        }
+        try {
+          stopWebcam();
+          pcStream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
+        } catch (err) {
+          console.warn('[photo] getUserMedia denied/failed', err);
+          toast('Camera blocked or unavailable — use Pick file', 'warn');
+          return input.click();   // graceful fallback
+        }
+        const preview = $('#pcPreview');
+        preview.innerHTML = '';
+        const video = document.createElement('video');
+        video.autoplay = true; video.playsInline = true; video.muted = true;
+        video.style.cssText = 'width:100%;border-radius:6px;background:#000';
+        video.srcObject = pcStream;
+        const bar = el('div', { style: 'display:flex;gap:8px;margin-top:6px' }, [
+          el('button', { class: 'btn sm', type: 'button', onclick: () => snapFromVideo(video) }, '📸 Snap'),
+          el('button', { class: 'btn sm subtle', type: 'button', onclick: () => { stopWebcam(); preview.innerHTML = ''; } }, 'Cancel'),
+        ]);
+        preview.appendChild(video); preview.appendChild(bar);
+        try { await video.play(); } catch (_) {}
+      }
+      webcamBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); startWebcamCapture(); });
       drop.addEventListener('click', () => input.click());
       drop.addEventListener('keydown', (ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); input.click(); } });
       ['dragenter','dragover'].forEach(evt => drop.addEventListener(evt, (ev) => { ev.preventDefault(); ev.stopPropagation(); drop.classList.add('dragover'); }));

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer-extras.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer-extras.js
@@ -363,4 +363,284 @@
 
   function countMeshes(o) { let n = 0; o.traverse(x => { if (x.isMesh) n++; }); return n; }
   function bbToArray(b) { return [b.min.x, b.min.y, b.min.z, b.max.x, b.max.y, b.max.z]; }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // 3D MARKUP — text · arrow · freehand draw · revision cloud · dimension ·
+  // callout. (Previously startMarkup/clearMarkup were referenced by the host
+  // but never defined, so the whole markup menu was a no-op.)
+  //
+  // While a markup tool is active we disable OrbitControls rotate so the
+  // left button is free for drawing; pan (right-drag) + zoom (wheel) still
+  // work. Esc, "Clear markups", or finishing exits and restores rotate.
+  // ════════════════════════════════════════════════════════════════════════
+  let markupGroup = null;
+  let markupMode = null;          // text|arrow|draw|cloud|dim|callout|null
+  let markupGesture = null;       // active drag/click gesture
+  let markupClicks = [];          // accumulated points for multi-click tools
+  let markupPreview = null;       // transient preview object during a drag
+  let rotatePrev = null;          // saved controls.enableRotate
+  const MARKUP_COLOR = 0xffcc33;
+  const markupRay = new THREE.Raycaster();
+
+  function ensureMarkupGroup(h) {
+    if (!markupGroup) { markupGroup = new THREE.Group(); markupGroup.name = 'sting-markup'; h.scene.add(markupGroup); }
+    return markupGroup;
+  }
+  function disposeObj(o) {
+    o.traverse && o.traverse(c => {
+      if (c.geometry && c.geometry.dispose) c.geometry.dispose();
+      if (c.material) {
+        const m = c.material; if (m.map && m.map.dispose) m.map.dispose();
+        if (m.dispose) m.dispose();
+      }
+    });
+  }
+  function markupSpan(h) {
+    return (h.modelBounds && !h.modelBounds.isEmpty())
+      ? h.modelBounds.getSize(new THREE.Vector3()).length() : 10;
+  }
+
+  // screen → 3D: raycast the model; fall back to a plane through the orbit
+  // target facing the camera so markup still lands on empty space.
+  function markupPoint(h, ev) {
+    const dom = h.renderer.domElement;
+    const rect = dom.getBoundingClientRect();
+    const ndc = new THREE.Vector2(
+      ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+      -((ev.clientY - rect.top) / rect.height) * 2 + 1
+    );
+    markupRay.setFromCamera(ndc, h.camera);
+    if (h.modelRoot) {
+      const hits = markupRay.intersectObject(h.modelRoot, true);
+      if (hits && hits.length) return hits[0].point.clone();
+    }
+    const n = new THREE.Vector3(); h.camera.getWorldDirection(n);
+    const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(n, h.controls.target);
+    const out = new THREE.Vector3();
+    return markupRay.ray.intersectPlane(plane, out) ? out : h.controls.target.clone();
+  }
+
+  function roundRect(ctx, x, y, w, hh, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + hh, r);
+    ctx.arcTo(x + w, y + hh, x, y + hh, r);
+    ctx.arcTo(x, y + hh, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+  }
+  function makeLabel(h, text, color) {
+    const fontSize = 30, pad = 10;
+    const c = document.createElement('canvas');
+    let ctx = c.getContext('2d');
+    ctx.font = fontSize + 'px sans-serif';
+    const w = Math.max(24, Math.ceil(ctx.measureText(text).width)) + pad * 2;
+    const hh = fontSize + pad * 2;
+    c.width = w; c.height = hh;
+    ctx = c.getContext('2d');
+    ctx.font = fontSize + 'px sans-serif';
+    ctx.fillStyle = 'rgba(18,18,26,0.86)'; roundRect(ctx, 0, 0, w, hh, 8); ctx.fill();
+    ctx.strokeStyle = color || '#ffcc33'; ctx.lineWidth = 2; roundRect(ctx, 1, 1, w - 2, hh - 2, 7); ctx.stroke();
+    ctx.fillStyle = color || '#ffcc33'; ctx.textBaseline = 'middle';
+    ctx.fillText(text, pad, hh / 2 + 1);
+    const tex = new THREE.CanvasTexture(c); tex.minFilter = THREE.LinearFilter;
+    const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, depthTest: false, transparent: true }));
+    const s = markupSpan(h) * 0.022;
+    sprite.scale.set(s * (w / hh), s, 1);
+    sprite.renderOrder = 999;
+    return sprite;
+  }
+
+  function placeText(h, p, text) {
+    const sprite = makeLabel(h, text, '#ffe08a');
+    sprite.position.copy(p);
+    markupGroup.add(sprite);
+  }
+  function placeArrow(h, a, b) {
+    const g = ensureMarkupGroup(h);
+    const mat = new THREE.LineBasicMaterial({ color: MARKUP_COLOR });
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([a, b]), mat));
+    // arrowhead cone at b, pointing a→b
+    const dir = new THREE.Vector3().subVectors(b, a); const len = dir.length() || 1; dir.normalize();
+    const headLen = Math.min(len * 0.25, markupSpan(h) * 0.03);
+    const cone = new THREE.Mesh(
+      new THREE.ConeGeometry(headLen * 0.5, headLen, 12),
+      new THREE.MeshBasicMaterial({ color: MARKUP_COLOR }));
+    cone.position.copy(b);
+    cone.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
+    cone.translateY(-headLen / 2);
+    g.add(cone);
+  }
+  function placePolyline(h, pts, color, closed) {
+    if (pts.length < 2) return;
+    const arr = closed ? pts.concat([pts[0]]) : pts;
+    const g = ensureMarkupGroup(h);
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(arr),
+      new THREE.LineBasicMaterial({ color: color || MARKUP_COLOR })));
+  }
+  function placeDimension(h, a, b) {
+    const g = ensureMarkupGroup(h);
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([a, b]),
+      new THREE.LineBasicMaterial({ color: 0x4f9dff })));
+    addMarker(g, a, 0x4f9dff); addMarker(g, b, 0x4f9dff);
+    const mid = new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5);
+    const label = makeLabel(h, a.distanceTo(b).toFixed(2) + ' m', '#7fbfff');
+    label.position.copy(mid);
+    g.add(label);
+    if (host() && host().bridge) host().bridge.send('markupDimension', { distance: a.distanceTo(b) });
+  }
+  function placeCallout(h, anchor, labelPos, text) {
+    const g = ensureMarkupGroup(h);
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([anchor, labelPos]),
+      new THREE.LineBasicMaterial({ color: MARKUP_COLOR })));
+    addMarker(g, anchor, MARKUP_COLOR);
+    const label = makeLabel(h, text, '#ffcc33');
+    label.position.copy(labelPos);
+    g.add(label);
+  }
+  // Revision cloud: a scalloped loop of arcs around the drag rectangle,
+  // built on the plane through the two drag points facing the camera.
+  function placeCloud(h, a, b) {
+    const g = ensureMarkupGroup(h);
+    const n = new THREE.Vector3(); h.camera.getWorldDirection(n); n.normalize();
+    let u = new THREE.Vector3(1, 0, 0).cross(n); if (u.lengthSq() < 1e-6) u = new THREE.Vector3(0, 1, 0).cross(n);
+    u.normalize();
+    const v = new THREE.Vector3().crossVectors(n, u).normalize();
+    // a,b projected onto (u,v) about a
+    const d = new THREE.Vector3().subVectors(b, a);
+    const w = d.dot(u), hgt = d.dot(v);
+    const corners = [a.clone(),
+      a.clone().addScaledVector(u, w),
+      a.clone().addScaledVector(u, w).addScaledVector(v, hgt),
+      a.clone().addScaledVector(v, hgt)];
+    const bump = Math.max(Math.hypot(w, hgt) * 0.06, markupSpan(h) * 0.01);
+    const pts = [];
+    for (let e = 0; e < 4; e++) {
+      const p0 = corners[e], p1 = corners[(e + 1) % 4];
+      const edge = new THREE.Vector3().subVectors(p1, p0); const elen = edge.length();
+      const segs = Math.max(2, Math.round(elen / (bump * 1.6)));
+      const outward = new THREE.Vector3().crossVectors(edge.clone().normalize(), n).normalize();
+      for (let i = 0; i < segs; i++) {
+        const t0 = i / segs, tm = (i + 0.5) / segs;
+        pts.push(p0.clone().addScaledVector(edge, t0));
+        pts.push(p0.clone().addScaledVector(edge, tm).addScaledVector(outward, bump));
+      }
+    }
+    placePolyline(h, pts, 0xff5a5a, true);
+  }
+
+  // ── pointer wiring ──
+  let _markupHandlers = null;
+  function attachMarkupInput(h) {
+    detachMarkupInput();
+    const dom = h.renderer.domElement;
+    const onDown = (ev) => {
+      if (ev.button !== 0 || !markupMode) return;
+      markupGesture = { start: markupPoint(h, ev), screen: { x: ev.clientX, y: ev.clientY }, points: [] };
+      if (markupMode === 'draw') markupGesture.points.push(markupGesture.start);
+    };
+    const onMove = (ev) => {
+      if (!markupGesture) return;
+      const p = markupPoint(h, ev);
+      if (markupMode === 'draw') { markupGesture.points.push(p); refreshPreview(h, markupGesture.points, false, 0xffcc33); }
+      else if (markupMode === 'arrow' || markupMode === 'dim' || markupMode === 'cloud') {
+        refreshPreview(h, [markupGesture.start, p], false, markupMode === 'dim' ? 0x4f9dff : 0xffcc33);
+      }
+    };
+    const onUp = (ev) => {
+      if (!markupGesture) return;
+      const end = markupPoint(h, ev);
+      const moved = Math.hypot(ev.clientX - markupGesture.screen.x, ev.clientY - markupGesture.screen.y);
+      clearPreview(h);
+      finishGesture(h, markupGesture.start, end, moved);
+      markupGesture = null;
+    };
+    dom.addEventListener('pointerdown', onDown);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    _markupHandlers = { dom, onDown, onMove, onUp };
+  }
+  function detachMarkupInput() {
+    if (!_markupHandlers) return;
+    const { dom, onDown, onMove, onUp } = _markupHandlers;
+    dom.removeEventListener('pointerdown', onDown);
+    window.removeEventListener('pointermove', onMove);
+    window.removeEventListener('pointerup', onUp);
+    _markupHandlers = null;
+  }
+  function refreshPreview(h, pts, closed, color) {
+    clearPreview(h);
+    if (pts.length < 2) return;
+    markupPreview = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints(closed ? pts.concat([pts[0]]) : pts),
+      new THREE.LineBasicMaterial({ color: color || 0xffffff }));
+    ensureMarkupGroup(h).add(markupPreview);
+  }
+  function clearPreview(h) {
+    if (markupPreview && markupGroup) { markupGroup.remove(markupPreview); disposeObj(markupPreview); }
+    markupPreview = null;
+  }
+
+  const DRAG_THRESHOLD = 5; // px
+  function finishGesture(h, start, end, moved) {
+    const dragged = moved > DRAG_THRESHOLD;
+    switch (markupMode) {
+      case 'text': {
+        if (dragged) return;
+        const t = (window.prompt('Markup text:') || '').trim();
+        if (t) placeText(h, start, t);
+        break;
+      }
+      case 'arrow':
+        if (dragged) placeArrow(h, start, end);
+        break;
+      case 'draw':
+        if (markupGesture && markupGesture.points.length >= 2) placePolyline(h, markupGesture.points, 0xffcc33, false);
+        break;
+      case 'cloud':
+        if (dragged) placeCloud(h, start, end);
+        break;
+      case 'dim':
+        // two clicks
+        markupClicks.push(start);
+        if (markupClicks.length === 2) { placeDimension(h, markupClicks[0], markupClicks[1]); markupClicks = []; }
+        break;
+      case 'callout':
+        markupClicks.push(start);
+        if (markupClicks.length === 2) {
+          const t = (window.prompt('Callout text:') || '').trim() || 'Note';
+          placeCallout(h, markupClicks[0], markupClicks[1], t);
+          markupClicks = [];
+        }
+        break;
+    }
+  }
+
+  function markupKeydown(ev) { if (ev.key === 'Escape' && markupMode) ext.stopMarkup(); }
+
+  ext.startMarkup = function (mode) {
+    const h = host(); if (!h) return;
+    ensureMarkupGroup(h);
+    markupMode = mode || 'text';
+    markupClicks = [];
+    if (rotatePrev === null && h.controls) { rotatePrev = h.controls.enableRotate; h.controls.enableRotate = false; }
+    attachMarkupInput(h);
+    window.addEventListener('keydown', markupKeydown);
+    if (h.bridge) h.bridge.send('markupModeChanged', { mode: markupMode });
+  };
+  ext.stopMarkup = function () {
+    const h = host();
+    detachMarkupInput();
+    clearPreview(h);
+    window.removeEventListener('keydown', markupKeydown);
+    if (h && h.controls && rotatePrev !== null) { h.controls.enableRotate = rotatePrev; rotatePrev = null; }
+    markupMode = null; markupGesture = null; markupClicks = [];
+    if (h && h.bridge) h.bridge.send('markupModeChanged', { mode: null });
+  };
+  ext.clearMarkup = function () {
+    const h = host();
+    ext.stopMarkup();
+    if (markupGroup && h) { h.scene.remove(markupGroup); disposeObj(markupGroup); }
+    markupGroup = null;
+  };
 })();

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -72,6 +72,9 @@
       <div class="toolbar-group">
         <button class="tbtn" id="btnMarkup" title="Markup">✏ Markup <span class="caret">▾</span></button>
       </div>
+      <div class="toolbar-group">
+        <button class="tbtn" id="btnMeet" title="Live meeting">🎥 Meet <span class="caret">▾</span></button>
+      </div>
 
       <div class="toolbar-group">
         <button class="tbtn" id="btnClashes" title="Open clash tray">⚠ <span id="clashBadge" class="badge muted">0</span></button>
@@ -463,8 +466,9 @@
       <input id="pcFileInput" type="file" accept="image/*" capture="environment" style="display:none" />
       <div id="pcDrop" class="attachment-drop" tabindex="0"
            role="button" aria-label="Tap to pick / take a photo, or drop a file here">
-        <button class="btn ghost" id="pcPickBtn" type="button">📷 Take photo / pick file</button>
-        <div class="hint">JPEG / PNG · max 25 MB · drop a file here or use the camera on mobile</div>
+        <button class="btn ghost" id="pcPickBtn" type="button">🗂 Pick file</button>
+        <button class="btn ghost" id="pcWebcamBtn" type="button">📸 Use webcam</button>
+        <div class="hint">JPEG / PNG · max 25 MB · drop a file here, use the webcam, or the camera on mobile</div>
       </div>
       <div id="pcPreview" class="photo-preview"></div>
 
@@ -563,12 +567,23 @@
   <div class="menu-item" id="iAll">📋 All issues</div>
 </div>
 <div class="menu" id="menuMarkup">
-  <div class="menu-item" id="mkDraw">✎ Draw</div>
+  <div class="menu-item" id="mkDraw">✎ Draw (freehand)</div>
   <div class="menu-item" id="mkArrow">→ Arrow</div>
   <div class="menu-item" id="mkText">T Text</div>
+  <div class="menu-item" id="mkCloud">☁ Revision cloud</div>
+  <div class="menu-item" id="mkDim">↔ Dimension note</div>
+  <div class="menu-item" id="mkCallout">▭ Callout</div>
+  <div class="menu-sep"></div>
+  <div class="menu-item danger" id="mkClear">Clear markups</div>
   <div class="menu-sep"></div>
   <div class="menu-item" id="mkScreenshot">📷 Screenshot</div>
   <div class="menu-item" id="mkShare">🔗 Share view link</div>
+</div>
+<div class="menu" id="menuMeet">
+  <div class="menu-item" id="meetStart">▶ Start a live meeting</div>
+  <div class="menu-item" id="meetJoin">↳ Join by session ID</div>
+  <div class="menu-sep"></div>
+  <div class="menu-item" id="meetCopy">🔗 Copy join link</div>
 </div>
 
 <!-- Settings popover (was a no-op TaskDialog) -->

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -544,9 +544,18 @@
       bindMenu('#btnMarkup', '#menuMarkup', {
         '#mkScreenshot': () => takeScreenshot(),
         '#mkShare':      () => shareCurrentView(),
-        '#mkText':  () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'text'  } }); toast('Markup: click to place text'); },
-        '#mkArrow': () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'arrow' } }); toast('Markup: drag to draw arrow'); },
-        '#mkDraw':  () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'draw'  } }); toast('Markup: drag to draw freehand'); }
+        '#mkText':    () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'text'    } }); toast('Markup: click a surface to place text'); },
+        '#mkArrow':   () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'arrow'   } }); toast('Markup: drag from tail to head'); },
+        '#mkDraw':    () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'draw'    } }); toast('Markup: drag to draw freehand'); },
+        '#mkCloud':   () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'cloud'   } }); toast('Markup: drag a box for a revision cloud'); },
+        '#mkDim':     () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'dim'     } }); toast('Markup: click two points for a dimension'); },
+        '#mkCallout': () => { handleHostCommand({ type: 'startMarkup', payload: { mode: 'callout' } }); toast('Markup: click a point, then a label spot'); },
+        '#mkClear':   () => { handleHostCommand({ type: 'clearMarkup' }); toast('Markups cleared'); },
+      });
+      bindMenu('#btnMeet', '#menuMeet', {
+        '#meetStart': () => startMeeting(),
+        '#meetJoin':  () => joinMeeting(),
+        '#meetCopy':  () => copyMeetingLink(),
       });
 
       $('#btnClashes').addEventListener('click', () => switchBottomTab('clashes'));
@@ -671,6 +680,57 @@
         const it = $(sel, menu);
         if (it) it.addEventListener('click', () => { menu.classList.remove('open'); items[sel](); });
       }
+    }
+
+    // ── Live meetings entry point ─────────────────────────────────────────────
+    // The realtime co-presence client (meeting-sync.js) is URL-driven: it only
+    // activates with ?meeting=<sessionId>. These controls CREATE a session via
+    // the existing API, copy a shareable join link, and reload into it so the
+    // client connects (camera-follow + presence + overlay co-presence).
+    function meetingJoinUrl(sessionId) {
+      const u = new URL(location.href);
+      u.searchParams.set('meeting', sessionId);
+      if (projectId) u.searchParams.set('project', projectId);
+      if (modelId) u.searchParams.set('model', modelId);
+      return u.toString();
+    }
+    function copyToClipboard(text) {
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) { navigator.clipboard.writeText(text); return; }
+      } catch (_) {}
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+        document.body.appendChild(ta); ta.select();
+        document.execCommand('copy'); ta.remove();
+      } catch (_) {}
+    }
+    async function startMeeting() {
+      if (!projectId) return toast('No project — cannot start a meeting', 'warn');
+      const displayName = (() => { try { return (localStorage.getItem('planscape_user') || 'Host').split('@')[0]; } catch (_) { return 'Host'; } })();
+      const resp = await api(`/api/projects/${projectId}/meeting-sessions`, {
+        method: 'POST',
+        body: JSON.stringify({ modelId: modelId || null, displayName, surface: 'web' }),
+      });
+      const id = resp && (resp.id || resp.Id);
+      if (!id) return toast('Could not start meeting (check sign-in)', 'error');
+      const link = meetingJoinUrl(id);
+      copyToClipboard(link);
+      toast('Meeting started — join link copied. Opening session…');
+      logHistory && logHistory('Started a live meeting');
+      // Reload this tab INTO the meeting so meeting-sync.js activates.
+      setTimeout(() => { location.href = link; }, 700);
+    }
+    function joinMeeting() {
+      const id = (prompt('Paste the meeting session ID to join:') || '').trim();
+      if (!id) return;
+      location.href = meetingJoinUrl(id);
+    }
+    function copyMeetingLink() {
+      const cur = new URLSearchParams(location.search).get('meeting');
+      if (!cur) return toast('Not in a meeting yet — Start one first', 'warn');
+      copyToClipboard(meetingJoinUrl(cur));
+      toast('Join link copied to clipboard');
     }
     document.addEventListener('click', () => $$('.menu.open').forEach(m => m.classList.remove('open')));
 
@@ -3439,6 +3499,10 @@
     // block has run.)
     let pendingPhotoFile = null;             // staged file in capture modal
     let pendingPhotoObjectUrl = null;        // preview url to revoke on close
+    let pcStream = null;                     // active getUserMedia webcam stream
+    function stopWebcam() {
+      if (pcStream) { try { pcStream.getTracks().forEach(t => t.stop()); } catch (_) {} pcStream = null; }
+    }
 
     // ── API helpers — match the existing loadIssues / loadClashes pattern ──
     async function loadSitePhotos(filters = {}) {
@@ -3820,6 +3884,7 @@
     function closePhotoCaptureModal() {
       const modal = $('#photoCaptureModal');
       if (!modal) return;
+      stopWebcam();   // release the camera if a live preview was open
       modal.classList.remove('open');
       pendingPhotoFile = null;
       if (pendingPhotoObjectUrl) { try { URL.revokeObjectURL(pendingPhotoObjectUrl); } catch (_) {} pendingPhotoObjectUrl = null; }
@@ -3857,6 +3922,50 @@
       }
       pickBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); input.click(); });
       input.addEventListener('change', () => { stagePhoto(input.files?.[0]); input.value = ''; });
+
+      // Desktop webcam capture (getUserMedia). Falls back to the file picker
+      // when there's no camera or permission is denied. Mobile keeps its
+      // native camera via the file input's capture="environment".
+      const webcamBtn = $('#pcWebcamBtn');
+      function snapFromVideo(video) {
+        const w = video.videoWidth || 1280, h = video.videoHeight || 720;
+        const canvas = document.createElement('canvas');
+        canvas.width = w; canvas.height = h;
+        canvas.getContext('2d').drawImage(video, 0, 0, w, h);
+        canvas.toBlob((blob) => {
+          stopWebcam();
+          if (!blob) { toast('Could not capture frame', 'error'); $('#pcPreview').innerHTML = ''; return; }
+          const file = new File([blob], 'webcam-' + Date.now() + '.jpg', { type: 'image/jpeg' });
+          stagePhoto(file);          // same path as a picked file
+        }, 'image/jpeg', 0.92);
+      }
+      async function startWebcamCapture() {
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+          toast('Webcam not available — opening file picker', 'warn');
+          return input.click();
+        }
+        try {
+          stopWebcam();
+          pcStream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
+        } catch (err) {
+          console.warn('[photo] getUserMedia denied/failed', err);
+          toast('Camera blocked or unavailable — use Pick file', 'warn');
+          return input.click();   // graceful fallback
+        }
+        const preview = $('#pcPreview');
+        preview.innerHTML = '';
+        const video = document.createElement('video');
+        video.autoplay = true; video.playsInline = true; video.muted = true;
+        video.style.cssText = 'width:100%;border-radius:6px;background:#000';
+        video.srcObject = pcStream;
+        const bar = el('div', { style: 'display:flex;gap:8px;margin-top:6px' }, [
+          el('button', { class: 'btn sm', type: 'button', onclick: () => snapFromVideo(video) }, '📸 Snap'),
+          el('button', { class: 'btn sm subtle', type: 'button', onclick: () => { stopWebcam(); preview.innerHTML = ''; } }, 'Cancel'),
+        ]);
+        preview.appendChild(video); preview.appendChild(bar);
+        try { await video.play(); } catch (_) {}
+      }
+      webcamBtn?.addEventListener('click', (ev) => { ev.stopPropagation(); startWebcamCapture(); });
       drop.addEventListener('click', () => input.click());
       drop.addEventListener('keydown', (ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); input.click(); } });
       ['dragenter','dragover'].forEach(evt => drop.addEventListener(evt, (ev) => { ev.preventDefault(); ev.stopPropagation(); drop.classList.add('dragover'); }));

--- a/Planscape/assets/viewer/viewer-extras.js
+++ b/Planscape/assets/viewer/viewer-extras.js
@@ -363,4 +363,284 @@
 
   function countMeshes(o) { let n = 0; o.traverse(x => { if (x.isMesh) n++; }); return n; }
   function bbToArray(b) { return [b.min.x, b.min.y, b.min.z, b.max.x, b.max.y, b.max.z]; }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // 3D MARKUP — text · arrow · freehand draw · revision cloud · dimension ·
+  // callout. (Previously startMarkup/clearMarkup were referenced by the host
+  // but never defined, so the whole markup menu was a no-op.)
+  //
+  // While a markup tool is active we disable OrbitControls rotate so the
+  // left button is free for drawing; pan (right-drag) + zoom (wheel) still
+  // work. Esc, "Clear markups", or finishing exits and restores rotate.
+  // ════════════════════════════════════════════════════════════════════════
+  let markupGroup = null;
+  let markupMode = null;          // text|arrow|draw|cloud|dim|callout|null
+  let markupGesture = null;       // active drag/click gesture
+  let markupClicks = [];          // accumulated points for multi-click tools
+  let markupPreview = null;       // transient preview object during a drag
+  let rotatePrev = null;          // saved controls.enableRotate
+  const MARKUP_COLOR = 0xffcc33;
+  const markupRay = new THREE.Raycaster();
+
+  function ensureMarkupGroup(h) {
+    if (!markupGroup) { markupGroup = new THREE.Group(); markupGroup.name = 'sting-markup'; h.scene.add(markupGroup); }
+    return markupGroup;
+  }
+  function disposeObj(o) {
+    o.traverse && o.traverse(c => {
+      if (c.geometry && c.geometry.dispose) c.geometry.dispose();
+      if (c.material) {
+        const m = c.material; if (m.map && m.map.dispose) m.map.dispose();
+        if (m.dispose) m.dispose();
+      }
+    });
+  }
+  function markupSpan(h) {
+    return (h.modelBounds && !h.modelBounds.isEmpty())
+      ? h.modelBounds.getSize(new THREE.Vector3()).length() : 10;
+  }
+
+  // screen → 3D: raycast the model; fall back to a plane through the orbit
+  // target facing the camera so markup still lands on empty space.
+  function markupPoint(h, ev) {
+    const dom = h.renderer.domElement;
+    const rect = dom.getBoundingClientRect();
+    const ndc = new THREE.Vector2(
+      ((ev.clientX - rect.left) / rect.width) * 2 - 1,
+      -((ev.clientY - rect.top) / rect.height) * 2 + 1
+    );
+    markupRay.setFromCamera(ndc, h.camera);
+    if (h.modelRoot) {
+      const hits = markupRay.intersectObject(h.modelRoot, true);
+      if (hits && hits.length) return hits[0].point.clone();
+    }
+    const n = new THREE.Vector3(); h.camera.getWorldDirection(n);
+    const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(n, h.controls.target);
+    const out = new THREE.Vector3();
+    return markupRay.ray.intersectPlane(plane, out) ? out : h.controls.target.clone();
+  }
+
+  function roundRect(ctx, x, y, w, hh, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + hh, r);
+    ctx.arcTo(x + w, y + hh, x, y + hh, r);
+    ctx.arcTo(x, y + hh, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+  }
+  function makeLabel(h, text, color) {
+    const fontSize = 30, pad = 10;
+    const c = document.createElement('canvas');
+    let ctx = c.getContext('2d');
+    ctx.font = fontSize + 'px sans-serif';
+    const w = Math.max(24, Math.ceil(ctx.measureText(text).width)) + pad * 2;
+    const hh = fontSize + pad * 2;
+    c.width = w; c.height = hh;
+    ctx = c.getContext('2d');
+    ctx.font = fontSize + 'px sans-serif';
+    ctx.fillStyle = 'rgba(18,18,26,0.86)'; roundRect(ctx, 0, 0, w, hh, 8); ctx.fill();
+    ctx.strokeStyle = color || '#ffcc33'; ctx.lineWidth = 2; roundRect(ctx, 1, 1, w - 2, hh - 2, 7); ctx.stroke();
+    ctx.fillStyle = color || '#ffcc33'; ctx.textBaseline = 'middle';
+    ctx.fillText(text, pad, hh / 2 + 1);
+    const tex = new THREE.CanvasTexture(c); tex.minFilter = THREE.LinearFilter;
+    const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, depthTest: false, transparent: true }));
+    const s = markupSpan(h) * 0.022;
+    sprite.scale.set(s * (w / hh), s, 1);
+    sprite.renderOrder = 999;
+    return sprite;
+  }
+
+  function placeText(h, p, text) {
+    const sprite = makeLabel(h, text, '#ffe08a');
+    sprite.position.copy(p);
+    markupGroup.add(sprite);
+  }
+  function placeArrow(h, a, b) {
+    const g = ensureMarkupGroup(h);
+    const mat = new THREE.LineBasicMaterial({ color: MARKUP_COLOR });
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([a, b]), mat));
+    // arrowhead cone at b, pointing a→b
+    const dir = new THREE.Vector3().subVectors(b, a); const len = dir.length() || 1; dir.normalize();
+    const headLen = Math.min(len * 0.25, markupSpan(h) * 0.03);
+    const cone = new THREE.Mesh(
+      new THREE.ConeGeometry(headLen * 0.5, headLen, 12),
+      new THREE.MeshBasicMaterial({ color: MARKUP_COLOR }));
+    cone.position.copy(b);
+    cone.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
+    cone.translateY(-headLen / 2);
+    g.add(cone);
+  }
+  function placePolyline(h, pts, color, closed) {
+    if (pts.length < 2) return;
+    const arr = closed ? pts.concat([pts[0]]) : pts;
+    const g = ensureMarkupGroup(h);
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(arr),
+      new THREE.LineBasicMaterial({ color: color || MARKUP_COLOR })));
+  }
+  function placeDimension(h, a, b) {
+    const g = ensureMarkupGroup(h);
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([a, b]),
+      new THREE.LineBasicMaterial({ color: 0x4f9dff })));
+    addMarker(g, a, 0x4f9dff); addMarker(g, b, 0x4f9dff);
+    const mid = new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5);
+    const label = makeLabel(h, a.distanceTo(b).toFixed(2) + ' m', '#7fbfff');
+    label.position.copy(mid);
+    g.add(label);
+    if (host() && host().bridge) host().bridge.send('markupDimension', { distance: a.distanceTo(b) });
+  }
+  function placeCallout(h, anchor, labelPos, text) {
+    const g = ensureMarkupGroup(h);
+    g.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints([anchor, labelPos]),
+      new THREE.LineBasicMaterial({ color: MARKUP_COLOR })));
+    addMarker(g, anchor, MARKUP_COLOR);
+    const label = makeLabel(h, text, '#ffcc33');
+    label.position.copy(labelPos);
+    g.add(label);
+  }
+  // Revision cloud: a scalloped loop of arcs around the drag rectangle,
+  // built on the plane through the two drag points facing the camera.
+  function placeCloud(h, a, b) {
+    const g = ensureMarkupGroup(h);
+    const n = new THREE.Vector3(); h.camera.getWorldDirection(n); n.normalize();
+    let u = new THREE.Vector3(1, 0, 0).cross(n); if (u.lengthSq() < 1e-6) u = new THREE.Vector3(0, 1, 0).cross(n);
+    u.normalize();
+    const v = new THREE.Vector3().crossVectors(n, u).normalize();
+    // a,b projected onto (u,v) about a
+    const d = new THREE.Vector3().subVectors(b, a);
+    const w = d.dot(u), hgt = d.dot(v);
+    const corners = [a.clone(),
+      a.clone().addScaledVector(u, w),
+      a.clone().addScaledVector(u, w).addScaledVector(v, hgt),
+      a.clone().addScaledVector(v, hgt)];
+    const bump = Math.max(Math.hypot(w, hgt) * 0.06, markupSpan(h) * 0.01);
+    const pts = [];
+    for (let e = 0; e < 4; e++) {
+      const p0 = corners[e], p1 = corners[(e + 1) % 4];
+      const edge = new THREE.Vector3().subVectors(p1, p0); const elen = edge.length();
+      const segs = Math.max(2, Math.round(elen / (bump * 1.6)));
+      const outward = new THREE.Vector3().crossVectors(edge.clone().normalize(), n).normalize();
+      for (let i = 0; i < segs; i++) {
+        const t0 = i / segs, tm = (i + 0.5) / segs;
+        pts.push(p0.clone().addScaledVector(edge, t0));
+        pts.push(p0.clone().addScaledVector(edge, tm).addScaledVector(outward, bump));
+      }
+    }
+    placePolyline(h, pts, 0xff5a5a, true);
+  }
+
+  // ── pointer wiring ──
+  let _markupHandlers = null;
+  function attachMarkupInput(h) {
+    detachMarkupInput();
+    const dom = h.renderer.domElement;
+    const onDown = (ev) => {
+      if (ev.button !== 0 || !markupMode) return;
+      markupGesture = { start: markupPoint(h, ev), screen: { x: ev.clientX, y: ev.clientY }, points: [] };
+      if (markupMode === 'draw') markupGesture.points.push(markupGesture.start);
+    };
+    const onMove = (ev) => {
+      if (!markupGesture) return;
+      const p = markupPoint(h, ev);
+      if (markupMode === 'draw') { markupGesture.points.push(p); refreshPreview(h, markupGesture.points, false, 0xffcc33); }
+      else if (markupMode === 'arrow' || markupMode === 'dim' || markupMode === 'cloud') {
+        refreshPreview(h, [markupGesture.start, p], false, markupMode === 'dim' ? 0x4f9dff : 0xffcc33);
+      }
+    };
+    const onUp = (ev) => {
+      if (!markupGesture) return;
+      const end = markupPoint(h, ev);
+      const moved = Math.hypot(ev.clientX - markupGesture.screen.x, ev.clientY - markupGesture.screen.y);
+      clearPreview(h);
+      finishGesture(h, markupGesture.start, end, moved);
+      markupGesture = null;
+    };
+    dom.addEventListener('pointerdown', onDown);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    _markupHandlers = { dom, onDown, onMove, onUp };
+  }
+  function detachMarkupInput() {
+    if (!_markupHandlers) return;
+    const { dom, onDown, onMove, onUp } = _markupHandlers;
+    dom.removeEventListener('pointerdown', onDown);
+    window.removeEventListener('pointermove', onMove);
+    window.removeEventListener('pointerup', onUp);
+    _markupHandlers = null;
+  }
+  function refreshPreview(h, pts, closed, color) {
+    clearPreview(h);
+    if (pts.length < 2) return;
+    markupPreview = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints(closed ? pts.concat([pts[0]]) : pts),
+      new THREE.LineBasicMaterial({ color: color || 0xffffff }));
+    ensureMarkupGroup(h).add(markupPreview);
+  }
+  function clearPreview(h) {
+    if (markupPreview && markupGroup) { markupGroup.remove(markupPreview); disposeObj(markupPreview); }
+    markupPreview = null;
+  }
+
+  const DRAG_THRESHOLD = 5; // px
+  function finishGesture(h, start, end, moved) {
+    const dragged = moved > DRAG_THRESHOLD;
+    switch (markupMode) {
+      case 'text': {
+        if (dragged) return;
+        const t = (window.prompt('Markup text:') || '').trim();
+        if (t) placeText(h, start, t);
+        break;
+      }
+      case 'arrow':
+        if (dragged) placeArrow(h, start, end);
+        break;
+      case 'draw':
+        if (markupGesture && markupGesture.points.length >= 2) placePolyline(h, markupGesture.points, 0xffcc33, false);
+        break;
+      case 'cloud':
+        if (dragged) placeCloud(h, start, end);
+        break;
+      case 'dim':
+        // two clicks
+        markupClicks.push(start);
+        if (markupClicks.length === 2) { placeDimension(h, markupClicks[0], markupClicks[1]); markupClicks = []; }
+        break;
+      case 'callout':
+        markupClicks.push(start);
+        if (markupClicks.length === 2) {
+          const t = (window.prompt('Callout text:') || '').trim() || 'Note';
+          placeCallout(h, markupClicks[0], markupClicks[1], t);
+          markupClicks = [];
+        }
+        break;
+    }
+  }
+
+  function markupKeydown(ev) { if (ev.key === 'Escape' && markupMode) ext.stopMarkup(); }
+
+  ext.startMarkup = function (mode) {
+    const h = host(); if (!h) return;
+    ensureMarkupGroup(h);
+    markupMode = mode || 'text';
+    markupClicks = [];
+    if (rotatePrev === null && h.controls) { rotatePrev = h.controls.enableRotate; h.controls.enableRotate = false; }
+    attachMarkupInput(h);
+    window.addEventListener('keydown', markupKeydown);
+    if (h.bridge) h.bridge.send('markupModeChanged', { mode: markupMode });
+  };
+  ext.stopMarkup = function () {
+    const h = host();
+    detachMarkupInput();
+    clearPreview(h);
+    window.removeEventListener('keydown', markupKeydown);
+    if (h && h.controls && rotatePrev !== null) { h.controls.enableRotate = rotatePrev; rotatePrev = null; }
+    markupMode = null; markupGesture = null; markupClicks = [];
+    if (h && h.bridge) h.bridge.send('markupModeChanged', { mode: null });
+  };
+  ext.clearMarkup = function () {
+    const h = host();
+    ext.stopMarkup();
+    if (markupGroup && h) { h.scene.remove(markupGroup); disposeObj(markupGroup); }
+    markupGroup = null;
+  };
 })();

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -72,6 +72,9 @@
       <div class="toolbar-group">
         <button class="tbtn" id="btnMarkup" title="Markup">✏ Markup <span class="caret">▾</span></button>
       </div>
+      <div class="toolbar-group">
+        <button class="tbtn" id="btnMeet" title="Live meeting">🎥 Meet <span class="caret">▾</span></button>
+      </div>
 
       <div class="toolbar-group">
         <button class="tbtn" id="btnClashes" title="Open clash tray">⚠ <span id="clashBadge" class="badge muted">0</span></button>
@@ -463,8 +466,9 @@
       <input id="pcFileInput" type="file" accept="image/*" capture="environment" style="display:none" />
       <div id="pcDrop" class="attachment-drop" tabindex="0"
            role="button" aria-label="Tap to pick / take a photo, or drop a file here">
-        <button class="btn ghost" id="pcPickBtn" type="button">📷 Take photo / pick file</button>
-        <div class="hint">JPEG / PNG · max 25 MB · drop a file here or use the camera on mobile</div>
+        <button class="btn ghost" id="pcPickBtn" type="button">🗂 Pick file</button>
+        <button class="btn ghost" id="pcWebcamBtn" type="button">📸 Use webcam</button>
+        <div class="hint">JPEG / PNG · max 25 MB · drop a file here, use the webcam, or the camera on mobile</div>
       </div>
       <div id="pcPreview" class="photo-preview"></div>
 
@@ -563,12 +567,23 @@
   <div class="menu-item" id="iAll">📋 All issues</div>
 </div>
 <div class="menu" id="menuMarkup">
-  <div class="menu-item" id="mkDraw">✎ Draw</div>
+  <div class="menu-item" id="mkDraw">✎ Draw (freehand)</div>
   <div class="menu-item" id="mkArrow">→ Arrow</div>
   <div class="menu-item" id="mkText">T Text</div>
+  <div class="menu-item" id="mkCloud">☁ Revision cloud</div>
+  <div class="menu-item" id="mkDim">↔ Dimension note</div>
+  <div class="menu-item" id="mkCallout">▭ Callout</div>
+  <div class="menu-sep"></div>
+  <div class="menu-item danger" id="mkClear">Clear markups</div>
   <div class="menu-sep"></div>
   <div class="menu-item" id="mkScreenshot">📷 Screenshot</div>
   <div class="menu-item" id="mkShare">🔗 Share view link</div>
+</div>
+<div class="menu" id="menuMeet">
+  <div class="menu-item" id="meetStart">▶ Start a live meeting</div>
+  <div class="menu-item" id="meetJoin">↳ Join by session ID</div>
+  <div class="menu-sep"></div>
+  <div class="menu-item" id="meetCopy">🔗 Copy join link</div>
 </div>
 
 <!-- Settings popover (was a no-op TaskDialog) -->


### PR DESCRIPTION
## What
Three viewer UX gaps closed. Edited `assets/viewer` source; `wwwroot` regenerated **byte-identical** (CI gate). No CSS changes.

### 1. Live meetings entry point
The co-presence client (`meeting-sync.js`) was only reachable via a hand-typed `?meeting=<id>`. New **🎥 Meet** toolbar menu:
- **Start** → `POST /api/projects/{id}/meeting-sessions` (creator joins as host) → copies the shareable **join link** → reloads this tab into the session so `meeting-sync.js` activates (camera-follow + presence + overlay co-presence).
- **Join by session ID** → navigates into `?meeting=<id>`.
- **Copy join link**.
Proven server-side: create → `ACTIVE`, `/join` → 200, participants list, `/hubs/meeting` negotiate → 200.

### 2. Desktop webcam capture
The "Take photo / pick file" only opened the file picker on desktop. Added a **📸 Use webcam** path: `getUserMedia` → live `<video>` preview → **Snap** → `canvas.toBlob` → `File` → same `stagePhoto()` path. Stream stopped on snap/cancel/close. No-camera / permission-denied → graceful fallback to the file picker. Mobile keeps its native camera.

### 3. Working 3D markup (+ new tools)
`startMarkup`/`clearMarkup` were referenced by the host but **never defined** — the whole markup menu was a no-op. Implemented in `viewer-extras.js`: **text · arrow · freehand draw**, plus **revision cloud · dimension note · callout**. Screen→3D via raycast (plane fallback). While a tool is active, OrbitControls rotate is disabled so the left button draws (pan/zoom still work); **Esc** or **Clear markups** exits. **PDF/document markup is intentionally out of scope** (separate future feature).

## Verify (done locally)
- `node --check` on coordination-viewer.js + viewer-extras.js + viewer.html ES module → clean.
- assets ↔ wwwroot **byte-equal** (all 5 files).
- Meeting create/join/participants/hub-negotiate all 200 against the live server.

## MANUAL browser checklist
1. **Meet → Start a live meeting** — link is copied + the tab reloads into the session (presence panel appears). Open the copied link in a **2nd tab** (same login) → both show each other; orbit in one tab → the other follows (Follow presenter on).
2. **Capture site photo → 📸 Use webcam** — allow camera → live preview → **Snap** attaches the frame. Deny camera → it falls back to the file picker.
3. **Markup** → place **Text**, **Arrow** (drag), **Draw** (drag), **Revision cloud** (drag a box), **Dimension** (two clicks), **Callout** (two clicks); **Clear markups** removes them; **Esc** exits the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)