### PR TITLE
Add AugmentTagFamiliesCommand & update T1 tier formulas

### DIFF
--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - ARCH (COMPLETE with Warnings)
 Tag Family #1: STING - Wall Tag
 TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Walls
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_TYPE_CLASSIFICATION_TXT,Type:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_TYPE_CLASSIFICATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -301,7 +301,7 @@ TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Walls
 Tag Family #2: STING - Floor Tag
 TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Floors
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_FLR_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_FLR_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -369,7 +369,7 @@ TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Floors
 Tag Family #3: STING - Ceiling Tag
 TAG7: ARCH_TAG_7_PARA_CEIL_TXT  •  Category: Ceilings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_CEILING_TYPE_CLASSIFICATION_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_CEILING_TYPE_CLASSIFICATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -430,7 +430,7 @@ TAG7: ARCH_TAG_7_PARA_CEIL_TXT  •  Category: Ceilings
 Tag Family #4: STING - Roof Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roofs
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_ROOF_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -496,7 +496,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roofs
 Tag Family #5: STING - Door Tag
 TAG7: ARCH_TAG_7_PARA_DOOR_TXT  •  Category: Doors
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_DOOR_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_DOOR_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -562,7 +562,7 @@ TAG7: ARCH_TAG_7_PARA_DOOR_TXT  •  Category: Doors
 Tag Family #6: STING - Window Tag
 TAG7: ARCH_TAG_7_PARA_WIN_TXT  •  Category: Windows
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WINDOW_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WINDOW_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -626,7 +626,7 @@ TAG7: ARCH_TAG_7_PARA_WIN_TXT  •  Category: Windows
 Tag Family #7: STING - Room Tag
 TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Rooms
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -684,7 +684,7 @@ TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Rooms
 Tag Family #8: STING - Stair Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stairs
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STAIR_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -747,7 +747,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stairs
 Tag Family #9: STING - Ramp Tag
 TAG7: ARCH_TAG_7_PARA_RAMP_TXT  •  Category: Ramps
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAMP_SLOPE_PCT,Slope:,%,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAMP_SLOPE_PCT, """")",NOM,BLACK,2.0,None,None
@@ -805,7 +805,7 @@ TAG7: ARCH_TAG_7_PARA_RAMP_TXT  •  Category: Ramps
 Tag Family #10: STING - Railing Tag
 TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Railings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_HEIGHT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_HEIGHT_MM, """")",NOM,BLACK,2.0,None,None
@@ -862,7 +862,7 @@ TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Railings
 Tag Family #11: STING - Furniture Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -919,7 +919,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture
 Tag Family #12: STING - Casework Tag
 TAG7: ARCH_TAG_7_PARA_CASEWORK_TXT  •  Category: Casework
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_CASEWORK_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_CASEWORK_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -976,7 +976,7 @@ TAG7: ARCH_TAG_7_PARA_CASEWORK_TXT  •  Category: Casework
 Tag Family #13: STING - Curtain Panel Tag
 TAG7: ARCH_TAG_7_PARA_CURTAIN_TXT  •  Category: Curtain Panels
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_PANEL_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_PANEL_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -1033,7 +1033,7 @@ TAG7: ARCH_TAG_7_PARA_CURTAIN_TXT  •  Category: Curtain Panels
 Tag Family #14: STING - Curtain Wall Mullion Tag
 TAG7: ARCH_TAG_7_PARA_MULLION_TXT  •  Category: Curtain Wall Mullions
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_MULLION_DEPTH_MM,D:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_MULLION_DEPTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -1092,7 +1092,7 @@ TAG7: ARCH_TAG_7_PARA_MULLION_TXT  •  Category: Curtain Wall Mullions
 Tag Family #15: STING - Signage Tag
 TAG7: ARCH_TAG_7_PARA_SIGNAGE_TXT  •  Category: Signage
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_SIGN_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_SIGN_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1147,7 +1147,7 @@ TAG7: ARCH_TAG_7_PARA_SIGNAGE_TXT  •  Category: Signage
 Tag Family #16: STING - Parking Tag
 TAG7: ARCH_TAG_7_PARA_PARKING_TXT  •  Category: Parking
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_PARK_BAY_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_PARK_BAY_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -1205,7 +1205,7 @@ TAG7: ARCH_TAG_7_PARA_PARKING_TXT  •  Category: Parking
 Tag Family #17: STING - Areas Tag
 TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Areas
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -1252,7 +1252,7 @@ TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Areas
 Tag Family #18: STING - Wall Sweeps Tag
 TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Wall Sweeps
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_TYPE_CLASSIFICATION_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_TYPE_CLASSIFICATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1305,7 +1305,7 @@ TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Wall Sweeps
 Tag Family #19: STING - Slab Edges Tag
 TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Slab Edges
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_FLR_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_FLR_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1359,7 +1359,7 @@ TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Slab Edges
 Tag Family #20: STING - Roof Soffits Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roof Soffits
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_CEILING_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_CEILING_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1412,7 +1412,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roof Soffits
 Tag Family #21: STING - Fascia Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Fascia
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_ROOF_COVERING_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_COVERING_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1465,7 +1465,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Fascia
 Tag Family #22: STING - Gutter Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Gutters
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_ROOF_PLM_DRN_SYSTEM_TYPE_TXT,Drain:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_PLM_DRN_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1519,7 +1519,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Gutters
 Tag Family #23: STING - Mass Tag
 TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Mass
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,GIA:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -1571,7 +1571,7 @@ TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Mass
 Tag Family #24: STING - Furniture Systems Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture Systems
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1626,7 +1626,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture Systems
 Tag Family #25: STING - Food Service Equipment Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Food Service Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1681,7 +1681,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Food Service Equipment
 Tag Family #26: STING - Medical Equipment Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Medical Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1736,7 +1736,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Medical Equipment
 Tag Family #27: STING - Entourage Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Entourage
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1788,7 +1788,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Entourage
 Tag Family #28: STING - Stair Runs Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Runs
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STAIR_RISE_MM,R:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_RISE_MM, """")",NOM,BLACK,2.0,None,None
@@ -1845,7 +1845,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Runs
 Tag Family #29: STING - Stair Landings Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Landings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STAIR_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -1899,7 +1899,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Landings
 Tag Family #30: STING - Stair Supports Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Supports
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_MATERIAL_TXT,Mat:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1952,7 +1952,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Supports
 Tag Family #31: STING - Top Rails Tag
 TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Top Rails
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_HEIGHT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_HEIGHT_MM, """")",NOM,BLACK,2.0,None,None
@@ -2006,7 +2006,7 @@ TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Top Rails
 Tag Family #32: STING - Handrails Tag
 TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Handrails
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_HEIGHT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_HEIGHT_MM, """")",NOM,BLACK,2.0,None,None
@@ -2060,7 +2060,7 @@ TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Handrails
 Tag Family #33: STING - Vertical Circulation Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Vertical Circulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2113,7 +2113,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Vertical Circulation
 Tag Family #34: STING - Architectural Sheet Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets — Architectural discipline
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2145,7 +2145,7 @@ TAG7: SHT_TAG_7_TXT  •  Category: Sheets — Architectural discipline
 Tag Family #35: STING - Architectural Column Tag
 TAG7: ARCH_TAG_7_PARA_COLUMNS_TXT  •  Category: Columns — Architectural discipline
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STRUCT_COLUMN_SZ_TXT,Size:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STRUCT_COLUMN_SZ_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2212,7 +2212,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Roofs / Walls / Curtain Wall
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,Common,Text,LPS Air Terminal Tag,ELC_LPS_AIRTERM_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH_DesignConstruction.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_ARCH_DesignConstruction.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - ARCH (COMPLETE with Warnings)
 Tag Family #1: STING - Wall Tag
 TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Walls
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_TYPE_CLASSIFICATION_TXT,Type:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_TYPE_CLASSIFICATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -289,7 +289,7 @@ TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Walls
 Tag Family #2: STING - Floor Tag
 TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Floors
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_FLR_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_FLR_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -345,7 +345,7 @@ TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Floors
 Tag Family #3: STING - Ceiling Tag
 TAG7: ARCH_TAG_7_PARA_CEIL_TXT  •  Category: Ceilings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_CEILING_TYPE_CLASSIFICATION_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_CEILING_TYPE_CLASSIFICATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -394,7 +394,7 @@ TAG7: ARCH_TAG_7_PARA_CEIL_TXT  •  Category: Ceilings
 Tag Family #4: STING - Roof Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roofs
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_ROOF_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -448,7 +448,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roofs
 Tag Family #5: STING - Door Tag
 TAG7: ARCH_TAG_7_PARA_DOOR_TXT  •  Category: Doors
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_DOOR_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_DOOR_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -502,7 +502,7 @@ TAG7: ARCH_TAG_7_PARA_DOOR_TXT  •  Category: Doors
 Tag Family #6: STING - Window Tag
 TAG7: ARCH_TAG_7_PARA_WIN_TXT  •  Category: Windows
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WINDOW_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WINDOW_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -554,7 +554,7 @@ TAG7: ARCH_TAG_7_PARA_WIN_TXT  •  Category: Windows
 Tag Family #7: STING - Room Tag
 TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Rooms
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -606,7 +606,7 @@ TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Rooms
 Tag Family #8: STING - Stair Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stairs
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STAIR_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -657,7 +657,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stairs
 Tag Family #9: STING - Ramp Tag
 TAG7: ARCH_TAG_7_PARA_RAMP_TXT  •  Category: Ramps
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAMP_SLOPE_PCT,Slope:,%,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAMP_SLOPE_PCT, """")",NOM,BLACK,2.0,None,None
@@ -703,7 +703,7 @@ TAG7: ARCH_TAG_7_PARA_RAMP_TXT  •  Category: Ramps
 Tag Family #10: STING - Railing Tag
 TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Railings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_HEIGHT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_HEIGHT_MM, """")",NOM,BLACK,2.0,None,None
@@ -748,7 +748,7 @@ TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Railings
 Tag Family #11: STING - Furniture Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -793,7 +793,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture
 Tag Family #12: STING - Casework Tag
 TAG7: ARCH_TAG_7_PARA_CASEWORK_TXT  •  Category: Casework
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_CASEWORK_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_CASEWORK_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -838,7 +838,7 @@ TAG7: ARCH_TAG_7_PARA_CASEWORK_TXT  •  Category: Casework
 Tag Family #13: STING - Curtain Panel Tag
 TAG7: ARCH_TAG_7_PARA_CURTAIN_TXT  •  Category: Curtain Panels
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_PANEL_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_PANEL_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -883,7 +883,7 @@ TAG7: ARCH_TAG_7_PARA_CURTAIN_TXT  •  Category: Curtain Panels
 Tag Family #14: STING - Curtain Wall Mullion Tag
 TAG7: ARCH_TAG_7_PARA_MULLION_TXT  •  Category: Curtain Wall Mullions
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_MULLION_DEPTH_MM,D:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_MULLION_DEPTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -930,7 +930,7 @@ TAG7: ARCH_TAG_7_PARA_MULLION_TXT  •  Category: Curtain Wall Mullions
 Tag Family #15: STING - Signage Tag
 TAG7: ARCH_TAG_7_PARA_SIGNAGE_TXT  •  Category: Signage
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_SIGN_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_SIGN_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -973,7 +973,7 @@ TAG7: ARCH_TAG_7_PARA_SIGNAGE_TXT  •  Category: Signage
 Tag Family #16: STING - Parking Tag
 TAG7: ARCH_TAG_7_PARA_PARKING_TXT  •  Category: Parking
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_PARK_BAY_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_PARK_BAY_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -1019,7 +1019,7 @@ TAG7: ARCH_TAG_7_PARA_PARKING_TXT  •  Category: Parking
 Tag Family #17: STING - Areas Tag
 TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Areas
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -1060,7 +1060,7 @@ TAG7: ARCH_TAG_7_PARA_ROOM_TXT  •  Category: Areas
 Tag Family #18: STING - Wall Sweeps Tag
 TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Wall Sweeps
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_TYPE_CLASSIFICATION_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_TYPE_CLASSIFICATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1101,7 +1101,7 @@ TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Wall Sweeps
 Tag Family #19: STING - Slab Edges Tag
 TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Slab Edges
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_FLR_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_FLR_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1143,7 +1143,7 @@ TAG7: ARCH_TAG_7_PARA_FLOOR_TXT  •  Category: Slab Edges
 Tag Family #20: STING - Roof Soffits Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roof Soffits
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_CEILING_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_CEILING_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1184,7 +1184,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Roof Soffits
 Tag Family #21: STING - Fascia Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Fascia
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_ROOF_COVERING_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_COVERING_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1225,7 +1225,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Fascia
 Tag Family #22: STING - Gutter Tag
 TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Gutters
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_ROOF_PLM_DRN_SYSTEM_TYPE_TXT,Drain:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_ROOF_PLM_DRN_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1267,7 +1267,7 @@ TAG7: ARCH_TAG_7_PARA_ROOF_TXT  •  Category: Gutters
 Tag Family #23: STING - Mass Tag
 TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Mass
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,GIA:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -1307,7 +1307,7 @@ TAG7: ARCH_TAG_7_PARA_WALL_TXT  •  Category: Mass
 Tag Family #24: STING - Furniture Systems Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture Systems
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1350,7 +1350,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Furniture Systems
 Tag Family #25: STING - Food Service Equipment Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Food Service Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1393,7 +1393,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Food Service Equipment
 Tag Family #26: STING - Medical Equipment Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Medical Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1436,7 +1436,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Medical Equipment
 Tag Family #27: STING - Entourage Tag
 TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Entourage
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1476,7 +1476,7 @@ TAG7: ARCH_TAG_7_PARA_FURNITURE_TXT  •  Category: Entourage
 Tag Family #28: STING - Stair Runs Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Runs
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STAIR_RISE_MM,R:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_RISE_MM, """")",NOM,BLACK,2.0,None,None
@@ -1521,7 +1521,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Runs
 Tag Family #29: STING - Stair Landings Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Landings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STAIR_WIDTH_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STAIR_WIDTH_MM, """")",NOM,BLACK,2.0,None,None
@@ -1563,7 +1563,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Landings
 Tag Family #30: STING - Stair Supports Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Supports
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_MATERIAL_TXT,Mat:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1604,7 +1604,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Stair Supports
 Tag Family #31: STING - Top Rails Tag
 TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Top Rails
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_HEIGHT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_HEIGHT_MM, """")",NOM,BLACK,2.0,None,None
@@ -1646,7 +1646,7 @@ TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Top Rails
 Tag Family #32: STING - Handrails Tag
 TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Handrails
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_RAILING_HEIGHT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_RAILING_HEIGHT_MM, """")",NOM,BLACK,2.0,None,None
@@ -1688,7 +1688,7 @@ TAG7: ARCH_TAG_7_PARA_RAILING_TXT  •  Category: Handrails
 Tag Family #33: STING - Vertical Circulation Tag
 TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Vertical Circulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1729,7 +1729,7 @@ TAG7: ARCH_TAG_7_PARA_STAIR_TXT  •  Category: Vertical Circulation
 Tag Family #34: STING - Architectural Sheet Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets — Architectural discipline
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1767,7 +1767,7 @@ TAG7: SHT_TAG_7_TXT  •  Category: Sheets — Architectural discipline
 Tag Family #35: STING - Architectural Column Tag
 TAG7: ARCH_TAG_7_PARA_COLUMNS_TXT  •  Category: Columns — Architectural discipline
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STRUCT_COLUMN_SZ_TXT,Size:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STRUCT_COLUMN_SZ_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1822,7 +1822,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Roofs / Walls / Curtain Wall
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,Common,Text,LPS Air Terminal Tag,ELC_LPS_AIRTERM_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - GEN (COMPLETE with Warnings)
 Tag Family #1: STING - Generic Model Tag
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Generic Models
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -284,7 +284,7 @@ TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Generic Models
 Tag Family #2: STING - Specialty Equipment Tag
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -339,7 +339,7 @@ TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 Tag Family #3: STING - Site Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Site
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -393,7 +393,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Site
 Tag Family #4: STING - Planting Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Planting
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,GEN_SPECIES_TXT,Species:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, GEN_SPECIES_TXT, """")",NOM,BLACK,2.0,None,None
@@ -444,7 +444,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Planting
 Tag Family #5: STING - Hardscape Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Hardscape
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_EXTERIOR_FINISH_TXT,Fin:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_EXTERIOR_FINISH_TXT, """")",NOM,BLACK,2.0,None,None
@@ -495,7 +495,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Hardscape
 Tag Family #6: STING - Roads Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Roads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,GEN_ROAD_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, GEN_ROAD_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -546,7 +546,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Roads
 Tag Family #7: STING - Pads Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Pads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_THICKNESS_MM,Thickness:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_THICKNESS_MM, """")",NOM,BLACK,2.0,None,None
@@ -597,7 +597,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Pads
 Tag Family #8: STING - Toposolid Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_MAT_ELEM_TYPE_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_MAT_ELEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -647,7 +647,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid
 Tag Family #9: STING - Parts Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Parts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -691,7 +691,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Parts
 Tag Family #10: STING - Assemblies Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Assemblies
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Code:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -736,7 +736,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Assemblies
 Tag Family #11: STING - Detail Items Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Detail Items
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -784,7 +784,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Detail Items
 Tag Family #12: STING - Profiles Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Profiles
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -832,7 +832,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Profiles
 Tag Family #13: STING - Materials Tag
 TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T1,MAT_NAME,,,0,✓,Common,Text,Show Tier 1 - 2,Add directly,NOM,BLACK,2.5,None,None
 3,T1,MAT_CATEGORY,,,0,✓,Common,Text,Show Tier 1 - 3,Add directly,NOM,BLACK,2.5,None,None
 4,T2,MAT_MANUFACTURER,Mfr:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MAT_MANUFACTURER, """")",NOM,BLACK,2.0,None,None
@@ -898,7 +898,7 @@ TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 Tag Family #14: STING - Point Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Point Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_POINT_LOAD_KN,,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_POINT_LOAD_KN, """")",NOM,BLACK,2.0,None,None
@@ -943,7 +943,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Point Loads
 Tag Family #15: STING - Line Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Line Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_LINE_LOAD_KN_M,,kN/m,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_LINE_LOAD_KN_M, """")",NOM,BLACK,2.0,None,None
@@ -988,7 +988,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Line Loads
 Tag Family #16: STING - Area Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Area Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_AREA_LOAD_KN_M2,,kN/m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_AREA_LOAD_KN_M2, """")",NOM,BLACK,2.0,None,None
@@ -1033,7 +1033,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Area Loads
 Tag Family #17: STING - Internal Point Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_POINT_LOAD_KN,,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_POINT_LOAD_KN, """")",NOM,BLACK,2.0,None,None
@@ -1078,7 +1078,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 Tag Family #18: STING - Internal Line Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_LINE_LOAD_KN_M,,kN/m,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_LINE_LOAD_KN_M, """")",NOM,BLACK,2.0,None,None
@@ -1123,7 +1123,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 Tag Family #19: STING - Internal Area Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_AREA_LOAD_KN_M2,,kN/m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_AREA_LOAD_KN_M2, """")",NOM,BLACK,2.0,None,None
@@ -1169,7 +1169,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 Tag Family #20: STING - Analytical Members Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_SECTION_PROFILE_TXT,Section:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_SECTION_PROFILE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1214,7 +1214,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 Tag Family #21: STING - Analytical Nodes Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Nodes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,STR_TAG_7_PARA_ANLYT_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_ANLYT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1257,7 +1257,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Nodes
 Tag Family #22: STING - Analytical Panels Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Panels
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_MATERIAL_GRADE_TXT,Grade:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_MATERIAL_GRADE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1301,7 +1301,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Panels
 Tag Family #23: STING - Analytical Openings Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Openings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,STR_TAG_7_PARA_ANLYT_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_ANLYT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1344,7 +1344,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Openings
 Tag Family #24: STING - Analytical Links Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Links
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,STR_TAG_7_PARA_ANLYT_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_ANLYT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1388,7 +1388,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Links
 Tag Family #25: STING - Model Groups Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Model Groups
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1431,7 +1431,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Model Groups
 Tag Family #26: STING - RVT Links Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: RVT Links
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1474,7 +1474,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: RVT Links
 Tag Family #27: STING - Property Lines Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Lines
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,RGL_PLOT_AREA_SQ_M,,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_PLOT_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -1518,7 +1518,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Lines
 Tag Family #28: STING - Property Line Segments Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Line Segments
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,ARCH_TAG_7_PARA_SITE_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_SITE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1561,7 +1561,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Line Segments
 Tag Family #29: STING - Bolt Tag
 TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Bolt
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BOLT_GRADE_TXT,Grade:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BOLT_GRADE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1613,7 +1613,7 @@ TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Bolt
 Tag Family #30: STING - Toposolid Links Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid Links
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,ARCH_TAG_7_PARA_SITE_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_SITE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1656,7 +1656,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid Links
 Tag Family #31: STING - Weld Tag
 TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Weld
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_WELD_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_WELD_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1708,7 +1708,7 @@ TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Weld
 Tag Family #32: STING - Wire Tag
 TAG7: ELC_TAG_7_PARA_CIRC_TXT  •  Category: Wire
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_WIRE_SIZE_TXT,Size:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_WIRE_SIZE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1760,7 +1760,7 @@ TAG7: ELC_TAG_7_PARA_CIRC_TXT  •  Category: Wire
 Tag Family #33: STING - Sheet Document Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets (ViewSheet)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1812,7 +1812,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Generic Models / Specialty Equipmen
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -1863,7 +1863,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Generic Models / Specialty Equipmen
 Tag Family #35: STING - Specialty Equipment Tag Asset
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_SERIAL_NR_TXT,Ser:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_SERIAL_NR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1918,7 +1918,7 @@ TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 Tag Family #36: STING - Specialty Equipment Tag General
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN_DesignConstruction.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_GEN_DesignConstruction.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - GEN (COMPLETE with Warnings)
 Tag Family #1: STING - Generic Model Tag
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Generic Models
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -272,7 +272,7 @@ TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Generic Models
 Tag Family #2: STING - Specialty Equipment Tag
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -315,7 +315,7 @@ TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 Tag Family #3: STING - Site Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Site
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -357,7 +357,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Site
 Tag Family #4: STING - Planting Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Planting
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,GEN_SPECIES_TXT,Species:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, GEN_SPECIES_TXT, """")",NOM,BLACK,2.0,None,None
@@ -396,7 +396,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Planting
 Tag Family #5: STING - Hardscape Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Hardscape
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_EXTERIOR_FINISH_TXT,Fin:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_EXTERIOR_FINISH_TXT, """")",NOM,BLACK,2.0,None,None
@@ -435,7 +435,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Hardscape
 Tag Family #6: STING - Roads Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Roads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,GEN_ROAD_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, GEN_ROAD_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -474,7 +474,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Roads
 Tag Family #7: STING - Pads Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Pads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_THICKNESS_MM,Thickness:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_THICKNESS_MM, """")",NOM,BLACK,2.0,None,None
@@ -513,7 +513,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Pads
 Tag Family #8: STING - Toposolid Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_MAT_ELEM_TYPE_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_MAT_ELEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -551,7 +551,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid
 Tag Family #9: STING - Parts Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Parts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -589,7 +589,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Parts
 Tag Family #10: STING - Assemblies Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Assemblies
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_PRODCT_COD_TXT,Code:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -628,7 +628,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Assemblies
 Tag Family #11: STING - Detail Items Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Detail Items
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -664,7 +664,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Detail Items
 Tag Family #12: STING - Profiles Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Profiles
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -700,7 +700,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Profiles
 Tag Family #13: STING - Materials Tag
 TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T1,MAT_NAME,,,0,✓,Common,Text,Show Tier 1 - 2,Add directly,NOM,BLACK,2.5,None,None
 3,T1,MAT_CATEGORY,,,0,✓,Common,Text,Show Tier 1 - 3,Add directly,NOM,BLACK,2.5,None,None
 4,T2,MAT_MANUFACTURER,Mfr:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MAT_MANUFACTURER, """")",NOM,BLACK,2.0,None,None
@@ -754,7 +754,7 @@ TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 Tag Family #14: STING - Point Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Point Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_POINT_LOAD_KN,,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_POINT_LOAD_KN, """")",NOM,BLACK,2.0,None,None
@@ -793,7 +793,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Point Loads
 Tag Family #15: STING - Line Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Line Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_LINE_LOAD_KN_M,,kN/m,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_LINE_LOAD_KN_M, """")",NOM,BLACK,2.0,None,None
@@ -832,7 +832,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Line Loads
 Tag Family #16: STING - Area Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Area Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_AREA_LOAD_KN_M2,,kN/m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_AREA_LOAD_KN_M2, """")",NOM,BLACK,2.0,None,None
@@ -871,7 +871,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Area Loads
 Tag Family #17: STING - Internal Point Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_POINT_LOAD_KN,,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_POINT_LOAD_KN, """")",NOM,BLACK,2.0,None,None
@@ -910,7 +910,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 Tag Family #18: STING - Internal Line Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_LINE_LOAD_KN_M,,kN/m,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_LINE_LOAD_KN_M, """")",NOM,BLACK,2.0,None,None
@@ -949,7 +949,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 Tag Family #19: STING - Internal Area Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_AREA_LOAD_KN_M2,,kN/m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_AREA_LOAD_KN_M2, """")",NOM,BLACK,2.0,None,None
@@ -989,7 +989,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 Tag Family #20: STING - Analytical Members Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_SECTION_PROFILE_TXT,Section:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_SECTION_PROFILE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1028,7 +1028,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 Tag Family #21: STING - Analytical Nodes Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Nodes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,STR_TAG_7_PARA_ANLYT_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_ANLYT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1065,7 +1065,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Nodes
 Tag Family #22: STING - Analytical Panels Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Panels
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_MATERIAL_GRADE_TXT,Grade:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_MATERIAL_GRADE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1103,7 +1103,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Panels
 Tag Family #23: STING - Analytical Openings Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Openings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,STR_TAG_7_PARA_ANLYT_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_ANLYT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1140,7 +1140,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Openings
 Tag Family #24: STING - Analytical Links Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Links
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,STR_TAG_7_PARA_ANLYT_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, STR_TAG_7_PARA_ANLYT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1178,7 +1178,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Links
 Tag Family #25: STING - Model Groups Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Model Groups
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1215,7 +1215,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: Model Groups
 Tag Family #26: STING - RVT Links Tag
 TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: RVT Links
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,GEN_TAG_7_PARA_MISC_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, GEN_TAG_7_PARA_MISC_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1252,7 +1252,7 @@ TAG7: GEN_TAG_7_PARA_MISC_TXT  •  Category: RVT Links
 Tag Family #27: STING - Property Lines Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Lines
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,RGL_PLOT_AREA_SQ_M,,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_PLOT_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -1290,7 +1290,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Lines
 Tag Family #28: STING - Property Line Segments Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Line Segments
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,ARCH_TAG_7_PARA_SITE_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_SITE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1327,7 +1327,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Property Line Segments
 Tag Family #29: STING - Bolt Tag
 TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Bolt
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BOLT_GRADE_TXT,Grade:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BOLT_GRADE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1367,7 +1367,7 @@ TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Bolt
 Tag Family #30: STING - Toposolid Links Tag
 TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid Links
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,ARCH_TAG_7_PARA_SITE_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ARCH_TAG_7_PARA_SITE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1404,7 +1404,7 @@ TAG7: GEN_TAG_7_PARA_SITE_TXT  •  Category: Toposolid Links
 Tag Family #31: STING - Weld Tag
 TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Weld
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_WELD_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_WELD_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1444,7 +1444,7 @@ TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Weld
 Tag Family #32: STING - Wire Tag
 TAG7: ELC_TAG_7_PARA_CIRC_TXT  •  Category: Wire
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_WIRE_SIZE_TXT,Size:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_WIRE_SIZE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1484,7 +1484,7 @@ TAG7: ELC_TAG_7_PARA_CIRC_TXT  •  Category: Wire
 Tag Family #33: STING - Sheet Document Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets (ViewSheet)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1536,7 +1536,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Generic Models / Specialty Equipmen
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -1576,7 +1576,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Generic Models / Specialty Equipmen
 Tag Family #35: STING - Specialty Equipment Tag Asset
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_SERIAL_NR_TXT,Ser:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_SERIAL_NR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1619,7 +1619,7 @@ TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 Tag Family #36: STING - Specialty Equipment Tag General
 TAG7: GEN_TAG_7_PARA_EQUIP_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_HEALTH.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_HEALTH.csv
@@ -2,71 +2,3426 @@
 # STING_TAG_CONFIG_v5_0_HEALTH.csv
 # Healthcare Pack — Tag families across H/MG/RP disciplines
 # Phase H-1, branch claude/research-hospital-design-0Uxbi
-# Updated: Phase 179 — added warning parameters for all 16 healthcare validators
+# Updated: Phase 187 SYNC — full style catalog + T1-T10 for all 58 families
 #   Warnings align with TAG_CONFIG_v5_0_VALIDATION.csv Section 15 (HEALTHCARE_RULE entries)
-#   and STING_TAG_CONFIG_v5_0_HEALTH_DesignConstruction.csv tier definitions
 # Format: TagFamilyName,TagDiscipline,Category,RoomBound,DefaultLabel,Description
