### PR TITLE
Export Centre — complete pipeline overhaul (rebased on main, supersedes #318)

### DIFF
--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -1413,6 +1413,18 @@ namespace StingTools.Core
                 {
                     StingLog.Warn($"DocumentSaved geometry sync trigger: {geoEx.Message}");
                 }
+
+                // Unattended export — run any due scheduled-export jobs. No-op unless the
+                // user opted in (ExportCenterState.EnableSaveTriggeredSchedules) and a job
+                // is actually due; never throws out of the save handler.
+                try
+                {
+                    StingTools.Docs.ScheduledExportRunner.RunDue(doc, fromSave: true);
+                }
+                catch (Exception schEx)
+                {
+                    StingLog.Warn($"DocumentSaved scheduled export: {schEx.Message}");
+                }
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -2217,6 +2217,7 @@ namespace StingTools.Core
                 ("Tag3D",                "3D Tag",        "T3", DrawingColor.Crimson,      typeof(HubTag3DCommand).FullName),
                 ("CreateTagFamilies",    "Tag Families",  "TF", DrawingColor.DarkCyan,     typeof(HubCreateTagFamiliesCommand).FullName),
                 ("AutoTag",              "Auto Tag",      "AT", DrawingColor.DarkGreen,    typeof(HubAutoTagCommand).FullName),
+                ("ExportCenter",         "Export Center", "EX", DrawingColor.RoyalBlue,    typeof(HubExportCenterCommand).FullName),
             };
 
             var buttons = new List<PushButtonData>(12);
@@ -2630,6 +2631,14 @@ namespace StingTools.Core
     {
         public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
             => HubDispatcher.Run(data, "AutoTag", ref message);
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HubExportCenterCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
+            => HubDispatcher.Run(data, "ExportCenter", ref message);
     }
 
     [Transaction(TransactionMode.ReadOnly)]

--- a/StingTools/Docs/ExportCenterEngine.cs
+++ b/StingTools/Docs/ExportCenterEngine.cs
@@ -184,6 +184,34 @@ namespace StingTools.Docs
                     return ids;
                 }
 
+                case "Changed Since Last Export":
+                {
+                    // Issue-driven delta: a sheet is "changed" when it has never been
+                    // exported, or its current revision differs from the last-exported
+                    // revision recorded in state. The single biggest automation win for
+                    // an ISO 19650 re-issue — only the drawings that moved go out.
+                    var state = LoadState();
+                    var byUid = state.LastExports
+                        .GroupBy(r => r.SheetUniqueId)
+                        .ToDictionary(g => g.Key, g => g.OrderByDescending(r => r.ExportedUtc).First());
+                    var ids = new List<ElementId>();
+                    foreach (var s in sheets)
+                    {
+                        var (rev, _) = GetCurrentRevision(doc, s);
+                        if (!byUid.TryGetValue(s.UniqueId, out var rec) ||
+                            !string.Equals(rec.Revision ?? "", rev ?? "", StringComparison.OrdinalIgnoreCase))
+                            ids.Add(s.Id);
+                    }
+                    return ids;
+                }
+
+                case "Resume Last Failed":
+                {
+                    var state = LoadState();
+                    var failed = new HashSet<string>(state.LastRunFailedSheetIds ?? new List<string>());
+                    return sheets.Where(s => failed.Contains(s.UniqueId)).Select(s => s.Id).ToList();
+                }
+
                 case "Currently Opened":
                 {
                     // We can only inspect the active UI app from the dialog layer;
@@ -603,7 +631,7 @@ namespace StingTools.Docs
                     RunPdf(doc, profile, selectedIds, result,
                         (label) => progress?.Invoke(++done, total, label),
                         cancelRequested);
-                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(profile, result); }
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(doc, profile, result); }
                 }
 
                 // DWG
@@ -612,7 +640,7 @@ namespace StingTools.Docs
                     RunDwg(doc, profile, selectedIds, result,
                         (label) => progress?.Invoke(++done, total, label),
                         cancelRequested);
-                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(profile, result); }
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(doc, profile, result); }
                 }
 
                 // IFC
@@ -621,14 +649,14 @@ namespace StingTools.Docs
                     RunIfc(doc, profile, selectedIds, result,
                         (label) => progress?.Invoke(++done, total, label),
                         cancelRequested);
-                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(profile, result); }
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(doc, profile, result); }
                 }
 
                 if ((profile.Formats & ExportFormats.NWC) != 0)
                 {
                     RunNwc(doc, profile, result,
                         (label) => progress?.Invoke(++done, total, label));
-                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(profile, result); }
+                    if (cancelRequested != null && cancelRequested()) { result.Cancelled = true; return Finalize(doc, profile, result); }
                 }
                 if ((profile.Formats & ExportFormats.Image) != 0)
                     RunImage(doc, profile, selectedIds, result,
@@ -648,19 +676,146 @@ namespace StingTools.Docs
                 StingLog.Error("ExportCenterEngine.Run failed", ex);
                 result.Warnings.Add("Run failed: " + ex.Message);
             }
-            return Finalize(profile, result);
+            return Finalize(doc, profile, result);
         }
 
         /// <summary>
         /// Common cleanup path — was the body of a finally block guarded
         /// by a "Done:" label, but C# doesn't allow goto-into-finally.
         /// </summary>
