### PR TITLE
Tenant-isolation reconcile onto main — Path B (supersedes repo-review-hardening server half)

### DIFF
--- a/Planscape.Server/src/Planscape.Core/Entities/Meeting.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Meeting.cs
@@ -70,7 +70,7 @@ public class Meeting : ITenantScoped
 /// A person invited to or attending a meeting.
 /// Role distinguishes chair / secretary / attendee / notified-only (BCC).
 /// </summary>
-public class MeetingAttendee
+public class MeetingAttendee : ITenantScoped
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public Guid TenantId { get; set; }
@@ -103,7 +103,7 @@ public class MeetingAttendee
 /// <summary>
 /// One agenda item within a meeting (ordered list, outcomes recorded in-place).
 /// </summary>
-public class MeetingAgendaItem
+public class MeetingAgendaItem : ITenantScoped
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public Guid TenantId { get; set; }
@@ -131,7 +131,7 @@ public class MeetingAgendaItem
 /// <summary>
 /// Action item assigned during a coordination meeting.
 /// </summary>
-public class MeetingActionItem
+public class MeetingActionItem : ITenantScoped
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public Guid TenantId { get; set; }

--- a/Planscape.Server/src/Planscape.Core/Entities/SiteDiary.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/SiteDiary.cs
@@ -95,7 +95,7 @@ public class SiteDiary : ITenantScoped
 /// Join row that links a <see cref="DocumentRecord"/> to a
 /// <see cref="SiteDiary"/> entry — parallel to <see cref="IssueAttachment"/>.
 /// </summary>
-public class SiteDiaryAttachment
+public class SiteDiaryAttachment : ITenantScoped
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public Guid TenantId { get; set; }

--- a/Planscape.Server/src/Planscape.Core/Entities/StageGate.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/StageGate.cs
@@ -62,7 +62,7 @@ public class StageGate : ITenantScoped
 /// ISO 19650 information-state machine: PENDING → IN_PROGRESS → SUBMITTED →
 /// ACCEPTED (or REJECTED + back to IN_PROGRESS).
 /// </summary>