-# Phase 187 SYNC: TagFamilyCreatorCommand HealthcareVariantFamilies (58 entries) wired in; LABEL_DEFINITIONS.json category_labels backfilled with 58 healthcare entries; MR_PARAMETERS.txt +35 healthcare WARN params (CLN/MGS/RAD/CEQ/LIG/ELC/FAB/PLM). UPDATED=2026-05-20.
+# UPDATED=2026-06-09
+
+# ── TAG_FAMILY MANIFEST ──────────────────────────────────────────────────────
+# Format: TAG_FAMILY,FamilyName,Discipline,Category,RoomBound,DefaultLabelParam,Description
 TAG_FAMILY,STING - Clinical Room Tag,H,Rooms,1,CLN_ROOM_CLASS_TXT,Clinical room class label
-TAG_FAMILY,STING - Pressure Regime Tag,H,Rooms,1,CLN_PRESS_REGIME_TXT,Pressure cascade arrow + Δp
+TAG_FAMILY,STING - Pressure Regime Tag,H,Rooms,1,CLN_PRESS_REGIME_TXT,Pressure cascade arrow + delta-P
 TAG_FAMILY,STING - Infection Class Tag,H,Rooms,1,CLN_INFECT_CLASS_TXT,AIIR/PE banner
 TAG_FAMILY,STING - MRI Zone Tag,H,Generic Models,0,CLN_MRI_ZONE_INT,MRI Z1..Z4 zoning marker
-TAG_FAMILY,STING - Anti-Ligature (Door) Tag,H,Doors,0,LIG_PRODUCT_RATING_TXT,Anti-ligature fitting rating
-TAG_FAMILY,STING - Anti-Ligature (Plumbing Fixture) Tag,H,Plumbing Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature fitting rating
-TAG_FAMILY,STING - Anti-Ligature (Lighting Fixture) Tag,H,Lighting Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature fitting rating
-TAG_FAMILY,STING - Bedhead Trunking Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Bedhead trunking/services unit
-TAG_FAMILY,STING - Pendant Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Operating room / ICU pendant
-TAG_FAMILY,STING - Scrub Trough Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Pre-operative scrub trough
-TAG_FAMILY,STING - Hoist Track Tag,H,Generic Models,0,CLN_HOIST_TRACK_BOOL,Ceiling hoist track
-TAG_FAMILY,STING - Bariatric Tag,H,Rooms,1,CLN_BARI_DESIGN_KG_NR,Bariatric SWL marker
-TAG_FAMILY,STING - Nurse Call Tag,H,Nurse Call Devices,0,CLN_NURSECALL_TYPE_TXT,Nurse call station/post
-TAG_FAMILY,STING - Crash Cart Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Crash cart location
-TAG_FAMILY,STING - AED Cabinet Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,AED cabinet
-TAG_FAMILY,STING - Hand-Rub Dispenser Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Hand-rub dispenser
-TAG_FAMILY,STING - PTS Station Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Pneumatic tube station
-TAG_FAMILY,STING - AGV Dock Tag,H,Generic Models,0,CEQ_CATEGORY_TXT,AGV docking point
-TAG_FAMILY,STING - Mortuary Fridge Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Mortuary refrigeration
-TAG_FAMILY,STING - Imaging Modality Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,CT/MRI/X-ray/PET/Linac
-TAG_FAMILY,STING - Dialysis Station Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Dialysis chair / RO drop
-TAG_FAMILY,STING - Incubator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Neonatal incubator
-TAG_FAMILY,STING - Warming Cot Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Warming cot
-TAG_FAMILY,STING - Autoclave Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Sterilizer / autoclave
-TAG_FAMILY,STING - Washer Disinfector Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Washer-disinfector (HSDU)
-TAG_FAMILY,STING - Bedpan Washer Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Bedpan washer
-TAG_FAMILY,STING - Patient Monitor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Patient monitoring device
-TAG_FAMILY,STING - Medical Refrigerator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Medical refrigerator (pharmacy / lab)
-TAG_FAMILY,STING - Pharmacy Isolator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,USP <797> / <800> isolator
-TAG_FAMILY,STING - Operating Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Operating room surgical light
-TAG_FAMILY,STING - Examination Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Mobile / mounted exam light
-TAG_FAMILY,STING - HBO Chamber Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Hyperbaric oxygen chamber
-TAG_FAMILY,STING - Birth Pool Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Maternity birthing pool
-TAG_FAMILY,STING - IVF Workstation Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,IVF / ART laminar flow workstation
-TAG_FAMILY,STING - Cytotoxic Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Cytotoxic compounding hood
-TAG_FAMILY,STING - Lab Fume Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Laboratory fume hood (pathology)
-TAG_FAMILY,STING - Biosafety Cabinet Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,BSC Class II/III
-TAG_FAMILY,STING - Endoscope Reprocessor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Endoscope reprocessor (HTM 01-06)
-TAG_FAMILY,STING - Surgical Robot Bay Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Surgical robot envelope
-TAG_FAMILY,STING - RTLS Reader Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Real-time location reader
-TAG_FAMILY,STING - Medical Gas Pipeline Tag,MG,Pipes,0,MGS_GAS_TYPE_TXT,MGPS pipework
-TAG_FAMILY,STING - Medical Gas Terminal Unit Tag,MG,Plumbing Fixtures,0,MGS_GAS_TYPE_TXT,BS 5682 terminal unit
-TAG_FAMILY,STING - Zone Valve Box Tag,MG,Pipe Accessories,0,MGS_ZVB_REF_TXT,MGPS zone valve box
-TAG_FAMILY,STING - Area Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,MGPS area alarm panel
-TAG_FAMILY,STING - Master Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,MGPS master alarm panel
-TAG_FAMILY,STING - Manifold Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,MGPS manifold / cylinder bank
-TAG_FAMILY,STING - VIE Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Vacuum Insulated Evaporator (LOX)
-TAG_FAMILY,STING - Medical Air Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical air compressor plant
-TAG_FAMILY,STING - Medical Vacuum Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical vacuum pump plant
-TAG_FAMILY,STING - AGS Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,AGS receiver plant
-TAG_FAMILY,STING - X-ray Barrier Tag,RP,Walls,0,RAD_LEAD_MM_NR,X-ray shielded wall (mm Pb)
-TAG_FAMILY,STING - X-ray Door Tag,RP,Doors,0,RAD_LEAD_MM_NR,X-ray shielded door (mm Pb)
-TAG_FAMILY,STING - X-ray Window Tag,RP,Windows,0,RAD_LEAD_MM_NR,X-ray viewing window (mm Pb)
-TAG_FAMILY,STING - Linac Maze Tag,RP,Walls,0,RAD_LEAD_MM_NR,LINAC maze barrier
-TAG_FAMILY,STING - MRI Faraday Cage Tag,RP,Walls,0,CLN_RF_SHIELD_BOOL,MRI Faraday cage panel
-TAG_FAMILY,STING - 5-Gauss Marker Tag,RP,Generic Models,0,CLN_MRI_ZONE_INT,MRI 5-Gauss boundary marker
-TAG_FAMILY,STING - Controlled Area Sign Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Controlled / supervised area signage
-TAG_FAMILY,STING - Dosimetry Post Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Dosimetry monitoring post
+TAG_FAMILY,STING - Anti-Ligature (Door) Tag,H,Doors,0,LIG_PRODUCT_RATING_TXT,Anti-ligature door hardware rating
+TAG_FAMILY,STING - Anti-Ligature (Plumbing Fixture) Tag,H,Plumbing Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature plumbing fixture rating
+TAG_FAMILY,STING - Anti-Ligature (Lighting Fixture) Tag,H,Lighting Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature lighting fitting rating
+TAG_FAMILY,STING - Bedhead Trunking Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Bedhead trunking unit label
+TAG_FAMILY,STING - Pendant Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Theatre/ICU pendant label
+TAG_FAMILY,STING - Scrub Trough Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Surgical scrub trough label
+TAG_FAMILY,STING - Hoist Track Tag,H,Generic Models,0,CLN_HOIST_TRACK_BOOL,Overhead patient hoist track label
+TAG_FAMILY,STING - Bariatric Tag,H,Rooms,1,CLN_BARI_DESIGN_KG_NR,Bariatric design load label
+TAG_FAMILY,STING - Nurse Call Tag,H,Nurse Call Devices,0,CLN_NURSECALL_TYPE_TXT,Nurse call point label
+TAG_FAMILY,STING - Crash Cart Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Resuscitation crash cart label
+TAG_FAMILY,STING - AED Cabinet Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,AED defibrillator cabinet label
+TAG_FAMILY,STING - Hand-Rub Dispenser Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Hand-hygiene dispenser label
+TAG_FAMILY,STING - PTS Station Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Pneumatic tube station label
+TAG_FAMILY,STING - AGV Dock Tag,H,Generic Models,0,CEQ_CATEGORY_TXT,Autonomous guided vehicle docking label
+TAG_FAMILY,STING - Mortuary Fridge Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Mortuary refrigeration unit label
+TAG_FAMILY,STING - Imaging Modality Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Imaging modality equipment label
+TAG_FAMILY,STING - Dialysis Station Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Renal dialysis station label
+TAG_FAMILY,STING - Incubator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Neonatal incubator label
+TAG_FAMILY,STING - Warming Cot Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Neonatal warming cot label
+TAG_FAMILY,STING - Autoclave Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,CSSD autoclave label
+TAG_FAMILY,STING - Washer Disinfector Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,CSSD washer-disinfector label
+TAG_FAMILY,STING - Bedpan Washer Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Bedpan washer/macerator label
+TAG_FAMILY,STING - Patient Monitor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Bedside patient monitoring label
+TAG_FAMILY,STING - Medical Refrigerator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Medical/pharmacy refrigerator label
+TAG_FAMILY,STING - Pharmacy Isolator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Pharmacy isolator/laminar flow label
+TAG_FAMILY,STING - Operating Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Surgical operating light label
+TAG_FAMILY,STING - Examination Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Clinical examination light label
+TAG_FAMILY,STING - HBO Chamber Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Hyperbaric oxygen chamber label
+TAG_FAMILY,STING - Birth Pool Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Birthing pool label
+TAG_FAMILY,STING - IVF Workstation Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,IVF/embryology workstation label
+TAG_FAMILY,STING - Cytotoxic Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Cytotoxic preparation hood label
+TAG_FAMILY,STING - Lab Fume Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Laboratory fume cupboard label
+TAG_FAMILY,STING - Biosafety Cabinet Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Biosafety cabinet label
+TAG_FAMILY,STING - Endoscope Reprocessor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Endoscope washer-disinfector label
+TAG_FAMILY,STING - Surgical Robot Bay Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Surgical robot installation bay label
+TAG_FAMILY,STING - RTLS Reader Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Real-time location system reader label
+TAG_FAMILY,STING - Medical Gas Pipeline Tag,MG,Pipes,0,MGS_GAS_TYPE_TXT,Medical gas pipeline service label
+TAG_FAMILY,STING - Medical Gas Terminal Unit Tag,MG,Plumbing Fixtures,0,MGS_GAS_TYPE_TXT,BS 5682 terminal unit label
+TAG_FAMILY,STING - Zone Valve Box Tag,MG,Pipe Accessories,0,MGS_ZVB_REF_TXT,Zone valve box reference label
+TAG_FAMILY,STING - Area Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,Area alarm panel reference label
+TAG_FAMILY,STING - Master Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,Master alarm panel reference label
+TAG_FAMILY,STING - Manifold Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Cylinder manifold label
+TAG_FAMILY,STING - VIE Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Vacuum insulated evaporator label
+TAG_FAMILY,STING - Medical Air Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical air compressor plant label
+TAG_FAMILY,STING - Medical Vacuum Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical vacuum plant label
+TAG_FAMILY,STING - AGS Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Anaesthetic gas scavenging plant label
+TAG_FAMILY,STING - X-ray Barrier Tag,RP,Walls,0,RAD_LEAD_MM_NR,X-ray primary/secondary barrier label
+TAG_FAMILY,STING - X-ray Door Tag,RP,Doors,0,RAD_LEAD_MM_NR,X-ray shielded door label
+TAG_FAMILY,STING - X-ray Window Tag,RP,Windows,0,RAD_LEAD_MM_NR,X-ray observation window label
+TAG_FAMILY,STING - Linac Maze Tag,RP,Walls,0,RAD_LEAD_MM_NR,Linac maze shielding label
+TAG_FAMILY,STING - MRI Faraday Cage Tag,RP,Walls,0,CLN_RF_SHIELD_BOOL,MRI RF shielding label
+TAG_FAMILY,STING - 5-Gauss Marker Tag,RP,Generic Models,0,CLN_MRI_ZONE_INT,MRI 5-gauss boundary marker
+TAG_FAMILY,STING - Controlled Area Sign Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Radiation controlled area sign label
+TAG_FAMILY,STING - Dosimetry Post Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Radiation dosimetry monitoring post label
 
