### PR TITLE
Kampala Temple STING project profile (full ISO 19650 tag)

### DIFF
--- a/StingTools/Data/Profiles/KampalaTemple/README.md
+++ b/StingTools/Data/Profiles/KampalaTemple/README.md
@@ -1,0 +1,112 @@
+# Kampala Uganda Temple — STING project profile (interim)
+
+A reusable, project-scoped STINGTOOLS configuration for the Kampala Temple
+project (Symbion Consulting Group Studios). It is **specific to this project but
+built to be cloned** for the next temple/multi-building job: copy the folder,
+rename the building codes, and you have a new profile.
+
+> **Status: INTERIM.** Attachments A1 and A2 define **no element tag-token
+> scheme** — A1 mentions tags once, as a quality-control check; A2 not at all.
+> The real tag/LOD standard is the **Owner BIM modeling / prototype standard**
+> on the SPD Temple Design Hub, which A2 §A says the team *"will be provided."*
+> This profile is the ISO 19650 BEP interim used **until that standard is
+> issued**, at which point the tokens are finalised in one pass.
+
+## What this profile does
+
+| Decision | Setting |
+|---|---|
+| **Full ISO 19650 asset tag** | `DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ` (e.g. `M-TPL-Z01-01-HVAC-SUP-AHU-0003`) |
+| **Separator / number pad** | `-` / 4 digits |
+| **Location = building = ISO Volume** | 6 buildings + external + project-wide (table below) |
+| **Systems** | Aligned to the project's **CSI MasterFormat divisions** (A2) |
+| **Status / Revision defaults** | `NEW` / `P01` |
+| **Collision mode** | `AutoIncrement` (no duplicate SEQ) |
+| **Compliance gate** | `0` (disabled — does not block during early authoring) |
+
+## The full tag, mapped to ISO 19650 fields
+
+The eight segments are a **superset** of the ISO 19650 container fields plus a
+full asset classification. Crucially, **ISO "Volume" is carried by `LOC`** (the
+building) — there is no missing token and no need for a 9th segment.
+
+| Segment | Meaning | ISO 19650 field |
+|---|---|---|
+| **DISC** | Discipline (M, E, P, A, S, FP, LV, C) | Role |
+| **LOC** | **Building** | **Volume** |
+| **ZONE** | Sub-zone within a building | (STING extension) |
+| **LVL** | Level (GF, 01, B1, RF …) | Level / Location |
+| **SYS** | System (CSI-aligned — see below) | — |
+| **FUNC** | Function (SUP, HTG, PWR …) | — |
+| **PROD** | Product (AHU, DB, DR …) | — |
+| **SEQ** | 4-digit sequence | Number |
+
+`DISC`, `LOC`, `ZONE`, `LVL` and `SEQ` auto-derive today from category +
+spatial + phase data. `SYS / FUNC / PROD` populate from STING's defaults
+(the CSI-aligned `SYS_MAP` below, the default function map, and family-aware
+product codes); their **values** are re-confirmed in one pass when the Owner
+prototype standard issues — but the full tag **structure** is in place now.
+
+The project + originator + type fields of the KUT container code
+(`KUT-ZZZ-XX-XX-M3-A-0001`) are project-level and live on the **sheet/model
+name** via the Drawing engine, not on every element.
+
+## Volume / building crosswalk (LOC ↔ KUT Volume)
+
+ISO 19650 puts **Volume on the container/sheet name**, not the element tag. The
+STING Drawing engine already emits
+`{Project}-{Originator}-{Volume}-{Level}-{Type}-{Role}-{Number}`. Use these
+Volume codes on sheets/models; the matching `LOC` code goes on elements.
+
+| Building (A1) | Element `LOC` | Sheet/model **Volume** (KUT) |
+|---|---|---|
+| Temple | `TPL` | `01` |
+| Meetinghouse | `MTH` | `02` |
+| Housing / ancillary | `HSG` | `03` |
+| Grounds building | `GRD` | `04` |
+| Utility building | `UTL` | `05` |
+| Guard house | `GDH` | `06` |
+| External / site | `EXT` | `XX` |
+| Project-wide / multi-building | `ZZ` | `ZZ` |
+
+## System ↔ CSI division (A2)
+
+A2 structures the engineering work by CSI MasterFormat division. The `SYS_MAP`
+in `project_config.json` follows that so model systems line up with the
+SpecLink/CSI spec sections.
+
+| `SYS` code | CSI division | System |
+|---|---|---|
+| `FP`, `FLS` | **21** | Fire protection / detection |
+| `DCW`,`DHW`,`HWS`,`SAN`,`RWD`,`SWD`,`GAS` | **22** | Plumbing / drainage / gas |
+| `HVAC` | **23** | Heating, ventilation, air conditioning |
+| `LV`, `LPS` | **26** | Electrical / lightning protection |
+| `COM`, `ICT` | **27** | Telecommunications / data |
+| `SEC` | **28** | Safety & security |
+| `ARC` | — | Architectural elements |
+| `STR` | — | Structural elements |
+
+This same `SYS` code is the natural key for the `SPEC_SECTION` parameter that
+links a modelled product to its RIB SpecLink CSI section.
+
+## How to use
+
+1. Copy `project_config.json` into the project's STING config location
+   (`<project>/_BIM_COORD/project_config.json`, or wherever
+   `TagConfig.LoadFromFile` is pointed for the project).
+2. Reload config in Revit (Tags → Configure, or restart the dock panel) so
+   `TagConfig` picks it up.
+3. Tagging commands (Auto Tag / Batch Tag / Validate) now produce
+   full `DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ` tags with the building (=ISO
+   Volume) + CSI-aligned systems.
+
+> **Gate:** STINGTOOLS has not yet been compiled/smoke-tested in Revit. Prove a
+> clean build + one Auto Tag on a throwaway project **before** loading this on a
+> live consultant model. This profile is correct on paper; the build is the
+> thing still to verify.
+
+## To clone for the next project
+
+Copy this folder, then in `project_config.json` change `LOC_CODES` /
+`CUSTOM_VALID_LOC` to the new buildings, update the Volume crosswalk here, and
+trim `SYS_MAP` to the disciplines on that job. Everything else carries over.