-        private static ExportRunResult Finalize(ExportProfile profile, ExportRunResult result)
+        private static ExportRunResult Finalize(Document doc, ExportProfile profile, ExportRunResult result)
         {
             result.FinishedUtc = DateTime.UtcNow;
+            try { PostRun(doc, profile, result); }
+            catch (Exception ex) { StingLog.Warn($"ExportCenter PostRun: {ex.Message}"); }
             if (profile.Output.GenerateReport)
                 WriteReport(profile, result);
             return result;
+        }
+
+        // ── Post-run automation (delta stamping / failed tracking / manifest / hook) ──
+
+        private static void PostRun(Document doc, ExportProfile profile, ExportRunResult result)
+        {
+            var ok = result.Rows.Where(r => r.Success && !string.IsNullOrEmpty(r.OutputPath)).ToList();
+
+            // 1) Persist per-sheet last-export records + this run's failed sheets so the
+            //    "Changed Since Last Export" and "Resume Last Failed" sets work next time.
+            if (doc != null && profile.Output.StampLastExport)
+            {
+                try
+                {
+                    var state = LoadState();
+                    var byUid = state.LastExports.ToDictionary(r => r.SheetUniqueId + "|" + r.Format, r => r);
+
+                    foreach (var r in ok)
+                    {
+                        var sheet = ResolveSheet(doc, r.SheetId);
+                        if (sheet == null) continue; // combined rows don't map to one sheet
+                        var (rev, _) = GetCurrentRevision(doc, sheet);
+                        var rec = new SheetExportRecord
+                        {
+                            SheetUniqueId = sheet.UniqueId, SheetNumber = sheet.SheetNumber,
+                            Revision = rev, Format = r.Format, Path = r.OutputPath, ExportedUtc = DateTime.UtcNow,
+                        };
+                        byUid[rec.SheetUniqueId + "|" + rec.Format] = rec;
+                    }
+                    state.LastExports = byUid.Values.ToList();
+
+                    state.LastRunFailedSheetIds = result.Rows
+                        .Where(r => !r.Success)
+                        .Select(r => ResolveSheet(doc, r.SheetId)?.UniqueId)
+                        .Where(u => !string.IsNullOrEmpty(u))
+                        .Distinct().ToList();
+
+                    SaveState(state);
+                }
+                catch (Exception ex) { StingLog.Warn($"Last-export stamp: {ex.Message}"); }
+            }
+
+            // 2) SHA-256 manifest of every produced file (CDE integrity / ISO 19650 record).
+            string manifestPath = null;
+            if (profile.Output.WriteChecksumManifest && ok.Count > 0)
+            {
+                try { manifestPath = WriteChecksumManifest(profile, result, ok); }
+                catch (Exception ex) { result.Warnings.Add("Checksum manifest failed: " + ex.Message); }
+            }
+
+            // 3) Post-export shell hook (copy to network / notify / zip). Best-effort.
+            if (!string.IsNullOrWhiteSpace(profile.Output.PostExportCommand))
+            {
+                try { RunPostExportHook(profile, result, manifestPath); }
+                catch (Exception ex) { result.Warnings.Add("Post-export hook failed: " + ex.Message); }
+            }
+        }
+
+        private static ViewSheet ResolveSheet(Document doc, string sheetIdText)
+        {
+            if (doc == null || string.IsNullOrEmpty(sheetIdText)) return null;
+            if (!long.TryParse(sheetIdText, out long raw)) return null;
+            return doc.GetElement(new ElementId(raw)) as ViewSheet;
+        }
+
+        private static string WriteChecksumManifest(ExportProfile profile, ExportRunResult result, List<ExportResultRow> ok)
+        {
+            string folder = profile.Output.LocalFolder;
+            if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder)) return null;
+            string stamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            string path = Path.Combine(folder, $"STING_Export_Manifest_{stamp}.json");
+
+            var entries = new List<object>();
+            using (var sha = System.Security.Cryptography.SHA256.Create())
+            {
+                foreach (var r in ok)
+                {
+                    if (!File.Exists(r.OutputPath)) continue;
+                    string hash;
+                    try { using var fs = File.OpenRead(r.OutputPath); hash = Convert.ToHexString(sha.ComputeHash(fs)); }
+                    catch (Exception ex) { StingLog.Warn($"Hash {r.OutputPath}: {ex.Message}"); continue; }
+                    entries.Add(new
+                    {
+                        r.Format, r.SheetNumber, r.SheetTitle,
+                        File = Path.GetFileName(r.OutputPath), Bytes = r.FileSizeBytes,
+                        Sha256 = hash.ToLowerInvariant(),
+                    });
+                }
+            }
+
+            var manifest = new
+            {
+                generated = DateTime.UtcNow.ToString("o"),
+                profile = profile.Name,
+                project = StingTools.Core.TagConfig.ConfigSource,
+                fileCount = entries.Count,
+                algorithm = "SHA-256",
+                files = entries,
+            };
+            File.WriteAllText(path, JsonConvert.SerializeObject(manifest, Formatting.Indented));
+            StingLog.Info($"Export checksum manifest written: {path}");
+            return path;
+        }
+
+        private static void RunPostExportHook(ExportProfile profile, ExportRunResult result, string manifestPath)
+        {
+            string cmd = profile.Output.PostExportCommand
+                .Replace("{manifest}", manifestPath ?? "")
+                .Replace("{folder}",   profile.Output.LocalFolder ?? "")
+                .Replace("{count}",    result.Success.ToString())
+                .Replace("{report}",   ""); // report path is written after this; left blank by design
+
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments = "/c " + cmd,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = Directory.Exists(profile.Output.LocalFolder) ? profile.Output.LocalFolder : Environment.CurrentDirectory,
+            };
+            using var p = System.Diagnostics.Process.Start(psi);
+            // Don't block the UI indefinitely on a runaway hook.
+            if (p != null && !p.WaitForExit(30000))
+                result.Warnings.Add("Post-export hook still running after 30s — left detached.");
+            StingLog.Info($"Post-export hook executed: {cmd}");
         }
 
         private static int CountFormatPasses(ExportProfile p)
@@ -774,14 +929,9 @@ namespace StingTools.Docs
                 var singleView = new List<View> { view };
                 bool ok = RobustPdfExport(doc, new List<ElementId> { view.Id }, folder, stem, opts,
                     out string finalPath, out long bytes, out int pageCount, out string err,
-                    tmp =>
-                    {
-                        // Post-process the verified temp file BEFORE the atomic move,
-                        // so a configured watermark / bookmark lands on every
-                        // OnePerSheet output and the published PDF is final in one step.
-                        if (profile.Pdf.AddBookmarks)  TryInjectBookmarks(tmp, singleView, profile, result);
-                        if (profile.Pdf.ApplyWatermark) TryInjectWatermark(tmp, profile.Pdf, result);
-                    });
+                    // Post-process the verified temp file BEFORE the atomic move so the
+                    // watermark / bookmark / cover land on the published PDF in one step.
+                    tmp => ExportCenterPdfPostProcess.PostProcessExport(tmp, singleView, profile, result));
                 row.OutputPath = finalPath;
                 row.Success = ok;
                 if (ok)
@@ -841,7 +991,7 @@ namespace StingTools.Docs
                 stem = ResolveConflict(folder, stem, "pdf", profile.Output.ConflictMode, out bool skip);
                 if (skip) { row.Success = false; row.Error = "Skipped — file exists"; return; }
 
-                var ordered = OrderForMerge(views, profile.Pdf.MergeOrderSheetIds);
+                var ordered = OrderForMerge(views, profile.Pdf.MergeOrderSheetIds, profile.Pdf.MergeOrder);
 
                 var opts = new PDFExportOptions
                 {
@@ -854,11 +1004,7 @@ namespace StingTools.Docs
 
                 bool ok = RobustPdfExport(doc, ordered.Select(v => v.Id).ToList(), folder, stem, opts,
                     out string finalPath, out long bytes, out int pageCount, out string err,
-                    tmp =>
-                    {
-                        if (profile.Pdf.AddBookmarks)  TryInjectBookmarks(tmp, ordered, profile, result);
-                        if (profile.Pdf.ApplyWatermark) TryInjectWatermark(tmp, profile.Pdf, result);
-                    });
+                    tmp => ExportCenterPdfPostProcess.PostProcessExport(tmp, ordered, profile, result));
                 row.OutputPath = finalPath;
                 row.Success = ok;
                 if (ok)
@@ -881,35 +1027,29 @@ namespace StingTools.Docs
             }
         }
 
-        private static List<View> OrderForMerge(List<View> views, List<string> mergeOrder)
+        private static List<View> OrderForMerge(List<View> views, List<string> mergeOrder, string mergeMode = "SheetNumber")
         {
-            if (mergeOrder == null || mergeOrder.Count == 0)
-                return views.OrderBy(v => v is ViewSheet s ? s.SheetNumber : v.Name).ToList();
-
-            var index = mergeOrder.Select((id, i) => new { id, i }).ToDictionary(x => x.id, x => x.i);
-            return views.OrderBy(v => index.TryGetValue(v.Id.ToString(), out int i) ? i : int.MaxValue).ToList();
-        }
-
-        private static void TryInjectBookmarks(string pdfPath, List<View> views,
-            ExportProfile profile, ExportRunResult result)
-        {
-            // Backed by PDFsharp 6.x (added as a NuGet package). Best-effort —
-            // a bookmark failure must not abort the export.
-            try { ExportCenterPdfPostProcess.InjectBookmarks(pdfPath, views, profile); }
-            catch (Exception ex)
+            // An explicit per-sheet order (saved drag-to-reorder) always wins.
+            if (mergeOrder != null && mergeOrder.Count > 0)
             {
-                result.Warnings.Add($"Bookmark injection failed for '{Path.GetFileName(pdfPath)}': {ex.Message}");
+                var index = mergeOrder.Select((id, i) => new { id, i }).ToDictionary(x => x.id, x => x.i);
+                return views.OrderBy(v => index.TryGetValue(v.Id.ToString(), out int i) ? i : int.MaxValue).ToList();
+            }
+
+            string Num(View v) => v is ViewSheet s ? s.SheetNumber ?? "" : v.Name ?? "";
+            switch (mergeMode)
+            {
+                case "IssueDate":
+                    return views.OrderBy(v => v is ViewSheet s ? (ReadParam(s, "Sheet Issue Date") ?? "") : "")
+                                .ThenBy(Num).ToList();
+                case "Discipline":
+                    return views.OrderBy(v => v is ViewSheet s ? GetDisciplinePrefix(s.SheetNumber) : "")
+                                .ThenBy(Num).ToList();
+                default: // SheetNumber
+                    return views.OrderBy(Num).ToList();
             }
         }
 
-        private static void TryInjectWatermark(string pdfPath, PdfExportSettings pdf, ExportRunResult result)
-        {
-            try { ExportCenterPdfPostProcess.InjectWatermark(pdfPath, pdf); }
-            catch (Exception ex)
-            {
-                result.Warnings.Add($"Watermark injection failed for '{Path.GetFileName(pdfPath)}': {ex.Message}");
-            }
-        }
 
         // PDFExportOptions.RasterQuality is RasterQualityType in Revit
         // 2025+; the legacy DPI-buckets enum was retired.

