### PR TITLE
docs: Phase 195 — deploy/clobber post-mortem for the Yes/No gate fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,56 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 195 — deploy/clobber post-mortem: why the Yes/No fix kept "relapsing")
+
+Operational lesson, not a code change. After Phase 193/194 made the
+gate params Yes/No in the repo, the tag-creation error
+(`shared parameter … cannot be added with type "Text" because it
+conflicts with the existing "Yes/No"`) **kept recurring in Revit** even
+though the committed data was correct. The repeated failures were never
+a logic / canonical-type problem — they were a **runtime data-path
+problem** that was never verified.
+
+**Root cause.** STING resolves its data via
+`DataPath = <folder of the loaded StingTools.dll>\data`
+(`StingToolsApp.cs`), and `TagFamilyCreatorCommand.AddSharedParameters`
+reads each param's *type straight from whatever `MR_PARAMETERS.txt` that
+`DataPath` resolves to* (it is not hardcoded). On this machine both
+Revit add-ins load `C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.dll`, so
+the live `DataPath` is `CompiledPlugin\data` — and that folder kept
+being **overwritten back to a stale TEXT `MR_PARAMETERS.txt` by a
+parallel build** (the Export Centre `build.bat`, building from a branch
+cut before the Yes/No fix). So `LoadSharedParams` could report 0
+conflicts one moment and `CreateTagFamilies` 141 conflicts minutes
+later — the file on disk at `DataPath` had been re-clobbered in between.
+Every "fix" edited repo files while the runtime kept reading the
+clobbered copy.
+
+**Resolution (what finally worked).**
+1. **Merge the canonical Yes/No data to `main`** (PR #324) so no branch
+   build can reintroduce TEXT, and pull `main` into the parallel Export
+   Centre branch (#322) so its build carries Yes/No too.
+2. **Deploy to the exact loaded `DataPath`** (`CompiledPlugin\data`),
+   not just `%APPDATA%\…\Addins\2025\data`.
+3. **Verify the loaded file is Yes/No at runtime before recreating** —
+   read the `MR_PARAMETERS.txt` that sits at `DataPath` (and the
+   `Data path:` line in `StingTools.log`), confirm `TAG_PARA_STATE_2_BOOL`
+   etc. read `YESNO` and the tag-config CSV is the current set. Do not
+   assume the deploy reached the loaded path.
+
+After deploying Yes/No to `CompiledPlugin\data` and fully restarting
+Revit, `LoadSharedParams` reported **0 type conflicts** and tag
+families recreated clean.
+
+**Guardrail for next time.** The hazard is multiple `StingTools.dll` +
+`data\` copies on one machine plus a *shared* `CompiledPlugin` deploy
+target that parallel builds overwrite. Keep one install, deploy from
+`main`, and confirm the live `DataPath`'s `MR_PARAMETERS.txt` matches the
+intended type before any tag-family operation. (`FindDataFile` resolves
+`DataPath\file` first, then a recursive first-match — a stale nested
+copy under `DataPath` can otherwise win; a future hardening could log
+the resolved path on every load and prefer the direct file.)
+
 #### Completed (Phase 194 — Yes/No-canonical gates — corrects PR #324's Text-canonical choice)
 
 PR #324 (Phase 193) fixed the recurring "Inconsistent Units" error by


### PR DESCRIPTION
Docs-only. Adds a **Phase 195** post-mortem to `docs/CHANGELOG.md` capturing why the Yes/No tag-gate fix (Phase 193/194, PR #324) appeared to "relapse" repeatedly in Revit.

## Why
Phases 193/194 already document the *fix* (gates → Yes/No, formulas → bare, drift guard). They do **not** capture the operational reason it kept failing in Revit after the data was already correct in the repo:

- STING resolves data via `DataPath = <loaded StingTools.dll folder>\data`, and the param **type is read straight from that `MR_PARAMETERS.txt`** (not hardcoded).
- The live `DataPath` was `CompiledPlugin\data`, which a **parallel Export Centre build (`build.bat`) kept overwriting back to stale TEXT** — so repo/file fixes never reached the runtime.
- Signature: `LoadSharedParams` = 0 conflicts one moment, `CreateTagFamilies` = 141 the next.

## Resolution recorded
1. Merge canonical Yes/No to `main` (#324) + pull `main` into the Export Centre branch (#322) so no build reintroduces TEXT.
2. Deploy to the **exact loaded `DataPath`**.
3. **Verify the loaded `MR_PARAMETERS.txt` is Yes/No at runtime before recreating** — don't assume the deploy reached the loaded path.

Plus a guardrail (one install, deploy from `main`, confirm the live `DataPath`) and a note that `FindDataFile`'s recursive first-match could prefer the direct file + log the resolved path in a future hardening.

No code/data change — single file, +50 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScxQnPv1YESkSbDWDNaJb5)_