-# ═══════════════════════════════════════════════════════════════════════════════
+# ──────────────────────────────────────────────────────────────────────────
+# STYLE CATALOG — 150 visibility parameters injected into every tag family
+# ──────────────────────────────────────────────────────────────────────────
+#!STYLE_CATALOG_BEGIN
+#,Group,Parameter,Datatype,Default,Category,Role,Description
+1,TextStyle,TAG_2NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLACK
+2,TextStyle,TAG_2NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLUE
+3,TextStyle,TAG_2NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREEN
+4,TextStyle,TAG_2NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM RED
+5,TextStyle,TAG_2NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM ORANGE
+6,TextStyle,TAG_2NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM PURPLE
+7,TextStyle,TAG_2NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREY
+8,TextStyle,TAG_2NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM WHITE
+9,TextStyle,TAG_2BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLACK
+10,TextStyle,TAG_2BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLUE
+11,TextStyle,TAG_2BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREEN
+12,TextStyle,TAG_2BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD RED
+13,TextStyle,TAG_2BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD ORANGE
+14,TextStyle,TAG_2BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD PURPLE
+15,TextStyle,TAG_2BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREY
+16,TextStyle,TAG_2BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD WHITE
+17,TextStyle,TAG_2ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLACK
+18,TextStyle,TAG_2ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLUE
+19,TextStyle,TAG_2ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREEN
+20,TextStyle,TAG_2ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC RED
+21,TextStyle,TAG_2ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC ORANGE
+22,TextStyle,TAG_2ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC PURPLE
+23,TextStyle,TAG_2ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREY
+24,TextStyle,TAG_2ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC WHITE
+25,TextStyle,TAG_2BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLACK
+26,TextStyle,TAG_2BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLUE
+27,TextStyle,TAG_2BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREEN
+28,TextStyle,TAG_2BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC RED
+29,TextStyle,TAG_2BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC ORANGE
+30,TextStyle,TAG_2BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC PURPLE
+31,TextStyle,TAG_2BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREY
+32,TextStyle,TAG_2BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC WHITE
+33,TextStyle,TAG_2.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLACK
+34,TextStyle,TAG_2.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLUE
+35,TextStyle,TAG_2.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREEN
+36,TextStyle,TAG_2.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM RED
+37,TextStyle,TAG_2.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM ORANGE
+38,TextStyle,TAG_2.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM PURPLE
+39,TextStyle,TAG_2.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREY
+40,TextStyle,TAG_2.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM WHITE
+41,TextStyle,TAG_2.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLACK
+42,TextStyle,TAG_2.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLUE
+43,TextStyle,TAG_2.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREEN
+44,TextStyle,TAG_2.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD RED
+45,TextStyle,TAG_2.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD ORANGE
+46,TextStyle,TAG_2.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD PURPLE
+47,TextStyle,TAG_2.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREY
+48,TextStyle,TAG_2.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD WHITE
+49,TextStyle,TAG_2.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLACK
+50,TextStyle,TAG_2.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLUE
+51,TextStyle,TAG_2.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREEN
+52,TextStyle,TAG_2.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC RED
+53,TextStyle,TAG_2.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC ORANGE
+54,TextStyle,TAG_2.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC PURPLE
+55,TextStyle,TAG_2.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREY
+56,TextStyle,TAG_2.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC WHITE
+57,TextStyle,TAG_2.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLACK
+58,TextStyle,TAG_2.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLUE
+59,TextStyle,TAG_2.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREEN
+60,TextStyle,TAG_2.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC RED
+61,TextStyle,TAG_2.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC ORANGE
+62,TextStyle,TAG_2.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC PURPLE
+63,TextStyle,TAG_2.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREY
+64,TextStyle,TAG_2.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC WHITE
+65,TextStyle,TAG_3NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLACK
+66,TextStyle,TAG_3NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLUE
+67,TextStyle,TAG_3NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREEN
+68,TextStyle,TAG_3NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM RED
+69,TextStyle,TAG_3NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM ORANGE
+70,TextStyle,TAG_3NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM PURPLE
+71,TextStyle,TAG_3NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREY
+72,TextStyle,TAG_3NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM WHITE
+73,TextStyle,TAG_3BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLACK
+74,TextStyle,TAG_3BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLUE
+75,TextStyle,TAG_3BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREEN
+76,TextStyle,TAG_3BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD RED
+77,TextStyle,TAG_3BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD ORANGE
+78,TextStyle,TAG_3BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD PURPLE
+79,TextStyle,TAG_3BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREY
+80,TextStyle,TAG_3BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD WHITE
+81,TextStyle,TAG_3ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLACK
+82,TextStyle,TAG_3ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLUE
+83,TextStyle,TAG_3ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREEN
+84,TextStyle,TAG_3ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC RED
+85,TextStyle,TAG_3ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC ORANGE
+86,TextStyle,TAG_3ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC PURPLE
+87,TextStyle,TAG_3ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREY
+88,TextStyle,TAG_3ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC WHITE
+89,TextStyle,TAG_3BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLACK
+90,TextStyle,TAG_3BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLUE
+91,TextStyle,TAG_3BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREEN
+92,TextStyle,TAG_3BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC RED
+93,TextStyle,TAG_3BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC ORANGE
+94,TextStyle,TAG_3BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC PURPLE
+95,TextStyle,TAG_3BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREY
+96,TextStyle,TAG_3BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC WHITE
+97,TextStyle,TAG_3.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLACK
+98,TextStyle,TAG_3.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLUE
+99,TextStyle,TAG_3.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREEN
+100,TextStyle,TAG_3.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM RED
+101,TextStyle,TAG_3.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM ORANGE
+102,TextStyle,TAG_3.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM PURPLE
+103,TextStyle,TAG_3.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREY
+104,TextStyle,TAG_3.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM WHITE
+105,TextStyle,TAG_3.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLACK
+106,TextStyle,TAG_3.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLUE
+107,TextStyle,TAG_3.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREEN
+108,TextStyle,TAG_3.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD RED
+109,TextStyle,TAG_3.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD ORANGE
+110,TextStyle,TAG_3.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD PURPLE
+111,TextStyle,TAG_3.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREY
+112,TextStyle,TAG_3.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD WHITE
+113,TextStyle,TAG_3.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLACK
+114,TextStyle,TAG_3.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLUE
+115,TextStyle,TAG_3.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREEN
+116,TextStyle,TAG_3.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC RED
+117,TextStyle,TAG_3.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC ORANGE
+118,TextStyle,TAG_3.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC PURPLE
+119,TextStyle,TAG_3.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREY
+120,TextStyle,TAG_3.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC WHITE
+121,TextStyle,TAG_3.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLACK
+122,TextStyle,TAG_3.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLUE
+123,TextStyle,TAG_3.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREEN
+124,TextStyle,TAG_3.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC RED
+125,TextStyle,TAG_3.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC ORANGE
+126,TextStyle,TAG_3.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC PURPLE
+127,TextStyle,TAG_3.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREY
+128,TextStyle,TAG_3.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC WHITE
+129,TierGate,TAG_PARA_STATE_1_BOOL,TEXT,Yes,Common,Switch,Shows tier 1 rows when true (depth N enables 1..N cumulatively)
+130,TierGate,TAG_PARA_STATE_2_BOOL,TEXT,No,Common,Switch,Shows tier 2 rows when true (depth N enables 1..N cumulatively)
+131,TierGate,TAG_PARA_STATE_3_BOOL,TEXT,No,Common,Switch,Shows tier 3 rows when true (depth N enables 1..N cumulatively)
+132,TierGate,TAG_PARA_STATE_4_BOOL,TEXT,No,Common,Switch,Shows tier 4 rows when true (depth N enables 1..N cumulatively)
+133,TierGate,TAG_PARA_STATE_5_BOOL,TEXT,No,Common,Switch,Shows tier 5 rows when true (depth N enables 1..N cumulatively)
+134,TierGate,TAG_PARA_STATE_6_BOOL,TEXT,No,Common,Switch,Shows tier 6 rows when true (depth N enables 1..N cumulatively)
+135,TierGate,TAG_PARA_STATE_7_BOOL,TEXT,No,Common,Switch,Shows tier 7 rows when true (depth N enables 1..N cumulatively)
+136,TierGate,TAG_PARA_STATE_8_BOOL,TEXT,No,Common,Switch,Shows tier 8 rows when true (depth N enables 1..N cumulatively)
+137,TierGate,TAG_PARA_STATE_9_BOOL,TEXT,No,Common,Switch,Shows tier 9 rows when true (depth N enables 1..N cumulatively)
+138,TierGate,TAG_PARA_STATE_10_BOOL,TEXT,No,Common,Switch,Shows tier 10 rows when true (depth N enables 1..N cumulatively)
+139,Warning,TAG_WARN_VISIBLE_BOOL,YESNO,0,Common,Switch,Shows threshold warnings on the tag
+140,Warning,TAG_WARN_SEVERITY_FILTER_TXT,TEXT,HIGH,Common,Filter,Minimum warning severity to show (LOW | MEDIUM | HIGH | CRITICAL)
+141,Box,TAG_BOX_COLOR_R_INT,INTEGER,0,Common,Colour,Tag box colour — red channel 0-255
+142,Box,TAG_BOX_COLOR_G_INT,INTEGER,0,Common,Colour,Tag box colour — green channel 0-255
+143,Box,TAG_BOX_COLOR_B_INT,INTEGER,0,Common,Colour,Tag box colour — blue channel 0-255
+144,Box,TAG_BOX_VISIBLE_BOOL,YESNO,1,Common,Switch,Shows / hides the tag box
+145,Box,TAG_BOX_STYLE_TXT,TEXT,SOLID,Common,Style,Tag box style (SOLID | DASHED | NONE | ROUND)
+146,Leader,TAG_LEADER_COLOR_R_INT,INTEGER,0,Common,Colour,Leader colour — red channel 0-255
+147,Leader,TAG_LEADER_COLOR_G_INT,INTEGER,0,Common,Colour,Leader colour — green channel 0-255
+148,Leader,TAG_LEADER_COLOR_B_INT,INTEGER,0,Common,Colour,Leader colour — blue channel 0-255
+149,Scale,TAG_SCALE_TIER_AUTO_BOOL,YESNO,1,Common,Switch,Auto-compute depth tier from view scale
+150,Scale,TAG_DEPTH_TIER_INT,INTEGER,3,Common,Cache,Current depth tier (cached for fast redraw)
+#!STYLE_CATALOG_END
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TIER LABEL CONFIGURATION — Handover variant (T1-T10, 58 families)
+# Column order: #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ── Tag Family #1: STING - Clinical Room Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_CR_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_CR_A_TXT,,,0,,H,Text,Show T7 - CR Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_CR_B_TXT,,,0,,H,Text,Show T7 - CR Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_CR_C_TXT,,,0,,H,Text,Show T7 - CR Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_CR_D_TXT,,,0,,H,Text,Show T7 - CR Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_CR_E_TXT,,,0,,H,Text,Show T7 - CR Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_CR_F_TXT,,,0,✓,H,Text,Show T7 - CR Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #2: STING - Pressure Regime Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PR_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_PR_A_TXT,,,0,,H,Text,Show T7 - PR Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_PR_B_TXT,,,0,,H,Text,Show T7 - PR Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_PR_C_TXT,,,0,,H,Text,Show T7 - PR Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_PR_D_TXT,,,0,,H,Text,Show T7 - PR Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_PR_E_TXT,,,0,,H,Text,Show T7 - PR Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_PR_F_TXT,,,0,✓,H,Text,Show T7 - PR Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #3: STING - Infection Class Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_IC_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_IC_A_TXT,,,0,,H,Text,Show T7 - IC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_IC_B_TXT,,,0,,H,Text,Show T7 - IC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_IC_C_TXT,,,0,,H,Text,Show T7 - IC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_IC_D_TXT,,,0,,H,Text,Show T7 - IC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_IC_E_TXT,,,0,,H,Text,Show T7 - IC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_IC_F_TXT,,,0,✓,H,Text,Show T7 - IC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #4: STING - MRI Zone Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_MZ_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_MZ_A_TXT,,,0,,H,Text,Show T7 - MZ Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_MZ_B_TXT,,,0,,H,Text,Show T7 - MZ Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_MZ_C_TXT,,,0,,H,Text,Show T7 - MZ Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_MZ_D_TXT,,,0,,H,Text,Show T7 - MZ Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_MZ_E_TXT,,,0,,H,Text,Show T7 - MZ Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_MZ_F_TXT,,,0,✓,H,Text,Show T7 - MZ Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #5: STING - Anti-Ligature (Door) Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ALD_[A-F]_TXT  •  Discipline: H  •  Template: H_LIG
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,LIG_PRODUCT_RATING_TXT,Rating:,,0,,H,Text,Show T2 - Anti-Ligature Product Rating,"if(TAG_PARA_STATE_2_BOOL, LIG_PRODUCT_RATING_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,LIG_AREA_OBS_LOS_TXT,Obs LOS:,,0,,H,Text,Show T2 - Observation Line-of-Sight,"if(TAG_PARA_STATE_2_BOOL, LIG_AREA_OBS_LOS_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T3 - Serial Number,"if(TAG_PARA_STATE_3_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,✓,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_ALD_A_TXT,,,0,,H,Text,Show T7 - ALD Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_ALD_B_TXT,,,0,,H,Text,Show T7 - ALD Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_ALD_C_TXT,,,0,,H,Text,Show T7 - ALD Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_ALD_D_TXT,,,0,,H,Text,Show T7 - ALD Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_ALD_E_TXT,,,0,,H,Text,Show T7 - ALD Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_ALD_F_TXT,,,0,✓,H,Text,Show T7 - ALD Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #6: STING - Anti-Ligature (Plumbing Fixture) Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ALPF_[A-F]_TXT  •  Discipline: H  •  Template: H_LIG
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,LIG_PRODUCT_RATING_TXT,Rating:,,0,,H,Text,Show T2 - Anti-Ligature Product Rating,"if(TAG_PARA_STATE_2_BOOL, LIG_PRODUCT_RATING_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,LIG_AREA_OBS_LOS_TXT,Obs LOS:,,0,,H,Text,Show T2 - Observation Line-of-Sight,"if(TAG_PARA_STATE_2_BOOL, LIG_AREA_OBS_LOS_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T3 - Serial Number,"if(TAG_PARA_STATE_3_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,✓,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_ALPF_A_TXT,,,0,,H,Text,Show T7 - ALPF Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_ALPF_B_TXT,,,0,,H,Text,Show T7 - ALPF Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_ALPF_C_TXT,,,0,,H,Text,Show T7 - ALPF Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_ALPF_D_TXT,,,0,,H,Text,Show T7 - ALPF Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_ALPF_E_TXT,,,0,,H,Text,Show T7 - ALPF Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_ALPF_F_TXT,,,0,✓,H,Text,Show T7 - ALPF Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #7: STING - Anti-Ligature (Lighting Fixture) Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ALLF_[A-F]_TXT  •  Discipline: H  •  Template: H_LIG
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,LIG_PRODUCT_RATING_TXT,Rating:,,0,,H,Text,Show T2 - Anti-Ligature Product Rating,"if(TAG_PARA_STATE_2_BOOL, LIG_PRODUCT_RATING_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,LIG_AREA_OBS_LOS_TXT,Obs LOS:,,0,,H,Text,Show T2 - Observation Line-of-Sight,"if(TAG_PARA_STATE_2_BOOL, LIG_AREA_OBS_LOS_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T3 - Serial Number,"if(TAG_PARA_STATE_3_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,✓,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_ALLF_A_TXT,,,0,,H,Text,Show T7 - ALLF Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_ALLF_B_TXT,,,0,,H,Text,Show T7 - ALLF Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_ALLF_C_TXT,,,0,,H,Text,Show T7 - ALLF Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_ALLF_D_TXT,,,0,,H,Text,Show T7 - ALLF Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_ALLF_E_TXT,,,0,,H,Text,Show T7 - ALLF Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_ALLF_F_TXT,,,0,✓,H,Text,Show T7 - ALLF Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #8: STING - Bedhead Trunking Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BHT_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_BHT_A_TXT,,,0,,H,Text,Show T7 - BHT Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_BHT_B_TXT,,,0,,H,Text,Show T7 - BHT Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_BHT_C_TXT,,,0,,H,Text,Show T7 - BHT Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_BHT_D_TXT,,,0,,H,Text,Show T7 - BHT Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_BHT_E_TXT,,,0,,H,Text,Show T7 - BHT Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_BHT_F_TXT,,,0,✓,H,Text,Show T7 - BHT Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #9: STING - Pendant Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PND_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_PND_A_TXT,,,0,,H,Text,Show T7 - PND Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_PND_B_TXT,,,0,,H,Text,Show T7 - PND Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_PND_C_TXT,,,0,,H,Text,Show T7 - PND Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_PND_D_TXT,,,0,,H,Text,Show T7 - PND Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_PND_E_TXT,,,0,,H,Text,Show T7 - PND Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_PND_F_TXT,,,0,✓,H,Text,Show T7 - PND Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #10: STING - Scrub Trough Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ST_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_ST_A_TXT,,,0,,H,Text,Show T7 - ST Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_ST_B_TXT,,,0,,H,Text,Show T7 - ST Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_ST_C_TXT,,,0,,H,Text,Show T7 - ST Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_ST_D_TXT,,,0,,H,Text,Show T7 - ST Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_ST_E_TXT,,,0,,H,Text,Show T7 - ST Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_ST_F_TXT,,,0,✓,H,Text,Show T7 - ST Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #11: STING - Hoist Track Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_HT_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_HT_A_TXT,,,0,,H,Text,Show T7 - HT Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_HT_B_TXT,,,0,,H,Text,Show T7 - HT Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_HT_C_TXT,,,0,,H,Text,Show T7 - HT Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_HT_D_TXT,,,0,,H,Text,Show T7 - HT Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_HT_E_TXT,,,0,,H,Text,Show T7 - HT Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_HT_F_TXT,,,0,✓,H,Text,Show T7 - HT Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #12: STING - Bariatric Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BAR_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_BAR_A_TXT,,,0,,H,Text,Show T7 - BAR Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_BAR_B_TXT,,,0,,H,Text,Show T7 - BAR Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_BAR_C_TXT,,,0,,H,Text,Show T7 - BAR Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_BAR_D_TXT,,,0,,H,Text,Show T7 - BAR Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_BAR_E_TXT,,,0,,H,Text,Show T7 - BAR Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_BAR_F_TXT,,,0,✓,H,Text,Show T7 - BAR Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #13: STING - Nurse Call Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_NC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_NC_A_TXT,,,0,,H,Text,Show T7 - NC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_NC_B_TXT,,,0,,H,Text,Show T7 - NC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_NC_C_TXT,,,0,,H,Text,Show T7 - NC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_NC_D_TXT,,,0,,H,Text,Show T7 - NC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_NC_E_TXT,,,0,,H,Text,Show T7 - NC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_NC_F_TXT,,,0,✓,H,Text,Show T7 - NC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #14: STING - Crash Cart Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_CC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_CC_A_TXT,,,0,,H,Text,Show T7 - CC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_CC_B_TXT,,,0,,H,Text,Show T7 - CC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_CC_C_TXT,,,0,,H,Text,Show T7 - CC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_CC_D_TXT,,,0,,H,Text,Show T7 - CC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_CC_E_TXT,,,0,,H,Text,Show T7 - CC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_CC_F_TXT,,,0,✓,H,Text,Show T7 - CC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #15: STING - AED Cabinet Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_AED_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_AED_A_TXT,,,0,,H,Text,Show T7 - AED Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_AED_B_TXT,,,0,,H,Text,Show T7 - AED Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_AED_C_TXT,,,0,,H,Text,Show T7 - AED Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_AED_D_TXT,,,0,,H,Text,Show T7 - AED Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_AED_E_TXT,,,0,,H,Text,Show T7 - AED Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_AED_F_TXT,,,0,✓,H,Text,Show T7 - AED Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #16: STING - Hand-Rub Dispenser Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_HRD_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_HRD_A_TXT,,,0,,H,Text,Show T7 - HRD Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_HRD_B_TXT,,,0,,H,Text,Show T7 - HRD Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_HRD_C_TXT,,,0,,H,Text,Show T7 - HRD Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_HRD_D_TXT,,,0,,H,Text,Show T7 - HRD Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_HRD_E_TXT,,,0,,H,Text,Show T7 - HRD Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_HRD_F_TXT,,,0,✓,H,Text,Show T7 - HRD Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #17: STING - PTS Station Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PTS_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_PTS_A_TXT,,,0,,H,Text,Show T7 - PTS Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_PTS_B_TXT,,,0,,H,Text,Show T7 - PTS Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_PTS_C_TXT,,,0,,H,Text,Show T7 - PTS Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_PTS_D_TXT,,,0,,H,Text,Show T7 - PTS Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_PTS_E_TXT,,,0,,H,Text,Show T7 - PTS Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_PTS_F_TXT,,,0,✓,H,Text,Show T7 - PTS Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #18: STING - AGV Dock Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_AGV_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_AGV_A_TXT,,,0,,H,Text,Show T7 - AGV Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_AGV_B_TXT,,,0,,H,Text,Show T7 - AGV Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_AGV_C_TXT,,,0,,H,Text,Show T7 - AGV Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_AGV_D_TXT,,,0,,H,Text,Show T7 - AGV Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_AGV_E_TXT,,,0,,H,Text,Show T7 - AGV Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_AGV_F_TXT,,,0,✓,H,Text,Show T7 - AGV Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #19: STING - Mortuary Fridge Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_MF_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_MF_A_TXT,,,0,,H,Text,Show T7 - MF Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_MF_B_TXT,,,0,,H,Text,Show T7 - MF Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_MF_C_TXT,,,0,,H,Text,Show T7 - MF Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_MF_D_TXT,,,0,,H,Text,Show T7 - MF Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_MF_E_TXT,,,0,,H,Text,Show T7 - MF Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_MF_F_TXT,,,0,✓,H,Text,Show T7 - MF Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #20: STING - Imaging Modality Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_IM_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_IM_A_TXT,,,0,,H,Text,Show T7 - IM Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_IM_B_TXT,,,0,,H,Text,Show T7 - IM Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_IM_C_TXT,,,0,,H,Text,Show T7 - IM Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_IM_D_TXT,,,0,,H,Text,Show T7 - IM Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_IM_E_TXT,,,0,,H,Text,Show T7 - IM Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_IM_F_TXT,,,0,✓,H,Text,Show T7 - IM Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #21: STING - Dialysis Station Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_DS_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_DS_A_TXT,,,0,,H,Text,Show T7 - DS Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_DS_B_TXT,,,0,,H,Text,Show T7 - DS Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_DS_C_TXT,,,0,,H,Text,Show T7 - DS Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_DS_D_TXT,,,0,,H,Text,Show T7 - DS Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_DS_E_TXT,,,0,,H,Text,Show T7 - DS Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_DS_F_TXT,,,0,✓,H,Text,Show T7 - DS Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #22: STING - Incubator Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_INC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_INC_A_TXT,,,0,,H,Text,Show T7 - INC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_INC_B_TXT,,,0,,H,Text,Show T7 - INC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_INC_C_TXT,,,0,,H,Text,Show T7 - INC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_INC_D_TXT,,,0,,H,Text,Show T7 - INC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_INC_E_TXT,,,0,,H,Text,Show T7 - INC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_INC_F_TXT,,,0,✓,H,Text,Show T7 - INC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #23: STING - Warming Cot Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_WC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_WC_A_TXT,,,0,,H,Text,Show T7 - WC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_WC_B_TXT,,,0,,H,Text,Show T7 - WC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_WC_C_TXT,,,0,,H,Text,Show T7 - WC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_WC_D_TXT,,,0,,H,Text,Show T7 - WC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_WC_E_TXT,,,0,,H,Text,Show T7 - WC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_WC_F_TXT,,,0,✓,H,Text,Show T7 - WC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #24: STING - Autoclave Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_AC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_AC_A_TXT,,,0,,H,Text,Show T7 - AC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_AC_B_TXT,,,0,,H,Text,Show T7 - AC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_AC_C_TXT,,,0,,H,Text,Show T7 - AC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_AC_D_TXT,,,0,,H,Text,Show T7 - AC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_AC_E_TXT,,,0,,H,Text,Show T7 - AC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_AC_F_TXT,,,0,✓,H,Text,Show T7 - AC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #25: STING - Washer Disinfector Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_WD_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_WD_A_TXT,,,0,,H,Text,Show T7 - WD Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_WD_B_TXT,,,0,,H,Text,Show T7 - WD Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_WD_C_TXT,,,0,,H,Text,Show T7 - WD Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_WD_D_TXT,,,0,,H,Text,Show T7 - WD Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_WD_E_TXT,,,0,,H,Text,Show T7 - WD Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_WD_F_TXT,,,0,✓,H,Text,Show T7 - WD Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #26: STING - Bedpan Washer Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BPW_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_BPW_A_TXT,,,0,,H,Text,Show T7 - BPW Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_BPW_B_TXT,,,0,,H,Text,Show T7 - BPW Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_BPW_C_TXT,,,0,,H,Text,Show T7 - BPW Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_BPW_D_TXT,,,0,,H,Text,Show T7 - BPW Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_BPW_E_TXT,,,0,,H,Text,Show T7 - BPW Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_BPW_F_TXT,,,0,✓,H,Text,Show T7 - BPW Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #27: STING - Patient Monitor Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PM_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_PM_A_TXT,,,0,,H,Text,Show T7 - PM Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_PM_B_TXT,,,0,,H,Text,Show T7 - PM Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_PM_C_TXT,,,0,,H,Text,Show T7 - PM Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_PM_D_TXT,,,0,,H,Text,Show T7 - PM Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_PM_E_TXT,,,0,,H,Text,Show T7 - PM Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_PM_F_TXT,,,0,✓,H,Text,Show T7 - PM Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #28: STING - Medical Refrigerator Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_MEDR_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_MEDR_A_TXT,,,0,,H,Text,Show T7 - MEDR Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_MEDR_B_TXT,,,0,,H,Text,Show T7 - MEDR Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_MEDR_C_TXT,,,0,,H,Text,Show T7 - MEDR Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_MEDR_D_TXT,,,0,,H,Text,Show T7 - MEDR Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_MEDR_E_TXT,,,0,,H,Text,Show T7 - MEDR Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_MEDR_F_TXT,,,0,✓,H,Text,Show T7 - MEDR Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #29: STING - Pharmacy Isolator Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PI_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_PI_A_TXT,,,0,,H,Text,Show T7 - PI Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_PI_B_TXT,,,0,,H,Text,Show T7 - PI Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_PI_C_TXT,,,0,,H,Text,Show T7 - PI Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_PI_D_TXT,,,0,,H,Text,Show T7 - PI Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_PI_E_TXT,,,0,,H,Text,Show T7 - PI Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_PI_F_TXT,,,0,✓,H,Text,Show T7 - PI Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #30: STING - Operating Light Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_OL_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_OL_A_TXT,,,0,,H,Text,Show T7 - OL Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_OL_B_TXT,,,0,,H,Text,Show T7 - OL Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_OL_C_TXT,,,0,,H,Text,Show T7 - OL Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_OL_D_TXT,,,0,,H,Text,Show T7 - OL Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_OL_E_TXT,,,0,,H,Text,Show T7 - OL Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_OL_F_TXT,,,0,✓,H,Text,Show T7 - OL Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #31: STING - Examination Light Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_EL_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_EL_A_TXT,,,0,,H,Text,Show T7 - EL Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_EL_B_TXT,,,0,,H,Text,Show T7 - EL Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_EL_C_TXT,,,0,,H,Text,Show T7 - EL Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_EL_D_TXT,,,0,,H,Text,Show T7 - EL Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_EL_E_TXT,,,0,,H,Text,Show T7 - EL Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_EL_F_TXT,,,0,✓,H,Text,Show T7 - EL Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #32: STING - HBO Chamber Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_HBO_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_HBO_A_TXT,,,0,,H,Text,Show T7 - HBO Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_HBO_B_TXT,,,0,,H,Text,Show T7 - HBO Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_HBO_C_TXT,,,0,,H,Text,Show T7 - HBO Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_HBO_D_TXT,,,0,,H,Text,Show T7 - HBO Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_HBO_E_TXT,,,0,,H,Text,Show T7 - HBO Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_HBO_F_TXT,,,0,✓,H,Text,Show T7 - HBO Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #33: STING - Birth Pool Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BP_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_BP_A_TXT,,,0,,H,Text,Show T7 - BP Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_BP_B_TXT,,,0,,H,Text,Show T7 - BP Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_BP_C_TXT,,,0,,H,Text,Show T7 - BP Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_BP_D_TXT,,,0,,H,Text,Show T7 - BP Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_BP_E_TXT,,,0,,H,Text,Show T7 - BP Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_BP_F_TXT,,,0,✓,H,Text,Show T7 - BP Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #34: STING - IVF Workstation Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_IVF_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_IVF_A_TXT,,,0,,H,Text,Show T7 - IVF Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_IVF_B_TXT,,,0,,H,Text,Show T7 - IVF Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_IVF_C_TXT,,,0,,H,Text,Show T7 - IVF Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_IVF_D_TXT,,,0,,H,Text,Show T7 - IVF Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_IVF_E_TXT,,,0,,H,Text,Show T7 - IVF Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_IVF_F_TXT,,,0,✓,H,Text,Show T7 - IVF Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #35: STING - Cytotoxic Hood Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_CH_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_CH_A_TXT,,,0,,H,Text,Show T7 - CH Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_CH_B_TXT,,,0,,H,Text,Show T7 - CH Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_CH_C_TXT,,,0,,H,Text,Show T7 - CH Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_CH_D_TXT,,,0,,H,Text,Show T7 - CH Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_CH_E_TXT,,,0,,H,Text,Show T7 - CH Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_CH_F_TXT,,,0,✓,H,Text,Show T7 - CH Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #36: STING - Lab Fume Hood Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_LFH_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_LFH_A_TXT,,,0,,H,Text,Show T7 - LFH Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_LFH_B_TXT,,,0,,H,Text,Show T7 - LFH Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_LFH_C_TXT,,,0,,H,Text,Show T7 - LFH Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_LFH_D_TXT,,,0,,H,Text,Show T7 - LFH Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_LFH_E_TXT,,,0,,H,Text,Show T7 - LFH Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_LFH_F_TXT,,,0,✓,H,Text,Show T7 - LFH Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #37: STING - Biosafety Cabinet Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BSC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_BSC_A_TXT,,,0,,H,Text,Show T7 - BSC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_BSC_B_TXT,,,0,,H,Text,Show T7 - BSC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_BSC_C_TXT,,,0,,H,Text,Show T7 - BSC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_BSC_D_TXT,,,0,,H,Text,Show T7 - BSC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_BSC_E_TXT,,,0,,H,Text,Show T7 - BSC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_BSC_F_TXT,,,0,✓,H,Text,Show T7 - BSC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #38: STING - Endoscope Reprocessor Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ER_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_ER_A_TXT,,,0,,H,Text,Show T7 - ER Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_ER_B_TXT,,,0,,H,Text,Show T7 - ER Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_ER_C_TXT,,,0,,H,Text,Show T7 - ER Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_ER_D_TXT,,,0,,H,Text,Show T7 - ER Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_ER_E_TXT,,,0,,H,Text,Show T7 - ER Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_ER_F_TXT,,,0,✓,H,Text,Show T7 - ER Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #39: STING - Surgical Robot Bay Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_SRB_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_SRB_A_TXT,,,0,,H,Text,Show T7 - SRB Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_SRB_B_TXT,,,0,,H,Text,Show T7 - SRB Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_SRB_C_TXT,,,0,,H,Text,Show T7 - SRB Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_SRB_D_TXT,,,0,,H,Text,Show T7 - SRB Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_SRB_E_TXT,,,0,,H,Text,Show T7 - SRB Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_SRB_F_TXT,,,0,✓,H,Text,Show T7 - SRB Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #40: STING - RTLS Reader Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_RR_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,CLN_TAG_7_PARA_RR_A_TXT,,,0,,H,Text,Show T7 - RR Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,CLN_TAG_7_PARA_RR_B_TXT,,,0,,H,Text,Show T7 - RR Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,CLN_TAG_7_PARA_RR_C_TXT,,,0,,H,Text,Show T7 - RR Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,CLN_TAG_7_PARA_RR_D_TXT,,,0,,H,Text,Show T7 - RR Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,CLN_TAG_7_PARA_RR_E_TXT,,,0,,H,Text,Show T7 - RR Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,CLN_TAG_7_PARA_RR_F_TXT,,,0,✓,H,Text,Show T7 - RR Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #41: STING - Medical Gas Pipeline Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_MGP_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_MGP_A_TXT,,,0,,MG,Text,Show T7 - MGP Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_MGP_B_TXT,,,0,,MG,Text,Show T7 - MGP Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_MGP_C_TXT,,,0,,MG,Text,Show T7 - MGP Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_MGP_D_TXT,,,0,,MG,Text,Show T7 - MGP Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_MGP_E_TXT,,,0,,MG,Text,Show T7 - MGP Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_MGP_F_TXT,,,0,✓,MG,Text,Show T7 - MGP Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #42: STING - Medical Gas Terminal Unit Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_TU_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_TU_A_TXT,,,0,,MG,Text,Show T7 - TU Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_TU_B_TXT,,,0,,MG,Text,Show T7 - TU Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_TU_C_TXT,,,0,,MG,Text,Show T7 - TU Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_TU_D_TXT,,,0,,MG,Text,Show T7 - TU Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_TU_E_TXT,,,0,,MG,Text,Show T7 - TU Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_TU_F_TXT,,,0,✓,MG,Text,Show T7 - TU Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #43: STING - Zone Valve Box Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_ZVB_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_ZVB_A_TXT,,,0,,MG,Text,Show T7 - ZVB Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_ZVB_B_TXT,,,0,,MG,Text,Show T7 - ZVB Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_ZVB_C_TXT,,,0,,MG,Text,Show T7 - ZVB Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_ZVB_D_TXT,,,0,,MG,Text,Show T7 - ZVB Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_ZVB_E_TXT,,,0,,MG,Text,Show T7 - ZVB Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_ZVB_F_TXT,,,0,✓,MG,Text,Show T7 - ZVB Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #44: STING - Area Alarm Panel Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_AAP_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_AAP_A_TXT,,,0,,MG,Text,Show T7 - AAP Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_AAP_B_TXT,,,0,,MG,Text,Show T7 - AAP Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_AAP_C_TXT,,,0,,MG,Text,Show T7 - AAP Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_AAP_D_TXT,,,0,,MG,Text,Show T7 - AAP Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_AAP_E_TXT,,,0,,MG,Text,Show T7 - AAP Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_AAP_F_TXT,,,0,✓,MG,Text,Show T7 - AAP Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #45: STING - Master Alarm Panel Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_MAAP_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_MAAP_A_TXT,,,0,,MG,Text,Show T7 - MAAP Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_MAAP_B_TXT,,,0,,MG,Text,Show T7 - MAAP Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_MAAP_C_TXT,,,0,,MG,Text,Show T7 - MAAP Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_MAAP_D_TXT,,,0,,MG,Text,Show T7 - MAAP Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_MAAP_E_TXT,,,0,,MG,Text,Show T7 - MAAP Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_MAAP_F_TXT,,,0,✓,MG,Text,Show T7 - MAAP Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #46: STING - Manifold Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_MAN_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_MAN_A_TXT,,,0,,MG,Text,Show T7 - MAN Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_MAN_B_TXT,,,0,,MG,Text,Show T7 - MAN Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_MAN_C_TXT,,,0,,MG,Text,Show T7 - MAN Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_MAN_D_TXT,,,0,,MG,Text,Show T7 - MAN Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_MAN_E_TXT,,,0,,MG,Text,Show T7 - MAN Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_MAN_F_TXT,,,0,✓,MG,Text,Show T7 - MAN Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #47: STING - VIE Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_VIE_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_VIE_A_TXT,,,0,,MG,Text,Show T7 - VIE Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_VIE_B_TXT,,,0,,MG,Text,Show T7 - VIE Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_VIE_C_TXT,,,0,,MG,Text,Show T7 - VIE Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_VIE_D_TXT,,,0,,MG,Text,Show T7 - VIE Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_VIE_E_TXT,,,0,,MG,Text,Show T7 - VIE Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_VIE_F_TXT,,,0,✓,MG,Text,Show T7 - VIE Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #48: STING - Medical Air Plant Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_AIR_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_AIR_A_TXT,,,0,,MG,Text,Show T7 - AIR Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_AIR_B_TXT,,,0,,MG,Text,Show T7 - AIR Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_AIR_C_TXT,,,0,,MG,Text,Show T7 - AIR Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_AIR_D_TXT,,,0,,MG,Text,Show T7 - AIR Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_AIR_E_TXT,,,0,,MG,Text,Show T7 - AIR Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_AIR_F_TXT,,,0,✓,MG,Text,Show T7 - AIR Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #49: STING - Medical Vacuum Plant Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_VAC_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_VAC_A_TXT,,,0,,MG,Text,Show T7 - VAC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_VAC_B_TXT,,,0,,MG,Text,Show T7 - VAC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_VAC_C_TXT,,,0,,MG,Text,Show T7 - VAC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_VAC_D_TXT,,,0,,MG,Text,Show T7 - VAC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_VAC_E_TXT,,,0,,MG,Text,Show T7 - VAC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_VAC_F_TXT,,,0,✓,MG,Text,Show T7 - VAC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #50: STING - AGS Plant Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_AGS_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,MGS_TAG_7_PARA_AGS_A_TXT,,,0,,MG,Text,Show T7 - AGS Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,MGS_TAG_7_PARA_AGS_B_TXT,,,0,,MG,Text,Show T7 - AGS Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,MGS_TAG_7_PARA_AGS_C_TXT,,,0,,MG,Text,Show T7 - AGS Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,MGS_TAG_7_PARA_AGS_D_TXT,,,0,,MG,Text,Show T7 - AGS Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,MGS_TAG_7_PARA_AGS_E_TXT,,,0,,MG,Text,Show T7 - AGS Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,MGS_TAG_7_PARA_AGS_F_TXT,,,0,✓,MG,Text,Show T7 - AGS Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #51: STING - X-ray Barrier Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_XRB_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_XRB_A_TXT,,,0,,RP,Text,Show T7 - XRB Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_XRB_B_TXT,,,0,,RP,Text,Show T7 - XRB Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_XRB_C_TXT,,,0,,RP,Text,Show T7 - XRB Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_XRB_D_TXT,,,0,,RP,Text,Show T7 - XRB Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_XRB_E_TXT,,,0,,RP,Text,Show T7 - XRB Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_XRB_F_TXT,,,0,✓,RP,Text,Show T7 - XRB Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #52: STING - X-ray Door Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_XRD_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_XRD_A_TXT,,,0,,RP,Text,Show T7 - XRD Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_XRD_B_TXT,,,0,,RP,Text,Show T7 - XRD Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_XRD_C_TXT,,,0,,RP,Text,Show T7 - XRD Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_XRD_D_TXT,,,0,,RP,Text,Show T7 - XRD Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_XRD_E_TXT,,,0,,RP,Text,Show T7 - XRD Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_XRD_F_TXT,,,0,✓,RP,Text,Show T7 - XRD Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #53: STING - X-ray Window Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_XRW_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_XRW_A_TXT,,,0,,RP,Text,Show T7 - XRW Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_XRW_B_TXT,,,0,,RP,Text,Show T7 - XRW Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_XRW_C_TXT,,,0,,RP,Text,Show T7 - XRW Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_XRW_D_TXT,,,0,,RP,Text,Show T7 - XRW Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_XRW_E_TXT,,,0,,RP,Text,Show T7 - XRW Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_XRW_F_TXT,,,0,✓,RP,Text,Show T7 - XRW Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #54: STING - Linac Maze Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_LMZ_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_LMZ_A_TXT,,,0,,RP,Text,Show T7 - LMZ Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_LMZ_B_TXT,,,0,,RP,Text,Show T7 - LMZ Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_LMZ_C_TXT,,,0,,RP,Text,Show T7 - LMZ Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_LMZ_D_TXT,,,0,,RP,Text,Show T7 - LMZ Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_LMZ_E_TXT,,,0,,RP,Text,Show T7 - LMZ Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_LMZ_F_TXT,,,0,✓,RP,Text,Show T7 - LMZ Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #55: STING - MRI Faraday Cage Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_FC_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_FC_A_TXT,,,0,,RP,Text,Show T7 - FC Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_FC_B_TXT,,,0,,RP,Text,Show T7 - FC Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_FC_C_TXT,,,0,,RP,Text,Show T7 - FC Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_FC_D_TXT,,,0,,RP,Text,Show T7 - FC Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_FC_E_TXT,,,0,,RP,Text,Show T7 - FC Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_FC_F_TXT,,,0,✓,RP,Text,Show T7 - FC Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #56: STING - 5-Gauss Marker Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_FGM_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_FGM_A_TXT,,,0,,RP,Text,Show T7 - FGM Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_FGM_B_TXT,,,0,,RP,Text,Show T7 - FGM Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_FGM_C_TXT,,,0,,RP,Text,Show T7 - FGM Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_FGM_D_TXT,,,0,,RP,Text,Show T7 - FGM Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_FGM_E_TXT,,,0,,RP,Text,Show T7 - FGM Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_FGM_F_TXT,,,0,✓,RP,Text,Show T7 - FGM Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #57: STING - Controlled Area Sign Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_CAS_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_CAS_A_TXT,,,0,,RP,Text,Show T7 - CAS Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_CAS_B_TXT,,,0,,RP,Text,Show T7 - CAS Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_CAS_C_TXT,,,0,,RP,Text,Show T7 - CAS Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_CAS_D_TXT,,,0,,RP,Text,Show T7 - CAS Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_CAS_E_TXT,,,0,,RP,Text,Show T7 - CAS Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_CAS_F_TXT,,,0,✓,RP,Text,Show T7 - CAS Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #58: STING - Dosimetry Post Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_DPT_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - Intl Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Ref,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T5,ASS_CST_UNIT_RATE_NR_DISP_TXT,Rate:,,0,,Common,Text,Show T5 - Cost - Unit Rate,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_UNIT_RATE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+8,T5,ASS_CST_CURRENCY_TXT, ,,0,,Common,Text,Show T5 - Cost - Currency Code,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_CURRENCY_TXT, """")",NOM,PURPLE,2.0,None,None
+9,T5,ASS_CST_FX_TO_BASE_NR_DISP_TXT,FX:,,0,,Common,Text,Show T5 - Cost - FX to Base,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_TO_BASE_NR_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+10,T5,ASS_CST_FX_DATE_DT, FX date:,,0,,Common,Text,Show T5 - Cost - FX Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_FX_DATE_DT, """")",NOM,PURPLE,2.0,None,None
+11,T5,ASS_CST_AS_OF_DT, As of:,,0,✓,Common,Text,Show T5 - Cost - As-of Date,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_AS_OF_DT, """")",NOM,PURPLE,2.0,None,None
+12,T5,ASS_CST_STALE_BOOL,Stale:,,0,,Common,Text,Show T5 - Cost - Stale Flag,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_BOOL, """")",BOLD,ORANGE,2.0,None,None
+13,T5,ASS_CST_STALE_REASON_TXT, - ,,0,✓,Common,Text,Show T5 - Cost - Stale Reason,"if(TAG_PARA_STATE_5_BOOL, ASS_CST_STALE_REASON_TXT, """")",NOM,ORANGE,2.0,None,None
+14,T5,ASS_PMT_PCT_COMPLETE_NR_DISP_TXT,Cmpl:,%,0,,Common,Text,Show T5 - Payment - % Complete,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_PCT_COMPLETE_NR_DISP_TXT, """")",BOLD,GREEN,2.0,None,None
+15,T5,ASS_PMT_CERT_NO_NR_DISP_TXT, Cert#:,,0,,Common,Text,Show T5 - Payment - Cert No,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_NO_NR_DISP_TXT, """")",NOM,GREEN,2.0,None,None
+16,T5,ASS_PMT_CERT_DATE_DT, Certified:,,0,,Common,Text,Show T5 - Payment - Cert Date,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_CERT_DATE_DT, """")",NOM,GREEN,2.0,None,None
+17,T5,ASS_PMT_LAST_VALUED_DT, Valued:,,0,✓,Common,Text,Show T5 - Payment - Last Valued,"if(TAG_PARA_STATE_5_BOOL, ASS_PMT_LAST_VALUED_DT, """")",NOM,GREEN,2.0,None,None
+18,T5,ASS_VAR_NO_TXT,Var:,,0,,Common,Text,Show T5 - Variation - Number,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_NO_TXT, """")",BOLD,RED,2.0,None,None
+19,T5,ASS_VAR_INSTRUCTION_DT, Instr:,,0,,Common,Text,Show T5 - Variation - Instr Date,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_INSTRUCTION_DT, """")",NOM,RED,2.0,None,None
+20,T5,ASS_VAR_VALUATION_NR_DISP_TXT, Val:,,0,✓,Common,Text,Show T5 - Variation - Valuation,"if(TAG_PARA_STATE_5_BOOL, ASS_VAR_VALUATION_NR_DISP_TXT, """")",NOM,RED,2.0,None,None
+21,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+22,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+23,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+24,T7,RAD_TAG_7_PARA_DPT_A_TXT,,,0,,RP,Text,Show T7 - DPT Narrative - Section A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_A_TXT, """")",NOM,BLACK,2.0,None,None
+25,T7,RAD_TAG_7_PARA_DPT_B_TXT,,,0,,RP,Text,Show T7 - DPT Narrative - Section B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_B_TXT, """")",NOM,BLACK,2.0,None,None
+26,T7,RAD_TAG_7_PARA_DPT_C_TXT,,,0,,RP,Text,Show T7 - DPT Narrative - Section C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_C_TXT, """")",NOM,BLACK,2.0,None,None
+27,T7,RAD_TAG_7_PARA_DPT_D_TXT,,,0,,RP,Text,Show T7 - DPT Narrative - Section D,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_D_TXT, """")",NOM,BLACK,2.0,None,None
+28,T7,RAD_TAG_7_PARA_DPT_E_TXT,,,0,,RP,Text,Show T7 - DPT Narrative - Section E,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_E_TXT, """")",NOM,BLACK,2.0,None,None
+29,T7,RAD_TAG_7_PARA_DPT_F_TXT,,,0,✓,RP,Text,Show T7 - DPT Narrative - Section F,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_F_TXT, """")",NOM,BLACK,2.0,None,None
+30,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+31,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+32,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+33,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+34,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+35,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+36,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+37,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+38,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ══════════════════════════════════════════════════════════════════════════════
+# WARNING PARAMETERS — Healthcare Pack (H/MG/RP disciplines)
 # WARNING PARAMETERS — Healthcare Pack (H / MG / RP disciplines)
 # Phase 179 — derived from 16 HealthcareValidatorGate validators
 # Format: #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_HEALTH_DesignConstruction.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_HEALTH_DesignConstruction.csv
@@ -1,78 +1,2443 @@
-#!SCHEMA_VERSION=5.6,VARIANT=DesignConstruction
+#!SCHEMA_VERSION=5.6
+#!VARIANT=DesignConstruction
 # STING_TAG_CONFIG_v5_0_HEALTH_DesignConstruction.csv
-# Healthcare Pack — Tag families across H/MG/RP disciplines
+# Healthcare Pack — Design/Construction variant (T5=tender costs; T7=construction narrative A-C)
 # Phase H-1, branch claude/research-hospital-design-0Uxbi
-# Updated: Phase 179 — added warning parameters for all 16 healthcare validators
-#   Warnings align with TAG_CONFIG_v5_0_VALIDATION.csv Section 15 (HEALTHCARE_RULE entries)
-#   and STING_TAG_CONFIG_v5_0_HEALTH_DesignConstruction.csv tier definitions
+# Updated: Phase 187 SYNC — full style catalog + T1-T10 DC variant for all 58 families
+#   T4-T10 differences vs Handover: T5 reduced to 3 tender-cost rows;
+#   T7 shows TAG7 narrative sections A-C only (construction context)
 # Format: TagFamilyName,TagDiscipline,Category,RoomBound,DefaultLabel,Description
-# Phase 187 SYNC: TagFamilyCreatorCommand HealthcareVariantFamilies (58 entries) wired in; LABEL_DEFINITIONS.json category_labels backfilled with 58 healthcare entries; MR_PARAMETERS.txt +35 healthcare WARN params (CLN/MGS/RAD/CEQ/LIG/ELC/FAB/PLM). UPDATED=2026-05-20.
-# DesignConstruction variant (Phase 187): clinical content is largely stage-independent,
-# so the family roster is identical to the Handover CSV. Per-tier T4-T10 differences for
-# DC presentation (e.g. commissioning audit trail rows, fab status, QC inspector) are
-# inherited from the discipline-specific DC siblings (ARCH/GEN/MEP/STR _DesignConstruction).
-# When the HEALTH pack needs DC-specific clinical tier rows (e.g. RDS commissioning sign-off),
-# replace this stub with per-family Tier blocks following the v5.6 schema.
+# UPDATED=2026-06-09
+
+# ── TAG_FAMILY MANIFEST ──────────────────────────────────────────────────────
+# Format: TAG_FAMILY,FamilyName,Discipline,Category,RoomBound,DefaultLabelParam,Description
 TAG_FAMILY,STING - Clinical Room Tag,H,Rooms,1,CLN_ROOM_CLASS_TXT,Clinical room class label
-TAG_FAMILY,STING - Pressure Regime Tag,H,Rooms,1,CLN_PRESS_REGIME_TXT,Pressure cascade arrow + Δp
+TAG_FAMILY,STING - Pressure Regime Tag,H,Rooms,1,CLN_PRESS_REGIME_TXT,Pressure cascade arrow + delta-P
 TAG_FAMILY,STING - Infection Class Tag,H,Rooms,1,CLN_INFECT_CLASS_TXT,AIIR/PE banner
 TAG_FAMILY,STING - MRI Zone Tag,H,Generic Models,0,CLN_MRI_ZONE_INT,MRI Z1..Z4 zoning marker
-TAG_FAMILY,STING - Anti-Ligature (Door) Tag,H,Doors,0,LIG_PRODUCT_RATING_TXT,Anti-ligature fitting rating
-TAG_FAMILY,STING - Anti-Ligature (Plumbing Fixture) Tag,H,Plumbing Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature fitting rating
-TAG_FAMILY,STING - Anti-Ligature (Lighting Fixture) Tag,H,Lighting Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature fitting rating
-TAG_FAMILY,STING - Bedhead Trunking Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Bedhead trunking/services unit
-TAG_FAMILY,STING - Pendant Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Operating room / ICU pendant
-TAG_FAMILY,STING - Scrub Trough Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Pre-operative scrub trough
-TAG_FAMILY,STING - Hoist Track Tag,H,Generic Models,0,CLN_HOIST_TRACK_BOOL,Ceiling hoist track
-TAG_FAMILY,STING - Bariatric Tag,H,Rooms,1,CLN_BARI_DESIGN_KG_NR,Bariatric SWL marker
-TAG_FAMILY,STING - Nurse Call Tag,H,Nurse Call Devices,0,CLN_NURSECALL_TYPE_TXT,Nurse call station/post
-TAG_FAMILY,STING - Crash Cart Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Crash cart location
-TAG_FAMILY,STING - AED Cabinet Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,AED cabinet
-TAG_FAMILY,STING - Hand-Rub Dispenser Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Hand-rub dispenser
-TAG_FAMILY,STING - PTS Station Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Pneumatic tube station
-TAG_FAMILY,STING - AGV Dock Tag,H,Generic Models,0,CEQ_CATEGORY_TXT,AGV docking point
-TAG_FAMILY,STING - Mortuary Fridge Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Mortuary refrigeration
-TAG_FAMILY,STING - Imaging Modality Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,CT/MRI/X-ray/PET/Linac
-TAG_FAMILY,STING - Dialysis Station Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Dialysis chair / RO drop
-TAG_FAMILY,STING - Incubator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Neonatal incubator
-TAG_FAMILY,STING - Warming Cot Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Warming cot
-TAG_FAMILY,STING - Autoclave Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Sterilizer / autoclave
-TAG_FAMILY,STING - Washer Disinfector Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Washer-disinfector (HSDU)
-TAG_FAMILY,STING - Bedpan Washer Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Bedpan washer
-TAG_FAMILY,STING - Patient Monitor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Patient monitoring device
-TAG_FAMILY,STING - Medical Refrigerator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Medical refrigerator (pharmacy / lab)
-TAG_FAMILY,STING - Pharmacy Isolator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,USP <797> / <800> isolator
-TAG_FAMILY,STING - Operating Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Operating room surgical light
-TAG_FAMILY,STING - Examination Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Mobile / mounted exam light
-TAG_FAMILY,STING - HBO Chamber Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Hyperbaric oxygen chamber
-TAG_FAMILY,STING - Birth Pool Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Maternity birthing pool
-TAG_FAMILY,STING - IVF Workstation Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,IVF / ART laminar flow workstation
-TAG_FAMILY,STING - Cytotoxic Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Cytotoxic compounding hood
-TAG_FAMILY,STING - Lab Fume Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Laboratory fume hood (pathology)
-TAG_FAMILY,STING - Biosafety Cabinet Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,BSC Class II/III
-TAG_FAMILY,STING - Endoscope Reprocessor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Endoscope reprocessor (HTM 01-06)
-TAG_FAMILY,STING - Surgical Robot Bay Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Surgical robot envelope
-TAG_FAMILY,STING - RTLS Reader Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Real-time location reader
-TAG_FAMILY,STING - Medical Gas Pipeline Tag,MG,Pipes,0,MGS_GAS_TYPE_TXT,MGPS pipework
-TAG_FAMILY,STING - Medical Gas Terminal Unit Tag,MG,Plumbing Fixtures,0,MGS_GAS_TYPE_TXT,BS 5682 terminal unit
-TAG_FAMILY,STING - Zone Valve Box Tag,MG,Pipe Accessories,0,MGS_ZVB_REF_TXT,MGPS zone valve box
-TAG_FAMILY,STING - Area Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,MGPS area alarm panel
-TAG_FAMILY,STING - Master Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,MGPS master alarm panel
-TAG_FAMILY,STING - Manifold Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,MGPS manifold / cylinder bank
-TAG_FAMILY,STING - VIE Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Vacuum Insulated Evaporator (LOX)
-TAG_FAMILY,STING - Medical Air Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical air compressor plant
-TAG_FAMILY,STING - Medical Vacuum Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical vacuum pump plant
-TAG_FAMILY,STING - AGS Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,AGS receiver plant
-TAG_FAMILY,STING - X-ray Barrier Tag,RP,Walls,0,RAD_LEAD_MM_NR,X-ray shielded wall (mm Pb)
-TAG_FAMILY,STING - X-ray Door Tag,RP,Doors,0,RAD_LEAD_MM_NR,X-ray shielded door (mm Pb)
-TAG_FAMILY,STING - X-ray Window Tag,RP,Windows,0,RAD_LEAD_MM_NR,X-ray viewing window (mm Pb)
-TAG_FAMILY,STING - Linac Maze Tag,RP,Walls,0,RAD_LEAD_MM_NR,LINAC maze barrier
-TAG_FAMILY,STING - MRI Faraday Cage Tag,RP,Walls,0,CLN_RF_SHIELD_BOOL,MRI Faraday cage panel
-TAG_FAMILY,STING - 5-Gauss Marker Tag,RP,Generic Models,0,CLN_MRI_ZONE_INT,MRI 5-Gauss boundary marker
-TAG_FAMILY,STING - Controlled Area Sign Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Controlled / supervised area signage
-TAG_FAMILY,STING - Dosimetry Post Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Dosimetry monitoring post
+TAG_FAMILY,STING - Anti-Ligature (Door) Tag,H,Doors,0,LIG_PRODUCT_RATING_TXT,Anti-ligature door hardware rating
+TAG_FAMILY,STING - Anti-Ligature (Plumbing Fixture) Tag,H,Plumbing Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature plumbing fixture rating
+TAG_FAMILY,STING - Anti-Ligature (Lighting Fixture) Tag,H,Lighting Fixtures,0,LIG_PRODUCT_RATING_TXT,Anti-ligature lighting fitting rating
+TAG_FAMILY,STING - Bedhead Trunking Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Bedhead trunking unit label
+TAG_FAMILY,STING - Pendant Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Theatre/ICU pendant label
+TAG_FAMILY,STING - Scrub Trough Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Surgical scrub trough label
+TAG_FAMILY,STING - Hoist Track Tag,H,Generic Models,0,CLN_HOIST_TRACK_BOOL,Overhead patient hoist track label
+TAG_FAMILY,STING - Bariatric Tag,H,Rooms,1,CLN_BARI_DESIGN_KG_NR,Bariatric design load label
+TAG_FAMILY,STING - Nurse Call Tag,H,Nurse Call Devices,0,CLN_NURSECALL_TYPE_TXT,Nurse call point label
+TAG_FAMILY,STING - Crash Cart Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Resuscitation crash cart label
+TAG_FAMILY,STING - AED Cabinet Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,AED defibrillator cabinet label
+TAG_FAMILY,STING - Hand-Rub Dispenser Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Hand-hygiene dispenser label
+TAG_FAMILY,STING - PTS Station Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Pneumatic tube station label
+TAG_FAMILY,STING - AGV Dock Tag,H,Generic Models,0,CEQ_CATEGORY_TXT,Autonomous guided vehicle docking label
+TAG_FAMILY,STING - Mortuary Fridge Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Mortuary refrigeration unit label
+TAG_FAMILY,STING - Imaging Modality Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Imaging modality equipment label
+TAG_FAMILY,STING - Dialysis Station Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Renal dialysis station label
+TAG_FAMILY,STING - Incubator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Neonatal incubator label
+TAG_FAMILY,STING - Warming Cot Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Neonatal warming cot label
+TAG_FAMILY,STING - Autoclave Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,CSSD autoclave label
+TAG_FAMILY,STING - Washer Disinfector Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,CSSD washer-disinfector label
+TAG_FAMILY,STING - Bedpan Washer Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Bedpan washer/macerator label
+TAG_FAMILY,STING - Patient Monitor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Bedside patient monitoring label
+TAG_FAMILY,STING - Medical Refrigerator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Medical/pharmacy refrigerator label
+TAG_FAMILY,STING - Pharmacy Isolator Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Pharmacy isolator/laminar flow label
+TAG_FAMILY,STING - Operating Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Surgical operating light label
+TAG_FAMILY,STING - Examination Light Tag,H,Lighting Fixtures,0,CEQ_CATEGORY_TXT,Clinical examination light label
+TAG_FAMILY,STING - HBO Chamber Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Hyperbaric oxygen chamber label
+TAG_FAMILY,STING - Birth Pool Tag,H,Plumbing Fixtures,0,CEQ_CATEGORY_TXT,Birthing pool label
+TAG_FAMILY,STING - IVF Workstation Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,IVF/embryology workstation label
+TAG_FAMILY,STING - Cytotoxic Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Cytotoxic preparation hood label
+TAG_FAMILY,STING - Lab Fume Hood Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Laboratory fume cupboard label
+TAG_FAMILY,STING - Biosafety Cabinet Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Biosafety cabinet label
+TAG_FAMILY,STING - Endoscope Reprocessor Tag,H,Medical Equipment,0,CEQ_CATEGORY_TXT,Endoscope washer-disinfector label
+TAG_FAMILY,STING - Surgical Robot Bay Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Surgical robot installation bay label
+TAG_FAMILY,STING - RTLS Reader Tag,H,Specialty Equipment,0,CEQ_CATEGORY_TXT,Real-time location system reader label
+TAG_FAMILY,STING - Medical Gas Pipeline Tag,MG,Pipes,0,MGS_GAS_TYPE_TXT,Medical gas pipeline service label
+TAG_FAMILY,STING - Medical Gas Terminal Unit Tag,MG,Plumbing Fixtures,0,MGS_GAS_TYPE_TXT,BS 5682 terminal unit label
+TAG_FAMILY,STING - Zone Valve Box Tag,MG,Pipe Accessories,0,MGS_ZVB_REF_TXT,Zone valve box reference label
+TAG_FAMILY,STING - Area Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,Area alarm panel reference label
+TAG_FAMILY,STING - Master Alarm Panel Tag,MG,Plumbing Fixtures,0,MGS_AAP_REF_TXT,Master alarm panel reference label
+TAG_FAMILY,STING - Manifold Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Cylinder manifold label
+TAG_FAMILY,STING - VIE Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Vacuum insulated evaporator label
+TAG_FAMILY,STING - Medical Air Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical air compressor plant label
+TAG_FAMILY,STING - Medical Vacuum Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Medical vacuum plant label
+TAG_FAMILY,STING - AGS Plant Tag,MG,Mechanical Equipment,0,MGS_GAS_TYPE_TXT,Anaesthetic gas scavenging plant label
+TAG_FAMILY,STING - X-ray Barrier Tag,RP,Walls,0,RAD_LEAD_MM_NR,X-ray primary/secondary barrier label
+TAG_FAMILY,STING - X-ray Door Tag,RP,Doors,0,RAD_LEAD_MM_NR,X-ray shielded door label
+TAG_FAMILY,STING - X-ray Window Tag,RP,Windows,0,RAD_LEAD_MM_NR,X-ray observation window label
+TAG_FAMILY,STING - Linac Maze Tag,RP,Walls,0,RAD_LEAD_MM_NR,Linac maze shielding label
+TAG_FAMILY,STING - MRI Faraday Cage Tag,RP,Walls,0,CLN_RF_SHIELD_BOOL,MRI RF shielding label
+TAG_FAMILY,STING - 5-Gauss Marker Tag,RP,Generic Models,0,CLN_MRI_ZONE_INT,MRI 5-gauss boundary marker
+TAG_FAMILY,STING - Controlled Area Sign Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Radiation controlled area sign label
+TAG_FAMILY,STING - Dosimetry Post Tag,RP,Generic Models,0,RAD_DOSE_DESIGN_GOAL_TXT,Radiation dosimetry monitoring post label
 
-# ═══════════════════════════════════════════════════════════════════════════════
+# ──────────────────────────────────────────────────────────────────────────
+# STYLE CATALOG — 150 visibility parameters injected into every tag family
+# ──────────────────────────────────────────────────────────────────────────
+#!STYLE_CATALOG_BEGIN
+#,Group,Parameter,Datatype,Default,Category,Role,Description
+1,TextStyle,TAG_2NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLACK
+2,TextStyle,TAG_2NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM BLUE
+3,TextStyle,TAG_2NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREEN
+4,TextStyle,TAG_2NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM RED
+5,TextStyle,TAG_2NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM ORANGE
+6,TextStyle,TAG_2NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM PURPLE
+7,TextStyle,TAG_2NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM GREY
+8,TextStyle,TAG_2NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm NOM WHITE
+9,TextStyle,TAG_2BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLACK
+10,TextStyle,TAG_2BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD BLUE
+11,TextStyle,TAG_2BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREEN
+12,TextStyle,TAG_2BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD RED
+13,TextStyle,TAG_2BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD ORANGE
+14,TextStyle,TAG_2BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD PURPLE
+15,TextStyle,TAG_2BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD GREY
+16,TextStyle,TAG_2BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLD WHITE
+17,TextStyle,TAG_2ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLACK
+18,TextStyle,TAG_2ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC BLUE
+19,TextStyle,TAG_2ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREEN
+20,TextStyle,TAG_2ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC RED
+21,TextStyle,TAG_2ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC ORANGE
+22,TextStyle,TAG_2ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC PURPLE
+23,TextStyle,TAG_2ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC GREY
+24,TextStyle,TAG_2ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm ITALIC WHITE
+25,TextStyle,TAG_2BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLACK
+26,TextStyle,TAG_2BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC BLUE
+27,TextStyle,TAG_2BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREEN
+28,TextStyle,TAG_2BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC RED
+29,TextStyle,TAG_2BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC ORANGE
+30,TextStyle,TAG_2BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC PURPLE
+31,TextStyle,TAG_2BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC GREY
+32,TextStyle,TAG_2BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2mm BOLDITALIC WHITE
+33,TextStyle,TAG_2.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLACK
+34,TextStyle,TAG_2.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM BLUE
+35,TextStyle,TAG_2.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREEN
+36,TextStyle,TAG_2.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM RED
+37,TextStyle,TAG_2.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM ORANGE
+38,TextStyle,TAG_2.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM PURPLE
+39,TextStyle,TAG_2.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM GREY
+40,TextStyle,TAG_2.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm NOM WHITE
+41,TextStyle,TAG_2.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLACK
+42,TextStyle,TAG_2.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD BLUE
+43,TextStyle,TAG_2.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREEN
+44,TextStyle,TAG_2.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD RED
+45,TextStyle,TAG_2.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD ORANGE
+46,TextStyle,TAG_2.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD PURPLE
+47,TextStyle,TAG_2.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD GREY
+48,TextStyle,TAG_2.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLD WHITE
+49,TextStyle,TAG_2.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLACK
+50,TextStyle,TAG_2.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC BLUE
+51,TextStyle,TAG_2.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREEN
+52,TextStyle,TAG_2.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC RED
+53,TextStyle,TAG_2.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC ORANGE
+54,TextStyle,TAG_2.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC PURPLE
+55,TextStyle,TAG_2.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC GREY
+56,TextStyle,TAG_2.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm ITALIC WHITE
+57,TextStyle,TAG_2.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLACK
+58,TextStyle,TAG_2.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC BLUE
+59,TextStyle,TAG_2.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREEN
+60,TextStyle,TAG_2.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC RED
+61,TextStyle,TAG_2.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC ORANGE
+62,TextStyle,TAG_2.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC PURPLE
+63,TextStyle,TAG_2.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC GREY
+64,TextStyle,TAG_2.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 2.5mm BOLDITALIC WHITE
+65,TextStyle,TAG_3NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLACK
+66,TextStyle,TAG_3NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM BLUE
+67,TextStyle,TAG_3NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREEN
+68,TextStyle,TAG_3NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM RED
+69,TextStyle,TAG_3NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM ORANGE
+70,TextStyle,TAG_3NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM PURPLE
+71,TextStyle,TAG_3NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM GREY
+72,TextStyle,TAG_3NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm NOM WHITE
+73,TextStyle,TAG_3BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLACK
+74,TextStyle,TAG_3BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD BLUE
+75,TextStyle,TAG_3BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREEN
+76,TextStyle,TAG_3BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD RED
+77,TextStyle,TAG_3BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD ORANGE
+78,TextStyle,TAG_3BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD PURPLE
+79,TextStyle,TAG_3BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD GREY
+80,TextStyle,TAG_3BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLD WHITE
+81,TextStyle,TAG_3ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLACK
+82,TextStyle,TAG_3ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC BLUE
+83,TextStyle,TAG_3ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREEN
+84,TextStyle,TAG_3ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC RED
+85,TextStyle,TAG_3ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC ORANGE
+86,TextStyle,TAG_3ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC PURPLE
+87,TextStyle,TAG_3ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC GREY
+88,TextStyle,TAG_3ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm ITALIC WHITE
+89,TextStyle,TAG_3BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLACK
+90,TextStyle,TAG_3BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC BLUE
+91,TextStyle,TAG_3BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREEN
+92,TextStyle,TAG_3BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC RED
+93,TextStyle,TAG_3BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC ORANGE
+94,TextStyle,TAG_3BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC PURPLE
+95,TextStyle,TAG_3BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC GREY
+96,TextStyle,TAG_3BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3mm BOLDITALIC WHITE
+97,TextStyle,TAG_3.5NOM_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLACK
+98,TextStyle,TAG_3.5NOM_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM BLUE
+99,TextStyle,TAG_3.5NOM_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREEN
+100,TextStyle,TAG_3.5NOM_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM RED
+101,TextStyle,TAG_3.5NOM_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM ORANGE
+102,TextStyle,TAG_3.5NOM_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM PURPLE
+103,TextStyle,TAG_3.5NOM_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM GREY
+104,TextStyle,TAG_3.5NOM_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm NOM WHITE
+105,TextStyle,TAG_3.5BOLD_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLACK
+106,TextStyle,TAG_3.5BOLD_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD BLUE
+107,TextStyle,TAG_3.5BOLD_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREEN
+108,TextStyle,TAG_3.5BOLD_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD RED
+109,TextStyle,TAG_3.5BOLD_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD ORANGE
+110,TextStyle,TAG_3.5BOLD_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD PURPLE
+111,TextStyle,TAG_3.5BOLD_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD GREY
+112,TextStyle,TAG_3.5BOLD_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLD WHITE
+113,TextStyle,TAG_3.5ITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLACK
+114,TextStyle,TAG_3.5ITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC BLUE
+115,TextStyle,TAG_3.5ITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREEN
+116,TextStyle,TAG_3.5ITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC RED
+117,TextStyle,TAG_3.5ITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC ORANGE
+118,TextStyle,TAG_3.5ITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC PURPLE
+119,TextStyle,TAG_3.5ITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC GREY
+120,TextStyle,TAG_3.5ITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm ITALIC WHITE
+121,TextStyle,TAG_3.5BOLDITALIC_BLACK_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLACK
+122,TextStyle,TAG_3.5BOLDITALIC_BLUE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC BLUE
+123,TextStyle,TAG_3.5BOLDITALIC_GREEN_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREEN
+124,TextStyle,TAG_3.5BOLDITALIC_RED_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC RED
+125,TextStyle,TAG_3.5BOLDITALIC_ORANGE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC ORANGE
+126,TextStyle,TAG_3.5BOLDITALIC_PURPLE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC PURPLE
+127,TextStyle,TAG_3.5BOLDITALIC_GREY_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC GREY
+128,TextStyle,TAG_3.5BOLDITALIC_WHITE_BOOL,YESNO,0,Common,Switch,Gates label row rendered at 3.5mm BOLDITALIC WHITE
+129,TierGate,TAG_PARA_STATE_1_BOOL,TEXT,Yes,Common,Switch,Shows tier 1 rows when true (depth N enables 1..N cumulatively)
+130,TierGate,TAG_PARA_STATE_2_BOOL,TEXT,No,Common,Switch,Shows tier 2 rows when true (depth N enables 1..N cumulatively)
+131,TierGate,TAG_PARA_STATE_3_BOOL,TEXT,No,Common,Switch,Shows tier 3 rows when true (depth N enables 1..N cumulatively)
+132,TierGate,TAG_PARA_STATE_4_BOOL,TEXT,No,Common,Switch,Shows tier 4 rows when true (depth N enables 1..N cumulatively)
+133,TierGate,TAG_PARA_STATE_5_BOOL,TEXT,No,Common,Switch,Shows tier 5 rows when true (depth N enables 1..N cumulatively)
+134,TierGate,TAG_PARA_STATE_6_BOOL,TEXT,No,Common,Switch,Shows tier 6 rows when true (depth N enables 1..N cumulatively)
+135,TierGate,TAG_PARA_STATE_7_BOOL,TEXT,No,Common,Switch,Shows tier 7 rows when true (depth N enables 1..N cumulatively)
+136,TierGate,TAG_PARA_STATE_8_BOOL,TEXT,No,Common,Switch,Shows tier 8 rows when true (depth N enables 1..N cumulatively)
+137,TierGate,TAG_PARA_STATE_9_BOOL,TEXT,No,Common,Switch,Shows tier 9 rows when true (depth N enables 1..N cumulatively)
+138,TierGate,TAG_PARA_STATE_10_BOOL,TEXT,No,Common,Switch,Shows tier 10 rows when true (depth N enables 1..N cumulatively)
+139,Warning,TAG_WARN_VISIBLE_BOOL,YESNO,0,Common,Switch,Shows threshold warnings on the tag
+140,Warning,TAG_WARN_SEVERITY_FILTER_TXT,TEXT,HIGH,Common,Filter,Minimum warning severity to show (LOW | MEDIUM | HIGH | CRITICAL)
+141,Box,TAG_BOX_COLOR_R_INT,INTEGER,0,Common,Colour,Tag box colour — red channel 0-255
+142,Box,TAG_BOX_COLOR_G_INT,INTEGER,0,Common,Colour,Tag box colour — green channel 0-255
+143,Box,TAG_BOX_COLOR_B_INT,INTEGER,0,Common,Colour,Tag box colour — blue channel 0-255
+144,Box,TAG_BOX_VISIBLE_BOOL,YESNO,1,Common,Switch,Shows / hides the tag box
+145,Box,TAG_BOX_STYLE_TXT,TEXT,SOLID,Common,Style,Tag box style (SOLID | DASHED | NONE | ROUND)
+146,Leader,TAG_LEADER_COLOR_R_INT,INTEGER,0,Common,Colour,Leader colour — red channel 0-255
+147,Leader,TAG_LEADER_COLOR_G_INT,INTEGER,0,Common,Colour,Leader colour — green channel 0-255
+148,Leader,TAG_LEADER_COLOR_B_INT,INTEGER,0,Common,Colour,Leader colour — blue channel 0-255
+149,Scale,TAG_SCALE_TIER_AUTO_BOOL,YESNO,1,Common,Switch,Auto-compute depth tier from view scale
+150,Scale,TAG_DEPTH_TIER_INT,INTEGER,3,Common,Cache,Current depth tier (cached for fast redraw)
+#!STYLE_CATALOG_END
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TIER LABEL CONFIGURATION — DesignConstruction variant (T1-T10, 58 families)
+# Column order: #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ── Tag Family #1: STING - Clinical Room Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_CR_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_CR_A_TXT,,,0,,H,Text,Show T7 - CR Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_CR_B_TXT,,,0,,H,Text,Show T7 - CR Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_CR_C_TXT,,,0,✓,H,Text,Show T7 - CR Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CR_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #2: STING - Pressure Regime Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PR_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_PR_A_TXT,,,0,,H,Text,Show T7 - PR Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_PR_B_TXT,,,0,,H,Text,Show T7 - PR Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_PR_C_TXT,,,0,✓,H,Text,Show T7 - PR Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PR_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #3: STING - Infection Class Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_IC_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_IC_A_TXT,,,0,,H,Text,Show T7 - IC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_IC_B_TXT,,,0,,H,Text,Show T7 - IC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_IC_C_TXT,,,0,✓,H,Text,Show T7 - IC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #4: STING - MRI Zone Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_MZ_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_MZ_A_TXT,,,0,,H,Text,Show T7 - MZ Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_MZ_B_TXT,,,0,,H,Text,Show T7 - MZ Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_MZ_C_TXT,,,0,✓,H,Text,Show T7 - MZ Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MZ_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #5: STING - Anti-Ligature (Door) Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ALD_[A-F]_TXT  •  Discipline: H  •  Template: H_LIG
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,LIG_PRODUCT_RATING_TXT,Rating:,,0,,H,Text,Show T2 - Anti-Ligature Product Rating,"if(TAG_PARA_STATE_2_BOOL, LIG_PRODUCT_RATING_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,LIG_AREA_OBS_LOS_TXT,Obs LOS:,,0,,H,Text,Show T2 - Observation Line-of-Sight,"if(TAG_PARA_STATE_2_BOOL, LIG_AREA_OBS_LOS_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T3 - Serial Number,"if(TAG_PARA_STATE_3_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,✓,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_ALD_A_TXT,,,0,,H,Text,Show T7 - ALD Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_ALD_B_TXT,,,0,,H,Text,Show T7 - ALD Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_ALD_C_TXT,,,0,✓,H,Text,Show T7 - ALD Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALD_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #6: STING - Anti-Ligature (Plumbing Fixture) Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ALPF_[A-F]_TXT  •  Discipline: H  •  Template: H_LIG
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,LIG_PRODUCT_RATING_TXT,Rating:,,0,,H,Text,Show T2 - Anti-Ligature Product Rating,"if(TAG_PARA_STATE_2_BOOL, LIG_PRODUCT_RATING_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,LIG_AREA_OBS_LOS_TXT,Obs LOS:,,0,,H,Text,Show T2 - Observation Line-of-Sight,"if(TAG_PARA_STATE_2_BOOL, LIG_AREA_OBS_LOS_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T3 - Serial Number,"if(TAG_PARA_STATE_3_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,✓,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_ALPF_A_TXT,,,0,,H,Text,Show T7 - ALPF Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_ALPF_B_TXT,,,0,,H,Text,Show T7 - ALPF Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_ALPF_C_TXT,,,0,✓,H,Text,Show T7 - ALPF Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALPF_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #7: STING - Anti-Ligature (Lighting Fixture) Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ALLF_[A-F]_TXT  •  Discipline: H  •  Template: H_LIG
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,LIG_PRODUCT_RATING_TXT,Rating:,,0,,H,Text,Show T2 - Anti-Ligature Product Rating,"if(TAG_PARA_STATE_2_BOOL, LIG_PRODUCT_RATING_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,LIG_AREA_OBS_LOS_TXT,Obs LOS:,,0,,H,Text,Show T2 - Observation Line-of-Sight,"if(TAG_PARA_STATE_2_BOOL, LIG_AREA_OBS_LOS_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T3 - Serial Number,"if(TAG_PARA_STATE_3_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,✓,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_ALLF_A_TXT,,,0,,H,Text,Show T7 - ALLF Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_ALLF_B_TXT,,,0,,H,Text,Show T7 - ALLF Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_ALLF_C_TXT,,,0,✓,H,Text,Show T7 - ALLF Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ALLF_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #8: STING - Bedhead Trunking Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BHT_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_BHT_A_TXT,,,0,,H,Text,Show T7 - BHT Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_BHT_B_TXT,,,0,,H,Text,Show T7 - BHT Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_BHT_C_TXT,,,0,✓,H,Text,Show T7 - BHT Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BHT_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #9: STING - Pendant Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PND_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_PND_A_TXT,,,0,,H,Text,Show T7 - PND Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_PND_B_TXT,,,0,,H,Text,Show T7 - PND Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_PND_C_TXT,,,0,✓,H,Text,Show T7 - PND Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PND_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #10: STING - Scrub Trough Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ST_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_ST_A_TXT,,,0,,H,Text,Show T7 - ST Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_ST_B_TXT,,,0,,H,Text,Show T7 - ST Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_ST_C_TXT,,,0,✓,H,Text,Show T7 - ST Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ST_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #11: STING - Hoist Track Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_HT_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_HT_A_TXT,,,0,,H,Text,Show T7 - HT Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_HT_B_TXT,,,0,,H,Text,Show T7 - HT Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_HT_C_TXT,,,0,✓,H,Text,Show T7 - HT Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HT_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #12: STING - Bariatric Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BAR_[A-F]_TXT  •  Discipline: H  •  Template: H_ROOM
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CLN_ROOM_CLASS_TXT,Rm Class:,,0,,H,Text,Show T2 - Clinical Room Class,"if(TAG_PARA_STATE_2_BOOL, CLN_ROOM_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CLN_DEPT_TXT,Dept:,,0,,H,Text,Show T2 - Department,"if(TAG_PARA_STATE_2_BOOL, CLN_DEPT_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CLN_FUNC_AREA_TXT,Area:,,0,,H,Text,Show T2 - Functional Area,"if(TAG_PARA_STATE_2_BOOL, CLN_FUNC_AREA_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_HTM_STANDARD_TXT,HTM:,,0,,H,Text,Show T2 - HTM Standard Reference,"if(TAG_PARA_STATE_2_BOOL, CLN_HTM_STANDARD_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,ASS_STATUS_TXT,Status:,,0,,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,CLN_BED_COUNT_INT,Beds:,,0,✓,H,Text,Show T2 - Bed Count,"if(TAG_PARA_STATE_2_BOOL, CLN_BED_COUNT_INT, """")",NOM,BLACK,2.0,None,None
+8,T3,CLN_PRESS_REGIME_TXT,Press:,,0,,H,Text,Show T3 - Pressure Regime,"if(TAG_PARA_STATE_3_BOOL, CLN_PRESS_REGIME_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CLN_INFECT_CLASS_TXT,Infect:,,0,,H,Text,Show T3 - Infection Class,"if(TAG_PARA_STATE_3_BOOL, CLN_INFECT_CLASS_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T3 - MRI Zone Classification,"if(TAG_PARA_STATE_3_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_LOC_TXT,Loc:,,0,✓,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_BAR_A_TXT,,,0,,H,Text,Show T7 - BAR Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_BAR_B_TXT,,,0,,H,Text,Show T7 - BAR Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_BAR_C_TXT,,,0,✓,H,Text,Show T7 - BAR Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BAR_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #13: STING - Nurse Call Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_NC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_NC_A_TXT,,,0,,H,Text,Show T7 - NC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_NC_B_TXT,,,0,,H,Text,Show T7 - NC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_NC_C_TXT,,,0,✓,H,Text,Show T7 - NC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_NC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #14: STING - Crash Cart Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_CC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_CC_A_TXT,,,0,,H,Text,Show T7 - CC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_CC_B_TXT,,,0,,H,Text,Show T7 - CC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_CC_C_TXT,,,0,✓,H,Text,Show T7 - CC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #15: STING - AED Cabinet Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_AED_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_AED_A_TXT,,,0,,H,Text,Show T7 - AED Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_AED_B_TXT,,,0,,H,Text,Show T7 - AED Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_AED_C_TXT,,,0,✓,H,Text,Show T7 - AED Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AED_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #16: STING - Hand-Rub Dispenser Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_HRD_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_HRD_A_TXT,,,0,,H,Text,Show T7 - HRD Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_HRD_B_TXT,,,0,,H,Text,Show T7 - HRD Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_HRD_C_TXT,,,0,✓,H,Text,Show T7 - HRD Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HRD_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #17: STING - PTS Station Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PTS_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_PTS_A_TXT,,,0,,H,Text,Show T7 - PTS Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_PTS_B_TXT,,,0,,H,Text,Show T7 - PTS Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_PTS_C_TXT,,,0,✓,H,Text,Show T7 - PTS Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PTS_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #18: STING - AGV Dock Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_AGV_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_AGV_A_TXT,,,0,,H,Text,Show T7 - AGV Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_AGV_B_TXT,,,0,,H,Text,Show T7 - AGV Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_AGV_C_TXT,,,0,✓,H,Text,Show T7 - AGV Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AGV_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #19: STING - Mortuary Fridge Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_MF_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_MF_A_TXT,,,0,,H,Text,Show T7 - MF Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_MF_B_TXT,,,0,,H,Text,Show T7 - MF Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_MF_C_TXT,,,0,✓,H,Text,Show T7 - MF Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MF_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #20: STING - Imaging Modality Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_IM_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_IM_A_TXT,,,0,,H,Text,Show T7 - IM Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_IM_B_TXT,,,0,,H,Text,Show T7 - IM Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_IM_C_TXT,,,0,✓,H,Text,Show T7 - IM Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IM_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #21: STING - Dialysis Station Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_DS_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_DS_A_TXT,,,0,,H,Text,Show T7 - DS Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_DS_B_TXT,,,0,,H,Text,Show T7 - DS Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_DS_C_TXT,,,0,✓,H,Text,Show T7 - DS Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_DS_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #22: STING - Incubator Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_INC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_INC_A_TXT,,,0,,H,Text,Show T7 - INC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_INC_B_TXT,,,0,,H,Text,Show T7 - INC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_INC_C_TXT,,,0,✓,H,Text,Show T7 - INC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_INC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #23: STING - Warming Cot Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_WC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_WC_A_TXT,,,0,,H,Text,Show T7 - WC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_WC_B_TXT,,,0,,H,Text,Show T7 - WC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_WC_C_TXT,,,0,✓,H,Text,Show T7 - WC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #24: STING - Autoclave Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_AC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_AC_A_TXT,,,0,,H,Text,Show T7 - AC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_AC_B_TXT,,,0,,H,Text,Show T7 - AC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_AC_C_TXT,,,0,✓,H,Text,Show T7 - AC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_AC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #25: STING - Washer Disinfector Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_WD_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_WD_A_TXT,,,0,,H,Text,Show T7 - WD Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_WD_B_TXT,,,0,,H,Text,Show T7 - WD Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_WD_C_TXT,,,0,✓,H,Text,Show T7 - WD Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_WD_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #26: STING - Bedpan Washer Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BPW_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_BPW_A_TXT,,,0,,H,Text,Show T7 - BPW Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_BPW_B_TXT,,,0,,H,Text,Show T7 - BPW Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_BPW_C_TXT,,,0,✓,H,Text,Show T7 - BPW Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BPW_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #27: STING - Patient Monitor Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PM_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_PM_A_TXT,,,0,,H,Text,Show T7 - PM Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_PM_B_TXT,,,0,,H,Text,Show T7 - PM Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_PM_C_TXT,,,0,✓,H,Text,Show T7 - PM Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PM_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #28: STING - Medical Refrigerator Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_MEDR_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_MEDR_A_TXT,,,0,,H,Text,Show T7 - MEDR Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_MEDR_B_TXT,,,0,,H,Text,Show T7 - MEDR Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_MEDR_C_TXT,,,0,✓,H,Text,Show T7 - MEDR Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_MEDR_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #29: STING - Pharmacy Isolator Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_PI_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_PI_A_TXT,,,0,,H,Text,Show T7 - PI Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_PI_B_TXT,,,0,,H,Text,Show T7 - PI Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_PI_C_TXT,,,0,✓,H,Text,Show T7 - PI Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_PI_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #30: STING - Operating Light Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_OL_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_OL_A_TXT,,,0,,H,Text,Show T7 - OL Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_OL_B_TXT,,,0,,H,Text,Show T7 - OL Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_OL_C_TXT,,,0,✓,H,Text,Show T7 - OL Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_OL_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #31: STING - Examination Light Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_EL_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_EL_A_TXT,,,0,,H,Text,Show T7 - EL Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_EL_B_TXT,,,0,,H,Text,Show T7 - EL Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_EL_C_TXT,,,0,✓,H,Text,Show T7 - EL Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_EL_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #32: STING - HBO Chamber Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_HBO_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_HBO_A_TXT,,,0,,H,Text,Show T7 - HBO Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_HBO_B_TXT,,,0,,H,Text,Show T7 - HBO Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_HBO_C_TXT,,,0,✓,H,Text,Show T7 - HBO Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_HBO_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #33: STING - Birth Pool Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BP_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_BP_A_TXT,,,0,,H,Text,Show T7 - BP Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_BP_B_TXT,,,0,,H,Text,Show T7 - BP Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_BP_C_TXT,,,0,✓,H,Text,Show T7 - BP Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BP_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #34: STING - IVF Workstation Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_IVF_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_IVF_A_TXT,,,0,,H,Text,Show T7 - IVF Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_IVF_B_TXT,,,0,,H,Text,Show T7 - IVF Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_IVF_C_TXT,,,0,✓,H,Text,Show T7 - IVF Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_IVF_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #35: STING - Cytotoxic Hood Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_CH_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_CH_A_TXT,,,0,,H,Text,Show T7 - CH Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_CH_B_TXT,,,0,,H,Text,Show T7 - CH Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_CH_C_TXT,,,0,✓,H,Text,Show T7 - CH Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_CH_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #36: STING - Lab Fume Hood Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_LFH_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_LFH_A_TXT,,,0,,H,Text,Show T7 - LFH Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_LFH_B_TXT,,,0,,H,Text,Show T7 - LFH Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_LFH_C_TXT,,,0,✓,H,Text,Show T7 - LFH Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_LFH_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #37: STING - Biosafety Cabinet Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_BSC_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_BSC_A_TXT,,,0,,H,Text,Show T7 - BSC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_BSC_B_TXT,,,0,,H,Text,Show T7 - BSC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_BSC_C_TXT,,,0,✓,H,Text,Show T7 - BSC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_BSC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #38: STING - Endoscope Reprocessor Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_ER_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_ER_A_TXT,,,0,,H,Text,Show T7 - ER Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_ER_B_TXT,,,0,,H,Text,Show T7 - ER Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_ER_C_TXT,,,0,✓,H,Text,Show T7 - ER Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_ER_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #39: STING - Surgical Robot Bay Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_SRB_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_SRB_A_TXT,,,0,,H,Text,Show T7 - SRB Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_SRB_B_TXT,,,0,,H,Text,Show T7 - SRB Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_SRB_C_TXT,,,0,✓,H,Text,Show T7 - SRB Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_SRB_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #40: STING - RTLS Reader Tag ──────────────────────────────────────
+# TAG7: CLN_TAG_7_PARA_RR_[A-F]_TXT  •  Discipline: H  •  Template: H_EQUIP
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T2 - Equipment Category,"if(TAG_PARA_STATE_2_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T2 - Manufacturer,"if(TAG_PARA_STATE_2_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T2 - Model Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CEQ_SERIAL_TXT,S/N:,,0,,H,Text,Show T2 - Serial Number,"if(TAG_PARA_STATE_2_BOOL, CEQ_SERIAL_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T2 - HTM Reference,"if(TAG_PARA_STATE_2_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_COMM_DATE_TXT,Comm:,,0,,H,Text,Show T3 - Commissioning Date,"if(TAG_PARA_STATE_3_BOOL, CEQ_COMM_DATE_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MAINT_CYCLE_TXT,Maint:,,0,,H,Text,Show T3 - Maintenance Cycle,"if(TAG_PARA_STATE_3_BOOL, CEQ_MAINT_CYCLE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,CLN_TAG_7_PARA_RR_A_TXT,,,0,,H,Text,Show T7 - RR Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,CLN_TAG_7_PARA_RR_B_TXT,,,0,,H,Text,Show T7 - RR Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,CLN_TAG_7_PARA_RR_C_TXT,,,0,✓,H,Text,Show T7 - RR Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, CLN_TAG_7_PARA_RR_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #41: STING - Medical Gas Pipeline Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_MGP_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_MGP_A_TXT,,,0,,MG,Text,Show T7 - MGP Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_MGP_B_TXT,,,0,,MG,Text,Show T7 - MGP Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_MGP_C_TXT,,,0,✓,MG,Text,Show T7 - MGP Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MGP_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #42: STING - Medical Gas Terminal Unit Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_TU_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_TU_A_TXT,,,0,,MG,Text,Show T7 - TU Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_TU_B_TXT,,,0,,MG,Text,Show T7 - TU Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_TU_C_TXT,,,0,✓,MG,Text,Show T7 - TU Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_TU_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #43: STING - Zone Valve Box Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_ZVB_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_ZVB_A_TXT,,,0,,MG,Text,Show T7 - ZVB Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_ZVB_B_TXT,,,0,,MG,Text,Show T7 - ZVB Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_ZVB_C_TXT,,,0,✓,MG,Text,Show T7 - ZVB Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_ZVB_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #44: STING - Area Alarm Panel Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_AAP_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_AAP_A_TXT,,,0,,MG,Text,Show T7 - AAP Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_AAP_B_TXT,,,0,,MG,Text,Show T7 - AAP Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_AAP_C_TXT,,,0,✓,MG,Text,Show T7 - AAP Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AAP_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #45: STING - Master Alarm Panel Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_MAAP_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_MAAP_A_TXT,,,0,,MG,Text,Show T7 - MAAP Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_MAAP_B_TXT,,,0,,MG,Text,Show T7 - MAAP Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_MAAP_C_TXT,,,0,✓,MG,Text,Show T7 - MAAP Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAAP_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #46: STING - Manifold Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_MAN_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_MAN_A_TXT,,,0,,MG,Text,Show T7 - MAN Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_MAN_B_TXT,,,0,,MG,Text,Show T7 - MAN Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_MAN_C_TXT,,,0,✓,MG,Text,Show T7 - MAN Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_MAN_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #47: STING - VIE Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_VIE_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_VIE_A_TXT,,,0,,MG,Text,Show T7 - VIE Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_VIE_B_TXT,,,0,,MG,Text,Show T7 - VIE Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_VIE_C_TXT,,,0,✓,MG,Text,Show T7 - VIE Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VIE_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #48: STING - Medical Air Plant Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_AIR_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_AIR_A_TXT,,,0,,MG,Text,Show T7 - AIR Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_AIR_B_TXT,,,0,,MG,Text,Show T7 - AIR Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_AIR_C_TXT,,,0,✓,MG,Text,Show T7 - AIR Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AIR_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #49: STING - Medical Vacuum Plant Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_VAC_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_VAC_A_TXT,,,0,,MG,Text,Show T7 - VAC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_VAC_B_TXT,,,0,,MG,Text,Show T7 - VAC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_VAC_C_TXT,,,0,✓,MG,Text,Show T7 - VAC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_VAC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #50: STING - AGS Plant Tag ──────────────────────────────────────
+# TAG7: MGS_TAG_7_PARA_AGS_[A-F]_TXT  •  Discipline: MG  •  Template: MG_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,MGS_GAS_TYPE_TXT,Gas:,,0,,MG,Text,Show T2 - Medical Gas Type,"if(TAG_PARA_STATE_2_BOOL, MGS_GAS_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+3,T2,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T2 - System Type,"if(TAG_PARA_STATE_2_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T2 - Function Code,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,MGS_ZVB_REF_TXT,ZVB Ref:,,0,,MG,Text,Show T2 - Zone Valve Box Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_ZVB_REF_TXT, """")",NOM,BLACK,2.0,None,None
+6,T2,MGS_AAP_REF_TXT,AAP Ref:,,0,,MG,Text,Show T2 - Area Alarm Panel Reference,"if(TAG_PARA_STATE_2_BOOL, MGS_AAP_REF_TXT, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,CEQ_CATEGORY_TXT,Cat:,,0,,H,Text,Show T3 - Equipment Category,"if(TAG_PARA_STATE_3_BOOL, CEQ_CATEGORY_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,CEQ_MANUFACTURER_TXT,Mfr:,,0,,H,Text,Show T3 - Manufacturer,"if(TAG_PARA_STATE_3_BOOL, CEQ_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_MODEL_TXT,Model:,,0,,H,Text,Show T3 - Model Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_MODEL_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,CEQ_HTM_REF_TXT,HTM:,,0,,H,Text,Show T3 - HTM Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,MGS_TAG_7_PARA_AGS_A_TXT,,,0,,MG,Text,Show T7 - AGS Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,MGS_TAG_7_PARA_AGS_B_TXT,,,0,,MG,Text,Show T7 - AGS Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,MGS_TAG_7_PARA_AGS_C_TXT,,,0,✓,MG,Text,Show T7 - AGS Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, MGS_TAG_7_PARA_AGS_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #51: STING - X-ray Barrier Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_XRB_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_XRB_A_TXT,,,0,,RP,Text,Show T7 - XRB Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_XRB_B_TXT,,,0,,RP,Text,Show T7 - XRB Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_XRB_C_TXT,,,0,✓,RP,Text,Show T7 - XRB Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRB_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #52: STING - X-ray Door Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_XRD_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_XRD_A_TXT,,,0,,RP,Text,Show T7 - XRD Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_XRD_B_TXT,,,0,,RP,Text,Show T7 - XRD Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_XRD_C_TXT,,,0,✓,RP,Text,Show T7 - XRD Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRD_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #53: STING - X-ray Window Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_XRW_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_XRW_A_TXT,,,0,,RP,Text,Show T7 - XRW Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_XRW_B_TXT,,,0,,RP,Text,Show T7 - XRW Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_XRW_C_TXT,,,0,✓,RP,Text,Show T7 - XRW Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_XRW_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #54: STING - Linac Maze Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_LMZ_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_LMZ_A_TXT,,,0,,RP,Text,Show T7 - LMZ Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_LMZ_B_TXT,,,0,,RP,Text,Show T7 - LMZ Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_LMZ_C_TXT,,,0,✓,RP,Text,Show T7 - LMZ Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_LMZ_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #55: STING - MRI Faraday Cage Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_FC_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_FC_A_TXT,,,0,,RP,Text,Show T7 - FC Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_FC_B_TXT,,,0,,RP,Text,Show T7 - FC Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_FC_C_TXT,,,0,✓,RP,Text,Show T7 - FC Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FC_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #56: STING - 5-Gauss Marker Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_FGM_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_FGM_A_TXT,,,0,,RP,Text,Show T7 - FGM Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_FGM_B_TXT,,,0,,RP,Text,Show T7 - FGM Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_FGM_C_TXT,,,0,✓,RP,Text,Show T7 - FGM Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_FGM_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #57: STING - Controlled Area Sign Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_CAS_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_CAS_A_TXT,,,0,,RP,Text,Show T7 - CAS Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_CAS_B_TXT,,,0,,RP,Text,Show T7 - CAS Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_CAS_C_TXT,,,0,✓,RP,Text,Show T7 - CAS Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_CAS_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ── Tag Family #58: STING - Dosimetry Post Tag ──────────────────────────────────────
+# TAG7: RAD_TAG_7_PARA_DPT_[A-F]_TXT  •  Discipline: RP  •  Template: RP_FAMILY
+#,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T2,RAD_LEAD_MM_NR,Pb:,mm,0,,RP,Text,Show T2 - Lead Equivalent Thickness,"if(TAG_PARA_STATE_2_BOOL, RAD_LEAD_MM_NR, """")",NOM,BLACK,2.0,None,None
+3,T2,RAD_BARRIER_TYPE_TXT,Barrier:,,0,,RP,Text,Show T2 - Barrier Material Type,"if(TAG_PARA_STATE_2_BOOL, RAD_BARRIER_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+4,T2,RAD_DOSE_DESIGN_GOAL_TXT,Dose:,,0,,RP,Text,Show T2 - Design Dose Goal,"if(TAG_PARA_STATE_2_BOOL, RAD_DOSE_DESIGN_GOAL_TXT, """")",NOM,BLACK,2.0,None,None
+5,T2,CLN_MRI_ZONE_INT,MRI Z:,,0,,H,Text,Show T2 - MRI Zone Classification,"if(TAG_PARA_STATE_2_BOOL, CLN_MRI_ZONE_INT, """")",NOM,BLACK,2.0,None,None
+6,T2,CLN_RF_SHIELD_BOOL,RF Shield:,,0,,H,Text,Show T2 - RF Shielding Present,"if(TAG_PARA_STATE_2_BOOL, CLN_RF_SHIELD_BOOL, """")",NOM,BLACK,2.0,None,None
+7,T2,ASS_STATUS_TXT,Status:,,0,✓,Common,Text,Show T2 - Asset Status,"if(TAG_PARA_STATE_2_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
+8,T3,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show T3 - Function Code,"if(TAG_PARA_STATE_3_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None
+9,T3,ASS_SYSTEM_TYPE_TXT,Sys:,,0,,Common,Text,Show T3 - System Type,"if(TAG_PARA_STATE_3_BOOL, ASS_SYSTEM_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
+10,T3,CEQ_HTM_REF_TXT,Std:,,0,,H,Text,Show T3 - Standard Reference,"if(TAG_PARA_STATE_3_BOOL, CEQ_HTM_REF_TXT, """")",NOM,BLACK,2.0,None,None
+11,T3,ASS_PRODCT_COD_TXT,Prod:,,0,,Common,Text,Show T3 - Product Code,"if(TAG_PARA_STATE_3_BOOL, ASS_PRODCT_COD_TXT, """")",NOM,BLACK,2.0,None,None
+12,T3,ASS_LOC_TXT,Loc:,,0,,Common,Text,Show T3 - Location Code,"if(TAG_PARA_STATE_3_BOOL, ASS_LOC_TXT, """")",NOM,BLACK,2.0,None,None
+13,T3,ASS_ZONE_TXT,Zone:,,0,✓,Common,Text,Show T3 - Zone Code,"if(TAG_PARA_STATE_3_BOOL, ASS_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
+1,T4,COMM_STATE_TXT,Comm:,,0,,Common,Text,Show T4 - Commissioning - State,"if(TAG_PARA_STATE_4_BOOL, COMM_STATE_TXT, """")",BOLD,BLUE,2.0,None,None
+2,T4,COMM_DATE_TXT,on,,0,,Common,Text,Show T4 - Commissioning - Date,"if(TAG_PARA_STATE_4_BOOL, COMM_DATE_TXT, """")",BOLD,BLUE,2.0,None,None
+3,T4,COMM_OPERATIVE_TXT,by,,0,✓,Common,Text,Show T4 - Commissioning - Operative,"if(TAG_PARA_STATE_4_BOOL, COMM_OPERATIVE_TXT, """")",BOLD,BLUE,2.0,None,None
+4,T5,CST_UG_PRICE_UGX_DISP_TXT,,UGX,0,,Common,Text,Show T5 - Cost - UG Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_UG_PRICE_UGX_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+5,T5,CST_INTL_PRICE_USD_DISP_TXT,/ ,USD,0,,Common,Text,Show T5 - Cost - International Tender Price,"if(TAG_PARA_STATE_5_BOOL, CST_INTL_PRICE_USD_DISP_TXT, """")",NOM,PURPLE,2.0,None,None
+6,T5,CST_QUOTE_REF_TXT,Quote:,,0,✓,Common,Text,Show T5 - Cost - Quote Reference,"if(TAG_PARA_STATE_5_BOOL, CST_QUOTE_REF_TXT, """")",NOM,PURPLE,2.0,None,None
+7,T6,CBN_A1_A3_KG_CO2E_DISP_TXT,A1-A3:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Product A1-A3,"if(TAG_PARA_STATE_6_BOOL, CBN_A1_A3_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+8,T6,CBN_A4_KG_CO2E_DISP_TXT,| A4:,kgCO₂e,0,,Common,Text,Show T6 - Carbon - Transport A4,"if(TAG_PARA_STATE_6_BOOL, CBN_A4_KG_CO2E_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+9,T6,CBN_B6_KG_CO2E_YR_DISP_TXT,| B6:,kgCO₂e/yr,0,✓,Common,Text,Show T6 - Carbon - Operational B6,"if(TAG_PARA_STATE_6_BOOL, CBN_B6_KG_CO2E_YR_DISP_TXT, """")",ITALIC,GREEN,2.0,None,None
+10,T7,RAD_TAG_7_PARA_DPT_A_TXT,,,0,,RP,Text,Show T7 - DPT Construction Narrative A,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_A_TXT, """")",NOM,BLACK,2.0,None,None
+11,T7,RAD_TAG_7_PARA_DPT_B_TXT,,,0,,RP,Text,Show T7 - DPT Construction Narrative B,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_B_TXT, """")",NOM,BLACK,2.0,None,None
+12,T7,RAD_TAG_7_PARA_DPT_C_TXT,,,0,✓,RP,Text,Show T7 - DPT Construction Narrative C,"if(TAG_PARA_STATE_7_BOOL, RAD_TAG_7_PARA_DPT_C_TXT, """")",NOM,BLACK,2.0,None,None
+13,T8,CLASH_TRIAGE_SEVERITY_NR_DISP_TXT,Sev:,/5,0,,Common,Text,Show T8 - Clash - Triage Severity,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_SEVERITY_NR_DISP_TXT, """")",BOLD,RED,2.0,None,None
+14,T8,CLASH_TRIAGE_CATEGORY_TXT,,,0,,Common,Text,Show T8 - Clash - Triage Category,"if(TAG_PARA_STATE_8_BOOL, CLASH_TRIAGE_CATEGORY_TXT, """")",BOLD,RED,2.0,None,None
+15,T8,CLASH_RESOLUTION_STATUS_TXT,Res:,,0,✓,Common,Text,Show T8 - Clash - Resolution Status,"if(TAG_PARA_STATE_8_BOOL, CLASH_RESOLUTION_STATUS_TXT, """")",BOLD,RED,2.0,None,None
+16,T9,ASBUILT_DEVIATION_MM_DISP_TXT,Δ:,mm,0,,Common,Text,Show T9 - As-built - Deviation,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_DEVIATION_MM_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+17,T9,ASBUILT_CAPTURE_DATE_TXT,on,,0,,Common,Text,Show T9 - As-built - Capture Date,"if(TAG_PARA_STATE_9_BOOL, ASBUILT_CAPTURE_DATE_TXT, """")",ITALIC,GREY,2.0,None,None
+18,T9,HEALTH_SCORE_LAST_NR_DISP_TXT,Health:,/100,0,✓,Common,Text,Show T9 - Health Score,"if(TAG_PARA_STATE_9_BOOL, HEALTH_SCORE_LAST_NR_DISP_TXT, """")",ITALIC,GREY,2.0,None,None
+19,T10,IFC_PSET_OVERRIDE_TXT,IFC:,,0,,Common,Text,Show T10 - Compliance - IFC PSet Override,"if(TAG_PARA_STATE_10_BOOL, IFC_PSET_OVERRIDE_TXT, """")",NOM,GREY,2.0,None,None
+20,T10,ACC_ISSUE_ID_TXT,ACC:,,0,,Common,Text,Show T10 - Compliance - ACC Issue,"if(TAG_PARA_STATE_10_BOOL, ACC_ISSUE_ID_TXT, """")",NOM,GREY,2.0,None,None
+21,T10,ACC_SYNC_STATUS_TXT,Sync:,,0,✓,Common,Text,Show T10 - Compliance - ACC Sync Status,"if(TAG_PARA_STATE_10_BOOL, ACC_SYNC_STATUS_TXT, """")",NOM,GREY,2.0,None,None
+
+# ══════════════════════════════════════════════════════════════════════════════
+# WARNING PARAMETERS — Healthcare Pack DesignConstruction variant
 # WARNING PARAMETERS — Healthcare Pack (H / MG / RP disciplines)
 # Phase 179 — derived from 16 HealthcareValidatorGate validators
 # Format: #,Sev,Warning Parameter Name,Threshold Condition,Standard,Dis.,Type,Name,Calculated Value Formula

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - MEP (COMPLETE with Warnings)
 Tag Family #1: STING - Air Terminal Tag
 TAG7: HVC_TAG_7_PARA_AT_TXT  •  Category: Air Terminals
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
@@ -293,7 +293,7 @@ TAG7: HVC_TAG_7_PARA_AT_TXT  •  Category: Air Terminals
 Tag Family #2: STING - Duct Accessory Tag
 TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Accessories
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_DCT_PROPERTY_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_PROPERTY_TXT, """")",NOM,BLACK,2.0,None,None
@@ -350,7 +350,7 @@ TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Accessories
 Tag Family #3: STING - Duct Fitting Tag
 TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,HVC_DCT_PROPERTY_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_PROPERTY_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -406,8 +406,8 @@ TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Fittings
 Tag Family #4: STING - Duct Tag
 TAG7: HVC_TAG_7_PARA_DUCT_TXT  •  Category: Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,HVC_DCT_PROPERTY_TXT,[,],0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,HVC_DCT_PROPERTY_TXT,[,],0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
 5,T2,HVC_VEL_MPS,|,m/s,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, HVC_VEL_MPS, """")",NOM,BLACK,2.0,None,None
@@ -487,7 +487,7 @@ TAG7: HVC_TAG_7_PARA_DUCT_TXT  •  Category: Ducts
 Tag Family #5: STING - Flex Duct Tag
 TAG7: HVC_TAG_7_PARA_FLEXDUCT_TXT  •  Category: Flex Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
 4,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -543,7 +543,7 @@ TAG7: HVC_TAG_7_PARA_FLEXDUCT_TXT  •  Category: Flex Ducts
 Tag Family #6: STING - Mechanical Equipment Tag
 TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Mechanical Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_CAP_KW,Cooling:,kW,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_CAP_KW, """")",NOM,BLACK,2.0,None,None
@@ -634,7 +634,7 @@ TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Mechanical Equipment
 Tag Family #7: STING - Flex Pipe Tag
 TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Flex Pipes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_MAT_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -688,7 +688,7 @@ TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Flex Pipes
 Tag Family #8: STING - Pipe Accessory Tag
 TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Accessories
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_DESCRIPTION_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -742,7 +742,7 @@ TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Accessories
 Tag Family #9: STING - Pipe Fitting Tag
 TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_MAT_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -797,8 +797,8 @@ TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Fittings
 Tag Family #10: STING - Pipe Tag
 TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Pipes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_FLW_LPS,Flow:,L/s,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
 5,T2,PLM_VEL_MPS,|,m/s,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, PLM_VEL_MPS, """")",NOM,BLACK,2.0,None,None
@@ -875,7 +875,7 @@ TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Pipes
 Tag Family #11: STING - Plumbing Fixture Tag
 TAG7: PLM_TAG_7_PARA_FIXTURE_TXT  •  Category: Plumbing Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_FLW_LPS,|,L/s,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
@@ -946,7 +946,7 @@ TAG7: PLM_TAG_7_PARA_FIXTURE_TXT  •  Category: Plumbing Fixtures
 Tag Family #12: STING - Fire Alarm Device Tag
 TAG7: FLS_TAG_7_PARA_FA_TXT  •  Category: Fire Alarm Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,FLS_SFTY_DEV_TYPE_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_DEV_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FLS_SFTY_DEV_ZONE_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_DEV_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1010,7 +1010,7 @@ TAG7: FLS_TAG_7_PARA_FA_TXT  •  Category: Fire Alarm Devices
 Tag Family #13: STING - Sprinkler Tag
 TAG7: FLS_TAG_7_PARA_SPR_TXT  •  Category: Sprinklers
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,FLS_SFTY_COVERAGE_AREA_SQ_M,Coverage:,m²,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_COVERAGE_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
 4,T2,FLS_SFTY_K_FACTOR_NR,| K=,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_K_FACTOR_NR, """")",NOM,BLACK,2.0,None,None
@@ -1077,7 +1077,7 @@ TAG7: FLS_TAG_7_PARA_SPR_TXT  •  Category: Sprinklers
 Tag Family #14: STING - Cable Tray Fitting Tag
 TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Tray Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CTR_MAT_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1130,7 +1130,7 @@ TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Tray Fittings
 Tag Family #15: STING - Cable Tray Tag
 TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Trays
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ELC_CTR_MAT_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MNT_HGT_MM,| Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")",NOM,BLACK,2.0,None,None
@@ -1194,7 +1194,7 @@ TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Trays
 Tag Family #16: STING - Conduit Fitting Tag
 TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduit Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_SZ_MM, """")",NOM,BLACK,2.0,None,None
@@ -1245,8 +1245,8 @@ TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduit Fittings
 Tag Family #17: STING - Conduit Tag
 TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduits
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CKT_NR,Ckt:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CKT_NR, """")",NOM,BLACK,2.0,None,None
 5,T2,ELC_CDT_MAT_TXT,|,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1313,8 +1313,8 @@ TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduits
 Tag Family #18: STING - Electrical Equipment Tag
 TAG7: ELC_TAG_7_PARA_PANEL_TXT  •  Category: Electrical Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_PNL_DESIGNATION_NAME_TXT,Panel:,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_PNL_DESIGNATION_NAME_TXT,Panel:,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_PNL_VLT_V,,V,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_PNL_VLT_V, """")",NOM,BLACK,2.0,None,None
 5,T2,ELC_PNL_PHS_COUNT_NR,|,Ph,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ELC_PNL_PHS_COUNT_NR, """")",NOM,BLACK,2.0,None,None
@@ -1402,7 +1402,7 @@ TAG7: ELC_TAG_7_PARA_PANEL_TXT  •  Category: Electrical Equipment
 Tag Family #19: STING - Electrical Fixture Tag
 TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Electrical Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ELC_PWR_KW,Power:,kW,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_PWR_KW, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_VLT_PRIMARY_RATING_V,|,V,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_VLT_PRIMARY_RATING_V, """")",NOM,BLACK,2.0,None,None
@@ -1457,7 +1457,7 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Electrical Fixtures
 Tag Family #20: STING - Lighting Device Tag
 TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ELC_CKT_NR,Ckt:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_CKT_NR, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_PNL_DESIGNATION_NAME_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_PNL_DESIGNATION_NAME_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1511,8 +1511,8 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Devices
 Tag Family #21: STING - Lighting Fixture Tag
 TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,LTG_FIX_TYPE_CLASSIFICATION_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,LTG_FIX_TYPE_CLASSIFICATION_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,LTG_FIX_LMP_WATTAGE_W,,W,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, LTG_FIX_LMP_WATTAGE_W, """")",NOM,BLACK,2.0,None,None
 5,T2,CST_FIX_LUMEN_OUTPUT_LM,|,lm,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, CST_FIX_LUMEN_OUTPUT_LM, """")",NOM,BLACK,2.0,None,None
@@ -1583,7 +1583,7 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Fixtures
 Tag Family #22: STING - Communication Device Tag
 TAG7: COM_TAG_7_PARA_BMS_TXT  •  Category: Communication Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,COM_C_PROTOCOL_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, COM_C_PROTOCOL_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,COM_C_NETWORK_ADDRESS_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, COM_C_NETWORK_ADDRESS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1643,7 +1643,7 @@ TAG7: COM_TAG_7_PARA_BMS_TXT  •  Category: Communication Devices
 Tag Family #23: STING - Data Device Tag
 TAG7: ICT_TAG_7_PARA_DATA_TXT  •  Category: Data Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ICT_OUTLET_TYPE_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ICT_OUTLET_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")",NOM,BLACK,2.0,None,None
@@ -1696,7 +1696,7 @@ TAG7: ICT_TAG_7_PARA_DATA_TXT  •  Category: Data Devices
 Tag Family #24: STING - Nurse Call Device Tag
 TAG7: NCL_TAG_7_PARA_NURSECALL_TXT  •  Category: Nurse Call Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,NCL_ZONE_TXT,Zone:,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, NCL_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")",NOM,BLACK,2.0,None,None
@@ -1747,7 +1747,7 @@ TAG7: NCL_TAG_7_PARA_NURSECALL_TXT  •  Category: Nurse Call Devices
 Tag Family #25: STING - Security Device Tag
 TAG7: SEC_TAG_7_PARA_SECURITY_TXT  •  Category: Security Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SEC_DEV_ZONE_TXT,Zone:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SEC_DEV_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_DESCRIPTION_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1800,7 +1800,7 @@ TAG7: SEC_TAG_7_PARA_SECURITY_TXT  •  Category: Security Devices
 Tag Family #26: STING - Telephone Devices Tag
 TAG7: ICT_TAG_7_PARA_TEL_TXT  •  Category: Telephone Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ICT_OUTLET_TYPE_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ICT_OUTLET_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ICT_PORT_NR_TXT,Port:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ICT_PORT_NR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1856,7 +1856,7 @@ TAG7: ICT_TAG_7_PARA_TEL_TXT  •  Category: Telephone Devices
 Tag Family #27: STING - Generic Model Tag
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Generic Models
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1918,7 +1918,7 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Generic Models
 Tag Family #28: STING - Specialty Equipment Tag
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1985,8 +1985,8 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 Tag Family #29: STING - Duct Insulation Tag
 TAG7: HVC_TAG_7_PARA_DUCT_INSULATION_TXT  •  Category: Duct Insulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2037,8 +2037,8 @@ TAG7: HVC_TAG_7_PARA_DUCT_INSULATION_TXT  •  Category: Duct Insulation
 Tag Family #30: STING - Duct Lining Tag
 TAG7: HVC_TAG_7_PARA_DUCT_LINING_TXT  •  Category: Duct Lining
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,HVC_TAG_7_PARA_DUCT_LINING_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_DUCT_LINING_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2089,8 +2089,8 @@ TAG7: HVC_TAG_7_PARA_DUCT_LINING_TXT  •  Category: Duct Lining
 Tag Family #31: STING - Pipe Insulation Tag
 TAG7: PLM_TAG_7_PARA_PIPE_INSULATION_TXT  •  Category: Pipe Insulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,PLM_TAG_7_PARA_PIPE_INSULATION_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, PLM_TAG_7_PARA_PIPE_INSULATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2142,7 +2142,7 @@ TAG7: PLM_TAG_7_PARA_PIPE_INSULATION_TXT  •  Category: Pipe Insulation
 Tag Family #32: STING - Plumbing Equipment Tag
 TAG7: PLM_TAG_7_PARA_PLM_EQUIP_TXT  •  Category: Plumbing Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_EQP_CAPACITY_L,Cap:,L,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_EQP_CAPACITY_L, """")",NOM,BLACK,2.0,None,None
@@ -2207,8 +2207,8 @@ TAG7: PLM_TAG_7_PARA_PLM_EQUIP_TXT  •  Category: Plumbing Equipment
 Tag Family #33: STING - Mechanical Control Devices Tag
 TAG7: HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT  •  Category: Mechanical Control Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,MEC_CTRL_FUNCTION_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,MEC_CTRL_FUNCTION_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MEC_CTRL_SIGNAL_TXT,Signal:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MEC_CTRL_SIGNAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2258,7 +2258,7 @@ TAG7: HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT  •  Category: Mechanical Control Device
 Tag Family #34: STING - Mechanical Equipment Sets Tag
 TAG7: HVC_TAG_7_PARA_MECH_EQUIP_SETS_TXT  •  Category: Mechanical Equipment Sets
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T3,MEC_SET_CAPACITY_KW,Capacity:,kW,0,✓,Common,Text,Show Tier 3 - 3,"if(TAG_PARA_STATE_3_BOOL, MEC_SET_CAPACITY_KW, """")",NOM,BLACK,2.0,None,None
 4,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -2314,8 +2314,8 @@ TAG7: HVC_TAG_7_PARA_MECH_EQUIP_SETS_TXT  •  Category: Mechanical Equipment Se
 Tag Family #35: STING - Electrical Connectors Tag
 TAG7: ELC_TAG_7_PARA_ELC_CONNECTORS_TXT  •  Category: Electrical Connectors
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CONN_TYPE_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CONN_TYPE_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CKT_BRK_RATING_A,,A,1,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CKT_BRK_RATING_A, """")",NOM,BLACK,2.0,None,None
 5,T3,ELC_TAG_7_PARA_ELC_CONNECTORS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_ELC_CONNECTORS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2363,8 +2363,8 @@ TAG7: ELC_TAG_7_PARA_ELC_CONNECTORS_TXT  •  Category: Electrical Connectors
 Tag Family #36: STING - Fire Protection Tag
 TAG7: FLS_TAG_7_PARA_FIRE_PROT_TXT  •  Category: Fire Protection
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN,,min,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN,,min,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FLS_PROT_PRODUCT_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FLS_PROT_PRODUCT_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,FLS_PROT_CORROSION_PROT_LVL_NR,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, FLS_PROT_CORROSION_PROT_LVL_NR, """")",NOM,BLACK,2.0,None,None
@@ -2418,9 +2418,9 @@ TAG7: FLS_TAG_7_PARA_FIRE_PROT_TXT  •  Category: Fire Protection
 Tag Family #37: STING - MEP Fabrication Containment Tag
 TAG7: ELC_TAG_7_PARA_FAB_CONTAINMENT_TXT  •  Category: MEP Fabrication Containment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_CONTAINMENT_W_MM,,×,0,,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-3,T1,FAB_CONTAINMENT_D_MM,,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_CONTAINMENT_W_MM,,×,0,,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+3,T1,FAB_CONTAINMENT_D_MM,,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 4,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 6,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -2470,9 +2470,9 @@ TAG7: ELC_TAG_7_PARA_FAB_CONTAINMENT_TXT  •  Category: MEP Fabrication Contain
 Tag Family #38: STING - MEP Fabrication Ductwork Tag
 TAG7: HVC_TAG_7_PARA_FAB_DUCTWORK_TXT  •  Category: MEP Fabrication Ductwork
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_DCT_W_MM,,×,0,,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-3,T1,FAB_DCT_H_MM,,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_DCT_W_MM,,×,0,,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+3,T1,FAB_DCT_H_MM,,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 4,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 6,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -2522,8 +2522,8 @@ TAG7: HVC_TAG_7_PARA_FAB_DUCTWORK_TXT  •  Category: MEP Fabrication Ductwork
 Tag Family #39: STING - MEP Fabrication Ductwork Stiffeners Tag
 TAG7: HVC_TAG_7_PARA_FAB_DCT_STIFFENERS_TXT  •  Category: MEP Fabrication Ductwork Stiffeners
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_STIFF_TYPE_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_STIFF_TYPE_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FAB_DCT_W_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FAB_DCT_W_MM, """")",NOM,BLACK,2.0,None,None
 5,T2,FAB_DCT_H_MM,H:,mm,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, FAB_DCT_H_MM, """")",NOM,BLACK,2.0,None,None
@@ -2574,8 +2574,8 @@ TAG7: HVC_TAG_7_PARA_FAB_DCT_STIFFENERS_TXT  •  Category: MEP Fabrication Duct
 Tag Family #40: STING - MEP Fabrication Hangers Tag
 TAG7: MEP_TAG_7_PARA_FAB_HANGERS_TXT  •  Category: MEP Fabrication Hangers
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_HANGER_TYPE_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_HANGER_TYPE_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FAB_HANGER_LOAD_KN,Load:,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FAB_HANGER_LOAD_KN, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2623,8 +2623,8 @@ TAG7: MEP_TAG_7_PARA_FAB_HANGERS_TXT  •  Category: MEP Fabrication Hangers
 Tag Family #41: STING - MEP Fabrication Pipework Tag
 TAG7: PLM_TAG_7_PARA_FAB_PIPEWORK_TXT  •  Category: MEP Fabrication Pipework
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_PIPE_DN_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_PIPE_DN_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -2673,7 +2673,7 @@ TAG7: PLM_TAG_7_PARA_FAB_PIPEWORK_TXT  •  Category: MEP Fabrication Pipework
 Tag Family #42: STING - Materials Tag
 TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T1,MAT_NAME,,,0,✓,Common,Text,Show Tier 1 - 2,Add directly,NOM,BLACK,2.5,None,None
 3,T1,MAT_CATEGORY,,,0,✓,Common,Text,Show Tier 1 - 3,Add directly,NOM,BLACK,2.5,None,None
 4,T2,MAT_MANUFACTURER,Mfr:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MAT_MANUFACTURER, """")",NOM,BLACK,2.0,None,None
@@ -2738,7 +2738,7 @@ TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 Tag Family #43: STING - Audio Visual Devices Tag
 TAG7: ELC_TAG_7_PARA_COMM_TXT  •  Category: Audio Visual Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2794,7 +2794,7 @@ TAG7: ELC_TAG_7_PARA_COMM_TXT  •  Category: Audio Visual Devices
 Tag Family #44: STING - Spaces Tag
 TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Spaces (MEP)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -2844,7 +2844,7 @@ TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Spaces (MEP)
 Tag Family #45: STING - Zones Tag
 TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Zones (HVAC)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Zone Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -2948,8 +2948,8 @@ TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Zones (HVAC)
 Tag Family #46: STING - Tie-In Point Tag (Pipe — Plumbing & Hydraulic)
 TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_TIEIN_FLOW_DIR_TXT,Dir:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_FLOW_DIR_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,PLM_PPE_FLW_LPS,Flow:,L/s,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
@@ -3009,8 +3009,8 @@ TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes
 Tag Family #47: STING - Tie-In Point Tag (Duct — HVAC)
 TAG7: HVC_TAG_7_PARA_TIEIN_TXT  •  Category: Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,HVC_DCT_SZ_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,HVC_DCT_SZ_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_TIEIN_FLOW_DIR_TXT,Dir:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_FLOW_DIR_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
@@ -3071,8 +3071,8 @@ TAG7: HVC_TAG_7_PARA_TIEIN_TXT  •  Category: Ducts
 Tag Family #48: STING - Tie-In Point Tag (Conduit — Electrical LV/ELV)
 TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Conduits
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CDT_SZ_MM,∅,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CDT_SZ_MM,∅,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CDT_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_MAT_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,ASS_TIEIN_ELEV_TXT,Elev:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_ELEV_TXT, """")",NOM,BLACK,2.0,None,None
@@ -3127,8 +3127,8 @@ TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Conduits
 Tag Family #49: STING - Tie-In Point Tag (Cable Tray — Electrical)
 TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Cable Trays
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CTR_SZ_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CTR_SZ_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CTR_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,ELC_CTR_FILL_PCT,Fill:,%,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_FILL_PCT, """")",NOM,BLACK,2.0,None,None
@@ -3185,8 +3185,8 @@ TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Cable Trays
 Tag Family #50: STING - Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)
 TAG7: FLS_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Fire Protection System)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_FLW_LPS,Flow:,L/s,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
 5,T2,PLM_PSR_KPA,|,kPa,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, PLM_PSR_KPA, """")",NOM,BLACK,2.0,None,None
@@ -3244,8 +3244,8 @@ TAG7: FLS_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Fire Protection System)
 Tag Family #51: STING - Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)
 TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Gas System)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PSR_KPA,Press:,kPa,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PSR_KPA, """")",NOM,BLACK,2.0,None,None
 5,T2,ASS_TIEIN_FLOW_DIR_TXT,Dir:,,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_FLOW_DIR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -3304,7 +3304,7 @@ TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Gas System)
 Tag Family #52: STING - MEP Sheet Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets — MEP disciplines (M/E/P/FP/LV)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -3339,7 +3339,7 @@ Tag Family #53: STING - MEP Sleeve Tag
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3415,7 +3415,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,Common,Text,LPS Air Terminal Tag,ELC_LPS_AIRTERM_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3480,7 +3480,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment, Conduits
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_DOWNCOND_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_DOWNCOND_TAG_TXT,,,0,✓,Common,Text,LPS Down Conductor Tag,ELC_LPS_DOWNCOND_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3542,7 +3542,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,Common,Text,LPS Earth Electrode Tag,ELC_LPS_EARTH_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3603,7 +3603,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_BOND_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_BOND_TAG_TXT,,,0,✓,Common,Text,LPS Bonding Connection Tag,ELC_LPS_BOND_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3657,7 +3657,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_SPD_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_SPD_TAG_TXT,,,0,✓,Common,Text,LPS Surge Protection Device Tag,ELC_LPS_SPD_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3672,7 +3672,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_TESTCLAMP_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_TESTCLAMP_TAG_TXT,,,0,✓,Common,Text,LPS Test Clamp Tag,ELC_LPS_TESTCLAMP_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3729,7 +3729,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 Tag Family #60: STING - Specialty Equipment Tag Asset
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_SERIAL_NR_TXT,Ser:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_SERIAL_NR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -3786,7 +3786,7 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 Tag Family #61: STING - Specialty Equipment Tag General
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP_DesignConstruction.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_MEP_DesignConstruction.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - MEP (COMPLETE with Warnings)
 Tag Family #1: STING - Air Terminal Tag
 TAG7: HVC_TAG_7_PARA_AT_TXT  •  Category: Air Terminals
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
@@ -278,7 +278,7 @@ TAG7: HVC_TAG_7_PARA_AT_TXT  •  Category: Air Terminals
 Tag Family #2: STING - Duct Accessory Tag
 TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Accessories
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_DCT_PROPERTY_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_PROPERTY_TXT, """")",NOM,BLACK,2.0,None,None
@@ -322,7 +322,7 @@ TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Accessories
 Tag Family #3: STING - Duct Fitting Tag
 TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,HVC_DCT_PROPERTY_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_PROPERTY_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -365,8 +365,8 @@ TAG7: HVC_TAG_7_PARA_DCTACC_TXT  •  Category: Duct Fittings
 Tag Family #4: STING - Duct Tag
 TAG7: HVC_TAG_7_PARA_DUCT_TXT  •  Category: Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,HVC_DCT_PROPERTY_TXT,[,],0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,HVC_DCT_PROPERTY_TXT,[,],0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
 5,T2,HVC_VEL_MPS,|,m/s,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, HVC_VEL_MPS, """")",NOM,BLACK,2.0,None,None
@@ -433,7 +433,7 @@ TAG7: HVC_TAG_7_PARA_DUCT_TXT  •  Category: Ducts
 Tag Family #5: STING - Flex Duct Tag
 TAG7: HVC_TAG_7_PARA_FLEXDUCT_TXT  •  Category: Flex Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
 4,T2,RGL_STD_TXT,Std:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, RGL_STD_TXT, """")",NOM,BLACK,2.0,None,None
@@ -472,7 +472,7 @@ TAG7: HVC_TAG_7_PARA_FLEXDUCT_TXT  •  Category: Flex Ducts
 Tag Family #6: STING - Mechanical Equipment Tag
 TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Mechanical Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,HVC_CAP_KW,Cooling:,kW,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, HVC_CAP_KW, """")",NOM,BLACK,2.0,None,None
@@ -541,7 +541,7 @@ TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Mechanical Equipment
 Tag Family #7: STING - Flex Pipe Tag
 TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Flex Pipes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_MAT_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -583,7 +583,7 @@ TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Flex Pipes
 Tag Family #8: STING - Pipe Accessory Tag
 TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Accessories
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_DESCRIPTION_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -625,7 +625,7 @@ TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Accessories
 Tag Family #9: STING - Pipe Fitting Tag
 TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_MAT_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -668,8 +668,8 @@ TAG7: PLM_TAG_7_PARA_PIPEACC_TXT  •  Category: Pipe Fittings
 Tag Family #10: STING - Pipe Tag
 TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Pipes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_FLW_LPS,Flow:,L/s,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
 5,T2,PLM_VEL_MPS,|,m/s,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, PLM_VEL_MPS, """")",NOM,BLACK,2.0,None,None
@@ -734,7 +734,7 @@ TAG7: PLM_TAG_7_PARA_PIPE_TXT  •  Category: Pipes
 Tag Family #11: STING - Plumbing Fixture Tag
 TAG7: PLM_TAG_7_PARA_FIXTURE_TXT  •  Category: Plumbing Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,PLM_PPE_SZ_MM,DN,mm,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_SZ_MM, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_FLW_LPS,|,L/s,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
@@ -791,7 +791,7 @@ TAG7: PLM_TAG_7_PARA_FIXTURE_TXT  •  Category: Plumbing Fixtures
 Tag Family #12: STING - Fire Alarm Device Tag
 TAG7: FLS_TAG_7_PARA_FA_TXT  •  Category: Fire Alarm Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,FLS_SFTY_DEV_TYPE_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_DEV_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FLS_SFTY_DEV_ZONE_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_DEV_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -841,7 +841,7 @@ TAG7: FLS_TAG_7_PARA_FA_TXT  •  Category: Fire Alarm Devices
 Tag Family #13: STING - Sprinkler Tag
 TAG7: FLS_TAG_7_PARA_SPR_TXT  •  Category: Sprinklers
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,FLS_SFTY_COVERAGE_AREA_SQ_M,Coverage:,m²,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_COVERAGE_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
 4,T2,FLS_SFTY_K_FACTOR_NR,| K=,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FLS_SFTY_K_FACTOR_NR, """")",NOM,BLACK,2.0,None,None
@@ -894,7 +894,7 @@ TAG7: FLS_TAG_7_PARA_SPR_TXT  •  Category: Sprinklers
 Tag Family #14: STING - Cable Tray Fitting Tag
 TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Tray Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CTR_MAT_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -935,7 +935,7 @@ TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Tray Fittings
 Tag Family #15: STING - Cable Tray Tag
 TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Trays
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ELC_CTR_MAT_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MNT_HGT_MM,| Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")",NOM,BLACK,2.0,None,None
@@ -987,7 +987,7 @@ TAG7: ELC_TAG_7_PARA_TRAY_TXT  •  Category: Cable Trays
 Tag Family #16: STING - Conduit Fitting Tag
 TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduit Fittings
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_SZ_MM, """")",NOM,BLACK,2.0,None,None
@@ -1028,8 +1028,8 @@ TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduit Fittings
 Tag Family #17: STING - Conduit Tag
 TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduits
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CDT_SZ_MM,Conduit:,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CKT_NR,Ckt:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CKT_NR, """")",NOM,BLACK,2.0,None,None
 5,T2,ELC_CDT_MAT_TXT,|,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_MAT_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1086,8 +1086,8 @@ TAG7: ELC_TAG_7_PARA_CONDUIT_TXT  •  Category: Conduits
 Tag Family #18: STING - Electrical Equipment Tag
 TAG7: ELC_TAG_7_PARA_PANEL_TXT  •  Category: Electrical Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_PNL_DESIGNATION_NAME_TXT,Panel:,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_PNL_DESIGNATION_NAME_TXT,Panel:,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_PNL_VLT_V,,V,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_PNL_VLT_V, """")",NOM,BLACK,2.0,None,None
 5,T2,ELC_PNL_PHS_COUNT_NR,|,Ph,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ELC_PNL_PHS_COUNT_NR, """")",NOM,BLACK,2.0,None,None
@@ -1157,7 +1157,7 @@ TAG7: ELC_TAG_7_PARA_PANEL_TXT  •  Category: Electrical Equipment
 Tag Family #19: STING - Electrical Fixture Tag
 TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Electrical Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ELC_PWR_KW,Power:,kW,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_PWR_KW, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_VLT_PRIMARY_RATING_V,|,V,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_VLT_PRIMARY_RATING_V, """")",NOM,BLACK,2.0,None,None
@@ -1198,7 +1198,7 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Electrical Fixtures
 Tag Family #20: STING - Lighting Device Tag
 TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ELC_CKT_NR,Ckt:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ELC_CKT_NR, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_PNL_DESIGNATION_NAME_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_PNL_DESIGNATION_NAME_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1240,8 +1240,8 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Devices
 Tag Family #21: STING - Lighting Fixture Tag
 TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Fixtures
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,LTG_FIX_TYPE_CLASSIFICATION_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,LTG_FIX_TYPE_CLASSIFICATION_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,LTG_FIX_LMP_WATTAGE_W,,W,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, LTG_FIX_LMP_WATTAGE_W, """")",NOM,BLACK,2.0,None,None
 5,T2,CST_FIX_LUMEN_OUTPUT_LM,|,lm,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, CST_FIX_LUMEN_OUTPUT_LM, """")",NOM,BLACK,2.0,None,None
@@ -1300,7 +1300,7 @@ TAG7: ELC_TAG_7_PARA_CIRCUIT_TXT  •  Category: Lighting Fixtures
 Tag Family #22: STING - Communication Device Tag
 TAG7: COM_TAG_7_PARA_BMS_TXT  •  Category: Communication Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,COM_C_PROTOCOL_TXT,,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, COM_C_PROTOCOL_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,COM_C_NETWORK_ADDRESS_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, COM_C_NETWORK_ADDRESS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1348,7 +1348,7 @@ TAG7: COM_TAG_7_PARA_BMS_TXT  •  Category: Communication Devices
 Tag Family #23: STING - Data Device Tag
 TAG7: ICT_TAG_7_PARA_DATA_TXT  •  Category: Data Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ICT_OUTLET_TYPE_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ICT_OUTLET_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")",NOM,BLACK,2.0,None,None
@@ -1389,7 +1389,7 @@ TAG7: ICT_TAG_7_PARA_DATA_TXT  •  Category: Data Devices
 Tag Family #24: STING - Nurse Call Device Tag
 TAG7: NCL_TAG_7_PARA_NURSECALL_TXT  •  Category: Nurse Call Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,NCL_ZONE_TXT,Zone:,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, NCL_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MNT_HGT_MM,Ht:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MNT_HGT_MM, """")",NOM,BLACK,2.0,None,None
@@ -1428,7 +1428,7 @@ TAG7: NCL_TAG_7_PARA_NURSECALL_TXT  •  Category: Nurse Call Devices
 Tag Family #25: STING - Security Device Tag
 TAG7: SEC_TAG_7_PARA_SECURITY_TXT  •  Category: Security Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SEC_DEV_ZONE_TXT,Zone:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SEC_DEV_ZONE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_DESCRIPTION_TXT,|,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1469,7 +1469,7 @@ TAG7: SEC_TAG_7_PARA_SECURITY_TXT  •  Category: Security Devices
 Tag Family #26: STING - Telephone Devices Tag
 TAG7: ICT_TAG_7_PARA_TEL_TXT  •  Category: Telephone Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ICT_OUTLET_TYPE_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ICT_OUTLET_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ICT_PORT_NR_TXT,Port:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ICT_PORT_NR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1513,7 +1513,7 @@ TAG7: ICT_TAG_7_PARA_TEL_TXT  •  Category: Telephone Devices
 Tag Family #27: STING - Generic Model Tag
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Generic Models
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1563,7 +1563,7 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Generic Models
 Tag Family #28: STING - Specialty Equipment Tag
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1618,8 +1618,8 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 Tag Family #29: STING - Duct Insulation Tag
 TAG7: HVC_TAG_7_PARA_DUCT_INSULATION_TXT  •  Category: Duct Insulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1653,8 +1653,8 @@ TAG7: HVC_TAG_7_PARA_DUCT_INSULATION_TXT  •  Category: Duct Insulation
 Tag Family #30: STING - Duct Lining Tag
 TAG7: HVC_TAG_7_PARA_DUCT_LINING_TXT  •  Category: Duct Lining
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,HVC_TAG_7_PARA_DUCT_LINING_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_DUCT_LINING_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1695,8 +1695,8 @@ TAG7: HVC_TAG_7_PARA_DUCT_LINING_TXT  •  Category: Duct Lining
 Tag Family #31: STING - Pipe Insulation Tag
 TAG7: PLM_TAG_7_PARA_PIPE_INSULATION_TXT  •  Category: Pipe Insulation
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_INS_THICKNESS_MM,,mm,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,INS_MATERIAL_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, INS_MATERIAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,PLM_TAG_7_PARA_PIPE_INSULATION_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, PLM_TAG_7_PARA_PIPE_INSULATION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1736,7 +1736,7 @@ TAG7: PLM_TAG_7_PARA_PIPE_INSULATION_TXT  •  Category: Pipe Insulation
 Tag Family #32: STING - Plumbing Equipment Tag
 TAG7: PLM_TAG_7_PARA_PLM_EQUIP_TXT  •  Category: Plumbing Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_EQP_CAPACITY_L,Cap:,L,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_EQP_CAPACITY_L, """")",NOM,BLACK,2.0,None,None
@@ -1787,8 +1787,8 @@ TAG7: PLM_TAG_7_PARA_PLM_EQUIP_TXT  •  Category: Plumbing Equipment
 Tag Family #33: STING - Mechanical Control Devices Tag
 TAG7: HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT  •  Category: Mechanical Control Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,MEC_CTRL_FUNCTION_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,MEC_CTRL_FUNCTION_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,MEC_CTRL_SIGNAL_TXT,Signal:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MEC_CTRL_SIGNAL_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1826,7 +1826,7 @@ TAG7: HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT  •  Category: Mechanical Control Device
 Tag Family #34: STING - Mechanical Equipment Sets Tag
 TAG7: HVC_TAG_7_PARA_MECH_EQUIP_SETS_TXT  •  Category: Mechanical Equipment Sets
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T3,MEC_SET_CAPACITY_KW,Capacity:,kW,0,✓,Common,Text,Show Tier 3 - 3,"if(TAG_PARA_STATE_3_BOOL, MEC_SET_CAPACITY_KW, """")",NOM,BLACK,2.0,None,None
 4,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -1862,8 +1862,8 @@ TAG7: HVC_TAG_7_PARA_MECH_EQUIP_SETS_TXT  •  Category: Mechanical Equipment Se
 Tag Family #35: STING - Electrical Connectors Tag
 TAG7: ELC_TAG_7_PARA_ELC_CONNECTORS_TXT  •  Category: Electrical Connectors
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CONN_TYPE_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CONN_TYPE_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CKT_BRK_RATING_A,,A,1,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CKT_BRK_RATING_A, """")",NOM,BLACK,2.0,None,None
 5,T3,ELC_TAG_7_PARA_ELC_CONNECTORS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ELC_TAG_7_PARA_ELC_CONNECTORS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1899,8 +1899,8 @@ TAG7: ELC_TAG_7_PARA_ELC_CONNECTORS_TXT  •  Category: Electrical Connectors
 Tag Family #36: STING - Fire Protection Tag
 TAG7: FLS_TAG_7_PARA_FIRE_PROT_TXT  •  Category: Fire Protection
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN,,min,1,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN,,min,1,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FLS_PROT_PRODUCT_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FLS_PROT_PRODUCT_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,FLS_PROT_CORROSION_PROT_LVL_NR,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, FLS_PROT_CORROSION_PROT_LVL_NR, """")",NOM,BLACK,2.0,None,None
@@ -1940,9 +1940,9 @@ TAG7: FLS_TAG_7_PARA_FIRE_PROT_TXT  •  Category: Fire Protection
 Tag Family #37: STING - MEP Fabrication Containment Tag
 TAG7: ELC_TAG_7_PARA_FAB_CONTAINMENT_TXT  •  Category: MEP Fabrication Containment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_CONTAINMENT_W_MM,,×,0,,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-3,T1,FAB_CONTAINMENT_D_MM,,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_CONTAINMENT_W_MM,,×,0,,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+3,T1,FAB_CONTAINMENT_D_MM,,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 4,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 6,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -1980,9 +1980,9 @@ TAG7: ELC_TAG_7_PARA_FAB_CONTAINMENT_TXT  •  Category: MEP Fabrication Contain
 Tag Family #38: STING - MEP Fabrication Ductwork Tag
 TAG7: HVC_TAG_7_PARA_FAB_DUCTWORK_TXT  •  Category: MEP Fabrication Ductwork
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_DCT_W_MM,,×,0,,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-3,T1,FAB_DCT_H_MM,,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_DCT_W_MM,,×,0,,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+3,T1,FAB_DCT_H_MM,,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 4,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 6,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 6,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -2022,8 +2022,8 @@ TAG7: HVC_TAG_7_PARA_FAB_DUCTWORK_TXT  •  Category: MEP Fabrication Ductwork
 Tag Family #39: STING - MEP Fabrication Ductwork Stiffeners Tag
 TAG7: HVC_TAG_7_PARA_FAB_DCT_STIFFENERS_TXT  •  Category: MEP Fabrication Ductwork Stiffeners
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_STIFF_TYPE_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_STIFF_TYPE_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FAB_DCT_W_MM,W:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FAB_DCT_W_MM, """")",NOM,BLACK,2.0,None,None
 5,T2,FAB_DCT_H_MM,H:,mm,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, FAB_DCT_H_MM, """")",NOM,BLACK,2.0,None,None
@@ -2064,8 +2064,8 @@ TAG7: HVC_TAG_7_PARA_FAB_DCT_STIFFENERS_TXT  •  Category: MEP Fabrication Duct
 Tag Family #40: STING - MEP Fabrication Hangers Tag
 TAG7: MEP_TAG_7_PARA_FAB_HANGERS_TXT  •  Category: MEP Fabrication Hangers
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_HANGER_TYPE_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_HANGER_TYPE_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,FAB_HANGER_LOAD_KN,Load:,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, FAB_HANGER_LOAD_KN, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2099,8 +2099,8 @@ TAG7: MEP_TAG_7_PARA_FAB_HANGERS_TXT  •  Category: MEP Fabrication Hangers
 Tag Family #41: STING - MEP Fabrication Pipework Tag
 TAG7: PLM_TAG_7_PARA_FAB_PIPEWORK_TXT  •  Category: MEP Fabrication Pipework
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,FAB_PIPE_DN_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,FAB_PIPE_DN_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 4,T3,ASS_STATUS_TXT,,,0,✓,Common,Text,Show Tier 3 - 4,"if(TAG_PARA_STATE_3_BOOL, ASS_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 5,T3,ASS_CST_TOTAL_UGX_NR,,UGX,1,✓,Common,Text,Show Tier 3 - 5,"if(TAG_PARA_STATE_3_BOOL, ASS_CST_TOTAL_UGX_NR, """")",NOM,BLACK,2.0,None,None
@@ -2139,7 +2139,7 @@ TAG7: PLM_TAG_7_PARA_FAB_PIPEWORK_TXT  •  Category: MEP Fabrication Pipework
 Tag Family #42: STING - Materials Tag
 TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T1,MAT_NAME,,,0,✓,Common,Text,Show Tier 1 - 2,Add directly,NOM,BLACK,2.5,None,None
 3,T1,MAT_CATEGORY,,,0,✓,Common,Text,Show Tier 1 - 3,Add directly,NOM,BLACK,2.5,None,None
 4,T2,MAT_MANUFACTURER,Mfr:,,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, MAT_MANUFACTURER, """")",NOM,BLACK,2.0,None,None
@@ -2192,7 +2192,7 @@ TAG7: PROP_TAG_7_PARA_MATERIALS_TXT  •  Category: Materials
 Tag Family #43: STING - Audio Visual Devices Tag
 TAG7: ELC_TAG_7_PARA_COMM_TXT  •  Category: Audio Visual Devices
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_MANUFACTURER_TXT,Mfr:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_MANUFACTURER_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2236,7 +2236,7 @@ TAG7: ELC_TAG_7_PARA_COMM_TXT  •  Category: Audio Visual Devices
 Tag Family #44: STING - Spaces Tag
 TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Spaces (MEP)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -2280,7 +2280,7 @@ TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Spaces (MEP)
 Tag Family #45: STING - Zones Tag
 TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Zones (HVAC)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_ROOM_AREA_SQ_M,Zone Area:,m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_ROOM_AREA_SQ_M, """")",NOM,BLACK,2.0,None,None
@@ -2378,8 +2378,8 @@ TAG7: HVC_TAG_7_PARA_SPEC_TXT  •  Category: Zones (HVAC)
 Tag Family #46: STING - Tie-In Point Tag (Pipe — Plumbing & Hydraulic)
 TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_TIEIN_FLOW_DIR_TXT,Dir:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_FLOW_DIR_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,PLM_PPE_FLW_LPS,Flow:,L/s,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
@@ -2429,8 +2429,8 @@ TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes
 Tag Family #47: STING - Tie-In Point Tag (Duct — HVAC)
 TAG7: HVC_TAG_7_PARA_TIEIN_TXT  •  Category: Ducts
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,HVC_DCT_SZ_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,HVC_DCT_SZ_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_TIEIN_FLOW_DIR_TXT,Dir:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_FLOW_DIR_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,HVC_DCT_FLW_CFM,Flow:,CFM,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, HVC_DCT_FLW_CFM, """")",NOM,BLACK,2.0,None,None
@@ -2481,8 +2481,8 @@ TAG7: HVC_TAG_7_PARA_TIEIN_TXT  •  Category: Ducts
 Tag Family #48: STING - Tie-In Point Tag (Conduit — Electrical LV/ELV)
 TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Conduits
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CDT_SZ_MM,∅,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CDT_SZ_MM,∅,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CDT_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CDT_MAT_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,ASS_TIEIN_ELEV_TXT,Elev:,,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_ELEV_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2527,8 +2527,8 @@ TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Conduits
 Tag Family #49: STING - Tie-In Point Tag (Cable Tray — Electrical)
 TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Cable Trays
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,ELC_CTR_SZ_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,ELC_CTR_SZ_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ELC_CTR_MAT_TXT,Mat:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_MAT_TXT, """")",NOM,BLACK,2.0,None,None
 5,T2,ELC_CTR_FILL_PCT,Fill:,%,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ELC_CTR_FILL_PCT, """")",NOM,BLACK,2.0,None,None
@@ -2573,8 +2573,8 @@ TAG7: ELC_TAG_7_PARA_TIEIN_TXT  •  Category: Cable Trays
 Tag Family #50: STING - Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)
 TAG7: FLS_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Fire Protection System)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PPE_FLW_LPS,Flow:,L/s,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PPE_FLW_LPS, """")",NOM,BLACK,2.0,None,None
 5,T2,PLM_PSR_KPA,|,kPa,0,✓,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, PLM_PSR_KPA, """")",NOM,BLACK,2.0,None,None
@@ -2622,8 +2622,8 @@ TAG7: FLS_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Fire Protection System)
 Tag Family #51: STING - Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)
 TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Gas System)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
-2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TIEIN_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
+2,T1,PLM_PPE_SZ_MM,DN,mm,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 3,T2,ASS_TIEIN_STATUS_TXT,[,],0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_STATUS_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,PLM_PSR_KPA,Press:,kPa,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, PLM_PSR_KPA, """")",NOM,BLACK,2.0,None,None
 5,T2,ASS_TIEIN_FLOW_DIR_TXT,Dir:,,0,,Common,Text,Show Tier 2 - 5,"if(TAG_PARA_STATE_2_BOOL, ASS_TIEIN_FLOW_DIR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2672,7 +2672,7 @@ TAG7: PLM_TAG_7_PARA_TIEIN_TXT  •  Category: Pipes (Gas System)
 Tag Family #52: STING - MEP Sheet Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets — MEP disciplines (M/E/P/FP/LV)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -2713,7 +2713,7 @@ Tag Family #53: STING - MEP Sleeve Tag
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -2769,7 +2769,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_AIRTERM_TAG_TXT,,,0,✓,Common,Text,LPS Air Terminal Tag,ELC_LPS_AIRTERM_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -2823,7 +2823,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment, Conduits
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_DOWNCOND_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_DOWNCOND_TAG_TXT,,,0,✓,Common,Text,LPS Down Conductor Tag,ELC_LPS_DOWNCOND_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -2874,7 +2874,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,Common,Text,LPS Earth Electrode Tag,ELC_LPS_EARTH_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -2924,7 +2924,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_BOND_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_BOND_TAG_TXT,,,0,✓,Common,Text,LPS Bonding Connection Tag,ELC_LPS_BOND_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -2967,7 +2967,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_SPD_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_SPD_TAG_TXT,,,0,✓,Common,Text,LPS Surge Protection Device Tag,ELC_LPS_SPD_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3006,7 +3006,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_TESTCLAMP_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_TESTCLAMP_TAG_TXT,,,0,✓,Common,Text,LPS Test Clamp Tag,ELC_LPS_TESTCLAMP_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
@@ -3046,7 +3046,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Electrical Equipment
 Tag Family #60: STING - Specialty Equipment Tag Asset
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_SERIAL_NR_TXT,Ser:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_SERIAL_NR_TXT, """")",NOM,BLACK,2.0,None,None
@@ -3092,7 +3092,7 @@ TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 Tag Family #61: STING - Specialty Equipment Tag General
 TAG7: ASS_TAG_7_PARA_EQUIPMENT_TXT  •  Category: Specialty Equipment
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,ASS_FUNC_TXT,Func:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, ASS_FUNC_TXT, """")",NOM,BLACK,2.0,None,None

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_STR.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - STR (COMPLETE with Warnings)
 Tag Family #1: STING - Structural Column Tag
 TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Structural Columns
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_COL_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_COL_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -301,7 +301,7 @@ TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Structural Columns
 Tag Family #2: STING - Structural Framing Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Framing
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -379,7 +379,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Framing
 Tag Family #3: STING - Structural Foundation Tag
 TAG7: STR_TAG_7_PARA_FDN_TXT  •  Category: Structural Foundations
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_FDN_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_FDN_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -449,7 +449,7 @@ TAG7: STR_TAG_7_PARA_FDN_TXT  •  Category: Structural Foundations
 Tag Family #4: STING - Structural Slab Tag
 TAG7: STR_TAG_7_PARA_SLAB_TXT  •  Category: Floors (Structural)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STRUCT_SLAB_THICKNESS_MM,,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STRUCT_SLAB_THICKNESS_MM, """")",NOM,BLACK,2.0,None,None
@@ -514,7 +514,7 @@ TAG7: STR_TAG_7_PARA_SLAB_TXT  •  Category: Floors (Structural)
 Tag Family #5: STING - Structural Wall Tag
 TAG7: STR_TAG_7_PARA_WALL_TXT  •  Category: Walls (Structural/Load-bearing)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_THICKNESS_MM,,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_THICKNESS_MM, """")",NOM,BLACK,2.0,None,None
@@ -575,7 +575,7 @@ TAG7: STR_TAG_7_PARA_WALL_TXT  •  Category: Walls (Structural/Load-bearing)
 Tag Family #6: STING - Brace / Truss Tag
 TAG7: STR_TAG_7_PARA_BRACE_TXT  •  Category: Structural Framing (Bracing)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BRACE_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BRACE_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -634,7 +634,7 @@ TAG7: STR_TAG_7_PARA_BRACE_TXT  •  Category: Structural Framing (Bracing)
 Tag Family #7: STING - Structural Rebar Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Size:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -695,7 +695,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar
 Tag Family #8: STING - Structural Connection Tag
 TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Structural Connections
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_CONN_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_CONN_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -756,7 +756,7 @@ TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Structural Connections
 Tag Family #9: STING - Columns Tag
 TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Columns (Architectural)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_COL_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_COL_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -812,7 +812,7 @@ TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Columns (Architectural)
 Tag Family #10: STING - Structural Trusses Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Trusses
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -874,7 +874,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Trusses
 Tag Family #11: STING - Structural Stiffeners Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Stiffeners
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -927,7 +927,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Stiffeners
 Tag Family #12: STING - Structural Beam Systems Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Beam Systems
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -983,7 +983,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Beam Systems
 Tag Family #13: STING - Structural Rebar Couplers Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar Couplers
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Size:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -1035,7 +1035,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar Couplers
 Tag Family #14: STING - Structural Fabric Reinforcement Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Fabric Reinforcement
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Wire:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -1088,7 +1088,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Fabric Reinforcement
 Tag Family #15: STING - Structural Area Reinforcement Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Area Reinforcement
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Bar:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -1142,7 +1142,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Area Reinforcement
 Tag Family #16: STING - Structural Path Reinforcement Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Path Reinforcement
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Bar:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -1199,7 +1199,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Path Reinforcement
 Tag Family #17: STING - Internal Point Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_POINT_LOAD_KN,,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_POINT_LOAD_KN, """")",NOM,BLACK,2.0,None,None
@@ -1246,7 +1246,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 Tag Family #18: STING - Internal Line Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_LINE_LOAD_KN_M,,kN/m,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_LINE_LOAD_KN_M, """")",NOM,BLACK,2.0,None,None
@@ -1293,7 +1293,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 Tag Family #19: STING - Internal Area Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_AREA_LOAD_KN_M2,,kN/m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_AREA_LOAD_KN_M2, """")",NOM,BLACK,2.0,None,None
@@ -1341,7 +1341,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 Tag Family #20: STING - Analytical Members Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_SECTION_PROFILE_TXT,Section:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_SECTION_PROFILE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1387,7 +1387,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 Tag Family #21: STING - Structural Sheet Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets — Structural discipline
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1424,7 +1424,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Structural Foundations / Rebar
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,Common,Text,LPS Earth Electrode Tag,ELC_LPS_EARTH_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow

--- a/StingTools/Data/STING_TAG_CONFIG_v5_0_STR_DesignConstruction.csv
+++ b/StingTools/Data/STING_TAG_CONFIG_v5_0_STR_DesignConstruction.csv
@@ -230,7 +230,7 @@ STING Tag Configuration v5.0 - STR (COMPLETE with Warnings)
 Tag Family #1: STING - Structural Column Tag
 TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Structural Columns
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_COL_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_COL_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -289,7 +289,7 @@ TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Structural Columns
 Tag Family #2: STING - Structural Framing Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Framing
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -349,7 +349,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Framing
 Tag Family #3: STING - Structural Foundation Tag
 TAG7: STR_TAG_7_PARA_FDN_TXT  •  Category: Structural Foundations
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_FDN_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_FDN_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -408,7 +408,7 @@ TAG7: STR_TAG_7_PARA_FDN_TXT  •  Category: Structural Foundations
 Tag Family #4: STING - Structural Slab Tag
 TAG7: STR_TAG_7_PARA_SLAB_TXT  •  Category: Floors (Structural)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_STRUCT_SLAB_THICKNESS_MM,,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_STRUCT_SLAB_THICKNESS_MM, """")",NOM,BLACK,2.0,None,None
@@ -461,7 +461,7 @@ TAG7: STR_TAG_7_PARA_SLAB_TXT  •  Category: Floors (Structural)
 Tag Family #5: STING - Structural Wall Tag
 TAG7: STR_TAG_7_PARA_WALL_TXT  •  Category: Walls (Structural/Load-bearing)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,BLE_WALL_THICKNESS_MM,,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, BLE_WALL_THICKNESS_MM, """")",NOM,BLACK,2.0,None,None
@@ -510,7 +510,7 @@ TAG7: STR_TAG_7_PARA_WALL_TXT  •  Category: Walls (Structural/Load-bearing)
 Tag Family #6: STING - Brace / Truss Tag
 TAG7: STR_TAG_7_PARA_BRACE_TXT  •  Category: Structural Framing (Bracing)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BRACE_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BRACE_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -557,7 +557,7 @@ TAG7: STR_TAG_7_PARA_BRACE_TXT  •  Category: Structural Framing (Bracing)
 Tag Family #7: STING - Structural Rebar Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Size:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -606,7 +606,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar
 Tag Family #8: STING - Structural Connection Tag
 TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Structural Connections
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_CONN_TYPE_TXT,Type:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_CONN_TYPE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -655,7 +655,7 @@ TAG7: STR_TAG_7_PARA_CONN_TXT  •  Category: Structural Connections
 Tag Family #9: STING - Columns Tag
 TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Columns (Architectural)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_COL_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_COL_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -699,7 +699,7 @@ TAG7: STR_TAG_7_PARA_COL_TXT  •  Category: Columns (Architectural)
 Tag Family #10: STING - Structural Trusses Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Trusses
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -749,7 +749,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Trusses
 Tag Family #11: STING - Structural Stiffeners Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Stiffeners
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -790,7 +790,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Stiffeners
 Tag Family #12: STING - Structural Beam Systems Tag
 TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Beam Systems
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_BEAM_SECTION_TXT,Sec:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_BEAM_SECTION_TXT, """")",NOM,BLACK,2.0,None,None
@@ -834,7 +834,7 @@ TAG7: STR_TAG_7_PARA_BEAM_TXT  •  Category: Structural Beam Systems
 Tag Family #13: STING - Structural Rebar Couplers Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar Couplers
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Size:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -874,7 +874,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Rebar Couplers
 Tag Family #14: STING - Structural Fabric Reinforcement Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Fabric Reinforcement
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Wire:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -915,7 +915,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Fabric Reinforcement
 Tag Family #15: STING - Structural Area Reinforcement Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Area Reinforcement
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Bar:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -957,7 +957,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Area Reinforcement
 Tag Family #16: STING - Structural Path Reinforcement Tag
 TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Path Reinforcement
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_REBAR_SIZE_MM,Bar:,mm,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_REBAR_SIZE_MM, """")",NOM,BLACK,2.0,None,None
@@ -1002,7 +1002,7 @@ TAG7: STR_TAG_7_PARA_REBAR_TXT  •  Category: Structural Path Reinforcement
 Tag Family #17: STING - Internal Point Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_POINT_LOAD_KN,,kN,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_POINT_LOAD_KN, """")",NOM,BLACK,2.0,None,None
@@ -1043,7 +1043,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Point Loads
 Tag Family #18: STING - Internal Line Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_LINE_LOAD_KN_M,,kN/m,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_LINE_LOAD_KN_M, """")",NOM,BLACK,2.0,None,None
@@ -1084,7 +1084,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Line Loads
 Tag Family #19: STING - Internal Area Loads Tag
 TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_AREA_LOAD_KN_M2,,kN/m²,0,✓,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_AREA_LOAD_KN_M2, """")",NOM,BLACK,2.0,None,None
@@ -1126,7 +1126,7 @@ TAG7: STR_TAG_7_PARA_LOAD_TXT  •  Category: Internal Area Loads
 Tag Family #20: STING - Analytical Members Tag
 TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ASS_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,ASS_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,ASS_TAG_2_TXT,,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, ASS_TAG_2_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,ASS_DESCRIPTION_TXT,,,0,✓,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, ASS_DESCRIPTION_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,STR_SECTION_PROFILE_TXT,Section:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, STR_SECTION_PROFILE_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1166,7 +1166,7 @@ TAG7: STR_TAG_7_PARA_ANLYT_TXT  •  Category: Analytical Members
 Tag Family #21: STING - Structural Sheet Tag
 TAG7: SHT_TAG_7_TXT  •  Category: Sheets — Structural discipline
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,SHT_TAG_1_TXT,,,0,✓,---,---,---,Add directly,NOM,BLACK,2.5,None,None
+1,T1,SHT_TAG_1_TXT,,,0,✓,Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None
 2,T2,SHT_DISC_TXT,Disc:,,0,✓,Common,Text,Show Tier 2 - 2,"if(TAG_PARA_STATE_2_BOOL, SHT_DISC_TXT, """")",NOM,BLACK,2.0,None,None
 3,T2,SHT_FORM_TXT,Form:,,0,,Common,Text,Show Tier 2 - 3,"if(TAG_PARA_STATE_2_BOOL, SHT_FORM_TXT, """")",NOM,BLACK,2.0,None,None
 4,T2,SHT_LEVEL_TXT,Level:,,0,,Common,Text,Show Tier 2 - 4,"if(TAG_PARA_STATE_2_BOOL, SHT_LEVEL_TXT, """")",NOM,BLACK,2.0,None,None
@@ -1209,7 +1209,7 @@ TAG7: ELC_TAG_7_PARA_LPS_TXT  •  Category: Structural Foundations / Rebar
 
 ★ TIER 1 — COMPACT (always visible)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow
-1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,---,---,---,Add directly,BOLD,BLUE,2.5,None,None
+1,T1,ELC_LPS_EARTH_TAG_TXT,,,0,✓,Common,Text,LPS Earth Electrode Tag,ELC_LPS_EARTH_TAG_TXT,BOLD,BLUE,2.5,None,None
 
 ★ TIER 2 — TECHNICAL (gated by TAG_PARA_STATE_2_BOOL)
 #,Tier,Parameter,Prefix,Suffix,Spc,Brk,Discipline,Type,Name,Formula,Style,Color,Size,Box,Arrow

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -3522,4 +3522,288 @@ namespace StingTools.Tags
             }
         }
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Augment Tag Families — reinject T4-T10 into existing .rfa files
+    // ════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Reinjects T4-T10 shared parameters and visibility formulas into
+    /// existing STING tag family .rfa files without touching any already-
+    /// configured T1-T3 label rows.
+    ///
+    /// Safe by design:
+    ///   • <c>FamilyManager.AddParameter</c> is additive-only — if a shared
+    ///     parameter is already bound, the call is a no-op. T1-T3 parameters
+    ///     and their label elements are never removed or repositioned.
+    ///   • <c>FamilyLabelAuthor.AuthorLabelsMulti</c> only processes rows
+    ///     declared in T4..T10 of the CSV tier plans. T1-T3 label elements are
+    ///     completely outside its scope.
+    ///   • When <c>preserveHandEdits</c> is true (default), families where ANY
+    ///     text/annotation element has been manually positioned have their
+    ///     formula re-writes skipped — only the param bindings are added.
+    ///
+    /// Use case: you ran CreateTagFamilies and configured T1-T3 labels in the
+    /// Revit family editor. Later the CSV files gained T4-T10 content (or the
+    /// CSVs were updated). Run AugmentTagFamilies to bring every .rfa up to
+    /// date with the current CSV tier definitions without losing your label work.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class AugmentTagFamiliesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData,
+            ref string message, ElementSet elements)
+        {
+            UIApplication uiApp = ParameterHelpers.GetApp(commandData);
+            Document doc = uiApp.ActiveUIDocument?.Document;
+            var app = uiApp.Application;
+
+            // ── Step 1: Shared param file ──────────────────────────────
+            string sharedParamFile = StingToolsApp.FindDataFile("MR_PARAMETERS.txt");
+            if (string.IsNullOrEmpty(sharedParamFile))
+            {
+                TaskDialog.Show("Augment Tag Families",
+                    "Cannot find MR_PARAMETERS.txt.\nRun 'Check Data' to verify data files.");
+                return Result.Failed;
+            }
+
+            // ── Step 2: Load tier plans from CSVs ─────────────────────
+            Dictionary<string, Dictionary<string, TierPlan>> plansByMode;
+            Dictionary<string, TierPlan> plansByFamily;
+            bool preserveHandEdits;
+            try
+            {
+                plansByMode = TagConfigPlanResolver.LoadAllPerMode(doc);
+                plansByFamily = TagConfigPlanResolver.LoadAll(doc);
+                preserveHandEdits = TagConfigPlanResolver.ReadPreserveHandEdits(doc);
+            }
+            catch (Exception ex)
+            {
+                TaskDialog.Show("Augment Tag Families",
+                    $"Failed to load tier plans from CSVs:\n{ex.Message}");
+                return Result.Failed;
+            }
+
+            if (plansByFamily.Count == 0 && (plansByMode == null || plansByMode.Count == 0))
+            {
+                TaskDialog.Show("Augment Tag Families",
+                    "No tier plans found in tag config CSVs.\n\n" +
+                    "Ensure the STING_TAG_CONFIG_v5_0_*.csv files are present in the data folder " +
+                    "and contain T4..T10 tier rows.");
+                return Result.Cancelled;
+            }
+
+            // ── Step 3: Locate .rfa output folder ─────────────────────
+            string outputDir = TagFamilyConfig.GetOutputDirectory();
+            if (!Directory.Exists(outputDir))
+            {
+                TaskDialog.Show("Augment Tag Families",
+                    $"Tag family output directory does not exist:\n{outputDir}\n\n" +
+                    "Run 'Create Tag Families' first to generate the .rfa files.");
+                return Result.Failed;
+            }
+
+            string[] rfaFiles = Directory.GetFiles(outputDir, "STING - *.rfa");
+            if (rfaFiles.Length == 0)
+            {
+                TaskDialog.Show("Augment Tag Families",
+                    $"No STING tag family .rfa files found in:\n{outputDir}\n\n" +
+                    "Run 'Create Tag Families' first to generate the .rfa files.");
+                return Result.Failed;
+            }
+
+            // ── Step 4: Confirm with user ──────────────────────────────
+            var confirm = TaskDialog.Show("Augment Tag Families",
+                $"Found {rfaFiles.Length} STING .rfa files in:\n{outputDir}\n\n" +
+                "This will:\n" +
+                "  • Add any missing T4-T10 shared parameters (additive-only)\n" +
+                "  • Apply/update T4-T10 visibility formulas from the CSV tier definitions\n" +
+                "  • Leave ALL existing T1-T3 label rows completely untouched\n\n" +
+                $"Preserve hand-edited label positions: {(preserveHandEdits ? "YES" : "NO")}\n\n" +
+                "Continue?",
+                TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No);
+            if (confirm == TaskDialogResult.No) return Result.Cancelled;
+
+            // ── Step 5: Process each .rfa ──────────────────────────────
+            var report = new StringBuilder();
+            int success = 0, noplan = 0, failed = 0;
+
+            foreach (string rfaPath in rfaFiles)
+            {
+                string famName = Path.GetFileNameWithoutExtension(rfaPath);
+
+                // Build mode plans for this family from the loaded tier data
+                var modePlans = BuildModePlans(plansByMode, plansByFamily, famName);
+                if (modePlans.Count == 0)
+                {
+                    report.AppendLine($"  [SKIP] {famName} — no T4..T10 plan in CSVs");
+                    noplan++;
+                    continue;
+                }
+
+                Document famDoc = null;
+                try
+                {
+                    famDoc = app.OpenDocumentFile(rfaPath);
+                    if (famDoc == null)
+                    {
+                        report.AppendLine($"  [FAIL] {famName} — OpenDocumentFile returned null");
+                        failed++;
+                        continue;
+                    }
+
+                    var opts = new FamilyLabelAuthor.Options
+                    {
+                        App = app,
+                        SharedParamFile = sharedParamFile,
+                        PreserveHandEdits = preserveHandEdits,
+                        FamilyName = famName,
+                    };
+
+                    FamilyLabelAuthor.Result r = FamilyLabelAuthor.AuthorLabelsMulti(
+                        famDoc, modePlans, opts);
+
+                    // Save in-place (same path, overwrite)
+                    var saveOpts = new SaveAsOptions { OverwriteExistingFile = true };
+                    famDoc.SaveAs(rfaPath, saveOpts);
+
+                    report.AppendLine($"  [OK]   {famName} — " +
+                        $"bound={r.ParamsBound} formulas={r.FormulasApplied} " +
+                        $"skipped={r.FormulasSkipped} preserved={r.TiersPreserved}");
+                    foreach (var w in r.Warnings)
+                        StingLog.Warn($"AugmentTagFamilies {famName}: {w}");
+                    success++;
+                }
+                catch (Exception ex)
+                {
+                    report.AppendLine($"  [FAIL] {famName} — {ex.Message}");
+                    StingLog.Error($"AugmentTagFamilies: {famName}", ex);
+                    failed++;
+                }
+                finally
+                {
+                    try { famDoc?.Close(false); } catch { }
+                }
+            }
+
+            // ── Step 6: Optionally reload augmented families into project ─
+            if (success > 0 && doc != null)
+            {
+                var reload = TaskDialog.Show("Augment Tag Families — Reload?",
+                    $"Augmented {success} families successfully.\n\n" +
+                    "Reload all augmented .rfa files into the current project?\n" +
+                    "(Families already loaded will be overwritten with the updated version.)",
+                    TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No);
+
+                if (reload == TaskDialogResult.Yes)
+                {
+                    int reloaded = 0, reloadFailed = 0;
+                    foreach (string rfaPath in rfaFiles)
+                    {
+                        string famName = Path.GetFileNameWithoutExtension(rfaPath);
+                        try
+                        {
+                            Family existingFamily = null;
+                            foreach (Family f in new FilteredElementCollector(doc)
+                                .OfClass(typeof(Family)).Cast<Family>())
+                            {
+                                if (string.Equals(f.Name, famName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    existingFamily = f;
+                                    break;
+                                }
+                            }
+                            if (existingFamily == null) continue; // only reload what's already loaded
+
+                            using (Transaction tx = new Transaction(doc, $"STING Reload {famName}"))
+                            {
+                                tx.Start();
+                                doc.LoadFamily(rfaPath, new OverwriteLoadOptions(), out Family _);
+                                tx.Commit();
+                            }
+                            reloaded++;
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"AugmentTagFamilies reload {famName}: {ex.Message}");
+                            reloadFailed++;
+                        }
+                    }
+                    report.AppendLine();
+                    report.AppendLine($"Reloaded {reloaded} into project ({reloadFailed} failed).");
+                }
+            }
+
+            // ── Step 7: Summary ────────────────────────────────────────
+            string summary =
+                $"Augmented: {success}   No plan: {noplan}   Failed: {failed}\n" +
+                $"Source: {outputDir}\n\n" +
+                report.ToString();
+
+            TaskDialog.Show("Augment Tag Families — Complete", summary);
+
+            return failed == 0 ? Result.Succeeded : Result.Succeeded; // always Succeeded so caller sees the report
+        }
+
+        /// <summary>
+        /// Build the list of mode plans for a given family name by consulting
+        /// both the per-mode and the flat family maps (same logic as
+        /// <see cref="CreateTagFamiliesCommand.AuthorFromPlanIfAvailable"/>).
+        /// </summary>
+        private static List<FamilyLabelAuthor.ModePlan> BuildModePlans(
+            Dictionary<string, Dictionary<string, TierPlan>> plansByMode,
+            Dictionary<string, TierPlan> plansByFamily,
+            string famName)
+        {
+            var modePlans = new List<FamilyLabelAuthor.ModePlan>();
+
+            if (plansByMode != null)
+            {
+                foreach (var kv in plansByMode)
+                {
+                    if (kv.Value == null) continue;
+                    TierPlan plan = TagFamilyConfig.TryGetTierPlan(kv.Value, famName);
+                    if (plan == null) continue;
+                    modePlans.Add(new FamilyLabelAuthor.ModePlan
+                    {
+                        Mode = kv.Key,
+                        GateParam = HandoverModeHelper.GetSelectorBool(kv.Key),
+                        Plan = plan,
+                    });
+                }
+            }
+
+            if (modePlans.Count == 0 && plansByFamily != null)
+            {
+                TierPlan plan = TagFamilyConfig.TryGetTierPlan(plansByFamily, famName);
+                if (plan != null)
+                {
+                    modePlans.Add(new FamilyLabelAuthor.ModePlan
+                    {
+                        Mode = "", GateParam = null, Plan = plan,
+                    });
+                }
+            }
+
+            return modePlans;
+        }
+
+        /// <summary>IFamilyLoadOptions that always overwrites existing types.</summary>
+        private sealed class OverwriteLoadOptions : IFamilyLoadOptions
+        {
+            public bool OnFamilyFound(bool familyInUse, out bool overwriteParameterValues)
+            {
+                overwriteParameterValues = false; // preserve instance param values on placed tags
+                return true;
+            }
+            public bool OnSharedFamilyFound(Family sharedFamily, bool familyInUse,
+                out FamilySource source, out bool overwriteParameterValues)
+            {
+                source = FamilySource.Family;
+                overwriteParameterValues = false;
+                return true;
+            }
+        }
+    }
 }

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -3524,29 +3524,30 @@ namespace StingTools.Tags
     }
 
     // ════════════════════════════════════════════════════════════════════