--- a/StingTools/Data/Profiles/KampalaTemple/project_config.json
+++ b/StingTools/Data/Profiles/KampalaTemple/project_config.json
@@ -1,0 +1,51 @@
+{
+  "_profile": "Kampala Uganda Temple Project — interim BIM tagging profile",
+  "_version": "0.1-interim",
+  "_authored": "2026-06-17 by Mayanja Davis (BIM Manager)",
+  "_note": "FULL ISO 19650 asset tag. A1/A2 define no element tag-token scheme; this is the ISO 19650 BEP scheme used until the Owner BIM modeling / prototype standard is issued (SPD Temple Design Hub), at which point SYS/FUNC/PROD values are re-mapped in one pass. Systems are aligned to the project's CSI MasterFormat divisions (A2).",
+
+  "_ISO_FIELD_MAP": "Full 8-segment tag mapped to ISO 19650 container fields: DISC=Role · LOC=Volume(building) · ZONE=sub-zone(STING extension) · LVL=Level · SYS/FUNC/PROD=asset classification · SEQ=Number. ISO 'Volume' is carried by the LOC token (the building) — no separate token is required. Volume also appears on the sheet/model name via the Drawing engine ({Project}-{Originator}-{Volume}-{Level}-{Type}-{Role}-{Number}).",
+
+  "TAG_FORMAT": {
+    "separator": "-",
+    "num_pad": 4,
+    "segment_order": ["DISC", "LOC", "ZONE", "LVL", "SYS", "FUNC", "PROD", "SEQ"]
+  },
+
+  "STATUS_DEFAULT": "NEW",
+  "REV_DEFAULT": "P01",
+  "DEFAULT_COLLISION_MODE": "AutoIncrement",
+  "SEQ_INCLUDE_ZONE": false,
+  "COMPLIANCE_GATE_PCT": 0,
+  "VALIDATE_STRICT_MODE": false,
+
+  "_LOC_is_building": "LOC token = building. Crosswalk to the KUT container Volume code is in README.md.",
+  "LOC_CODES": ["TPL", "MTH", "HSG", "GRD", "UTL", "GDH", "EXT", "ZZ"],
+  "CUSTOM_VALID_LOC": ["TPL", "MTH", "HSG", "GRD", "UTL", "GDH", "EXT", "ZZ"],
+
+  "ZONE_CODES": ["Z01", "Z02", "Z03", "Z04", "ZZ", "XX"],
+  "CUSTOM_VALID_ZONE": ["Z01", "Z02", "Z03", "Z04", "ZZ", "XX"],
+
+  "_SYS_aligned_to_CSI": "SysCode -> Revit categories. CSI division per system is documented in README.md (21 FP, 22 Plumbing, 23 HVAC, 26 Electrical, 27 Telecom, 28 Safety/Security).",
+  "SYS_MAP": {
+    "HVAC": ["Mechanical Equipment", "Ducts", "Duct Fittings", "Duct Accessories", "Duct Insulations", "Flex Ducts", "Air Terminals"],
+    "DCW":  ["Pipes", "Pipe Fittings", "Pipe Accessories", "Pipe Insulations", "Flex Pipes"],
+    "DHW":  ["Pipes", "Pipe Fittings", "Pipe Accessories", "Pipe Insulations"],
+    "HWS":  ["Pipes", "Pipe Fittings", "Pipe Accessories", "Mechanical Equipment"],
+    "SAN":  ["Plumbing Fixtures", "Pipes", "Pipe Fittings", "Pipe Accessories"],
+    "RWD":  ["Pipes", "Pipe Fittings", "Pipe Accessories"],
+    "SWD":  ["Pipes", "Pipe Fittings", "Pipe Accessories"],
+    "GAS":  ["Pipes", "Pipe Fittings", "Pipe Accessories"],
+    "FP":   ["Sprinklers", "Pipes", "Pipe Fittings"],
+    "FLS":  ["Fire Alarm Devices"],
+    "LV":   ["Electrical Equipment", "Electrical Fixtures", "Cable Trays", "Conduits"],
+    "LPS":  ["Electrical Equipment", "Conduits", "Conduit Fittings"],
+    "COM":  ["Communication Devices"],
+    "ICT":  ["Data Devices"],
+    "SEC":  ["Security Devices"],
+    "ARC":  ["Walls", "Floors", "Ceilings", "Roofs", "Doors", "Windows", "Stairs", "Railings", "Ramps", "Rooms", "Furniture", "Casework"],
+    "STR":  ["Structural Columns", "Structural Framing", "Structural Foundations"],
+    "GEN":  ["Generic Models"]
+  },
+  "CUSTOM_VALID_SYS": ["HVAC","DCW","DHW","HWS","SAN","RWD","SWD","GAS","FP","FLS","LV","LPS","COM","ICT","SEC","ARC","STR","GEN"]
+}