-public class InformationDeliverable
+public class InformationDeliverable : ITenantScoped
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public Guid TenantId { get; set; }

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260609000000_TenantScopeIndexesAndBackfill.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260609000000_TenantScopeIndexesAndBackfill.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable enable
+
+namespace Planscape.Infrastructure.Data.Migrations;
+
+/// <summary>
+/// CP-2 (review-hardening) — five entities carried a <c>TenantId</c> column but
+/// did not implement <see cref="Planscape.Core.Entities.ITenantScoped"/>, so they
+/// were excluded from the global tenant query filter + auto-stamp + auto-index
+/// (PlanscapeDbContext.ApplyTenantQueryFilters / SaveChanges). They are now
+/// <c>ITenantScoped</c>: <c>InformationDeliverable</c>, <c>SiteDiaryAttachment</c>,
+/// <c>MeetingAttendee</c>, <c>MeetingAgendaItem</c>, <c>MeetingActionItem</c>.
+///
+/// This migration carries the two deploy-time steps that turning on the filter
+/// requires:
+///   1. the per-entity <c>TenantId</c> index EF's auto-HasIndex creates for
+///      ITenantScoped types (so the new filter predicate is indexed); and
+///   2. a ONE-TIME BACKFILL of <c>TenantId</c> on any legacy row where it is the
+///      empty GUID — copied from the row's tenant-scoped parent — so the new
+///      filter (TenantId == CurrentTenantId) does NOT hide pre-existing rows.
+///
+/// Backfill verified on a throwaway Postgres (seed empty-tenant child rows under
+/// real-tenant parents → run backfill → 0 empty-tenant rows remain, each row gets
+/// its parent's tenant, already-stamped rows untouched, rows stay visible under
+/// the filter). The decoy/cross-tenant row was not clobbered.
+///
+/// Repo convention (mirrors 20260602000000_IdempotencyRecords): hand-authored DDL
+/// with no .Designer.cs and no [Migration] attribute — dev/local build schema from
+/// OnModelCreating via RelationalDatabaseCreator.CreateTables(), so on dev the
+/// TenantId indexes already exist from the model. This file is the exact DDL +
+/// backfill for the prod migration pipeline (backlog P3-2). Indexes use
+/// IF NOT EXISTS so re-application against a model-built dev schema is a no-op;
+/// the backfill is idempotent (only touches the empty GUID).
+///
+/// Re-stamped 20260609000000 (post-20260608_TemplateOpRecords): the original
+/// CP-2 stamp 20260606000000 sorted BEFORE main's 20260607/20260608 migrations,
+/// which would have applied this filter-enabling migration before the tables it
+/// guards were created in the prod pipeline. The timestamp is the only change —
+/// DDL + backfill are byte-identical to the CP-2 original.
+/// </summary>
+public partial class TenantScopeIndexesAndBackfill : Migration
+{
+    private const string Empty = "00000000-0000-0000-0000-000000000000";
+
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // 1. TenantId indexes (idempotent — match EF's auto-HasIndex name IX_<Table>_TenantId).
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS \"IX_InformationDeliverables_TenantId\" ON \"InformationDeliverables\" (\"TenantId\");");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS \"IX_SiteDiaryAttachments_TenantId\" ON \"SiteDiaryAttachments\" (\"TenantId\");");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS \"IX_MeetingAttendees_TenantId\" ON \"MeetingAttendees\" (\"TenantId\");");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS \"IX_MeetingAgendaItems_TenantId\" ON \"MeetingAgendaItems\" (\"TenantId\");");
+        migrationBuilder.Sql("CREATE INDEX IF NOT EXISTS \"IX_MeetingActionItems_TenantId\" ON \"MeetingActionItems\" (\"TenantId\");");
+
+        // 2. One-time backfill: stamp legacy empty-tenant rows from their parent so
+        //    the now-active global filter doesn't hide them. Only touches the empty
+        //    GUID (already-stamped rows are left untouched).
+        migrationBuilder.Sql(
+            "UPDATE \"InformationDeliverables\" d SET \"TenantId\" = p.\"TenantId\" " +
+            "FROM \"Projects\" p WHERE d.\"ProjectId\" = p.\"Id\" AND d.\"TenantId\" = '" + Empty + "';");
+        migrationBuilder.Sql(
+            "UPDATE \"SiteDiaryAttachments\" a SET \"TenantId\" = s.\"TenantId\" " +
+            "FROM \"SiteDiaries\" s WHERE a.\"SiteDiaryId\" = s.\"Id\" AND a.\"TenantId\" = '" + Empty + "';");
+        migrationBuilder.Sql(
+            "UPDATE \"MeetingAttendees\" x SET \"TenantId\" = m.\"TenantId\" " +
+            "FROM \"Meetings\" m WHERE x.\"MeetingId\" = m.\"Id\" AND x.\"TenantId\" = '" + Empty + "';");
+        migrationBuilder.Sql(
+            "UPDATE \"MeetingAgendaItems\" x SET \"TenantId\" = m.\"TenantId\" " +
+            "FROM \"Meetings\" m WHERE x.\"MeetingId\" = m.\"Id\" AND x.\"TenantId\" = '" + Empty + "';");
+        migrationBuilder.Sql(
+            "UPDATE \"MeetingActionItems\" x SET \"TenantId\" = m.\"TenantId\" " +
+            "FROM \"Meetings\" m WHERE x.\"MeetingId\" = m.\"Id\" AND x.\"TenantId\" = '" + Empty + "';");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Indexes only — the backfill is a value correction that is not reversed
+        // (reverting TenantId to the empty GUID would re-introduce the hide-by-filter bug).
+        migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_InformationDeliverables_TenantId\";");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_SiteDiaryAttachments_TenantId\";");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_MeetingAttendees_TenantId\";");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_MeetingAgendaItems_TenantId\";");
+        migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_MeetingActionItems_TenantId\";");
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/PlanscapeDbContextModelSnapshot.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/PlanscapeDbContextModelSnapshot.cs
@@ -3308,6 +3308,8 @@ namespace Planscape.Infrastructure.Data.Migrations
 
                     b.HasIndex("Status");
 
+                    b.HasIndex("TenantId");
+
                     b.HasIndex("ProjectId", "Code")
                         .IsUnique();
 
@@ -4060,6 +4062,8 @@ namespace Planscape.Infrastructure.Data.Migrations
 
                     b.HasIndex("MeetingId");
 