--- a/StingTools/Docs/ExportCenterEngine.cs
+++ b/StingTools/Docs/ExportCenterEngine.cs
@@ -743,10 +743,17 @@ namespace StingTools.Docs
                 stem = ResolveConflict(folder, stem, "pdf", profile.Output.ConflictMode, out bool skip);
                 if (skip) { row.Success = false; row.Error = "Skipped — file exists"; return; }
 
+                // NOTE: In Revit 2022+ the PDFExportOptions.FileName property is
+                // ONLY honoured when Combine == true. With Combine == false Revit
+                // names every file via its own naming rule (e.g. "Sheet - <name>"),
+                // so File.Exists(stem.pdf) was always false and the export was
+                // reported as a failure even though a PDF had been written. Export
+                // the single view with Combine == true so the requested filename is
+                // produced exactly. (A single-view "combine" is just a 1-page PDF.)
                 var opts = new PDFExportOptions
                 {
                     FileName = stem,
-                    Combine = false,
+                    Combine = true,
                     AlwaysUseRaster = profile.Pdf.HiddenLineMode == "Raster",
                     RasterQuality = MapRasterQuality(profile.Pdf.RasterDpi),
                     ColorDepth = MapColorDepth(profile.Pdf.ColourScheme),
@@ -755,7 +762,17 @@ namespace StingTools.Docs
                 bool ok = doc.Export(folder, new List<ElementId> { view.Id }, opts);
                 row.OutputPath = Path.Combine(folder, stem + ".pdf");
                 row.Success = ok && File.Exists(row.OutputPath);
-                if (row.Success) row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                if (row.Success)
+                {
+                    row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
+                    // Per-sheet PDFs get the same post-processing as combined ones,
+                    // so a configured watermark / bookmark actually lands on every
+                    // OnePerSheet output instead of only on combined sets.
+                    if (profile.Pdf.AddBookmarks)
+                        TryInjectBookmarks(row.OutputPath, new List<View> { view }, profile, result);
+                    if (profile.Pdf.ApplyWatermark)
+                        TryInjectWatermark(row.OutputPath, profile.Pdf, result);
+                }
                 else row.Error = "PDF export returned false";
             }
             catch (Exception ex)

--- a/StingTools/Docs/ExportCenterEngine.cs
+++ b/StingTools/Docs/ExportCenterEngine.cs
@@ -771,21 +771,26 @@ namespace StingTools.Docs
                     ColorDepth = MapColorDepth(profile.Pdf.ColourScheme),
                 };
 
-                bool ok = doc.Export(folder, new List<ElementId> { view.Id }, opts);
-                row.OutputPath = Path.Combine(folder, stem + ".pdf");
-                row.Success = ok && File.Exists(row.OutputPath);
-                if (row.Success)
+                var singleView = new List<View> { view };
+                bool ok = RobustPdfExport(doc, new List<ElementId> { view.Id }, folder, stem, opts,
+                    out string finalPath, out long bytes, out int pageCount, out string err,
+                    tmp =>
+                    {
+                        // Post-process the verified temp file BEFORE the atomic move,
+                        // so a configured watermark / bookmark lands on every
+                        // OnePerSheet output and the published PDF is final in one step.
+                        if (profile.Pdf.AddBookmarks)  TryInjectBookmarks(tmp, singleView, profile, result);
+                        if (profile.Pdf.ApplyWatermark) TryInjectWatermark(tmp, profile.Pdf, result);
+                    });
+                row.OutputPath = finalPath;
+                row.Success = ok;
+                if (ok)
                 {
-                    row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
-                    // Per-sheet PDFs get the same post-processing as combined ones,
-                    // so a configured watermark / bookmark actually lands on every
-                    // OnePerSheet output instead of only on combined sets.
-                    if (profile.Pdf.AddBookmarks)
-                        TryInjectBookmarks(row.OutputPath, new List<View> { view }, profile, result);
-                    if (profile.Pdf.ApplyWatermark)
-                        TryInjectWatermark(row.OutputPath, profile.Pdf, result);
+                    row.FileSizeBytes = bytes;
+                    if (pageCount != 1)
+                        result.Warnings.Add($"{row.SheetNumber}: PDF has {pageCount} page(s), expected 1.");
                 }
-                else row.Error = "PDF export returned false";
+                else row.Error = err;
             }
             catch (Exception ex)
             {
@@ -847,18 +852,22 @@ namespace StingTools.Docs
                     ColorDepth = MapColorDepth(profile.Pdf.ColourScheme),
                 };
 
-                bool ok = doc.Export(folder, ordered.Select(v => v.Id).ToList(), opts);
-                row.OutputPath = Path.Combine(folder, stem + ".pdf");
-                row.Success = ok && File.Exists(row.OutputPath);
-                if (row.Success)
+                bool ok = RobustPdfExport(doc, ordered.Select(v => v.Id).ToList(), folder, stem, opts,
+                    out string finalPath, out long bytes, out int pageCount, out string err,
+                    tmp =>
+                    {
+                        if (profile.Pdf.AddBookmarks)  TryInjectBookmarks(tmp, ordered, profile, result);
+                        if (profile.Pdf.ApplyWatermark) TryInjectWatermark(tmp, profile.Pdf, result);
+                    });
+                row.OutputPath = finalPath;
+                row.Success = ok;
+                if (ok)
                 {
-                    row.FileSizeBytes = new FileInfo(row.OutputPath).Length;
-                    if (profile.Pdf.AddBookmarks)
-                        TryInjectBookmarks(row.OutputPath, ordered, profile, result);
-                    if (profile.Pdf.ApplyWatermark)
-                        TryInjectWatermark(row.OutputPath, profile.Pdf, result);
+                    row.FileSizeBytes = bytes;
+                    if (pageCount != ordered.Count)
+                        result.Warnings.Add($"Combined '{groupName}': PDF has {pageCount} page(s), expected {ordered.Count}.");
                 }
-                else row.Error = "Combined PDF export returned false";
+                else row.Error = err;
             }
             catch (Exception ex)
             {
@@ -918,6 +927,148 @@ namespace StingTools.Docs
             "BlackAndWhite" => ColorDepthType.BlackLine,
             _               => ColorDepthType.Color,
         };