-    //  Augment Tag Families — reinject T4-T10 into existing .rfa files
+    //  Augment Tag Families — full parameter sync for existing .rfa files
     // ════════════════════════════════════════════════════════════════════
 
     /// <summary>
-    /// Reinjects T4-T10 shared parameters and visibility formulas into
-    /// existing STING tag family .rfa files without touching any already-
-    /// configured T1-T3 label rows.
+    /// Brings every STING tag family .rfa on disk up to the complete
+    /// STING parameter contract without disturbing any already-configured labels.
     ///
-    /// Safe by design:
-    ///   • <c>FamilyManager.AddParameter</c> is additive-only — if a shared
-    ///     parameter is already bound, the call is a no-op. T1-T3 parameters
-    ///     and their label elements are never removed or repositioned.
-    ///   • <c>FamilyLabelAuthor.AuthorLabelsMulti</c> only processes rows
-    ///     declared in T4..T10 of the CSV tier plans. T1-T3 label elements are
-    ///     completely outside its scope.
-    ///   • When <c>preserveHandEdits</c> is true (default), families where ANY
-    ///     text/annotation element has been manually positioned have their
-    ///     formula re-writes skipped — only the param bindings are added.
+    /// What it injects (all additive — existing params are never removed or moved):
+    ///   1. Tag containers   — TAG1-TAG7, TAG7A-TAG7F (13 params)
+    ///   2. Visibility gates — TAG_PARA_STATE_1..10_BOOL + TAG_WARN_VISIBLE_BOOL
+    ///   3. Tag style matrix — 128 TAG_{size}{style}_{colour}_BOOL variants
+    ///   4. Appearance params — box colour/visible/style, leader colour,
+    ///                          TAG_SCALE_TIER_AUTO_BOOL, TAG_DEPTH_TIER_INT
+    ///   5. Description      — ASS_DESCRIPTION_TXT
+    ///   6. Category-specific label params from LABEL_DEFINITIONS.json
+    ///   7. T4-T10 label formula rows — from STING_TAG_CONFIG_v5_0_*.csv
     ///
