### PR TITLE
feat(deploy): tunnel-ready PublicBaseUrl + real SMTP onboarding email + viewer orbit/deselect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ shared/ifc/psd_out/
 # variants are not.
 tests/fixtures/*.ifc
 tests/fixtures/*.roundtrip.ifc
+tools/bin/

--- a/Planscape.Server/docker/docker-compose.yml
+++ b/Planscape.Server/docker/docker-compose.yml
@@ -45,6 +45,21 @@ services:
       # its API_BEARER (:149), so the api must read the SAME value here or the
       # converter→API derivative ingest is always rejected.
       - Converter__ApiBearer=${CONVERTER_API_BEARER:-}
+      # ── Outward URLs: single source of truth ──
+      # Set PUBLIC_BASE_URL in .env to the Cloudflare tunnel (or cloud) origin.
+      # EVERY outward link (invite/reset emails, share/QR) + CORS derives from it.
+      # Empty ⇒ falls back to the request host (fine for a bare localhost run).
+      - Planscape__PublicBaseUrl=${PUBLIC_BASE_URL:-}
+      # ── Real email via SMTP (Gmail app password is the pragmatic default) ──
+      # All blank ⇒ NullEmailService logs a LOUD warning and drops mail.
+      - Smtp__Host=${SMTP_HOST:-}
+      - Smtp__Port=${SMTP_PORT:-587}
+      - Smtp__Username=${SMTP_USERNAME:-}
+      - Smtp__Password=${SMTP_PASSWORD:-}
+      - Smtp__FromAddress=${SMTP_FROM_ADDRESS:-}
+      - Smtp__FromName=${SMTP_FROM_NAME:-Planscape}
+      # Gmail :587 uses STARTTLS ⇒ UseSsl=false. Gmail :465 ⇒ UseSsl=true.
+      - Smtp__UseSsl=${SMTP_USE_SSL:-false}
     depends_on:
       # NB: pgbouncer is intentionally NOT listed here. It lives behind the
       # optional `pool` profile (see below), and Compose rejects the whole
@@ -82,6 +97,19 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  # Mailpit — local SMTP capture (dev/proof). Catches every outbound email so the
+  # full send path + link can be PROVEN without real creds. Web UI on :8025, SMTP
+  # on :1025 (no auth). To send REAL mail instead, point SMTP_HOST at smtp.gmail.com
+  # + a valid app password in .env and restart api (env-only swap — see DEPLOYMENT.md).
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"   # web UI / REST  → http://localhost:8025
+      - "1025:1025"   # SMTP
+    environment:
+      - MP_SMTP_AUTH_ALLOW_INSECURE=true
+    restart: unless-stopped
 
   postgres:
     image: postgres:16-alpine

--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -845,8 +845,12 @@ public class AuthController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult> ForgotPassword([FromBody] ForgotPasswordRequest req)
     {
-        // Always return success to prevent email enumeration
-        var user = await _db.Users.FirstOrDefaultAsync(u => u.Email == req.Email && u.IsActive);
+        // Always return success to prevent email enumeration.
+        // IgnoreQueryFilters: this endpoint is anonymous, so the tenant global
+        // query filter (CurrentTenantId == Guid.Empty for an unauthenticated
+        // caller) would otherwise match NO users — exactly as Login does.
+        var user = await _db.Users.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(u => u.Email == req.Email && u.IsActive);
         if (user == null)
             return Ok(new { message = "If that email exists, a reset link has been sent." });
 
@@ -862,13 +866,15 @@ public class AuthController : ControllerBase
         user.RefreshTokenExpiresAt = DateTime.UtcNow.AddMinutes(expiryMinutes);
         await _db.SaveChangesAsync();
 
-        // Send reset email
+        // Send reset email — a real CLICKABLE link via PublicUrl (tunnel/cloud),
+        // not a developer "POST /api/…" instruction. SendPasswordResetEmailAsync
+        // builds {PublicBaseUrl}/reset-password?token=…&email=… which the
+        // reset-password.html page consumes.
         var emailService = HttpContext.RequestServices.GetService<Planscape.Core.Interfaces.IEmailService>();
         if (emailService != null)
         {
-            await emailService.SendNotificationAsync(user.Email, "Planscape Password Reset",
-                $"Use this token to reset your password (expires in 1 hour):\n\n{resetToken}\n\n" +
-                $"POST /api/auth/reset-password with {{ \"token\": \"{resetToken}\", \"newPassword\": \"...\" }}");
+            await emailService.SendPasswordResetEmailAsync(
+                user.Email, resetToken, Planscape.API.PublicUrl.Resolve(_config, Request));
         }
 
         return Ok(new { message = "If that email exists, a reset link has been sent." });
@@ -902,10 +908,13 @@ public class AuthController : ControllerBase
         // S6 — match against the hash, not the raw token. The token in
         // the email never appears in the DB.
         var hashed = $"RESET:{HashResetToken(req.Token)}";
-        var user = await _db.Users
+        // NB: do NOT require IsActive here — invited users start inactive and use
+        // this exact flow to set their first password. Setting the password
+        // ACTIVATES them (below), so the invite link is a complete onboarding step.
+        // IgnoreQueryFilters: anonymous endpoint, so bypass the tenant filter.
+        var user = await _db.Users.IgnoreQueryFilters()
             .FirstOrDefaultAsync(u => u.RefreshToken == hashed
-                && u.RefreshTokenExpiresAt > DateTime.UtcNow
-                && u.IsActive);
+                && u.RefreshTokenExpiresAt > DateTime.UtcNow);
 
         if (user == null)
             return BadRequest(new { message = "Invalid or expired reset token" });
@@ -916,6 +925,7 @@ public class AuthController : ControllerBase
         user.PasswordHash = HashPassword(req.NewPassword);
         user.RefreshToken = null;
         user.RefreshTokenExpiresAt = null;
+        user.IsActive = true;   // activate invited users on first password set
         await _db.SaveChangesAsync();
 
         // S6 / S5 — bump the iat-floor so any access token issued before

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -25,14 +25,17 @@ public class ProjectMembersController : ControllerBase
     private readonly PlanscapeDbContext _db;
     private readonly IEmailService _emailService;
     private readonly IProjectMembershipNotifier _membershipNotifier;
+    private readonly IConfiguration _config;
 
     public ProjectMembersController(PlanscapeDbContext db,
                                     IEmailService emailService,
-                                    IProjectMembershipNotifier membershipNotifier)
+                                    IProjectMembershipNotifier membershipNotifier,
+                                    IConfiguration config)
     {
         _db = db;
         _emailService = emailService;
         _membershipNotifier = membershipNotifier;
+        _config = config;
     }
 
     // ── GET all members for a project ─────────────────────────────────────────
@@ -234,7 +237,10 @@ public class ProjectMembersController : ControllerBase
                 Role          = UserRole.Contributor,
                 Iso19650Role  = req.Iso19650Role ?? "M",
                 IsActive      = false,  // awaiting first login / password set
-                RefreshToken  = $"INV:{inviteTokenHash}",
+                // RESET: (not INV:) so the invite link's token validates against
+                // /api/auth/reset-password, which sets the password AND activates
+                // the user. reset-password.html consumes ?token=…&email=….
+                RefreshToken  = $"RESET:{inviteTokenHash}",
                 RefreshTokenExpiresAt = DateTime.UtcNow.AddDays(14),
             };
             _db.Users.Add(user);
@@ -254,10 +260,12 @@ public class ProjectMembersController : ControllerBase
 
             await _db.SaveChangesAsync();
 
-            // Send invite email with password-reset link
+            // Send invite email with password-reset link. PublicUrl.Resolve uses
+            // Planscape:PublicBaseUrl (the tunnel/cloud URL) when set, so the link
+            // a remote guest receives is reachable — never the internal localhost.
             await _emailService.SendInviteEmailAsync(
                 user.Email, user.DisplayName, GetCurrentUserName(),
-                project.Name, $"{Request.Scheme}://{Request.Host}");
+                project.Name, Planscape.API.PublicUrl.Resolve(_config, Request), inviteToken);
         }
 
         // Add to project

--- a/Planscape.Server/src/Planscape.API/Controllers/QrController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/QrController.cs
@@ -20,11 +20,13 @@ public class QrController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
     private readonly IHttpContextAccessor _http;
+    private readonly IConfiguration _config;
 
-    public QrController(PlanscapeDbContext db, IHttpContextAccessor http)
+    public QrController(PlanscapeDbContext db, IHttpContextAccessor http, IConfiguration config)
     {
         _db = db;
         _http = http;
+        _config = config;
     }
 
     /// <summary>
@@ -44,7 +46,7 @@ public class QrController : ControllerBase
                 && e.Project!.TenantId == tenantId);
         if (el == null) return NotFound();
 
-        var baseUrl = $"{_http.HttpContext!.Request.Scheme}://{_http.HttpContext.Request.Host}";
+        var baseUrl = Planscape.API.PublicUrl.Resolve(_config, _http.HttpContext!.Request);
         var payload = JsonSerializer.Serialize(new
         {
             projectId = projectId.ToString(),

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -907,6 +907,15 @@ var corsOrigins = builder.Configuration.GetSection("Cors:Origins").Get<string[]>
     "exp://localhost:19000",
     "exp://localhost:8081",
 };
+// PublicBaseUrl (Cloudflare tunnel / cloud host) is the single source of truth for
+// outward URLs — it must also be a permitted CORS origin so the dashboard + viewer
+// served at that origin can call the API. Append it (deduped) when configured.
+{
+    var publicBase = builder.Configuration["Planscape:PublicBaseUrl"]?.Trim().TrimEnd('/');
+    if (!string.IsNullOrWhiteSpace(publicBase)
+        && !corsOrigins.Contains(publicBase, StringComparer.OrdinalIgnoreCase))
+        corsOrigins = corsOrigins.Append(publicBase).ToArray();
+}
 builder.Services.AddCors(options =>
 {
     // Dashboard policy keeps credentials allowed for the cookie-based web app.
@@ -1044,6 +1053,7 @@ app.UseStaticFiles(new Microsoft.AspNetCore.Builder.StaticFileOptions
         if (name.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
          || name == "coordination-viewer.js"
          || name == "viewer-extras.js"
+         || name == "meeting-sync.js"
          || name == "signalr-shim.js"
          || name == "coordination-viewer.css")
         {

--- a/Planscape.Server/src/Planscape.API/PublicUrl.cs
+++ b/Planscape.Server/src/Planscape.API/PublicUrl.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace Planscape.API;
+
+/// <summary>
+/// Single source of truth for the public-facing base URL used in every outward
+/// link (invite / password-reset emails, share + QR links, accept-invite pages).
+///
+/// When <c>Planscape:PublicBaseUrl</c> is set (env: <c>Planscape__PublicBaseUrl</c>)
+/// it WINS — this is required behind a reverse proxy / Cloudflare tunnel, where the
+/// request Host the app sees is the internal origin (localhost:5000), NOT the URL the
+/// recipient must click. Falling back to <c>{scheme}://{host}</c> keeps a bare
+/// localhost dev run working with zero config.
+///
+/// Config-first by design: moving from tunnel → cloud is an env change only
+/// (set PublicBaseUrl to the cloud hostname), no rebuild.
+/// </summary>
+public static class PublicUrl
+{
+    public static string Resolve(IConfiguration config, HttpRequest request)
+    {
+        var configured = config["Planscape:PublicBaseUrl"];
+        if (!string.IsNullOrWhiteSpace(configured))
+            return configured.Trim().TrimEnd('/');
+        return $"{request.Scheme}://{request.Host}".TrimEnd('/');
+    }
+}

--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -55,9 +55,16 @@
     // so a fresh git-clone still works on dev. The Settings menu writes
     // `planscape_api_base` and reloads.
     const storedApi = (typeof localStorage !== 'undefined' && localStorage.getItem('planscape_api_base')) || '';
+    // Same-origin fallback: when the viewer is SERVED by the API (the normal
+    // case — including over a Cloudflare tunnel), call the API at the serving
+    // origin so a remote guest never hits localhost. Only fall back to the
+    // localhost literal for file:// opens (origin === 'null'/empty).
+    const sameOrigin = (typeof window !== 'undefined' && window.location
+                        && /^https?:/.test(window.location.origin || '')) ? window.location.origin : '';
     const apiBase   = window.__PLANSCAPE_API__
                    || storedApi
                    || params.get('api')
+                   || sameOrigin
                    || 'http://localhost:5000';
     const token     = (typeof localStorage !== 'undefined' && localStorage.getItem('planscape_token')) || '';
     // Apply persisted theme on first paint so re-loads don't flash white.
@@ -4530,6 +4537,12 @@
               state.angleTool = false; state.anglePoints = [];
             }
           }
+          return origSend.call(V.bridge, type, payload);
+        }
+        // Empty-space click (engine raycast hit nothing) — clear the whole
+        // selection so the floating toolbar + multi-property pane disappear.
+        if (type === 'deselect') {
+          selectElementByGuid(null);
           return origSend.call(V.bridge, type, payload);
         }
         if (type === 'pick' && payload && payload.guid) {

--- a/Planscape.Server/src/Planscape.API/wwwroot/reset-password.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/reset-password.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Set your Planscape password</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; }
+    body { margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center;
+           font-family:'Segoe UI',Roboto,Helvetica,Arial,sans-serif; background:#0e1014; color:#e6e6e6; padding:24px; }
+    .card { width:100%; max-width:420px; background:#171a21; border:1px solid #262b36; border-radius:12px;
+            padding:28px 26px; box-shadow:0 8px 30px rgba(0,0,0,0.4); }
+    h1 { font-size:20px; margin:0 0 4px; }
+    p.sub { margin:0 0 20px; color:#9aa3b2; font-size:13px; }
+    label { display:block; font-size:12px; color:#9aa3b2; margin:14px 0 5px; }
+    input { width:100%; padding:11px 12px; border-radius:8px; border:1px solid #2d333f; background:#0e1014;
+            color:#e6e6e6; font-size:14px; }
+    input:focus { outline:none; border-color:#3b82f6; }
+    input[readonly] { color:#9aa3b2; }
+    button { width:100%; margin-top:20px; padding:12px; border:none; border-radius:8px; background:#3b82f6;
+             color:#fff; font-size:15px; font-weight:600; cursor:pointer; }
+    button:disabled { opacity:.55; cursor:default; }
+    .msg { margin-top:16px; font-size:13px; padding:10px 12px; border-radius:8px; display:none; }
+    .msg.err { display:block; background:rgba(239,68,68,.12); border:1px solid rgba(239,68,68,.4); color:#fca5a5; }
+    .msg.ok  { display:block; background:rgba(34,197,94,.12); border:1px solid rgba(34,197,94,.4); color:#86efac; }
+    .brand { font-weight:700; letter-spacing:.04em; color:#3b82f6; margin-bottom:18px; font-size:13px; }
+    a { color:#7fb2ff; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="brand">◢ PLANSCAPE</div>
+    <h1>Set your password</h1>
+    <p class="sub">Choose a password to activate your account, then sign in.</p>
+
+    <label>Email</label>
+    <input id="email" type="email" readonly />
+
+    <label>New password <span style="color:#6b7280">(min 8 characters)</span></label>
+    <input id="pw1" type="password" autocomplete="new-password" placeholder="••••••••" />
+
+    <label>Confirm password</label>
+    <input id="pw2" type="password" autocomplete="new-password" placeholder="••••••••" />
+
+    <button id="go">Set password</button>
+    <div id="msg" class="msg"></div>
+  </div>
+
+  <script>
+    // Same-origin: the page is served by the API (incl. over a Cloudflare
+    // tunnel), so a relative /api/... fetch always hits the right origin.
+    var qs = new URLSearchParams(location.search);
+    var token = qs.get('token') || '';
+    var email = qs.get('email') || '';
+    document.getElementById('email').value = email;
+
+    var msg = document.getElementById('msg');
+    var btn = document.getElementById('go');
+    function show(kind, text) { msg.className = 'msg ' + kind; msg.textContent = text; }
+
+    if (!token) {
+      show('err', 'This link is missing its reset token. Use the most recent email, or request a new link from the sign-in page.');
+    }
+
+    btn.addEventListener('click', async function () {
+      var p1 = document.getElementById('pw1').value;
+      var p2 = document.getElementById('pw2').value;
+      if (p1.length < 8) return show('err', 'Password must be at least 8 characters.');
+      if (p1 !== p2)     return show('err', 'Passwords do not match.');
+      if (!token)        return show('err', 'Missing reset token — request a new link.');
+      btn.disabled = true; show('ok', 'Setting your password…');
+      try {
+        var res = await fetch('/api/auth/reset-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: token, newPassword: p1 })
+        });
+        var data = await res.json().catch(function () { return {}; });
+        if (res.ok) {
+          show('ok', 'Password set! Redirecting to sign in…');
+          setTimeout(function () { location.href = '/'; }, 1400);
+        } else {
+          btn.disabled = false;
+          show('err', (data && data.message) || ('Could not reset password (HTTP ' + res.status + ').'));
+        }
+      } catch (e) {
+        btn.disabled = false;
+        show('err', 'Network error — check your connection and try again.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -781,7 +781,14 @@ THREE.ColorManagement.enabled = false;
   // the screen plane regardless of camera tilt.
   controls.zoomToCursor      = true;
   controls.screenSpacePanning = true;
-  controls.rotateSpeed = 0.9;
+  // NEGATIVE rotateSpeed — natural Z-up orbit sense. With camera.up=(0,0,1)
+  // OrbitControls builds _quat = setFromUnitVectors((0,0,1),(0,1,0)) — a
+  // −90°-about-X mapping — which inverts BOTH the polar and azimuth drag sense
+  // (drag-up dropped the camera to the horizon i.e. tilted DOWN; drag-left spun
+  // the wrong way). The rotate delta is multiplied by rotateSpeed, so a negative
+  // value flips both _rotateLeft + _rotateUp: drag-up now tilts up, drag-left
+  // spins left — natural. Magnitude unchanged.
+  controls.rotateSpeed = -0.9;
   controls.zoomSpeed   = 1.2;
   controls.panSpeed    = 1.0;
   // Stop the user from rolling the camera under the model.
@@ -999,7 +1006,17 @@ THREE.ColorManagement.enabled = false;
 
     setPointer(e);
     const hits = raycast();
-    if (hits.length === 0) return;
+    if (hits.length === 0) {
+      // Clicked empty space (raycast hit nothing) — deselect. Only for the
+      // plain pick tool; measurement / pin / clearance tools manage their own
+      // empty-click behaviour. Clears the engine highlight and tells the host
+      // to drop its selection set + hide the selection toolbar.
+      if (!longPress && (activeTool === 'pick' || !activeTool)) {
+        clearHighlight();
+        bridge.send('deselect', {});
+      }
+      return;
+    }
     const hit = hits[0];
     // Snap the hit point if a snap mode is active. Pin meshes (sprites) and
     // hits without face data fall back to raw hit.point.

--- a/Planscape.Server/src/Planscape.Core/Interfaces/IEmailService.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/IEmailService.cs
@@ -2,7 +2,10 @@ namespace Planscape.Core.Interfaces;
 
 public interface IEmailService
 {
-    Task SendInviteEmailAsync(string toEmail, string displayName, string inviterName, string projectName, string serverUrl, CancellationToken ct = default);
+    // resetToken (optional): when supplied, the invite link carries it so the
+    // invited user can set their password directly from the email — required
+    // because invited users start IsActive=false and forgot-password skips them.
+    Task SendInviteEmailAsync(string toEmail, string displayName, string inviterName, string projectName, string serverUrl, string? resetToken = null, CancellationToken ct = default);
     Task SendPasswordResetEmailAsync(string toEmail, string resetToken, string serverUrl, CancellationToken ct = default);
     Task SendNotificationAsync(string toEmail, string subject, string htmlBody, CancellationToken ct = default);
     Task SendAsync(string toEmail, string subject, string htmlBody, CancellationToken ct = default);

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/SmtpEmailService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/SmtpEmailService.cs
@@ -44,9 +44,15 @@ public class SmtpEmailService : IEmailService
 
     public async Task SendInviteEmailAsync(
         string toEmail, string displayName, string inviterName,
-        string projectName, string serverUrl, CancellationToken ct = default)
+        string projectName, string serverUrl, string? resetToken = null, CancellationToken ct = default)
     {
-        var acceptUrl = $"{serverUrl.TrimEnd('/')}/reset-password?email={Uri.EscapeDataString(toEmail)}";
+        var baseUrl = serverUrl.TrimEnd('/');
+        // With a reset token the invitee can set their password straight from the
+        // email; without one the link only prefills the email and they must
+        // request a reset link.
+        var acceptUrl = string.IsNullOrWhiteSpace(resetToken)
+            ? $"{baseUrl}/reset-password.html?email={Uri.EscapeDataString(toEmail)}"
+            : $"{baseUrl}/reset-password.html?token={Uri.EscapeDataString(resetToken)}&email={Uri.EscapeDataString(toEmail)}";
         var model = new Dictionary<string, string?>
         {
             ["DisplayName"]  = displayName,
@@ -62,7 +68,7 @@ public class SmtpEmailService : IEmailService
     public async Task SendPasswordResetEmailAsync(
         string toEmail, string resetToken, string serverUrl, CancellationToken ct = default)
     {
-        var resetUrl = $"{serverUrl.TrimEnd('/')}/reset-password?token={Uri.EscapeDataString(resetToken)}&email={Uri.EscapeDataString(toEmail)}";
+        var resetUrl = $"{serverUrl.TrimEnd('/')}/reset-password.html?token={Uri.EscapeDataString(resetToken)}&email={Uri.EscapeDataString(toEmail)}";
         var model = new Dictionary<string, string?>
         {
             ["ResetUrl"]  = resetUrl,
@@ -181,14 +187,18 @@ public class SmtpEmailService : IEmailService
         if (string.IsNullOrWhiteSpace(Host))
         {
             // No SMTP host configured — behave like NullEmailService to avoid a crash.
-            _logger.LogInformation("[Smtp:NoHost] to={ToEmail} subject={Subject}", toEmail, email.Subject);
+            _logger.LogWarning("[Smtp:NoHost] ⚠ EMAIL NOT SENT (Smtp:Host empty) to={ToEmail} subject={Subject}", toEmail, email.Subject);
             return;
         }
 
         using var client = new SmtpClient();
         try
         {
-            var secureOption = UseSsl ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTls;
+            // UseSsl=true ⇒ implicit TLS (Gmail :465). Otherwise StartTlsWhenAvailable:
+            // upgrades to TLS when the server advertises STARTTLS (Gmail :587) and stays
+            // plain when it doesn't (a local Mailpit/MailHog capture on :1025) — so the
+            // SAME service proves the path against a dev catcher and sends real mail to Gmail.
+            var secureOption = UseSsl ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTlsWhenAvailable;
             await client.ConnectAsync(Host, Port, secureOption, ct);
             if (!string.IsNullOrEmpty(Username))
                 await client.AuthenticateAsync(Username, Password, ct);
@@ -253,23 +263,31 @@ public class NullEmailService : IEmailService
 {
     private readonly ILogger<NullEmailService> _logger;
 
-    public NullEmailService(ILogger<NullEmailService> logger) => _logger = logger;
+    public NullEmailService(ILogger<NullEmailService> logger)
+    {
+        _logger = logger;
+        // LOUD on startup so a misconfigured deploy never silently drops mail.
+        _logger.LogWarning(
+            "[NullEmail] ⚠ NO SMTP CONFIGURED — emails (invites, password resets, notifications) "
+          + "will NOT be delivered, only logged. Set Smtp__Host / Smtp__Port / Smtp__Username / "
+          + "Smtp__Password / Smtp__FromAddress (e.g. Gmail smtp.gmail.com:587 + app password) to send real mail.");
+    }
 
     public Task SendInviteEmailAsync(
         string toEmail, string displayName, string inviterName,
-        string projectName, string serverUrl, CancellationToken ct = default)
+        string projectName, string serverUrl, string? resetToken = null, CancellationToken ct = default)
     {
-        _logger.LogInformation(
-            "[NullEmail] Invite: to={ToEmail}, displayName={DisplayName}, inviter={Inviter}, project={Project}, url={Url}",
-            toEmail, displayName, inviterName, projectName, serverUrl);
+        _logger.LogWarning(
+            "[NullEmail] ⚠ INVITE NOT SENT (no SMTP) to={ToEmail}, displayName={DisplayName}, inviter={Inviter}, project={Project}, url={Url}, hasToken={HasToken}",
+            toEmail, displayName, inviterName, projectName, serverUrl, !string.IsNullOrWhiteSpace(resetToken));
         return Task.CompletedTask;
     }
 
     public Task SendPasswordResetEmailAsync(
         string toEmail, string resetToken, string serverUrl, CancellationToken ct = default)
     {
-        _logger.LogInformation(
-            "[NullEmail] PasswordReset: to={ToEmail}, token={Token}, url={Url}",
+        _logger.LogWarning(
+            "[NullEmail] ⚠ PASSWORD-RESET NOT SENT (no SMTP) to={ToEmail}, token={Token}, url={Url}",
             toEmail, resetToken, serverUrl);
         return Task.CompletedTask;
     }
@@ -277,8 +295,8 @@ public class NullEmailService : IEmailService
     public Task SendNotificationAsync(
         string toEmail, string subject, string htmlBody, CancellationToken ct = default)
     {
-        _logger.LogInformation(
-            "[NullEmail] Notification: to={ToEmail}, subject={Subject}",
+        _logger.LogWarning(
+            "[NullEmail] ⚠ NOTIFICATION NOT SENT (no SMTP) to={ToEmail}, subject={Subject}",
             toEmail, subject);
         return Task.CompletedTask;
     }

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -55,9 +55,16 @@
     // so a fresh git-clone still works on dev. The Settings menu writes
     // `planscape_api_base` and reloads.
     const storedApi = (typeof localStorage !== 'undefined' && localStorage.getItem('planscape_api_base')) || '';
+    // Same-origin fallback: when the viewer is SERVED by the API (the normal
+    // case — including over a Cloudflare tunnel), call the API at the serving
+    // origin so a remote guest never hits localhost. Only fall back to the
+    // localhost literal for file:// opens (origin === 'null'/empty).
+    const sameOrigin = (typeof window !== 'undefined' && window.location
+                        && /^https?:/.test(window.location.origin || '')) ? window.location.origin : '';
     const apiBase   = window.__PLANSCAPE_API__
                    || storedApi
                    || params.get('api')
+                   || sameOrigin
                    || 'http://localhost:5000';
     const token     = (typeof localStorage !== 'undefined' && localStorage.getItem('planscape_token')) || '';
     // Apply persisted theme on first paint so re-loads don't flash white.
@@ -4530,6 +4537,12 @@
               state.angleTool = false; state.anglePoints = [];
             }
           }
+          return origSend.call(V.bridge, type, payload);
+        }
+        // Empty-space click (engine raycast hit nothing) — clear the whole
+        // selection so the floating toolbar + multi-property pane disappear.
+        if (type === 'deselect') {
+          selectElementByGuid(null);
           return origSend.call(V.bridge, type, payload);
         }
         if (type === 'pick' && payload && payload.guid) {

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -781,7 +781,14 @@ THREE.ColorManagement.enabled = false;
   // the screen plane regardless of camera tilt.
   controls.zoomToCursor      = true;
   controls.screenSpacePanning = true;
-  controls.rotateSpeed = 0.9;
+  // NEGATIVE rotateSpeed — natural Z-up orbit sense. With camera.up=(0,0,1)
+  // OrbitControls builds _quat = setFromUnitVectors((0,0,1),(0,1,0)) — a
+  // −90°-about-X mapping — which inverts BOTH the polar and azimuth drag sense
+  // (drag-up dropped the camera to the horizon i.e. tilted DOWN; drag-left spun
+  // the wrong way). The rotate delta is multiplied by rotateSpeed, so a negative
+  // value flips both _rotateLeft + _rotateUp: drag-up now tilts up, drag-left
+  // spins left — natural. Magnitude unchanged.
+  controls.rotateSpeed = -0.9;
   controls.zoomSpeed   = 1.2;
   controls.panSpeed    = 1.0;
   // Stop the user from rolling the camera under the model.
@@ -999,7 +1006,17 @@ THREE.ColorManagement.enabled = false;
 
     setPointer(e);
     const hits = raycast();
-    if (hits.length === 0) return;
+    if (hits.length === 0) {
+      // Clicked empty space (raycast hit nothing) — deselect. Only for the
+      // plain pick tool; measurement / pin / clearance tools manage their own
+      // empty-click behaviour. Clears the engine highlight and tells the host
+      // to drop its selection set + hide the selection toolbar.
+      if (!longPress && (activeTool === 'pick' || !activeTool)) {
+        clearHighlight();
+        bridge.send('deselect', {});
+      }
+      return;
+    }
     const hit = hits[0];
     // Snap the hit point if a snap mode is active. Pin meshes (sprites) and
     // hits without face data fall back to raw hit.point.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,158 @@
+# Planscape — Deployment & Remote-Guest Review
+
+How to put the Planscape server on the internet for a remote reviewer (e.g. a
+guest in West Africa) and send them a real, clickable invite — and how the same
+build moves from a tunnel to a cloud host by changing **env only**.
+
+Secrets (SMTP creds, tunnel tokens, JWT key) live **only** in
+`Planscape.Server/docker/.env`, which is **gitignored**. Never commit them.
+
+---
+
+## 0. Single source of truth: `Planscape__PublicBaseUrl`
+
+Every outward URL a guest receives — invite / password-reset email links,
+share + QR links — derives from **one** value:
+
+| Surface | Env (in `docker/.env`) | Config key | Used by |
+|---|---|---|---|
+| Public base URL | `PUBLIC_BASE_URL` | `Planscape:PublicBaseUrl` | `PublicUrl.Resolve()` → emails, QR, CORS |
+
+`PublicUrl.Resolve(config, request)` returns `Planscape:PublicBaseUrl` when set,
+otherwise falls back to `{scheme}://{host}` of the request. Behind a reverse
+proxy / Cloudflare tunnel the request host is the **internal** origin
+(`localhost:5000`), so **you must set `PUBLIC_BASE_URL`** or guests get unreachable
+`localhost` links. The web app + viewer call the API **same-origin** (relative),
+so when served from the tunnel they automatically talk to the tunnel API.
+
+`PUBLIC_BASE_URL` is also auto-added to the CORS allow-list.
+
+---
+
+## 1. Run order (THIS ORDER MATTERS)
+
+```
+tunnel  →  set PUBLIC_BASE_URL  →  restart api  →  send invite
+```
+
+If you send the invite before `PUBLIC_BASE_URL` points at the tunnel, the link in
+the email is wrong. Steps:
+
+```bash
+# 1. Start the quick tunnel (prints https://<random>.trycloudflare.com)
+cloudflared tunnel --url http://localhost:5000
+
+# 2. Put that URL in docker/.env
+#    PUBLIC_BASE_URL=https://<random>.trycloudflare.com
+
+# 3. Recreate the api container so it picks up the new env (no rebuild needed)
+cd Planscape.Server/docker
+JWT_KEY=$(grep '^JWT_KEY=' .env | cut -d= -f2-) docker compose up -d api
+
+# 4. Send the guest a reset/invite link (see §4)
+```
+
+> ⚠️ A Cloudflare **quick** tunnel URL **changes every restart**. Re-set
+> `PUBLIC_BASE_URL`, re-run `docker compose up -d api`, and re-share each session.
+> For a stable URL, use a **named** Cloudflare tunnel (`cloudflared tunnel create`)
+> or the cloud/Docker deploy below.
+
+---
+
+## 2. Email — real SMTP (Gmail app password) vs Mailpit capture
+
+The api wires `SmtpEmailService` whenever `Smtp__Host` is set, else
+`NullEmailService` (which now logs a **loud warning** so mail never silently drops).
+`docker/.env` injects the SMTP config into the container:
+
+| Env | Container config | Notes |
+|---|---|---|
+| `SMTP_HOST` | `Smtp__Host` | `smtp.gmail.com` or `mailpit` |
+| `SMTP_PORT` | `Smtp__Port` | `587` Gmail STARTTLS · `1025` Mailpit |
+| `SMTP_USE_SSL` | `Smtp__UseSsl` | `false` for 587/1025; `true` for 465 |
+| `SMTP_USERNAME` | `Smtp__Username` | Gmail address (blank ⇒ no AUTH, for Mailpit) |
+| `SMTP_PASSWORD` | `Smtp__Password` | 16-char app password |
+| `SMTP_FROM_ADDRESS` | `Smtp__FromAddress` | must equal the Gmail address |
+
+The send uses `StartTlsWhenAvailable`, so the **same** build secures Gmail (587
+advertises STARTTLS) and still talks to a plain Mailpit catcher.
+
+### 2a. Gmail app-password setup (real delivery)
+
+1. Enable **2-Step Verification** on the sending Google account.
+2. Create an app password at <https://myaccount.google.com/apppasswords> for that
+   **exact** account (Workspace accounts may need the admin to allow app passwords).
+3. Put it in `docker/.env` (16 chars, no spaces) — `SMTP_USERNAME` /
+   `SMTP_FROM_ADDRESS` must be that same Gmail address.
+4. `docker compose up -d api`. Verify quickly from the host:
+   ```bash
+   python - <<'PY'
+   import smtplib,ssl
+   s=smtplib.SMTP("smtp.gmail.com",587,timeout=20); s.starttls(context=ssl.create_default_context())
+   s.login("you@gmail.com","apppassword16"); print("AUTH OK"); s.quit()
+   PY
+   ```
+   `535 BadCredentials` ⇒ wrong/expired password or app passwords disabled for that
+   account. Fix that before expecting real mail.
+
+### 2b. Mailpit (prove the path with no creds)
+
+Mailpit captures every outbound email so you can prove the send path + verify the
+link without real creds. It's a compose service (web UI `http://localhost:8025`):
+
+```bash
+docker compose up -d mailpit
+# .env:  SMTP_HOST=mailpit  SMTP_PORT=1025  SMTP_USERNAME=  SMTP_PASSWORD=  SMTP_USE_SSL=false
+docker compose up -d api
+```
+
+Trigger a send, then read it back:
+
+```bash
+curl -s http://localhost:8025/api/v1/messages | jq '.messages[0] | {To,Subject}'
+# open the captured HTML to confirm the link points at the tunnel
+```
+
+**One-line swap to real Gmail:** change the four `SMTP_*` lines in `.env` back to
+the Gmail block (§2a) and `docker compose up -d api`. No rebuild.
+
+---
+
+## 3. Reset / set-password page
+
+Invite + forgot-password emails link to `/{PublicBaseUrl}/reset-password.html?token=…&email=…`.
+`wwwroot/reset-password.html` reads the token+email from the query, takes a new
+password, and POSTs same-origin to `/api/auth/reset-password`. Works over the tunnel
+unchanged (same-origin fetch).
+
+---
+
+## 4. Review with a remote guest
+
+1. Ensure the guest is a project member (invite once via the BIM Coordination
+   Center, or `POST /api/projects/{id}/members/invite`).
+2. Run §1 (tunnel → PUBLIC_BASE_URL → restart).
+3. Send them a set-password link:
+   ```bash
+   curl -X POST "$PUBLIC_BASE_URL/api/auth/forgot-password" \
+        -H 'Content-Type: application/json' \
+        -d '{"email":"guest@example.com"}'
+   ```
+   They receive an email with a clickable `…/reset-password.html?token=…` link.
+4. Guest, on a **second device** over the tunnel URL: open the link → set a
+   password → sign in at `$PUBLIC_BASE_URL/` → project visible → open the model in
+   the viewer → issues/clashes load.
+
+### Perf note (slow links)
+The GLB can be large over a tunnel. The streaming loader shows real progress
+(no stuck-at-0%). For a first review on a slow link, publish a **smaller** model.
+
+---
+
+## 5. Long-term home — same image, env only
+
+The tunnel is for ad-hoc reviews. The stable path is the existing Docker deploy
+(`docker compose up -d` on a cloud VM, or push the image to your registry). Moving
+there is **env-only**: set `PUBLIC_BASE_URL` to the cloud hostname, set the real
+`SMTP_*` Gmail/Postmark values, set a strong `JWT_KEY` + `DB_PASSWORD`. No code or
+image change — `PublicUrl` + the SMTP wiring already read everything from env.


### PR DESCRIPTION
Make Planscape reachable over a Cloudflare tunnel and send a remote guest a real, clickable onboarding email whose links **all derive from one env value** — so the same image moves tunnel→cloud by changing env only. Secrets stay in **gitignored** `docker/.env` (never committed). Viewer edits are in `assets/viewer/` + `wwwroot` **byte-equal**.

## PublicBaseUrl — single source of truth
- New `PublicUrl.Resolve(config, request)`: `Planscape:PublicBaseUrl` wins (tunnel/cloud), else `{scheme}://{host}`. Wired into invite + forgot-password email links and QR/share.
- `Program.cs` appends PublicBaseUrl to the CORS allow-list.
- **Viewer `apiBase` now falls back to the serving origin** (`window.location.origin`) instead of hardcoded `http://localhost:5000` — a guest on the tunnel never hits localhost.
- `docker-compose`: `Planscape__PublicBaseUrl` + `Smtp__*` wired from `.env`; `meeting-sync.js` added to the no-cache asset list.

## Real SMTP + onboarding
- `SmtpEmailService` reads `Smtp__Host/Port/Username/Password/FromAddress/FromName` from env; `StartTlsWhenAvailable` secures Gmail (587) yet still talks to a plain Mailpit catcher.
- `NullEmailService` + the no-host path now **log loud warnings** so email never silently drops.
- Invite generates a **RESET token** and emails a clickable `{PublicBaseUrl}/reset-password.html?token=…&email=…`; new **`reset-password.html`** sets the password same-origin.
- `reset-password` now **activates** invited (inactive) users on success.
- **BUGFIX:** `forgot-password` + `reset-password` are anonymous, so they must `.IgnoreQueryFilters()` (like `Login`). The tenant global query filter was matching **zero** users for an unauthenticated caller, so the reset email **never sent**. Now it does.
- **Mailpit** added as a compose service for local SMTP capture / proof.

## Viewer residual fixes (PHASE 0)
- **Orbit**: `rotateSpeed = -0.9` — with `camera.up=(0,0,1)` OrbitControls' `_quat` (a −90°-about-X map) inverts the drag sense; negating fixes it (drag-up tilts up, drag-left spins left).
- Clicking **empty space deselects** (clears highlight + the selection toolbar).

## Proven end-to-end (live Cloudflare tunnel + real Postgres + Mailpit)
Tunnel `https://carrier-computers-blackberry-claims.trycloudflare.com` (Johannesburg edge):
- forgot-password → **email delivered** (Mailpit), `To: beckykyomugisha@gmail.com`, link = **tunnel** `/reset-password.html?token=…` (**no localhost**).
- reset-password with that token → **200**; login as the guest over the tunnel → **sees NHW-2026**; `/viewer.html`, `/reset-password.html`, issues, models all **200**.

> Note: the supplied Gmail app password was rejected by Google (`535 BadCredentials`), so real delivery used the task-prescribed **Mailpit** capture to prove the full path + link; `docs/DEPLOYMENT.md` documents the **one-line env swap** to real Gmail (valid app password) and the run-order (tunnel → set PublicBaseUrl → restart → invite). The `clashes` 500 is pre-existing (fails for admin too) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)