+
+        // ── Robust PDF export (atomic write + verification + retry) ──────────────
+
+        // A genuinely-rendered single-sheet PDF is several KB; anything below this
+        // is an empty / failed render masquerading as a success.
+        private const long MinValidPdfBytes = 600;
+
+        /// <summary>
+        /// Export PDF robustly: render into a sibling temp folder, verify the
+        /// output (non-zero bytes + opens + page count), run any post-processing
+        /// on the verified temp file, then atomically rename it into place. The
+        /// target is checked for locks up-front and the whole render is retried
+        /// with backoff on transient I/O so a sheet open in Bluebeam/Acrobat or a
+        /// momentarily-busy printer doesn't fail the batch. Revit failure messages
+        /// raised during the export are captured and surfaced instead of the bare
+        /// "returned false".
+        /// </summary>
+        private static bool RobustPdfExport(Document doc, List<ElementId> ids, string folder,
+            string stem, PDFExportOptions opts, out string finalPath, out long bytes,
+            out int pageCount, out string error, Action<string> preMovePostProcess)
+        {
+            finalPath = Path.Combine(folder, stem + ".pdf");
+            bytes = 0; pageCount = 0; error = null;
+
+            // Fail fast (and clearly) if the destination is open in a viewer.
+            if (IsFileLocked(finalPath))
+            {
+                error = "target file is open in another application — close it " +
+                        "(Bluebeam / Acrobat) and re-run";
+                return false;
+            }
+
+            string tempDir  = Path.Combine(folder, ".sting_export_tmp");
+            string tempPath = Path.Combine(tempDir, stem + ".pdf");
+            opts.FileName = stem;
+
+            const int maxAttempts = 3;
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    Directory.CreateDirectory(tempDir);
+                    TryDeleteFile(tempPath);
+
+                    var captured = new List<string>();
+                    void OnFail(object s, Autodesk.Revit.DB.Events.FailuresProcessingEventArgs e)
+                    {
+                        try
+                        {
+                            foreach (var m in e.GetFailuresAccessor().GetFailureMessages())
+                                captured.Add(m.GetDescriptionText());
+                        }
+                        catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+                    }
+
+                    bool ok;
+                    doc.Application.FailuresProcessing += OnFail;
+                    try { ok = doc.Export(tempDir, ids, opts); }
+                    finally { doc.Application.FailuresProcessing -= OnFail; }
+
+                    if (!ok || !File.Exists(tempPath))
+                    {
+                        error = "Revit PDF export returned false"
+                            + (captured.Count > 0
+                                ? ": " + string.Join("; ", captured.Distinct())
+                                : " (no file produced)");
+                        // may be transient — fall through to the backoff + retry
+                    }
+                    else if (!VerifyPdf(tempPath, out bytes, out pageCount, out error))
+                    {
+                        // corrupt / empty output is not transient — stop now
+                        TryDeleteFile(tempPath); TryDeleteTempDir(tempDir);
+                        return false;
+                    }
+                    else
+                    {
+                        try { preMovePostProcess?.Invoke(tempPath); }
+                        catch (Exception ex) { StingLog.Warn($"PDF post-process: {ex.Message}"); }
+
+                        File.Move(tempPath, finalPath, true); // same-volume atomic rename
+                        try { bytes = new FileInfo(finalPath).Length; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+                        TryDeleteTempDir(tempDir);
+                        return true;
+                    }
+                }
+                catch (IOException ioex) { error = ioex.Message; }                 // transient lock → retry
+                catch (UnauthorizedAccessException uaex) { error = uaex.Message; } // transient lock → retry
+                catch (Autodesk.Revit.Exceptions.ApplicationException rex) { error = rex.Message; }
+                catch (Exception ex)
+                {
+                    error = ex.Message;
+                    TryDeleteFile(tempPath); TryDeleteTempDir(tempDir);
+                    return false;
+                }
+
+                if (attempt < maxAttempts) System.Threading.Thread.Sleep(400 * attempt);
+            }
+
+            TryDeleteFile(tempPath); TryDeleteTempDir(tempDir);
+            return false;
+        }
+
+        private static bool VerifyPdf(string path, out long bytes, out int pageCount, out string error)
+        {
+            bytes = 0; pageCount = 0; error = null;
+            if (!File.Exists(path)) { error = "no output file produced"; return false; }
+            bytes = new FileInfo(path).Length;
+            if (bytes < MinValidPdfBytes)
+            {
+                error = $"output is only {bytes} bytes — likely empty/corrupt";
+                return false;
+            }
+            return ExportCenterPdfPostProcess.TryReadPdfInfo(path, out pageCount, out error);
+        }
+
+        private static bool IsFileLocked(string path)
+        {
+            if (!File.Exists(path)) return false;
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                return false;
+            }
+            catch (IOException) { return true; }
+            catch (UnauthorizedAccessException) { return true; }
+        }
+
+        private static void TryDeleteFile(string p)
+        {
+            try { if (File.Exists(p)) File.Delete(p); }
+            catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+        }
+
+        private static void TryDeleteTempDir(string dir)
+        {
+            try
+            {
+                if (Directory.Exists(dir) && !Directory.EnumerateFileSystemEntries(dir).Any())
+                    Directory.Delete(dir);
+            }
+            catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+        }
 
         // ── DWG pipeline ────────────────────────────────────────────────────────
 

--- a/StingTools/Docs/ExportCenterEngine.cs
+++ b/StingTools/Docs/ExportCenterEngine.cs
@@ -264,10 +264,22 @@ namespace StingTools.Docs
         /// for sanitising disallowed characters and appending the format extension.
         /// </summary>
         public static string ResolveNaming(Document doc, View view, string template, OutputSettings outSettings)
+            => ResolveNaming(doc, view, template, outSettings, null);
+
+        /// <summary>
+        /// As <see cref="ResolveNaming(Document, View, string, OutputSettings)"/> but lets the
+        /// caller override individual tokens — used by the combined-PDF path so the
+        /// ISO 19650 filename carries set-level identity (e.g. the sheet-number slot
+        /// holds the set label) instead of the first sheet's specifics.
+        /// </summary>
+        public static string ResolveNaming(Document doc, View view, string template,
+            OutputSettings outSettings, Dictionary<string, string> overrides)
         {
             if (string.IsNullOrEmpty(template)) template = "{SheetNumber} - {SheetTitle}";
 
             var tokens = BuildTokenContext(doc, view);
+            if (overrides != null)
+                foreach (var kv in overrides) tokens[kv.Key] = kv.Value;
             return Regex.Replace(template, @"\{(?<key>[A-Za-z0-9_]+)(?::(?<fmt>[^}]+))?\}", m =>
             {
                 string key = m.Groups["key"].Value;
@@ -704,14 +716,14 @@ namespace StingTools.Docs
                     foreach (var g in groups)
                     {
                         if (cancel != null && cancel()) return;
-                        ExportCombinedPdf(doc, g.ToList<View>(), profile, result, g.Key);
+                        ExportCombinedPdf(doc, g.ToList<View>(), profile, result, g.Key, PdfCombineMode.OnePerDiscipline);
                         tick?.Invoke($"PDF (combined): {g.Key}");
                     }
                     break;
                 }
 
                 case PdfCombineMode.OnePerSet:
-                    ExportCombinedPdf(doc, sheets, profile, result, "All");
+                    ExportCombinedPdf(doc, sheets, profile, result, "All", PdfCombineMode.OnePerSet);
                     tick?.Invoke("PDF (combined): All");
                     break;
 
@@ -722,7 +734,7 @@ namespace StingTools.Docs
                             .Select(idText => long.TryParse(idText, out var n) ? doc.GetElement(new ElementId(n)) : null)
                             .OfType<View>().ToList();
                         if (groupSheets.Count == 0) continue;
-                        ExportCombinedPdf(doc, groupSheets, profile, result, kv.Key);
+                        ExportCombinedPdf(doc, groupSheets, profile, result, kv.Key, PdfCombineMode.CustomGroups);
                         tick?.Invoke($"PDF (custom): {kv.Key}");
                     }
                     break;
@@ -784,7 +796,8 @@ namespace StingTools.Docs
         }
 
         private static void ExportCombinedPdf(Document doc, List<View> views,
-            ExportProfile profile, ExportRunResult result, string groupName)
+            ExportProfile profile, ExportRunResult result, string groupName,
+            PdfCombineMode mode)
         {
             var row = new ExportResultRow
             {
@@ -796,9 +809,30 @@ namespace StingTools.Docs
             try
             {
                 string folder = SubFolderFor(profile, "PDF", profile.Output.SplitByDisciplineSubFolder ? groupName : null);
+
+                // Combined PDFs carry SET-level identity rather than the first
+                // sheet's specifics. The sheet-number slot of the ISO 19650 name
+                // becomes a set label, the level becomes "XX" (spans levels), and
+                // discipline/role reflect the group — so we get a clean
+                // "…-XX-DR-A-ALL-S2-P01.pdf" instead of "…-A002-S2-P01_All.pdf".
+                string repl = profile.Output.IllegalCharReplacement;
+                bool isAllSet = mode == PdfCombineMode.OnePerSet;
+                bool isDisc   = mode == PdfCombineMode.OnePerDiscipline;
+                string setLabel = (isAllSet || isDisc) ? "ALL" : Sanitise(groupName, repl);
+                var nameOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["SheetNumber"]   = setLabel,
+                    ["DrawingNumber"] = setLabel,
+                    ["SheetTitle"]    = isAllSet ? "All Sheets" : groupName,
+                    ["DrawingTitle"]  = isAllSet ? "All Sheets" : groupName,
+                    ["Level"]         = "XX",
+                };
+                if (isDisc) { nameOverrides["Discipline"] = groupName; nameOverrides["Role"] = groupName; }
+                else if (isAllSet) { nameOverrides["Discipline"] = "Z"; nameOverrides["Role"] = "Z"; }
+
                 string stem = Sanitise(
-                    ResolveNaming(doc, views[0], profile.Output.NamingTemplate, profile.Output) + "_" + groupName,
-                    profile.Output.IllegalCharReplacement);
+                    ResolveNaming(doc, views[0], profile.Output.NamingTemplate, profile.Output, nameOverrides),
+                    repl);
                 stem = ResolveConflict(folder, stem, "pdf", profile.Output.ConflictMode, out bool skip);
                 if (skip) { row.Success = false; row.Error = "Skipped — file exists"; return; }
 

--- a/StingTools/Docs/ExportCenterModels.cs
+++ b/StingTools/Docs/ExportCenterModels.cs
@@ -104,6 +104,21 @@ namespace StingTools.Docs
         public int WatermarkFontSize { get; set; } = 96;
         public string WatermarkColourHex { get; set; } = "#999999";
 
+        // ── Watermark & combine polish (Phase: Export Centre roadmap bundle C) ──
+        /// <summary>Derive the watermark phrase from each sheet's suitability
+        /// (WIP/S0/S1 → PRELIMINARY, S2 → FOR INFORMATION, S3 → FOR REVIEW,
+        /// S4 → FOR CONSTRUCTION, …). Overrides WatermarkText per page.</summary>
+        public bool AutoWatermarkBySuitability { get; set; }
+        /// <summary>Tile the watermark diagonally across the whole page rather than
+        /// stamping it once at the centre.</summary>
+        public bool WatermarkTile { get; set; }
+        /// <summary>Prepend an auto-generated drawing-register cover page to a
+        /// combined PDF (sheet number / title / revision table).</summary>
+        public bool PrependCoverSheet { get; set; }
+        /// <summary>Combined-PDF page order when no explicit MergeOrderSheetIds is
+        /// set: "SheetNumber" (default) / "IssueDate" / "Discipline".</summary>
+        public string MergeOrder { get; set; } = "SheetNumber";
+
         /// <summary>User-defined groups (CustomGroups mode). Map of group name → list of sheet ids (as strings).</summary>
         public Dictionary<string, List<string>> CustomGroups { get; set; } = new();
 
@@ -220,6 +235,16 @@ namespace StingTools.Docs
         public bool GenerateReport { get; set; } = true;
         public string ReportFormat { get; set; } = "XLSX";       // XLSX / CSV
         public bool OpenReportWhenDone { get; set; }
+
+        // ── Automation & integrity (Phase: Export Centre roadmap bundle D) ──
+        /// <summary>Write a SHA-256 manifest of every produced file (CDE integrity / ISO 19650 record).</summary>
+        public bool WriteChecksumManifest { get; set; }
+        /// <summary>Optional shell command run once after a successful run. Tokens:
+        /// {manifest} {folder} {count} {report}. Best-effort, never blocks.</summary>
+        public string PostExportCommand { get; set; } = "";
+        /// <summary>Record per-sheet last-exported revision + path so the
+        /// "Changed Since Last Export" delta set works. On by default.</summary>
+        public bool StampLastExport { get; set; } = true;
     }
 
     /// <summary>Persistent saved selection — names + a list of sheet/view ElementIds (as strings to survive across docs).</summary>