-    /// Use case: you ran CreateTagFamilies and configured T1-T3 labels in the
-    /// Revit family editor. Later the CSV files gained T4-T10 content (or the
-    /// CSVs were updated). Run AugmentTagFamilies to bring every .rfa up to
-    /// date with the current CSV tier definitions without losing your label work.
+    /// Safety guarantees:
+    ///   • FamilyManager.AddParameter is additive-only: already-bound params are skipped.
+    ///   • FamilyLabelAuthor.AuthorLabelsMulti only touches T4..T10 rows from the CSV tier plans.
+    ///   • T1-T3 label elements are completely outside its scope.
+    ///   • When PreserveHandEdits=true, formula writes are skipped on hand-positioned families
+    ///     (param bindings are still added — only the formula overwrite is deferred).
+    ///   • Families with no CSV tier plan still receive the full base + style + visibility params.
     /// </summary>
     [Transaction(TransactionMode.Manual)]
     [Regeneration(RegenerationOption.Manual)]
@@ -3585,15 +3586,6 @@ namespace StingTools.Tags
                 return Result.Failed;
             }
 
-            if (plansByFamily.Count == 0 && (plansByMode == null || plansByMode.Count == 0))
-            {
-                TaskDialog.Show("Augment Tag Families",
-                    "No tier plans found in tag config CSVs.\n\n" +
-                    "Ensure the STING_TAG_CONFIG_v5_0_*.csv files are present in the data folder " +
-                    "and contain T4..T10 tier rows.");
-                return Result.Cancelled;
-            }
-
             // ── Step 3: Locate .rfa output folder ─────────────────────
             string outputDir = TagFamilyConfig.GetOutputDirectory();
             if (!Directory.Exists(outputDir))
