### PR TITLE
Land multi-host A4/A6 substrate-drift endpoint + shared/ifc LF fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Line-ending policy.
+#
+# The IFC substrate manifest is BYTE-HASHED for cross-host drift detection
+# (stingtools_core/substrate.py + the server's SubstrateManifestProvider).
+# If a Windows checkout (core.autocrlf=true) materialised these files with CRLF
+# while a Linux CI/Docker server saw LF, the two halves would hash differently
+# for byte-identical content and drift forever. We pin the substrate to LF so the
+# on-disk bytes are canonical on every OS — the root-cause fix. (The hashers also
+# LF-normalise as defence in depth; this keeps any *other* byte-hash consumer safe
+# too.)
+#
+# Scoped deliberately to the substrate to avoid a repo-wide renormalisation diff.
+
+shared/ifc/**        text eol=lf
+**/_manifest.json    text eol=lf

--- a/Planscape.Server/src/Planscape.API/Controllers/SubstrateController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SubstrateController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Planscape.API.Services;
+
+namespace Planscape.API.Controllers;
+
+/// <summary>
+/// Phase A4 (multi-host integration) — substrate drift-check endpoint.
+///
+/// Every host (Revit, Bonsai, ArchiCAD-IFC, Tekla-IFC, StingBridge) computes
+/// a SHA-256 over its copy of the corporate IFC enum/pset manifest
+/// (<c>shared/ifc/enums/_manifest.json</c>) and, on login, compares it against
+/// the value this endpoint reports. A mismatch means the host is reading a
+/// stale or forked substrate — surfaced to the user as a warning so a
+/// federation of four tools can't silently coordinate on divergent enums.
+///
+/// The substrate is GLOBAL (one corporate vocabulary across every tenant and
+/// project), so this endpoint is intentionally NOT project-scoped. It requires
+/// authentication only.
+/// </summary>
+[ApiController]
+[Route("api/substrate")]
+[Authorize]
+public class SubstrateController : ControllerBase
+{
+    private readonly ISubstrateManifestProvider _provider;
+
+    public SubstrateController(ISubstrateManifestProvider provider)
+    {
+        _provider = provider;
+    }
+
+    /// <summary>
+    /// GET /api/substrate/manifest
+    /// Returns the server's substrate descriptor:
+    /// <c>{ "sha256": "&lt;64-hex&gt;", "schemaVersion": 2, "totalEnums": 52 }</c>.
+    /// The value is computed once per deployment and cached.
+    /// </summary>
+    [HttpGet("manifest")]
+    [ProducesResponseType(typeof(SubstrateManifestResponse), 200)]
+    public ActionResult<SubstrateManifestResponse> GetManifest()
+    {
+        return Ok(_provider.Get());
+    }
+}

--- a/Planscape.Server/src/Planscape.API/Planscape.API.csproj
+++ b/Planscape.Server/src/Planscape.API/Planscape.API.csproj
@@ -66,6 +66,13 @@
     <None Update="Data\IFC\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Phase A4 — ship the corporate substrate manifest next to the DLL so
+         SubstrateManifestProvider hashes the SAME file every host compares
+         against. Linked from the single source of truth (shared/ifc/) — never
+         forked — and copied to Data/IFC/Substrate/ at build. -->
+    <Content Include="$(MSBuildThisFileDirectory)..\..\..\shared\ifc\enums\_manifest.json"
+             Link="Data\IFC\Substrate\_manifest.json"
+             CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- Sync the desktop coordination viewer from the canonical source the

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -636,6 +636,10 @@ builder.Services.AddScoped<Planscape.Infrastructure.Services.IFederatedCoherence
 // Gap A–D — IFC alignment / georeferencing validator (called after every IFC ingest).
 builder.Services.AddScoped<Planscape.Core.Interfaces.IIfcAlignmentValidator,
     Planscape.Infrastructure.Services.IfcAlignmentValidator>();