@@ -261,6 +286,17 @@ namespace StingTools.Docs
         public string DefaultSetName { get; set; } = "All Sheets";
     }
 
+    /// <summary>Per-sheet last-export record for delta / issue-driven export.</summary>
+    public class SheetExportRecord
+    {
+        public string SheetUniqueId { get; set; }
+        public string SheetNumber { get; set; }
+        public string Revision { get; set; }
+        public string Format { get; set; }
+        public string Path { get; set; }
+        public DateTime ExportedUtc { get; set; } = DateTime.UtcNow;
+    }
+
     /// <summary>A scheduled export job persisted in project_config.json.</summary>
     public class ScheduledExport
     {
@@ -288,6 +324,17 @@ namespace StingTools.Docs
         public string LastNamingTemplate { get; set; }
         public string OdaLibraryPath { get; set; }
         public bool? AutocadComAvailable { get; set; }
+
+        // ── Automation tracking (Phase: Export Centre roadmap bundles B + D) ──
+        /// <summary>Per-sheet last-export records keyed by sheet UniqueId — drives the
+        /// "Changed Since Last Export" delta set.</summary>
+        public List<SheetExportRecord> LastExports { get; set; } = new();
+        /// <summary>Sheet UniqueIds that failed in the most recent run — drives the
+        /// "Resume Last Failed" set.</summary>
+        public List<string> LastRunFailedSheetIds { get; set; } = new();
+        /// <summary>Opt-in: run any due ScheduledExports when a document is saved.
+        /// Off by default so files never appear unexpectedly.</summary>
+        public bool EnableSaveTriggeredSchedules { get; set; }
 
         // ── Built-in profile factory ────────────────────────────────────────────
 
@@ -382,6 +429,8 @@ namespace StingTools.Docs
             S("By Discipline: Structural");
             S("Issued Sheets");
             S("Revised This Week");
+            S("Changed Since Last Export");
+            S("Resume Last Failed");
             S("Currently Opened");
             return built;
         }

--- a/StingTools/Docs/ExportCenterPdfPostProcess.cs
+++ b/StingTools/Docs/ExportCenterPdfPostProcess.cs
@@ -164,6 +164,30 @@ namespace StingTools.Docs
             }
         }
 
+        /// <summary>
+        /// Output-verification probe used by the robust export path: opens the
+        /// PDF read-only and reports its page count. A file that fails to open is
+        /// corrupt; 0 pages means an empty render. Returns false (with a reason)
+        /// in either case so the engine can fail the row rather than silently
+        /// publishing a bad drawing.
+        /// </summary>
+        internal static bool TryReadPdfInfo(string pdfPath, out int pageCount, out string error)
+        {
+            pageCount = 0; error = null;
+            try
+            {
+                using var d = PdfReader.Open(pdfPath, PdfDocumentOpenMode.InformationOnly);
+                pageCount = d.PageCount;
+                if (pageCount <= 0) { error = "PDF reports 0 pages"; return false; }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = "PDF failed to open (corrupt): " + ex.Message;
+                return false;
+            }
+        }
+
         // ── Helpers ─────────────────────────────────────────────────────────────
 
         private static string ResolveLevelLabel(View v)

--- a/StingTools/Docs/ExportCenterPdfPostProcess.cs
+++ b/StingTools/Docs/ExportCenterPdfPostProcess.cs
@@ -109,12 +109,46 @@ namespace StingTools.Docs
         }
 
         /// <summary>
-        /// Stamp every page with the configured watermark — diagonal centre by
-        /// default. Honours opacity (0–100) and font size.
+        /// One-call orchestrator for combined / per-sheet post-processing, run on the
+        /// verified temp PDF before the atomic move. Order matters: bookmarks map to
+        /// page objects, then the watermark stamps content pages, then the cover sheet
+        /// is prepended last (so it stays clean and page-object bookmark refs survive).
         /// </summary>