@@ -3616,10 +3608,15 @@ namespace StingTools.Tags
             // ── Step 4: Confirm with user ──────────────────────────────
             var confirm = TaskDialog.Show("Augment Tag Families",
                 $"Found {rfaFiles.Length} STING .rfa files in:\n{outputDir}\n\n" +
-                "This will:\n" +
-                "  • Add any missing T4-T10 shared parameters (additive-only)\n" +
-                "  • Apply/update T4-T10 visibility formulas from the CSV tier definitions\n" +
-                "  • Leave ALL existing T1-T3 label rows completely untouched\n\n" +
+                "This will inject ALL missing parameters (additive — nothing removed):\n" +
+                "  • Tag containers (TAG1-TAG7, TAG7A-TAG7F)\n" +
+                "  • Visibility gates (TAG_PARA_STATE_1..10_BOOL, TAG_WARN_VISIBLE_BOOL)\n" +
+                "  • Tag style matrix (128 TAG_{size}{style}_{colour}_BOOL variants)\n" +
+                "  • Appearance params (box colour/style, leader colour, scale/depth cache)\n" +
+                "  • Category-specific label params (LABEL_DEFINITIONS.json)\n" +
+                "  • T4-T10 label formulas (STING_TAG_CONFIG CSV tier definitions)\n\n" +
+                "T1-T3 label rows you have already configured are NOT touched.\n" +
+                "Families with no CSV tier plan still receive base + style + visibility params.\n\n" +
                 $"Preserve hand-edited label positions: {(preserveHandEdits ? "YES" : "NO")}\n\n" +
                 "Continue?",
                 TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No);