+// Phase A4 — substrate drift-check. Hash of shared/ifc/enums/_manifest.json,
+// computed once and cached (immutable per deployment). Hosts compare on login.
+builder.Services.AddSingleton<Planscape.API.Services.ISubstrateManifestProvider,
+    Planscape.API.Services.SubstrateManifestProvider>();
 
 if (isWorker)
 {

--- a/Planscape.Server/src/Planscape.API/Services/SubstrateManifestProvider.cs
+++ b/Planscape.Server/src/Planscape.API/Services/SubstrateManifestProvider.cs
@@ -1,0 +1,168 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Planscape.API.Services;
+
+/// <summary>
+/// Phase A4 (multi-host integration) — server half of the substrate
+/// drift-check. Computes the SHA-256 over the corporate IFC enum/pset
+/// manifest (<c>shared/ifc/enums/_manifest.json</c>) that every host
+/// compares against on login. A host whose hash differs is reading a
+/// stale or forked copy of the shared vocabulary — surfaced as a warning
+/// so coordination doesn't silently run on divergent enums.
+///
+/// The hash is computed over <b>LF-normalised</b> bytes so it agrees with
+/// the host-side hash (<c>stingtools_core.substrate.substrate_manifest_sha256</c>)
+/// regardless of whether either side's working tree checked the file out
+/// with CRLF (Windows) or LF (Linux). Hashing raw bytes would make a
+/// Windows host and a Linux server drift forever on identical content.
+///
+/// The substrate is immutable per deployment, so the value is computed
+/// once and cached for the process lifetime (registered as a singleton).
+/// </summary>
+public interface ISubstrateManifestProvider
+{
+    /// <summary>The cached substrate manifest descriptor for this deployment.</summary>
+    SubstrateManifestResponse Get();
+}
+
+/// <summary>Wire shape for <c>GET /api/substrate/manifest</c>.</summary>
+public sealed record SubstrateManifestResponse
+{
+    /// <summary>SHA-256 (lowercase hex) over the LF-normalised manifest bytes.</summary>
+    public string Sha256 { get; init; } = "";
+
+    /// <summary>The manifest schema version (<c>schema_version</c>).</summary>
+    public int SchemaVersion { get; init; }
+
+    /// <summary>Total enum count declared in the manifest (<c>total_enums</c>).</summary>
+    public int TotalEnums { get; init; }
+}
+
+/// <inheritdoc cref="ISubstrateManifestProvider"/>
+public sealed class SubstrateManifestProvider : ISubstrateManifestProvider
+{
+    private readonly Lazy<SubstrateManifestResponse> _cached;
+    private readonly ILogger<SubstrateManifestProvider> _logger;
+
+    public SubstrateManifestProvider(
+        IConfiguration config,
+        IHostEnvironment env,
+        ILogger<SubstrateManifestProvider> logger)
+    {
+        _logger = logger;
+        _cached = new Lazy<SubstrateManifestResponse>(() =>
+        {
+            var path = ResolveManifestPath(config, env);
+            if (path is null)
+            {
+                _logger.LogWarning(
+                    "Substrate manifest not found — /api/substrate/manifest will report an empty hash, " +
+                    "so hosts cannot drift-check. Set Substrate:ManifestPath or ship Data/IFC/Substrate/_manifest.json.");
+                return new SubstrateManifestResponse();
+            }
+
+            try
+            {
+                var resp = ComputeFromFile(path);
+                _logger.LogInformation(
+                    "Substrate manifest loaded from {Path}: sha256={Sha} schemaVersion={Schema} totalEnums={Total}",
+                    path, resp.Sha256, resp.SchemaVersion, resp.TotalEnums);
+                return resp;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to read substrate manifest at {Path}", path);
+                return new SubstrateManifestResponse();
+            }
+        });
+    }
+
+    public SubstrateManifestResponse Get() => _cached.Value;
+
+    /// <summary>
+    /// Compute the substrate descriptor from a manifest file. Public + static
+    /// so the unit test can exercise the hashing/parsing without a DI graph.
+    /// </summary>
+    public static SubstrateManifestResponse ComputeFromFile(string path)
+    {
+        var raw = File.ReadAllBytes(path);
+        var normalized = NormalizeNewlines(raw);
+        var sha = Convert.ToHexString(SHA256.HashData(normalized)).ToLowerInvariant();
+
+        int schemaVersion = 0, totalEnums = 0;
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("schema_version", out var sv) && sv.TryGetInt32(out var s)) schemaVersion = s;
+            if (root.TryGetProperty("total_enums", out var te) && te.TryGetInt32(out var t)) totalEnums = t;
+        }
+        catch (JsonException)
+        {
+            // A malformed manifest still yields a stable hash; counts stay 0.
+        }
+
+        return new SubstrateManifestResponse
+        {
+            Sha256 = sha,
+            SchemaVersion = schemaVersion,
+            TotalEnums = totalEnums,
+        };
+    }
+
+    /// <summary>Collapse CRLF/CR → LF so the hash is checkout-OS-independent.</summary>
+    internal static byte[] NormalizeNewlines(byte[] raw)
+    {
+        // Operate on bytes directly: the manifest is ASCII/UTF-8 JSON, so a
+        // byte-level newline collapse matches the host's
+        // raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n") exactly.
+        var text = Encoding.UTF8.GetString(raw).Replace("\r\n", "\n").Replace("\r", "\n");
+        return Encoding.UTF8.GetBytes(text);
+    }
+
+    /// <summary>
+    /// Resolve the manifest path. Priority:
+    ///   1. config <c>Substrate:ManifestPath</c> (absolute or relative to CWD),
+    ///   2. <c>{ContentRoot|BaseDirectory}/Data/IFC/Substrate/_manifest.json</c>
+    ///      (the build-copied artifact),
+    ///   3. dev fallback: walk up from the base/content root looking for the
+    ///      repo's <c>shared/ifc/enums/_manifest.json</c>.
+    /// Returns null if none resolve.
+    /// </summary>
+    private static string? ResolveManifestPath(IConfiguration config, IHostEnvironment env)
+    {
+        var configured = config["Substrate:ManifestPath"];
+        if (!string.IsNullOrWhiteSpace(configured) && File.Exists(configured))
+            return Path.GetFullPath(configured);
+
+        var rel = Path.Combine("Data", "IFC", "Substrate", "_manifest.json");
+        foreach (var root in new[] { AppContext.BaseDirectory, env.ContentRootPath })
+        {
+            if (string.IsNullOrEmpty(root)) continue;
+            var candidate = Path.Combine(root, rel);
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        // Dev fallback: locate the repo copy by walking parents.
+        var sentinel = Path.Combine("shared", "ifc", "enums", "_manifest.json");
+        foreach (var start in new[] { AppContext.BaseDirectory, env.ContentRootPath, Directory.GetCurrentDirectory() })
+        {
+            var dir = string.IsNullOrEmpty(start) ? null : new DirectoryInfo(start);
+            for (int i = 0; dir is not null && i < 12; i++, dir = dir.Parent)
+            {
+                var candidate = Path.Combine(dir.FullName, sentinel);
+                if (File.Exists(candidate)) return candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/SubstrateManifestTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/SubstrateManifestTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Planscape.API.Controllers;
+using Planscape.API.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Phase A4 — server half of the substrate drift-check. Proves
+/// <see cref="SubstrateManifestProvider.ComputeFromFile"/> returns a 64-hex
+/// SHA-256 + the manifest's schema/enum counts, that the hash is
+/// newline-normalised (so a Windows host and a Linux server agree), and that
+/// <see cref="SubstrateController"/> surfaces it.
+/// </summary>
+public class SubstrateManifestTests
+{
+    private const string SampleManifest =
+        "{\n  \"schema_version\": 2,\n  \"total_enums\": 52,\n  \"enums\": []\n}\n";
+
+    private static string WriteTemp(string content, string newline)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sting_substrate_{Guid.NewGuid():N}.json");
+        var normalized = content.Replace("\r\n", "\n").Replace("\n", newline);
+        File.WriteAllBytes(path, Encoding.UTF8.GetBytes(normalized));
+        return path;
+    }
+
+    [Fact]
+    public void ComputeFromFile_ReturnsSixtyFourHexSha_AndCounts()
+    {
+        var path = WriteTemp(SampleManifest, "\n");
+        try
+        {
+            var resp = SubstrateManifestProvider.ComputeFromFile(path);
+
+            Assert.Equal(64, resp.Sha256.Length);
+            Assert.Matches("^[0-9a-f]{64}$", resp.Sha256);
+            Assert.Equal(2, resp.SchemaVersion);
+            Assert.Equal(52, resp.TotalEnums);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ComputeFromFile_HashIsNewlineNormalized()
+    {
+        // CRLF (Windows checkout) and LF (Linux checkout) of identical content
+        // must hash the same, or every host drifts against the server forever.
+        var lf = WriteTemp(SampleManifest, "\n");
+        var crlf = WriteTemp(SampleManifest, "\r\n");
+        try
+        {
+            Assert.Equal(
+                SubstrateManifestProvider.ComputeFromFile(lf).Sha256,
+                SubstrateManifestProvider.ComputeFromFile(crlf).Sha256);
+        }
+        finally { File.Delete(lf); File.Delete(crlf); }
+    }
+
+    [Fact]
+    public void ComputeFromFile_MatchesExpectedSha_ForKnownBytes()
+    {
+        var path = WriteTemp(SampleManifest, "\n");
+        try
+        {
+            var expected = Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(SampleManifest.Replace("\r\n", "\n"))))
+                .ToLowerInvariant();
+            Assert.Equal(expected, SubstrateManifestProvider.ComputeFromFile(path).Sha256);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Controller_ReturnsManifestFromProvider()
+    {
+        var stub = new StubProvider(new SubstrateManifestResponse
+        {
+            Sha256 = new string('a', 64),
+            SchemaVersion = 2,
+            TotalEnums = 52,
+        });
+        var controller = new SubstrateController(stub);
+
+        var result = controller.GetManifest();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var body = Assert.IsType<SubstrateManifestResponse>(ok.Value);
+        Assert.Equal(64, body.Sha256.Length);
+        Assert.Matches("^[0-9a-f]{64}$", body.Sha256);
+        Assert.Equal(52, body.TotalEnums);
+    }
+
+    private sealed class StubProvider : ISubstrateManifestProvider
+    {
+        private readonly SubstrateManifestResponse _r;
+        public StubProvider(SubstrateManifestResponse r) => _r = r;
+        public SubstrateManifestResponse Get() => _r;
+    }
+}

--- a/StingBridge/bridge.py
+++ b/StingBridge/bridge.py
@@ -62,6 +62,7 @@ def _make_clients(cfg: BridgeConfig) -> tuple[ArchiCadClient, PlanscapeClient]:
         project_id=cfg.planscape_project_id,
     )
     ps.login(cfg.planscape_email, cfg.planscape_password)
+    _warn_on_substrate_drift(ps)
 
     return ac, ps
 
@@ -130,7 +131,28 @@ def _make_ps_client(cfg: BridgeConfig) -> PlanscapeClient:
         sys.exit(1)
     ps = PlanscapeClient(base_url=cfg.planscape_url, project_id=cfg.planscape_project_id)
     ps.login(cfg.planscape_email, cfg.planscape_password)
+    _warn_on_substrate_drift(ps)
     return ps
+
+
+def _warn_on_substrate_drift(ps: PlanscapeClient) -> None:
+    """Phase A4 — log a WARNING if this bridge's shared/ifc substrate differs
+    from the server's. Never raises: a drift-check failure must not stop sync."""
+    try:
+        from stingtools_core.planscape.client import check_substrate_drift
+    except ImportError:
+        # stingtools-core not on the path — skip silently (StingBridge can run
+        # the legacy sync without the shared core installed).
+        return
+    try:
+        ok, message = check_substrate_drift(ps)
+    except Exception as e:  # noqa: BLE001
+        log.debug("Substrate drift-check skipped: %s", e)
+        return
+    if not ok:
+        log.warning("%s", message)
+    else:
+        log.info("Substrate: %s", message)
 
 
 def cmd_watch_ifc(cfg: BridgeConfig, drop_dir: str) -> int:

--- a/StingBridge/planscape/client.py
+++ b/StingBridge/planscape/client.py
@@ -91,6 +91,23 @@ class PlanscapeClient:
         if not self._token or time.time() >= self._token_expiry:
             self.login(email, password)
 
+    # ── substrate drift-check (Phase A4) ─────────────────────────────────────
+
+    def get_substrate_manifest(self) -> dict:
+        """GET /api/substrate/manifest — the server's global substrate hash.
+
+        Returns ``{ "sha256", "schemaVersion", "totalEnums" }``. Used by the
+        worker-startup drift-check so a bridge running on a stale/forked
+        shared/ifc copy is warned before it ingests against divergent enums.
+        """
+        resp = self._session.get(
+            f"{self.base_url}/api/substrate/manifest", timeout=_TIMEOUT
+        )
+        if resp.status_code == 401:
+            raise PlanscapeAuthError("Token expired or invalid")
+        resp.raise_for_status()
+        return resp.json()
+
     # ── sync ─────────────────────────────────────────────────────────────────
 
     def ingest_ifc_data(

--- a/stingtools-bonsai/ops/coord_ops.py
+++ b/stingtools-bonsai/ops/coord_ops.py
@@ -96,7 +96,28 @@ class StingPlanscapeLoginOperator(bpy.types.Operator):
         context.scene[_TOKEN_KEY] = token
         context.scene[_EMAIL_KEY] = p.email
         self.report({"INFO"}, f"Logged in as {resp.get('userName') or p.email}")
+
+        # Phase A4 — substrate drift-check. Warn (never block) if this host
+        # reads a different shared/ifc vocabulary than the server.
+        self._check_substrate_drift(context, client)
         return {"FINISHED"}
+
+    def _check_substrate_drift(self, context, client) -> None:
+        """Compare local substrate hash with the server's; warn on mismatch."""
+        try:
+            from stingtools_core.planscape.client import check_substrate_drift
+        except ImportError:
+            # stingtools-core not importable in this Blender env — skip silently.
+            return
+        try:
+            ok, message = check_substrate_drift(client)
+        except Exception as e:  # noqa: BLE001 — drift-check must never break login
+            print(f"[STING] substrate drift-check skipped: {e}")
+            return
+        if not ok:
+            self.report({"WARNING"}, message)
+            context.scene["sting_substrate_drift"] = message
+        print(f"[STING] substrate: {message}")
 
 
 # ---------------------------------------------------------------------------

--- a/stingtools-bonsai/planscape/client.py
+++ b/stingtools-bonsai/planscape/client.py
@@ -141,3 +141,16 @@ class PlanscapeClient:
     def list_projects(self) -> Any:
         """GET /api/projects — used to help the user find their project id."""
         return self._request("GET", "/api/projects")
+
+    # ------------------------------------------------------------------
+    # substrate drift-check (Phase A4)
+    # ------------------------------------------------------------------
+    def get_substrate_manifest(self) -> dict:
+        """GET /api/substrate/manifest — the server's substrate hash.
+
+        Returns ``{ "sha256", "schemaVersion", "totalEnums" }``. The substrate
+        is global (not project-scoped). Used by the post-login drift-check so a
+        host reading a stale/forked shared/ifc vocabulary is warned, not left to
+        silently coordinate on divergent enums.
+        """
+        return self._request("GET", "/api/substrate/manifest")

--- a/stingtools-bonsai/tests/verify_blender.py
+++ b/stingtools-bonsai/tests/verify_blender.py
@@ -43,6 +43,47 @@ def section(t):
     print("\n========== " + t + " ==========")
 
 
+def _version_tuple(v):
+    parts = []
+    for p in str(v).split(".")[:3]:
+        num = "".join(ch for ch in p if ch.isdigit())
+        parts.append(int(num) if num else 0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts)
+
+
+class _RecLayout:
+    """Headless recording stand-in for Blender's UILayout.
+
+    Captures every label/operator emitted (recursively through box/column/row)
+    so A1-V can assert which panel branch was taken without a real UI region.
+    """
+
+    def __init__(self, sink):
+        self.sink = sink
+        self.alert = False
+
+    def label(self, text="", icon=""):
+        self.sink["labels"].append(text)
+
+    def operator(self, idname, text="", icon=""):
+        self.sink["operators"].append(idname)
+        return self
+
+    def box(self):
+        return _RecLayout(self.sink)
+
+    def column(self, align=False):
+        return _RecLayout(self.sink)
+
+    def row(self, align=False):
+        return _RecLayout(self.sink)
+
+    def separator(self):
+        pass
+
+
 # ---------------------------------------------------------------------------
 section("A. ENABLE BONSAI (for ifcopenshell)")
 try:
@@ -52,6 +93,12 @@ except Exception as e:  # noqa: BLE001
 try:
     import ifcopenshell  # type: ignore
     check("ifcopenshell importable", True, f"v{ifcopenshell.version}")
+    # A5-V — the Bonsai-bundled ifcopenshell must satisfy the pinned seam
+    # (>=0.8.0,<0.9). If this fails, update the pin in StingBridge/requirements.txt
+    # + blender_manifest.toml + core pyproject in lockstep.
+    vt = _version_tuple(ifcopenshell.version)
+    check("A5 — Bonsai ifcopenshell satisfies >=0.8.0,<0.9",
+          (0, 8, 0) <= vt < (0, 9, 0), f"v{ifcopenshell.version} -> {vt}")
 except Exception as e:  # noqa: BLE001
     check("ifcopenshell importable", False, str(e))
 
@@ -149,6 +196,116 @@ try:
 except Exception:  # noqa: BLE001
     traceback.print_exc()
     check("push module drove a real push", False, "exception (see traceback)")
+
+
+# ---------------------------------------------------------------------------
+section("A1. HARD-DEPENDENCY BANNER (panel branch on Bonsai presence)")
+try:
+    from bl_ext.user_default.stingtools_bonsai.ui import panel_main as _pm  # type: ignore
+    from bl_ext.user_default.stingtools_bonsai.core import bonsai as _bridge  # type: ignore
+
+    caps = _bridge.bonsai.capabilities
+    panel = _pm.StingMainPanel()
+
+    # (a) Force "Bonsai absent" → the root panel must draw the required-banner
+    #     and NOT offer its Diagnostics ops.
+    saved = caps.installed
+    try:
+        caps.installed = False
+        sink = {"labels": [], "operators": []}
+        panel.layout = _RecLayout(sink)
+        panel.draw(bpy.context)
+        banner = any("Bonsai is required" in t for t in sink["labels"])
+        no_diag = "sting.about" not in sink["operators"]
+        check("A1 — banner shown + ops hidden when Bonsai absent", banner and no_diag,
+              f"labels={sink['labels']!r}")
+    finally:
+        caps.installed = saved
+
+    # (b) With Bonsai present → Diagnostics ops render (no banner).
+    sink2 = {"labels": [], "operators": []}
+    panel.layout = _RecLayout(sink2)
+    panel.draw(bpy.context)
+    diag = "sting.about" in sink2["operators"]
+    no_banner = not any("Bonsai is required" in t for t in sink2["labels"])
+    check("A1 — diagnostics render when Bonsai present", caps.installed and diag and no_banner,
+          f"installed={caps.installed} ops={sink2['operators']!r}")
+except Exception:  # noqa: BLE001
+    traceback.print_exc()
+    check("A1 — panel branch on Bonsai presence", False, "exception (see traceback)")
+
+
+# ---------------------------------------------------------------------------
+section("A2. UNDO-AWARE IFC WRITE (tool.Ifc.run → Ctrl-Z reverts STING write)")
+try:
+    from bl_ext.user_default.stingtools_bonsai.core import bonsai as _b2  # type: ignore
+    bridge = _b2.bonsai
+
+    # Load the test IFC through Bonsai so tool.Ifc owns the active file
+    # (this is what makes writes land on Blender's undo stack).
+    loaded = False
+    try:
+        bpy.ops.bim.load_project(filepath=IFC)
+        loaded = True
+    except Exception as e:  # noqa: BLE001
+        print("bim.load_project note:", e)
+    check("A2 — IFC loaded via Bonsai (tool.Ifc active)", loaded)
+
+    model = bridge.active_ifc()
+    el = None
+    if model is not None:
+        walls = model.by_type("IfcWall") or model.by_type("IfcBuildingElement")
+        el = walls[0] if walls else None
+    check("A2 — found an element to write", el is not None)
+
+    if el is not None:
+        ok_write = bridge.add_pset(el, "Pset_StingTags", {"FullTag": "A2-UNDO-PROBE"})
+        check("A2 — add_pset returned True", bool(ok_write))
+
+        def _has_probe(elem):
+            try:
+                import ifcopenshell.util.element as _ue  # type: ignore
+                psets = _ue.get_psets(elem)
+                return psets.get("Pset_StingTags", {}).get("FullTag") == "A2-UNDO-PROBE"
+            except Exception:  # noqa: BLE001
+                return False
+
+        check("A2 — STING pset present after write", _has_probe(el))
+
+        # The whole point of A2: the write is on Bonsai's undo stack.
+        undone = False
+        try:
+            bpy.ops.ed.undo()
+            undone = not _has_probe(el)
+        except Exception as e:  # noqa: BLE001
+            print("undo note:", e)
+        check("A2 — Ctrl-Z (ed.undo) REVERTS the STING write", undone,
+              "if False, write went via bare ifcopenshell.api.run — _run/_tool_ifc not reached")
+except Exception:  # noqa: BLE001
+    traceback.print_exc()
+    check("A2 — undo-aware write", False, "exception (see traceback)")
+
+
+# ---------------------------------------------------------------------------
+section("A4. SUBSTRATE DRIFT-CHECK (server endpoint + client wiring)")
+try:
+    from bl_ext.user_default.stingtools_bonsai.planscape import client as _psc4  # type: ignore
+    cl4 = _psc4.PlanscapeClient(SERVER)
+    cl4.login(EMAIL, PASSWORD)
+    manifest = cl4.get_substrate_manifest()
+    sha = (manifest or {}).get("sha256", "")
+    check("A4 — GET /api/substrate/manifest returns 64-hex sha256",
+          isinstance(sha, str) and len(sha) == 64,
+          f"sha256={sha} schemaVersion={manifest.get('schemaVersion')} totalEnums={manifest.get('totalEnums')}")
+    try:
+        from stingtools_core.planscape.client import check_substrate_drift  # type: ignore
+        ok4, msg4 = check_substrate_drift(cl4)
+        check("A4 — host substrate in sync with server (no drift)", ok4, msg4)
+    except ImportError as e:
+        check("A4 — core drift helper importable", False, str(e))
+except Exception:  # noqa: BLE001
+    traceback.print_exc()
+    check("A4 — substrate drift-check", False, "exception (see traceback)")
 
 
 # ---------------------------------------------------------------------------

--- a/stingtools-core/python/pyproject.toml
+++ b/stingtools-core/python/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = []
 [project.optional-dependencies]
 planscape = ["httpx>=0.25"]
 ids       = ["ifctester>=0.0.10"]
-ifc       = ["ifcopenshell>=0.8.0"]
+# Phase A5 — pin to the ifcopenshell major Bonsai bundles (0.8.x); <0.9 keeps
+# the core seam in lockstep with StingBridge/requirements.txt + the manifest.
+ifc       = ["ifcopenshell>=0.8.0,<0.9"]
 realtime  = ["signalrcore>=0.9"]
 dev       = ["pytest>=7", "ruff>=0.4"]
 

--- a/stingtools-core/python/stingtools_core/planscape/client.py
+++ b/stingtools-core/python/stingtools_core/planscape/client.py
@@ -187,6 +187,18 @@ class PlanscapeClient:
         return out
 
     # ------------------------------------------------------------------
+    # substrate drift-check (Phase A4)
+    # ------------------------------------------------------------------
+
+    def get_substrate_manifest(self) -> dict:
+        """GET /api/substrate/manifest — the server's substrate hash.
+
+        Returns the server's ``{ "sha256", "schemaVersion", "totalEnums" }``.
+        The substrate is global (not project-scoped), so no project id.
+        """
+        return self._request("GET", "/api/substrate/manifest")
+
+    # ------------------------------------------------------------------
     # tag sync (existing endpoint)
     # ------------------------------------------------------------------
 
@@ -246,3 +258,44 @@ class PlanscapeClient:
                 raise PlanscapeNetworkError(f"HTTP {e.code} from {path}: {e.reason}") from e
             except _urlerr.URLError as e:
                 raise PlanscapeNetworkError(f"network error contacting {path}: {e.reason}") from e
+
+
+# ----------------------------------------------------------------------
+# substrate drift-check helper (Phase A4)
+# ----------------------------------------------------------------------
+
+def check_substrate_drift(client: Any, shared_ifc: Optional[Any] = None) -> tuple[bool, str]:
+    """Compare this host's substrate hash against the server's.
+
+    Returns ``(ok, message)``:
+      - ``(True, …)``  — in sync, or the server hasn't pinned a hash, or the
+        check could not be performed (network/transport error) — drift-check
+        never blocks login.
+      - ``(False, …)`` — the host reads a different (stale/forked) substrate
+        than the federation; ``message`` is suitable for a host warning.
+
+    ``client`` is duck-typed: any object exposing ``get_substrate_manifest()``
+    returning ``{"sha256": …}`` works (the core :class:`PlanscapeClient`, the
+    Bonsai add-on client, or the StingBridge client).
+    """
+    from .. import substrate
+
+    try:
+        local = substrate.substrate_manifest_sha256(shared_ifc)
+    except FileNotFoundError as e:
+        return True, f"substrate check skipped (no local manifest: {e})"
+
+    try:
+        remote = client.get_substrate_manifest()
+    except Exception as e:  # noqa: BLE001 — never block login on a transport hiccup
+        return True, f"substrate check skipped (server unreachable: {e})"
+
+    remote_hash = remote.get("sha256") if isinstance(remote, dict) else None
+    if substrate.compare(local, remote_hash):
+        return True, "substrate in sync with server"
+    return (
+        False,
+        "SUBSTRATE DRIFT — this host reads a different shared/ifc vocabulary "
+        f"than the server (local {local[:12]}… vs server {(remote_hash or '')[:12]}…). "
+        "Re-sync shared/ifc before coordinating.",
+    )

--- a/stingtools-core/python/stingtools_core/substrate.py
+++ b/stingtools-core/python/stingtools_core/substrate.py
@@ -28,10 +28,29 @@ def substrate_manifest_path(shared_ifc: Optional[Path] = None) -> Path:
     return base / MANIFEST_RELATIVE
 
 
+def _normalize_newlines(raw: bytes) -> bytes:
+    """Collapse CRLF/CR to LF so the hash is checkout-OS-independent.
+
+    The substrate ships in git; a Windows checkout with ``core.autocrlf=true``
+    materialises ``_manifest.json`` with CRLF line endings, while the LF blob is
+    what a Linux CI / Docker server build sees. Hashing the *raw* bytes would
+    therefore make a Windows host (Bonsai) and a Linux server drift *forever*
+    even on byte-identical content — the exact failure §6 of the integration
+    plan flags ("computed over the same file or it will always drift"). We hash
+    the LF-normalised content on BOTH halves so they agree regardless of how
+    each side's working tree was checked out.
+    """
+    return raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
 def substrate_manifest_sha256(shared_ifc: Optional[Path] = None) -> str:
-    """SHA-256 (hex) of this host's substrate manifest. The cross-host drift key."""
+    """SHA-256 (hex) of this host's substrate manifest. The cross-host drift key.
+
+    Computed over LF-normalised bytes (see :func:`_normalize_newlines`) so the
+    Windows-host hash equals the Linux-server hash for identical content.
+    """
     path = substrate_manifest_path(shared_ifc)
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashlib.sha256(_normalize_newlines(path.read_bytes())).hexdigest()
 
 
 def compare(local_hash: str, remote_hash: Optional[str]) -> bool:

--- a/stingtools-core/python/tests/test_adapter_boundary.py
+++ b/stingtools-core/python/tests/test_adapter_boundary.py
@@ -1,0 +1,62 @@
+"""Phase A6 — the adapter-boundary lint is itself under test.
+
+Loads tools/ci/check_adapter_boundary.py by path (it is a CI script, not a
+package module) and asserts: (1) every banned signature trips on a synthetic
+violating adapter, (2) legit Blender-UI glue does NOT false-positive, and
+(3) the real adapter tree is currently clean. A regression that re-introduces
+core logic into an adapter — or that weakens a rule — fails here in the core
+pytest gate, not only in the standalone CI step.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]
+_LINT = _REPO / "tools" / "ci" / "check_adapter_boundary.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_adapter_boundary", _LINT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_lint_script_exists():
+    assert _LINT.exists(), f"missing lint script at {_LINT}"
+
+
+def test_violating_fixture_trips_every_rule():
+    mod = _load()
+    violating = (
+        'D = {"IfcWall": "A", "IfcDuctSegment": "M", '
+        '"IfcCableSegment": "E", "IfcPipeSegment": "P"}\n'
+        "rel = m.by_type('IfcRelAssignsToGroup')\n"
+        "code = ''.join(c for c in name if c.isalpha())\n"
+        "_SEQ_COUNTERS = {}\n"
+    )
+    hit = set(mod.scan_text(violating))
+    expected = {vid for vid, _m, _rx in mod.BANNED}
+    assert hit == expected, f"rules not all tripped: missing {expected - hit}"
+
+
+def test_clean_glue_does_not_false_positive():
+    mod = _load()
+    clean = (
+        '_PRIORITY_ITEMS = [("LOW", "Low", ""), ("HIGH", "High", "")]\n'
+        "counters = {}\n"
+    )
+    assert mod.scan_text(clean) == []
+
+
+def test_real_adapters_are_clean():
+    mod = _load()
+    assert mod.main(verbose=False) == 0
+
+
+def test_builtin_self_test_passes():
+    mod = _load()
+    assert mod._self_test() == 0

--- a/stingtools-core/python/tests/test_substrate.py
+++ b/stingtools-core/python/tests/test_substrate.py
@@ -2,18 +2,35 @@
 
 from __future__ import annotations
 
+import hashlib
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from stingtools_core import substrate
+from stingtools_core.planscape.client import check_substrate_drift
 
 
 def test_manifest_hash_is_stable_hex():
     h = substrate.substrate_manifest_sha256()
     assert isinstance(h, str) and len(h) == 64
     assert h == substrate.substrate_manifest_sha256()  # deterministic
+
+
+def test_manifest_hash_is_newline_normalized():
+    """The hash must be identical whether the on-disk manifest is CRLF or LF.
+
+    Guards the cross-platform drift bug: a Windows (Bonsai) checkout with CRLF
+    must hash the same as a Linux (server) checkout with LF, or the two halves
+    drift forever on byte-identical content.
+    """
+    raw = substrate.substrate_manifest_path().read_bytes()
+    lf = raw.replace(b"\r\n", b"\n")
+    crlf = lf.replace(b"\n", b"\r\n")
+    assert hashlib.sha256(substrate._normalize_newlines(crlf)).hexdigest() \
+        == hashlib.sha256(substrate._normalize_newlines(lf)).hexdigest() \
+        == substrate.substrate_manifest_sha256()
 
 
 def test_compare_matches_and_mismatches():
@@ -23,3 +40,48 @@ def test_compare_matches_and_mismatches():
     # No server hash yet → treat as no-drift (nothing to compare against).
     assert substrate.compare(h, None) is True
     assert substrate.compare(h, "") is True
+
+
+# ----------------------------------------------------------------------
+# check_substrate_drift — mocked client (Phase A4-V)
+# ----------------------------------------------------------------------
+
+class _FakeClient:
+    """Duck-typed Planscape client returning a canned substrate manifest."""
+
+    def __init__(self, response=None, raises: Exception | None = None):
+        self._response = response
+        self._raises = raises
+
+    def get_substrate_manifest(self) -> dict:
+        if self._raises is not None:
+            raise self._raises
+        return self._response
+
+
+def test_drift_ok_when_hashes_match():
+    local = substrate.substrate_manifest_sha256()
+    client = _FakeClient({"sha256": local, "schemaVersion": 2, "totalEnums": 52})
+    ok, msg = check_substrate_drift(client)
+    assert ok is True
+    assert "in sync" in msg
+
+
+def test_drift_detected_when_hashes_differ():
+    client = _FakeClient({"sha256": "0" * 64, "schemaVersion": 2, "totalEnums": 52})
+    ok, msg = check_substrate_drift(client)
+    assert ok is False
+    assert "DRIFT" in msg
+
+
+def test_drift_ok_when_server_has_no_hash():
+    # Server hasn't pinned a substrate yet → nothing to drift against.
+    ok, msg = check_substrate_drift(_FakeClient({"sha256": None}))
+    assert ok is True
+
+
+def test_drift_never_blocks_on_transport_error():
+    # A network hiccup must not stop login.
+    ok, msg = check_substrate_drift(_FakeClient(raises=RuntimeError("boom")))
+    assert ok is True
+    assert "skipped" in msg

--- a/tools/ci/check_adapter_boundary.py
+++ b/tools/ci/check_adapter_boundary.py
@@ -12,7 +12,8 @@ re-implement core logic, by signature. It is deliberately narrow (targets the
 specific logic that was extracted to core in Phase A3) to avoid false positives
 on legitimate Blender UI / glue code.
 
-Run:  python tools/ci/check_adapter_boundary.py
+Run:        python tools/ci/check_adapter_boundary.py
+Self-test:  python tools/ci/check_adapter_boundary.py --self-test
 """
 
 from __future__ import annotations
@@ -33,7 +34,7 @@ ADAPTER_GLOBS = [
 BANNED = [
     (
         "IFC_CLASS_MAP",
-        "Re-implemented IFC-class → code mapping. Use "
+        "Re-implemented IFC-class -> code mapping. Use "
         "stingtools_core.hosts.inference.discipline_for_class / infer_discipline.",
         # 3+ "IfcXxx": "Y" entries strongly imply a discipline/product class map.
         re.compile(r'(?:["\']Ifc\w+["\']\s*:\s*["\'][A-Z]{1,2}["\']\s*,\s*){3,}', re.S),
@@ -66,31 +67,94 @@ def iter_adapter_files():
         yield from REPO.glob(pattern)
 
 
-def main() -> int:
+def scan_text(text: str) -> list[str]:
+    """Return the ids of every banned signature present in `text`."""
+    return [vid for vid, _msg, rx in BANNED if rx.search(text)]
+
+
+def _self_test() -> int:
+    """Prove the lint catches a deliberate violation AND clears real adapters.
+
+    A regression that re-introduces core logic into an adapter must be caught,
+    so we assert each banned signature fires against a synthetic fixture, then
+    assert the live adapter files are clean.
+    """
+    failures: list[str] = []
+
+    # 1. A synthetic adapter that re-implements every piece of core logic must
+    #    trip every rule.
+    violating = (
+        "DISC = {\n"
+        '    "IfcWall": "A",\n'
+        '    "IfcDuctSegment": "M",\n'
+        '    "IfcCableSegment": "E",\n'
+        '    "IfcPipeSegment": "P",\n'
+        "}\n"
+        "rel = model.by_type('IfcRelAssignsToGroup')\n"
+        "code = ''.join(c for c in name if c.isalpha())\n"
+        "_SEQ_COUNTERS = {}\n"
+    )
+    hit = set(scan_text(violating))
+    expected = {vid for vid, _m, _rx in BANNED}
+    missing = expected - hit
+    if missing:
+        failures.append(f"self-test fixture did NOT trip rules: {sorted(missing)}")
+
+    # 2. A clean glue file (legit Blender UI enum + local dict) must NOT trip.
+    clean = (
+        "_PRIORITY_ITEMS = [\n"
+        '    ("LOW", "Low", ""),\n'
+        '    ("HIGH", "High", ""),\n'
+        "]\n"
+        "counters = {}  # local grouping dict, acceptable glue\n"
+    )
+    false_pos = scan_text(clean)
+    if false_pos:
+        failures.append(f"self-test clean fixture false-positived: {false_pos}")
+
+    # 3. The real adapter tree must currently be clean.
+    real = main(verbose=False)
+    if real != 0:
+        failures.append("real adapter files are NOT clean")
+
+    if failures:
+        print("SELF-TEST FAILED:")
+        for f in failures:
+            print("  [X] " + f)
+        return 1
+    print("[OK] self-test passed: violations detected, clean files pass, real adapters clean.")
+    return 0
+
+
+def main(verbose: bool = True) -> int:
     violations: list[str] = []
     scanned = 0
+    by_id = {vid: msg for vid, msg, _rx in BANNED}
     for path in sorted(iter_adapter_files()):
         scanned += 1
         text = path.read_text(encoding="utf-8")
-        for vid, message, rx in BANNED:
-            if rx.search(text):
-                rel = path.relative_to(REPO)
-                violations.append(f"{rel}: [{vid}] {message}")
+        for vid in scan_text(text):
+            rel = path.relative_to(REPO)
+            violations.append(f"{rel}: [{vid}] {by_id[vid]}")
 
     if violations:
-        print("Adapter-boundary violations (logic must live in stingtools-core):\n")
-        for v in violations:
-            print("  ✗ " + v)
-        print(
-            f"\n{len(violations)} violation(s) across {scanned} adapter file(s). "
-            "Move the logic into stingtools_core.hosts.inference and call it."
-        )
+        if verbose:
+            print("Adapter-boundary violations (logic must live in stingtools-core):\n")
+            for v in violations:
+                print("  [X] " + v)
+            print(
+                f"\n{len(violations)} violation(s) across {scanned} adapter file(s). "
+                "Move the logic into stingtools_core.hosts.inference and call it."
+            )
         return 1
 
-    print(f"✓ adapter boundary clean — {scanned} adapter file(s) scanned, no core "
-          "logic re-implemented.")
+    if verbose:
+        print(f"[OK] adapter boundary clean - {scanned} adapter file(s) scanned, no core "
+              "logic re-implemented.")
     return 0
 
 
 if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        sys.exit(_self_test())
     sys.exit(main())


### PR DESCRIPTION
Lands genuinely-missing multi-host work onto current main: the **A4 substrate drift-check server endpoint**, its provider/service, the **A6 boundary-lint hardening**, and the **`.gitattributes` LF pin** for `shared/ifc` (root-cause fix for cross-host hash drift). Confirmed absent from main before this PR (no `SubstrateController`, no `shared/ifc` LF rule).

Cherry-picked the 2 commits from `claude/lucid-bohr-sy0qyd` (the most complete of the three duplicate branches), `-x` for traceability:
- `8e735f1ac` ← `804e9a622` — pin `shared/ifc/** text eol=lf`
- `33cec9a72` ← `b5546b962` — substrate-drift endpoint + service + client wiring + boundary-lint hardening

## What landed
- **`SubstrateController`** `GET /api/substrate/manifest` (`[Authorize]`, global/not project-scoped) → `{ sha256, schemaVersion, totalEnums }`.
- **`SubstrateManifestProvider`** (singleton, cached) — hashes `shared/ifc/enums/_manifest.json` **LF-normalized** (`\r\n`→`\n`) so a Windows host and a Linux server agree on identical content.
- **Program.cs / .csproj** — DI registration + Content-link the manifest from the single source of truth. Auto-merged into main's current versions cleanly; **build confirms** integration.
- **Client wiring** — `stingtools_core.planscape.client` substrate methods; Bonsai + StingBridge surface a non-blocking login warning on drift.
- **A6 boundary-lint** — ASCII markers (fixes a Windows cp1252 `UnicodeEncodeError` crash), `--self-test`, and a pytest mirror so re-introducing core logic into an adapter fails the pytest gate too.
- **`.gitattributes`** — `shared/ifc/** text eol=lf` (belt-and-suspenders to the code-level normalization; renormalizes future checkouts to LF on disk).

## Acceptance gates — all green
| Gate | Baseline (main) | After |
|---|---|---|
| `dotnet build` Planscape.Server | 0 errors | **0 errors** |
| stingtools-core pytest | 50 passed | **60 passed** (+10 new substrate/boundary tests) |
| `tools/ci/check_adapter_boundary.py` | exit 0 (crashed on Windows cp1252) | **exit 0, now native on Windows** |
| `SubstrateManifestTests` (.NET) | — | **4 passed** |

## Live endpoint proof (dotnet run + curl, against local Postgres/Redis)
- Unauthenticated `GET /api/substrate/manifest` → **401** (route mapped, auth enforced).
- Authenticated → **200** `{"sha256":"a6d77420ee7bc32d8825e898156f0b1dba2aa4665ddf77b119cbf9ce4a2fa1de","schemaVersion":2,"totalEnums":52}`.

## LF fix verified (Step 4)
- `git check-attr -a shared/ifc/...` → `text: set`, `eol: lf` (rule applies).
- The served `sha256` is the **LF-normalized** value (`a6d77420…`), **not** the raw-CRLF value (`7b0da677…`) — proven on a CRLF Windows checkout. So a Linux host (LF) and this server compute the **same** hash → **no drift**. Existing working trees renormalize on next checkout / `git add --renormalize`; the code-level normalization makes drift impossible regardless of EOL.

## Supersedes (delete on merge)
This fully supersedes all three duplicate branches:
- `claude/lucid-bohr-sy0qyd` (source — both commits)
- `claude/multi-host-phase-a` (identical 2 commits)
- `claude/optimistic-bell-EfjJw` (endpoint only — **missing the LF fix**, so strictly inferior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)