-        internal static void InjectWatermark(string pdfPath, PdfExportSettings pdf)
+        internal static void PostProcessExport(string pdfPath, List<View> pageViews,
+            ExportProfile profile, ExportRunResult result)
         {
-            if (!File.Exists(pdfPath) || string.IsNullOrEmpty(pdf?.WatermarkText)) return;
+            if (profile?.Pdf == null) return;
+            if (profile.Pdf.AddBookmarks)
+                Safe(() => InjectBookmarks(pdfPath, pageViews, profile), result, "Bookmark", pdfPath);
+            if (profile.Pdf.ApplyWatermark)
+                Safe(() => InjectWatermark(pdfPath, profile.Pdf, pageViews), result, "Watermark", pdfPath);
+            if (profile.Pdf.PrependCoverSheet && pageViews != null && pageViews.Count > 1)
+                Safe(() => PrependRegisterCover(pdfPath, pageViews, profile), result, "Cover sheet", pdfPath);
+        }
+
+        private static void Safe(Action a, ExportRunResult result, string what, string path)
+        {
+            try { a(); }
+            catch (Exception ex)
+            { result?.Warnings.Add($"{what} failed for '{Path.GetFileName(path)}': {ex.Message}"); }
+        }
+
+        /// <summary>Back-compat single-text overload — stamps the same text on every page.</summary>
+        internal static void InjectWatermark(string pdfPath, PdfExportSettings pdf)
+            => InjectWatermark(pdfPath, pdf, null);
+
+        /// <summary>
+        /// Stamp each page with the configured watermark — diagonal centre by default,
+        /// optionally tiled across the page. When <paramref name="pageViews"/> is
+        /// supplied, the text is resolved per page (token substitution + per-suitability
+        /// auto-phrase), so a 50-sheet combined PDF can carry "FOR CONSTRUCTION" on the
+        /// S4 sheets and "PRELIMINARY" on the S1 sheets in one pass.
+        /// </summary>
+        internal static void InjectWatermark(string pdfPath, PdfExportSettings pdf, List<View> pageViews)
+        {
+            if (!File.Exists(pdfPath) || pdf == null) return;
+            // With auto-by-suitability the base text may be empty; that's fine.
+            if (string.IsNullOrEmpty(pdf.WatermarkText) && !pdf.AutoWatermarkBySuitability) return;
 
             try
             {
@@ -122,35 +156,45 @@ namespace StingTools.Docs
 
                 XColor colour = ParseHexColour(pdf.WatermarkColourHex, 0x99, 0x99, 0x99);
                 colour.A = Math.Clamp(pdf.WatermarkOpacityPct, 0, 100) / 100.0;
-
                 var brush = new XSolidBrush(colour);
                 int fontSize = Math.Max(24, pdf.WatermarkFontSize);
                 var font = new XFont("Arial", fontSize, XFontStyleEx.Bold);
 
-                foreach (PdfPage page in doc.Pages)
+                for (int i = 0; i < doc.Pages.Count; i++)
                 {
-                    using var gfx = XGraphics.FromPdfPage(page, XGraphicsPdfPageOptions.Append);
+                    var page = doc.Pages[i];
+                    View v = (pageViews != null && i < pageViews.Count) ? pageViews[i] : null;
+                    string text = ResolveWatermarkText(pdf, v);
+                    if (string.IsNullOrWhiteSpace(text)) continue;
 
-                    double w = page.Width.Point;
-                    double h = page.Height.Point;
-                    var size = gfx.MeasureString(pdf.WatermarkText, font);
+                    using var gfx = XGraphics.FromPdfPage(page, XGraphicsPdfPageOptions.Append);
+                    double w = page.Width.Point, h = page.Height.Point;
+                    var size = gfx.MeasureString(text, font);
 
                     gfx.Save();
-                    switch (pdf.WatermarkPosition)
+                    if (pdf.WatermarkTile)
+                    {
+                        gfx.TranslateTransform(w / 2, h / 2);
+                        gfx.RotateTransform(-30);
+                        double diag = Math.Sqrt(w * w + h * h);
+                        double stepX = size.Width + fontSize * 2.5;
+                        double stepY = fontSize * 3.0;
+                        for (double y = -diag / 2; y < diag / 2; y += stepY)
+                            for (double x = -diag / 2; x < diag / 2; x += stepX)
+                                gfx.DrawString(text, font, brush, new XPoint(x, y));
+                    }
+                    else switch (pdf.WatermarkPosition)
                     {
                         case "TopLeft":
-                            gfx.DrawString(pdf.WatermarkText, font, brush,
-                                new XPoint(20, 20 + size.Height));
+                            gfx.DrawString(text, font, brush, new XPoint(20, 20 + size.Height));
                             break;
                         case "BottomRight":
-                            gfx.DrawString(pdf.WatermarkText, font, brush,
-                                new XPoint(w - size.Width - 20, h - 20));
+                            gfx.DrawString(text, font, brush, new XPoint(w - size.Width - 20, h - 20));
                             break;
                         default: // DiagonalCentre
                             gfx.TranslateTransform(w / 2, h / 2);
                             gfx.RotateTransform(-30);
-                            gfx.DrawString(pdf.WatermarkText, font, brush,
-                                new XPoint(-size.Width / 2, size.Height / 2));
+                            gfx.DrawString(text, font, brush, new XPoint(-size.Width / 2, size.Height / 2));
                             break;
                     }
                     gfx.Restore();
@@ -185,6 +229,115 @@ namespace StingTools.Docs
             {
                 error = "PDF failed to open (corrupt): " + ex.Message;
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Prepend an auto-generated drawing-register cover page to a combined PDF:
+        /// title + project + a Number / Title / Rev table of the contained sheets.
+        /// Inserted last so content-page bookmark refs and watermarks are unaffected.
+        /// </summary>
+        private static void PrependRegisterCover(string pdfPath, List<View> views, ExportProfile profile)
+        {
+            if (!File.Exists(pdfPath) || views == null || views.Count == 0) return;
+
+            using var doc = PdfReader.Open(pdfPath, PdfDocumentOpenMode.Modify);
+            if (doc.PageCount == 0) return;
+
+            double w = doc.Pages[0].Width.Point;
+            double h = doc.Pages[0].Height.Point;
+
+            var cover = doc.InsertPage(0);
+            cover.Width  = XUnit.FromPoint(w);
+            cover.Height = XUnit.FromPoint(h);
+
+            using var gfx = XGraphics.FromPdfPage(cover);
+            var black = XBrushes.Black;
+            var titleFont = new XFont("Arial", 28, XFontStyleEx.Bold);
+            var subFont   = new XFont("Arial", 11, XFontStyleEx.Regular);
+            var headFont  = new XFont("Arial", 11, XFontStyleEx.Bold);
+            var rowFont   = new XFont("Arial", 10, XFontStyleEx.Regular);
+
+            const double margin = 40;
+            double y = margin + 20;
+            gfx.DrawString("DRAWING REGISTER", titleFont, black, new XPoint(margin, y));
+            y += 26;
+
+            string proj = views[0]?.Document?.ProjectInformation?.Name ?? "";
+            gfx.DrawString($"{proj}     {views.Count} drawing(s)     {DateTime.Now:yyyy-MM-dd}",
+                subFont, black, new XPoint(margin, y));
+            y += 28;
+
+            double cNum = margin, cTitle = margin + 150, cRev = w - margin - 60;
+            gfx.DrawString("Number", headFont, black, new XPoint(cNum, y));
+            gfx.DrawString("Title",  headFont, black, new XPoint(cTitle, y));
+            gfx.DrawString("Rev",    headFont, black, new XPoint(cRev, y));
+            y += 6;
+            gfx.DrawLine(new XPen(XColors.Black, 0.75), margin, y, w - margin, y);
+            y += 14;
+
+            const double rowH = 15;
+            double bottom = h - margin;
+            int shown = 0;
+            foreach (var v in views)
+            {
+                if (y + rowH > bottom)
+                {
+                    gfx.DrawString($"… and {views.Count - shown} more", rowFont, black, new XPoint(cNum, y));
+                    break;
+                }
+                var tok = ExportCenterEngine.BuildTokenContext(v.Document, v);
+                string num   = tok.GetValueOrDefault("SheetNumber", "");
+                string title = tok.GetValueOrDefault("SheetTitle", v?.Name ?? "");
+                string rev   = tok.GetValueOrDefault("Revision", "");
+                if (title.Length > 60) title = title.Substring(0, 58) + "…";
+                gfx.DrawString(num,   rowFont, black, new XPoint(cNum, y));
+                gfx.DrawString(title, rowFont, black, new XPoint(cTitle, y));
+                gfx.DrawString(rev,   rowFont, black, new XPoint(cRev, y));
+                y += rowH; shown++;
+            }
+
+            doc.Save(pdfPath);
+        }
+
+        /// <summary>Resolve the watermark text for one page: per-suitability auto-phrase
+        /// (when enabled) and {token} substitution from the sheet's context.</summary>
+        private static string ResolveWatermarkText(PdfExportSettings pdf, View v)
+        {
+            string text = pdf.WatermarkText ?? "";
+            if (v != null)
+            {
+                try
+                {
+                    var tok = ExportCenterEngine.BuildTokenContext(v.Document, v);
+                    if (pdf.AutoWatermarkBySuitability)
+                        text = SuitabilityPhrase(tok.GetValueOrDefault("Suitability", ""));
+                    text = text
+                        .Replace("{Suitability}", tok.GetValueOrDefault("Suitability", ""))
+                        .Replace("{Revision}",    tok.GetValueOrDefault("Revision", ""))
+                        .Replace("{SheetNumber}", tok.GetValueOrDefault("SheetNumber", ""))
+                        .Replace("{Discipline}",  tok.GetValueOrDefault("Discipline", ""))
+                        .Replace("{Date}",        DateTime.Now.ToString("yyyy-MM-dd"));
+                }
+                catch (Exception ex) { StingLog.Warn($"Watermark text resolve: {ex.Message}"); }
+            }
+            return string.IsNullOrWhiteSpace(text) ? (pdf.WatermarkText ?? "") : text;
+        }
+
+        /// <summary>Map an ISO 19650 suitability code to a drawing-stamp phrase.</summary>
+        private static string SuitabilityPhrase(string suit)
+        {
+            switch ((suit ?? "").Trim().ToUpperInvariant())
+            {
+                case "WIP": case "S0": case "S1": return "PRELIMINARY";
+                case "S2": return "FOR INFORMATION";
+                case "S3": return "FOR REVIEW & COMMENT";
+                case "S4": return "FOR STAGE APPROVAL";
+                case "S6": case "S7": return "FOR PIM / AIM AUTHORISATION";
+                case "A1": case "A2": case "A3": case "AB":
+                case "B1": case "B2": case "B3": return "FOR CONSTRUCTION";
+                case "CR": return "AS BUILT";
+                default: return string.IsNullOrEmpty(suit) ? "DRAFT" : suit.ToUpperInvariant();
             }
         }
 

--- a/StingTools/Docs/ScheduledExportRunner.cs
+++ b/StingTools/Docs/ScheduledExportRunner.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+
+namespace StingTools.Docs
+{
+    // ════════════════════════════════════════════════════════════════════════════
+    //  ScheduledExportRunner — unattended driver for ExportCenterState.ScheduledExports.
+    //
+    //  A scheduled job names a saved profile + saved set and a NextRunUtc. When the
+    //  job is due, the engine runs it headlessly (no UI), records the result, and
+    //  re-schedules the next occurrence per its Repeat rule. Invoked manually via
+    //  ExportCenterRunSchedulesCommand, or automatically on DocumentSaved when the
+    //  user has opted in (EnableSaveTriggeredSchedules).
+    //
+    //  Headless by design — ExportCenterEngine.Run does no WPF / TaskDialog work, so
+    //  this is safe to call from an event handler on the Revit API thread.
+    // ════════════════════════════════════════════════════════════════════════════
+
+    public static class ScheduledExportRunner
+    {
+        /// <summary>
+        /// Run every enabled schedule whose NextRunUtc is in the past. Returns the
+        /// number of jobs run. <paramref name="fromSave"/> gates the save-triggered
+        /// path behind the opt-in flag so files never appear unexpectedly.
+        /// </summary>
+        public static int RunDue(Document doc, bool fromSave)
+        {
+            if (doc == null) return 0;
+
+            ExportCenterState state;
+            try { state = ExportCenterEngine.LoadState(); }
+            catch (Exception ex) { StingLog.Warn($"ScheduledExportRunner load: {ex.Message}"); return 0; }
+
+            if (fromSave && !state.EnableSaveTriggeredSchedules) return 0;
+            if (state.ScheduledExports == null || state.ScheduledExports.Count == 0) return 0;
+
+            var now = DateTime.UtcNow;
+            int ran = 0;
+            bool dirty = false;
+
+            foreach (var sch in state.ScheduledExports)
+            {
+                if (sch == null || !sch.Enabled || sch.NextRunUtc > now) continue;
+
+                var profile = state.Profiles.FirstOrDefault(p =>
+                    string.Equals(p.Name, sch.ProfileName, StringComparison.OrdinalIgnoreCase));
+                if (profile == null) { sch.LastResult = "Profile not found"; dirty = true; continue; }
+
+                string setName = string.IsNullOrEmpty(sch.SetName) ? profile.DefaultSetName : sch.SetName;
+                var set = state.SavedSets.FirstOrDefault(s =>
+                              string.Equals(s.Name, setName, StringComparison.OrdinalIgnoreCase))
+                          ?? state.SavedSets.FirstOrDefault(s => s.Name == "All Sheets");
+
+                try
+                {
+                    var ids = ExportCenterEngine.ResolveSet(doc, set, out _);
+                    if (ids.Count == 0)
+                    {
+                        sch.LastResult = "No sheets resolved";
+                    }
+                    else
+                    {
+                        var res = ExportCenterEngine.Run(doc, profile, ids);
+                        sch.LastResult = $"{res.Success} ok / {res.Failed} failed"
+                            + (res.Warnings.Count > 0 ? $" ({res.Warnings.Count} warning(s))" : "");
+                        ran++;
+                        StingLog.Info($"Scheduled export '{sch.ProfileName}' [{setName}]: {sch.LastResult}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    sch.LastResult = "Error: " + ex.Message;
+                    StingLog.Error($"Scheduled export '{sch.ProfileName}' failed", ex);
+                }
+
+                sch.LastRunUtc = now;
+                Reschedule(sch, now);
+                dirty = true;
+            }
+
+            if (dirty)
+                try { ExportCenterEngine.SaveState(state); }
+                catch (Exception ex) { StingLog.Warn($"ScheduledExportRunner save: {ex.Message}"); }
+
+            return ran;
+        }
+
+        private static void Reschedule(ScheduledExport sch, DateTime now)
+        {
+            switch ((sch.Repeat ?? "Once").Trim().ToLowerInvariant())
+            {
+                case "daily":   sch.NextRunUtc = now.AddDays(1);   break;
+                case "weekly":  sch.NextRunUtc = now.AddDays(7);   break;
+                case "monthly": sch.NextRunUtc = now.AddMonths(1); break;
+                default:        sch.Enabled = false;               break; // "Once" — disable after running
+            }
+        }
+    }
+
+    /// <summary>Manually run any due scheduled-export jobs from a button / workflow step.</summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ExportCenterRunSchedulesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var doc = data?.Application?.ActiveUIDocument?.Document;
+                if (doc == null) { message = "No document open."; return Result.Failed; }
+
+                int ran = ScheduledExportRunner.RunDue(doc, fromSave: false);
+                TaskDialog.Show("STING Export Centre",
+                    ran == 0
+                        ? "No scheduled export jobs were due."
+                        : $"Ran {ran} scheduled export job(s).\nSee the export folder and the STING_Export_Report CSV for details.");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("ExportCenterRunSchedulesCommand failed", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -1063,6 +1063,7 @@ namespace StingTools.UI
                     case "ExportSheetRegister": RunCommand<Docs.ExportSheetRegisterCommand>(app); break;
                     case "ExportCenter": RunCommand<Docs.ExportCenterCommand>(app); break;
                     case "ExportCenterPDF": RunCommand<Docs.ExportCenterPdfCommand>(app); break;
+                    case "ExportCenterRunSchedules": RunCommand<Docs.ExportCenterRunSchedulesCommand>(app); break;
 
                     // ── Sheet Manager Live Operations (modeless dialog dispatch) ──
                     case "SM_PlaceViewOnSheet":

--- a/StingTools/UI/StingExportCenterDialog.cs
+++ b/StingTools/UI/StingExportCenterDialog.cs
@@ -533,15 +533,28 @@ namespace StingTools.UI
             var card = NewSection("PDF — Combine, Bookmarks, Watermark");
             var sp = (StackPanel)card.Child;
 
-            // Combine mode
+            // Combine mode — friendly labels so the "merge everything into a single
+            // PDF" option is actually discoverable (raw enum names like "OnePerSet"
+            // told the user nothing).
+            var combineLabels = new (PdfCombineMode Mode, string Label)[]
+            {
+                (PdfCombineMode.OnePerSheet,      "Separate PDF per sheet"),
+                (PdfCombineMode.OnePerSet,        "Single combined PDF (all selected sheets)"),
+                (PdfCombineMode.OnePerDiscipline, "Combined PDF per discipline"),
+                (PdfCombineMode.CustomGroups,     "Combined PDF per custom group"),
+            };
             var combineBox = new ComboBox { Margin = new Thickness(0, 4, 0, 6) };
-            foreach (var v in Enum.GetNames(typeof(PdfCombineMode))) combineBox.Items.Add(v);
-            combineBox.SelectedItem = _profile.Pdf.CombineMode.ToString();
+            foreach (var pair in combineLabels)
+                combineBox.Items.Add(new ComboBoxItem { Content = pair.Label, Tag = pair.Mode });
+            combineBox.SelectedIndex = Array.FindIndex(combineLabels, p => p.Mode == _profile.Pdf.CombineMode);
+            if (combineBox.SelectedIndex < 0) combineBox.SelectedIndex = 0;
             combineBox.SelectionChanged += (_, __) =>
             {
-                Enum.TryParse<PdfCombineMode>(combineBox.SelectedItem?.ToString(), out var m);
-                _profile.Pdf.CombineMode = m;
-                UpdateStatusLine();
+                if ((combineBox.SelectedItem as ComboBoxItem)?.Tag is PdfCombineMode m)
+                {
+                    _profile.Pdf.CombineMode = m;
+                    UpdateStatusLine();
+                }
             };
             sp.Children.Add(LabelFor("Output mode", combineBox));
 

--- a/StingTools/UI/StingExportCenterDialog.cs
+++ b/StingTools/UI/StingExportCenterDialog.cs
@@ -586,7 +586,20 @@ namespace StingTools.UI
             sp.Children.Add(BindCheck("Apply watermark", () => _profile.Pdf.ApplyWatermark, v => _profile.Pdf.ApplyWatermark = v));
             var wmText = new TextBox { Text = _profile.Pdf.WatermarkText };
             wmText.TextChanged += (_, __) => _profile.Pdf.WatermarkText = wmText.Text;
-            sp.Children.Add(LabelFor("Watermark text", wmText));
+            sp.Children.Add(LabelFor("Watermark text  (tokens: {Suitability} {Revision} {SheetNumber} {Date})", wmText));
+            sp.Children.Add(BindCheck("Auto text by suitability (WIP→PRELIMINARY, S4→FOR CONSTRUCTION)",
+                () => _profile.Pdf.AutoWatermarkBySuitability, v => _profile.Pdf.AutoWatermarkBySuitability = v));
+            sp.Children.Add(BindCheck("Tile watermark diagonally across page",
+                () => _profile.Pdf.WatermarkTile, v => _profile.Pdf.WatermarkTile = v));
+
+            // Combine polish
+            sp.Children.Add(BindCheck("Prepend drawing-register cover (combined PDFs)",
+                () => _profile.Pdf.PrependCoverSheet, v => _profile.Pdf.PrependCoverSheet = v));
+            var mergeOrder = new ComboBox();
+            mergeOrder.Items.Add("SheetNumber"); mergeOrder.Items.Add("IssueDate"); mergeOrder.Items.Add("Discipline");
+            mergeOrder.SelectedItem = _profile.Pdf.MergeOrder;
+            mergeOrder.SelectionChanged += (_, __) => _profile.Pdf.MergeOrder = mergeOrder.SelectedItem?.ToString() ?? "SheetNumber";
+            sp.Children.Add(LabelFor("Combine order", mergeOrder));
 
             return card;
         }
@@ -948,6 +961,42 @@ namespace StingTools.UI
             rSp.Children.Add(BindCheck("Generate report", () => _profile.Output.GenerateReport, v => _profile.Output.GenerateReport = v));
             rSp.Children.Add(BindCheck("Open report when done", () => _profile.Output.OpenReportWhenDone, v => _profile.Output.OpenReportWhenDone = v));
             sp.Children.Add(report);
+
+            // Automation & integrity
+            var auto = NewSection("Automation & integrity");
+            var aSp = (StackPanel)auto.Child;
+            aSp.Children.Add(BindCheck("Write SHA-256 checksum manifest",
+                () => _profile.Output.WriteChecksumManifest, v => _profile.Output.WriteChecksumManifest = v));
+            aSp.Children.Add(BindCheck("Track last-exported revision (enables 'Changed Since Last Export')",
+                () => _profile.Output.StampLastExport, v => _profile.Output.StampLastExport = v));
+            var hook = new TextBox { Text = _profile.Output.PostExportCommand };
+            hook.TextChanged += (_, __) => _profile.Output.PostExportCommand = hook.Text;
+            aSp.Children.Add(LabelFor("Post-export command  (tokens: {manifest} {folder} {count})", hook));
+            aSp.Children.Add(BindCheck("Run due scheduled exports on document save (opt-in)",
+                () => _state.EnableSaveTriggeredSchedules,
+                v => { _state.EnableSaveTriggeredSchedules = v; ExportCenterEngine.SaveState(_state); }));
+            var runNow = new Button
+            {
+                Content = "Run due scheduled exports now",
+                Margin = new Thickness(0, 6, 0, 0),
+                Padding = new Thickness(8, 3, 8, 3),
+                HorizontalAlignment = HorizontalAlignment.Left,
+            };
+            runNow.Click += (_, __) =>
+            {
+                try
+                {
+                    int n = ScheduledExportRunner.RunDue(_doc, fromSave: false);
+                    Autodesk.Revit.UI.TaskDialog.Show("STING Export Centre",
+                        n == 0 ? "No scheduled export jobs were due." : $"Ran {n} scheduled export job(s).");
+                }
+                catch (Exception ex)
+                {
+                    Autodesk.Revit.UI.TaskDialog.Show("STING Export Centre", "Failed: " + ex.Message);
+                }
+            };
+            aSp.Children.Add(runNow);
+            sp.Children.Add(auto);
 
             return new ScrollViewer { Content = sp, VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
         }


### PR DESCRIPTION
## Why this exists

PR #310 was closed in favour of #318 on the basis that `main` already covers its PDF-pipeline items. I verified `main` directly and that's **only partly true** — `main` still carries the original bugs this work fixes. This branch is rebased cleanly onto current `main` and is now a **complete superset of #318**: it includes the bug fixes #318 dropped *and* the scheduler + delta automation #318 adds. **#318 can be closed in favour of this.**

## The bugs on `main` that #318 does not fix

- `ExportCenterEngine.ExportSinglePdf` still sets **`Combine = false`**. In Revit 2022+ that makes Revit ignore `PDFExportOptions.FileName` and name files by its own rule (`Sheet-<name>.pdf`), so `File.Exists(<custom stem>.pdf)` is always false → **every per-sheet export is reported "PDF export returned false"** even though a (mis-named) PDF was written. This is exactly the "0 successful / 3 failed" field symptom.
- Watermark only runs in the *combined* path — **OnePerSheet mode never stamps the watermark**.
- No output verification (0-byte / corrupt), no atomic write, no locked-file handling.

## What this branch contains (4 commits, cherry-picked onto `main` with no conflicts)

**Bug fixes (the part #318 drops)**
- **Export-failure fix** — per-sheet export uses `Combine = true`, so the ISO 19650 filename is produced exactly and the success check passes.
- **Robustness pack** — `RobustPdfExport`: render to a sibling temp folder, verify (non-zero bytes + opens + page count via PDFsharp), post-process the verified temp, then atomically rename into place. Locked-target detection ("close it in Bluebeam/Acrobat") + retry-with-backoff; Revit failure text captured via `Application.FailuresProcessing`.
- **Watermark on per-sheet PDFs**; **combined-naming cleanup** (`…-XX-DR-Z-ALL-S2-P01.pdf`, no `_All`); **combine-mode UX** labels; **Hub** ribbon button next to Auto Tag.

**Scheduler + delta + polish (parity with #318, plus more)**
- **Delta automation** — built-in sets "Changed Since Last Export" / "Resume Last Failed"; per-sheet last-export records persisted after each run.
- **ScheduledExportRunner** — headless driver for `ScheduledExports`, manual command + opt-in DocumentSaved trigger.
- **Watermark & combine polish** — per-page text (token + per-suitability auto-phrase), tiled diagonal, auto drawing-register cover page, combine-order selector. Post-processing unified through one `PostProcessExport` orchestrator (bookmarks → watermark → cover) on the verified temp.
- **SHA-256 checksum manifest** + **post-export shell hook**.

`main`'s existing advances (DwgMerger / OdaConverter / NwcExporter / XmlWriter / ISO-naming defaults / R2025 fixes) are untouched.

## Testing / caveat
Written against documented Revit 2025+ / PDFsharp 6 / .NET 8 APIs but **not compiled** in the Linux sandbox. Verify in Revit: a OnePerSheet export with watermark on (correct filenames + diagonal stamp on every page), a "Single combined PDF" export, and the cover-sheet/scheduler paths. The `Combine = true` per-sheet pattern is the standard Revit 2022+ workaround for custom PDF filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)