@@ -3632,16 +3629,6 @@ namespace StingTools.Tags
             foreach (string rfaPath in rfaFiles)
             {
                 string famName = Path.GetFileNameWithoutExtension(rfaPath);
-
-                // Build mode plans for this family from the loaded tier data
-                var modePlans = BuildModePlans(plansByMode, plansByFamily, famName);
-                if (modePlans.Count == 0)
-                {
-                    report.AppendLine($"  [SKIP] {famName} — no T4..T10 plan in CSVs");
-                    noplan++;
-                    continue;
-                }
-
                 Document famDoc = null;
                 try
                 {
@@ -3653,26 +3640,61 @@ namespace StingTools.Tags
                         continue;
                     }
 
-                    var opts = new FamilyLabelAuthor.Options
+                    // ── 5a: Detect the family's Revit category ─────────
+                    string categoryDisplay = DetectCategoryName(famDoc);
+
+                    // ── 5b: Build the FULL parameter list for this family
+                    //   Includes: TagParams + VisibilityParams + StyleParams
+                    //             + ASS_DESCRIPTION_TXT + category label params
+                    List<string> allParams = TagFamilyConfig.GetAllFamilyParams(
+                        categoryDisplay, famName);
+
+                    // ── 5c: Inject ALL missing shared parameters ────────
+                    int injected = InjectMissingParams(famDoc, allParams, sharedParamFile, app);
+
+                    // ── 5d: Apply T4-T10 label formulas from CSVs ──────
+                    var modePlans = BuildModePlans(plansByMode, plansByFamily, famName);
+                    int formulasApplied = 0, formulasSkipped = 0,
+                        tiersPreserved = 0, labelRebound = 0;
+                    string planTag = "(no CSV tier plan — base/style params only)";
+
+                    if (modePlans.Count > 0)
                     {
-                        App = app,
-                        SharedParamFile = sharedParamFile,
-                        PreserveHandEdits = preserveHandEdits,
-                        FamilyName = famName,
-                    };
+                        var opts = new FamilyLabelAuthor.Options
+                        {
+                            App = app,
+                            SharedParamFile = sharedParamFile,
+                            PreserveHandEdits = preserveHandEdits,
+                            FamilyName = famName,
+                        };
+                        FamilyLabelAuthor.Result r =
+                            FamilyLabelAuthor.AuthorLabelsMulti(famDoc, modePlans, opts);
+                        formulasApplied = r.FormulasApplied;
+                        formulasSkipped = r.FormulasSkipped;
+                        tiersPreserved  = r.TiersPreserved;
+                        labelRebound    = r.LabelRebound;
+                        planTag = modePlans.Count > 1
+                            ? $"modes=[{string.Join(",", modePlans.ConvertAll(m => m.Mode))}]"
+                            : "single-mode";
+                        foreach (var w in r.Warnings)
+                            StingLog.Warn($"AugmentTagFamilies {famName}: {w}");
+                    }
+                    else
+                    {
+                        noplan++;
+                    }
 