+                    b.HasIndex("TenantId");
+
                     b.HasIndex("MeetingId", "Status");
 
                     b.ToTable("MeetingActionItems");
@@ -4110,6 +4114,8 @@ namespace Planscape.Infrastructure.Data.Migrations
                         .HasColumnType("character varying(400)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("TenantId");
 
                     b.HasIndex("MeetingId", "OrderIndex");
 
@@ -4164,6 +4170,8 @@ namespace Planscape.Infrastructure.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("MeetingId");
+
+                    b.HasIndex("TenantId");
 
                     b.HasIndex("UserId");
 
@@ -7196,6 +7204,8 @@ namespace Planscape.Infrastructure.Data.Migrations
                     b.HasIndex("DocumentId");
 
                     b.HasIndex("SiteDiaryId");
+
+                    b.HasIndex("TenantId");
 
                     b.ToTable("SiteDiaryAttachments");
                 });

--- a/Planscape.Server/tests/Planscape.Tests/TenantScopedEntityConventionTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/TenantScopedEntityConventionTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Planscape.Core.Entities;
+using Xunit;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// CP-2 (review-hardening) regression guard. The DbContext applies a global
+/// tenant query filter + auto-stamp + auto-index to every <see cref="ITenantScoped"/>
+/// entity. An entity that carries a <c>TenantId</c> column but forgets to
+/// implement <c>ITenantScoped</c> silently opts out of that safety net — exactly
+/// the gap CP-2 closed for InformationDeliverable / SiteDiaryAttachment /
+/// MeetingAttendee / MeetingAgendaItem / MeetingActionItem.
+///
+/// This test fails the build if any new entity reintroduces the gap.
+/// </summary>
+public class TenantScopedEntityConventionTests
+{
+    [Fact]
+    public void Every_entity_with_a_TenantId_property_implements_ITenantScoped()
+    {
+        var assembly = typeof(ITenantScoped).Assembly; // Planscape.Core
+
+        var offenders = assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract
+                        && t.Namespace == "Planscape.Core.Entities")
+            .Where(HasOwnTenantIdProperty)
+            .Where(t => !typeof(ITenantScoped).IsAssignableFrom(t))
+            .Select(t => t.Name)
+            .OrderBy(n => n)
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            "Entities with a TenantId property must implement ITenantScoped so the global "
+            + "tenant query filter + auto-stamp covers them. Offenders: "
+            + string.Join(", ", offenders));
+    }
+
+    // A writable instance Guid TenantId property (the shape ITenantScoped requires
+    // and the DbContext filter/stamp keys off).
+    private static bool HasOwnTenantIdProperty(Type t)
+    {
+        var p = t.GetProperty("TenantId",
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+        return p != null && p.PropertyType == typeof(Guid) && p.CanRead && p.CanWrite;
+    }
+}


### PR DESCRIPTION
## Tenant-isolation reconcile — Path B (decision-made), reconciled onto current main

Closes the tenant-filter gap from `repo-review-hardening`, redone **Path B** (match the repo's hand-authored DDL migration convention) onto current main. One commit (`66668f4`).

### What it does
- Tags 3 entities `ITenantScoped` (`Meeting`, `SiteDiary`, `StageGate`) + the tenant-scope convention test.
- **Hand-written DDL migration `20260609000000_TenantScopeIndexesAndBackfill`** — correctly stamped **after** main's `20260607`/`20260608` (the original branch's defect was an out-of-order `20260606`), carrying the tenant-scope indexes + backfill.
- **Regenerated `PlanscapeDbContextModelSnapshot.cs`** — the original branch's other defect was adding the 5 indexes without regenerating the snapshot.

### Acceptance proof (the agreed substitute)
The "`dotnet ef database update` from zero" gate was waived as unmeetable pre-existing architecture (EF recognizes only ~1 of the 76 hand-authored DDL migrations). Substitute proof:
- `dotnet build` clean
- tenant-scope convention test passes
- `has-pending-model-changes` → "No changes" (verifies the snapshot now matches the model)

CI on this PR re-confirms build + server tests. This PR supersedes `repo-review-hardening`'s server half (the plugin half already landed via #315), so `repo-review-hardening` is deletable once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsB9zopnZq1PrJmuNvTj5Z)_