### PR DESCRIPTION
## What this adds

A project-scoped, reusable STINGTOOLS configuration for the **Kampala Uganda Temple Project** (Symbion Consulting Group Studios), under `StingTools/Data/Profiles/KampalaTemple/`.

It encodes the BEP-interim tagging scheme, grounded in the actual project documents (A1 AE Design Scope, A2 Engineering Scope, revised Work Program):

- **Full ISO 19650 asset tag:** `DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ`. ISO **"Volume" is carried by the `LOC` token** (the building) — this resolves the perceived "we have no Volume token" gap without adding a 9th segment. Volume also appears on the sheet/model name via the Drawing engine.
- **8 building/location codes** (Temple … Guard house + external + project-wide) with a crosswalk to the KUT container Volume codes (`01`–`06` / `XX` / `ZZ`).
- **System map aligned to the project's CSI MasterFormat divisions** (A2): 21 Fire Protection, 22 Plumbing, 23 HVAC, 26 Electrical, 27 Telecom, 28 Safety/Security.
- Sensible defaults: `NEW`/`P01`, `AutoIncrement` collisions, compliance gate disabled during early authoring.

`project_config.json` is valid JSON and plugs into `TagConfig.LoadFromFile`. The `README.md` documents the ISO field mapping, the Volume crosswalk, the CSI alignment, how to use it, and how to clone the profile for the next project.

## Why "interim"

A1 mentions tags once (as a QC check) and A2 not at all — **neither document defines an element tag-token scheme.** The authoritative tag/LOD standard is the Owner BIM modeling / prototype standard (SPD Temple Design Hub), which the team "will be provided" (A2 §A). This profile is the ISO 19650 interim; `SYS/FUNC/PROD` **values** get re-confirmed in one pass when that standard issues — the full tag **structure** is in place now.

## Verification status

⚠️ STINGTOOLS has not been compiled or smoke-tested in Revit in this environment. The JSON is schema-valid and matches `TagConfig`'s expected keys, but a clean build + one Auto Tag on a throwaway project should be confirmed before loading this on a live consultant model.

Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsB9zopnZq1PrJmuNvTj5Z)_