-                    FamilyLabelAuthor.Result r = FamilyLabelAuthor.AuthorLabelsMulti(
-                        famDoc, modePlans, opts);
-
-                    // Save in-place (same path, overwrite)
+                    // ── 5e: Save in-place ───────────────────────────────
                     var saveOpts = new SaveAsOptions { OverwriteExistingFile = true };
                     famDoc.SaveAs(rfaPath, saveOpts);
 
-                    report.AppendLine($"  [OK]   {famName} — " +
-                        $"bound={r.ParamsBound} formulas={r.FormulasApplied} " +
-                        $"skipped={r.FormulasSkipped} preserved={r.TiersPreserved}");
-                    foreach (var w in r.Warnings)
-                        StingLog.Warn($"AugmentTagFamilies {famName}: {w}");
+                    report.AppendLine($"  [OK]   {famName}");
+                    report.AppendLine(
+                        $"           cat=\"{categoryDisplay}\" " +
+                        $"injected={injected} {planTag}");
+                    report.AppendLine(
+                        $"           formulas={formulasApplied} skipped={formulasSkipped} " +
+                        $"preserved={tiersPreserved} label-rebound={labelRebound}");
                     success++;
                 }
                 catch (Exception ex)
@@ -3693,7 +3715,8 @@ namespace StingTools.Tags
                 var reload = TaskDialog.Show("Augment Tag Families — Reload?",
                     $"Augmented {success} families successfully.\n\n" +
                     "Reload all augmented .rfa files into the current project?\n" +
-                    "(Families already loaded will be overwritten with the updated version.)",
+                    "(Only families that are already loaded will be updated.)\n\n" +
+                    "overwriteParameterValues = false — existing placed-tag instance values are preserved.",
                     TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No);
 
                 if (reload == TaskDialogResult.Yes)
@@ -3704,19 +3727,19 @@ namespace StingTools.Tags
                         string famName = Path.GetFileNameWithoutExtension(rfaPath);
                         try
                         {
-                            Family existingFamily = null;
+                            // Only reload families that are already in the project
+                            bool found = false;
                             foreach (Family f in new FilteredElementCollector(doc)
                                 .OfClass(typeof(Family)).Cast<Family>())
                             {
-                                if (string.Equals(f.Name, famName, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    existingFamily = f;
-                                    break;
-                                }
+                                if (string.Equals(f.Name, famName,
+                                    StringComparison.OrdinalIgnoreCase))
+                                { found = true; break; }
                             }
-                            if (existingFamily == null) continue; // only reload what's already loaded
+                            if (!found) continue;
 
-                            using (Transaction tx = new Transaction(doc, $"STING Reload {famName}"))
+                            using (Transaction tx = new Transaction(doc,
+                                $"STING Reload {famName}"))
                             {
                                 tx.Start();
                                 doc.LoadFamily(rfaPath, new OverwriteLoadOptions(), out Family _);
@@ -3726,30 +3749,149 @@ namespace StingTools.Tags
                         }
                         catch (Exception ex)
                         {
-                            StingLog.Warn($"AugmentTagFamilies reload {famName}: {ex.Message}");
+                            StingLog.Warn(
+                                $"AugmentTagFamilies reload {famName}: {ex.Message}");
                             reloadFailed++;
                         }
                     }
                     report.AppendLine();
-                    report.AppendLine($"Reloaded {reloaded} into project ({reloadFailed} failed).");
+                    report.AppendLine(
+                        $"Reloaded {reloaded} into project ({reloadFailed} failed).");
                 }
             }
 
             // ── Step 7: Summary ────────────────────────────────────────
             string summary =
-                $"Augmented: {success}   No plan: {noplan}   Failed: {failed}\n" +
+                $"Processed {rfaFiles.Length}:  OK={success}  " +
+                $"No-CSV-plan={noplan}  Failed={failed}\n" +
                 $"Source: {outputDir}\n\n" +
                 report.ToString();
 
             TaskDialog.Show("Augment Tag Families — Complete", summary);
+            return Result.Succeeded;
+        }
 
-            return failed == 0 ? Result.Succeeded : Result.Succeeded; // always Succeeded so caller sees the report
+        // ─────────────────────────────────────────────────────────────
+        //  Static helpers
+        // ─────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Detect the Revit category display name from an open family document,
+        /// e.g. "Ducts", "Air Terminals", "Mechanical Equipment", "Lighting Fixtures".
+        /// Falls back to empty string on any failure so GetAllFamilyParams still works.
+        /// </summary>
+        private static string DetectCategoryName(Document famDoc)
+        {
+            try
+            {
+                var famCatId = famDoc.OwnerFamily?.FamilyCategoryId;
+                if (famCatId == null || famCatId == ElementId.InvalidElementId)
+                    return "";
+                var cat = Category.GetCategory(famDoc, famCatId);
+                return cat?.Name ?? "";
+            }
+            catch { return ""; }
         }
 
         /// <summary>
-        /// Build the list of mode plans for a given family name by consulting
-        /// both the per-mode and the flat family maps (same logic as
+        /// Open MR_PARAMETERS.txt and add every parameter in <paramref name="paramNames"/>
+        /// that is not already bound in the family. Additive-only: existing params are left
+        /// exactly as-is. Returns the count of newly added parameters.
+        /// </summary>
+        private static int InjectMissingParams(
+            Document famDoc,
+            IEnumerable<string> paramNames,
+            string sharedParamFile,
+            Autodesk.Revit.ApplicationServices.Application app)
+        {
+            string originalFile = app.SharedParametersFilename;
+            try
+            {
+                app.SharedParametersFilename = sharedParamFile;
+                DefinitionFile defFile = app.OpenSharedParameterFile();
+                if (defFile == null)
+                {
+                    StingLog.Warn(
+                        "AugmentTagFamilies.InjectMissingParams: cannot open shared param file");
+                    return 0;
+                }
+
+                // Build O(1) lookup of already-present param names
+                var present = new HashSet<string>(StringComparer.Ordinal);
+                FamilyManager famMan = famDoc.FamilyManager;
+                foreach (FamilyParameter fp in famMan.Parameters)
+                    present.Add(fp.Definition.Name);
+
+                // Collect definitions to add (skip already-present ones)
+                var toAdd = new List<ExternalDefinition>();
+                foreach (string pName in paramNames)
+                {
+                    if (present.Contains(pName)) continue;
+                    ExternalDefinition extDef = FindExternalDefinition(defFile, pName);
+                    if (extDef == null)
+                    {
+                        StingLog.Warn(
+                            $"AugmentTagFamilies: '{pName}' not found in MR_PARAMETERS.txt");
+                        continue;
+                    }
+                    toAdd.Add(extDef);
+                }
+
+                if (toAdd.Count == 0) return 0;
+
+                int added = 0;
+                using (Transaction tx = new Transaction(famDoc, "STING Inject Missing Params"))
+                {
+                    tx.Start();
+                    foreach (ExternalDefinition extDef in toAdd)
+                    {
+                        try
+                        {
+                            famMan.AddParameter(
+                                extDef,
+                                GroupTypeId.General,
+                                true /* isInstance = true: tags display per-instance values */);
+                            added++;
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn(
+                                $"AugmentTagFamilies: cannot add '{extDef.Name}': {ex.Message}");
+                        }
+                    }
+                    tx.Commit();
+                }
+                return added;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("AugmentTagFamilies.InjectMissingParams failed", ex);
+                return 0;
+            }
+            finally
+            {
+                // ALWAYS restore — prevents leaving Revit pointed at the wrong SP file
+                try { app.SharedParametersFilename = originalFile; } catch { }
+            }
+        }
+
+        /// <summary>Search every group in the definition file for a matching parameter name.</summary>
+        private static ExternalDefinition FindExternalDefinition(
+            DefinitionFile defFile, string paramName)
+        {
+            foreach (DefinitionGroup grp in defFile.Groups)
+                foreach (Definition def in grp.Definitions)
+                    if (def.Name == paramName && def is ExternalDefinition ext)
+                        return ext;
+            return null;
+        }
+
+        /// <summary>
+        /// Build the list of mode plans for a given family name by consulting both the
+        /// per-mode and the flat family tier-plan maps (same logic as
         /// <see cref="CreateTagFamiliesCommand.AuthorFromPlanIfAvailable"/>).
+        /// Returns an empty list when the family has no CSV tier plan entry — in that
+        /// case the caller still injects base + style + visibility params, just skips formulas.
         /// </summary>
         private static List<FamilyLabelAuthor.ModePlan> BuildModePlans(
             Dictionary<string, Dictionary<string, TierPlan>> plansByMode,
@@ -3767,9 +3909,9 @@ namespace StingTools.Tags
                     if (plan == null) continue;
                     modePlans.Add(new FamilyLabelAuthor.ModePlan
                     {
-                        Mode = kv.Key,
+                        Mode      = kv.Key,
                         GateParam = HandoverModeHelper.GetSelectorBool(kv.Key),
-                        Plan = plan,
+                        Plan      = plan,
                     });
                 }
             }
@@ -3789,12 +3931,15 @@ namespace StingTools.Tags
             return modePlans;
         }
 
-        /// <summary>IFamilyLoadOptions that always overwrites existing types.</summary>
+        /// <summary>
+        /// IFamilyLoadOptions that always accepts the incoming family without
+        /// overwriting instance parameter values on already-placed tags.
+        /// </summary>
         private sealed class OverwriteLoadOptions : IFamilyLoadOptions
         {
             public bool OnFamilyFound(bool familyInUse, out bool overwriteParameterValues)
             {
-                overwriteParameterValues = false; // preserve instance param values on placed tags
+                overwriteParameterValues = false; // preserve placed-tag instance values
                 return true;
             }
             public bool OnSharedFamilyFound(Family sharedFamily, bool familyInUse,

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -1479,6 +1479,7 @@ namespace StingTools.UI
                     case "ConfigureTagLabels": RunCommand<Tags.ConfigureTagLabelsCommand>(app); break;
                     case "ConfigureLoadedFamilies": RunCommand<Tags.ConfigureLoadedFamiliesCommand>(app); break;
                     case "AuditTagFamilies": RunCommand<Tags.AuditTagFamiliesCommand>(app); break;
+                    case "AugmentTagFamilies": RunCommand<Tags.AugmentTagFamiliesCommand>(app); break;
                     case "RetrofitProject": RunCommand<Temp.RetrofitProjectCommand>(app); break;
                     case "MigrateTagFamilies": RunCommand<Commands.TagStudio.MigrateTagFamiliesCommand>(app); break;
                     case "MigrateTagLabelRefs": RunCommand<Commands.TagStudio.MigrateTagLabelReferencesCommand>(app); break;


### PR DESCRIPTION
## Summary

This PR introduces a new `AugmentTagFamiliesCommand` that brings existing STING tag family `.rfa` files into full compliance with the v5.0 parameter contract, and updates the T1 tier formula across all tag configuration CSVs to use the ISO 19650 Asset Tag standard.

## Key Changes

- **New `AugmentTagFamiliesCommand` class** (`TagFamilyCreatorCommand.cs`)
  - Additive-only parameter injection: tag containers (TAG1–TAG7, TAG7A–TAG7F), visibility gates (TAG_PARA_STATE_1..10_BOOL + TAG_WARN_VISIBLE_BOOL), tag style matrix (128 variants), appearance params, and description field
  - Loads tier plans from STING_TAG_CONFIG_v5_0_*.csv files and applies T4–T10 label formulas via `FamilyLabelAuthor.AuthorLabelsMulti`
  - Safety guarantees: `FamilyManager.AddParameter` is additive-only; hand-positioned families are skipped when `PreserveHandEdits=true`; T1–T3 label elements remain untouched
  - Families without a CSV tier plan still receive the full base + style + visibility parameter set

- **T1 tier formula standardization** (all STING_TAG_CONFIG_v5_0_*.csv files)
  - Updated T1 row for ASS_TAG_1_TXT from `"Add directly"` placeholder to proper ISO 19650 Asset Tag formula
  - Changed from: `---,---,---,Add directly,NOM,BLACK,2.5,None,None`
  - Changed to: `Common,Text,ISO 19650 Asset Tag,ASS_TAG_1_TXT,BOLD,BLACK,2.5,None,None`
  - Applied across all discipline variants: HEALTH, HEALTH_DesignConstruction, MEP, MEP_DesignConstruction, ARCH, ARCH_DesignConstruction, GEN, GEN_DesignConstruction, STR, STR_DesignConstruction

- **Command registration** (`StingCommandHandler.cs`)
  - Registered `AugmentTagFamiliesCommand` in the command dispatch table

## Implementation Details

- The command is marked `[Transaction(TransactionMode.Manual)]` and `[Regeneration(RegenerationOption.Manual)]` for explicit control over family edits
- Comprehensive XML documentation explains the seven categories of parameters injected and the safety model
- CSV tier plans are parsed to extract T4–T10 label definitions; families without a plan entry still receive the base parameter contract
- The `PreserveHandEdits` flag allows deferring formula writes on hand-positioned families while still adding parameter bindings

https://claude.ai/code/session_01APQ9EsY8EQS9c8VcjgyGNx