### PR TITLE
Dock-panel buttons: KUT KPI dashboard + Niagara BMS bridge

### DIFF
--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -3661,6 +3661,9 @@ namespace StingTools.UI
                     case "Fohlio_Export": RunCommand<ExLink.FohlioExportCommand>(app); break;
                     case "Fohlio_Import": RunCommand<ExLink.FohlioImportCommand>(app); break;
                     case "Fohlio_Audit": RunCommand<ExLink.FohlioAuditCommand>(app); break;
+                    case "Niagara_ExportPoints": RunCommand<Commands.Twin.NiagaraPointListExportCommand>(app); break;
+                    case "Niagara_Reconcile": RunCommand<Commands.Twin.NiagaraReconcileCommand>(app); break;
+                    case "KUT_KpiDashboard": RunCommand<Commands.Kpi.KutKpiDashboardCommand>(app); break;
 
                     case "ExLinkBrowser": RunCommand<ExLink.ExLinkBrowserCommand>(app); break;
                     case "ExLinkExport": RunCommand<ExLink.ExLinkExportCommand>(app); break;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -3673,6 +3673,32 @@
                             </StackPanel>
                         </Border>
 
+                        <!-- BMS (NIAGARA) — controls submittal / station reconcile -->
+                        <TextBlock Style="{StaticResource SectionLabel}" Text="BMS (NIAGARA)"/>
+                        <Border Style="{StaticResource GroupBorder}" BorderBrush="#5E35B1">
+                            <StackPanel>
+                                <TextBlock Text="BMS model content + controls submittal — bridge to the Niagara station (ICT_HEALTHIOT_*)" FontSize="9" Foreground="#888" Margin="0,0,0,4"/>
+                                <WrapPanel>
+                                    <Button Style="{StaticResource GreenBtn}" Content="Export Points" Tag="Niagara_ExportPoints" Click="Cmd_Click"
+                                            ToolTip="Export a Niagara-ingestable BMS point list (controls submittal) from tagged ICT_HEALTHIOT_* devices"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="Reconcile" Tag="Niagara_Reconcile" Click="Cmd_Click"
+                                            ToolTip="Compare a Niagara/BACnet station export against the modelled BMS devices (station-only / model-only / matched)"/>
+                                </WrapPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- KUT KPI DASHBOARD (proposal §4.6) -->
+                        <TextBlock Style="{StaticResource SectionLabel}" Text="KUT KPI DASHBOARD"/>
+                        <Border Style="{StaticResource GroupBorder}" BorderBrush="#1A237E">
+                            <StackPanel>
+                                <TextBlock Text="§4.6 monthly KPI dashboard — compliance, clash burn-down, model health, Owner-system coverage" FontSize="9" Foreground="#888" Margin="0,0,0,4"/>
+                                <WrapPanel>
+                                    <Button Style="{StaticResource GreenBtn}" Content="KPI Dashboard" Tag="KUT_KpiDashboard" Click="Cmd_Click"
+                                            ToolTip="Kampala Temple KPI dashboard — RAG bars + per-discipline + clash burn-down + Fohlio/SpecLink/BMS coverage; exports HTML + CSV"/>
+                                </WrapPanel>
+                            </StackPanel>
+                        </Border>
+
                         <!-- CARBON and CHANGE TRACKING -->
                         <TextBlock Style="{StaticResource SectionLabel}" Text="CARBON and CHANGE TRACKING"/>
                         <Border Style="{StaticResource GroupBorder}">


### PR DESCRIPTION
## What & why

Surfaces the commands added on #325 as clickable panel buttons, so they're not only reachable via workflow/command tags. Kept as a **separate branch stacked on #325** so #325 lands clean (this diff is button-only).

The dock handler's `default` case does **not** auto-resolve via `WorkflowEngine.ResolveCommand` — it shows "Unknown Command" — so explicit handler cases are required (not just XAML).

## Changes
- **`StingDockPanel.xaml`** — two new groups after the FOHLIO FF&E group:
  - **BMS (NIAGARA)** → `Export Points` (`Niagara_ExportPoints`), `Reconcile` (`Niagara_Reconcile`)
  - **KUT KPI DASHBOARD** → `KPI Dashboard` (`KUT_KpiDashboard`)
- **`StingCommandHandler.cs`** — dispatch cases for the three tags, next to the existing Fohlio cases.

## Dependency / merge order
- **Depends on #325** (the `KutKpiDashboardCommand` + `Niagara*Command` classes live there).
- Based against `claude/blissful-goldberg-obw0pj` so the diff is button-only. **Retarget to `main` once #325 merges** (GitHub usually auto-retargets on base-branch merge).

## Verification
- XAML well-formed (XML-parsed); all 3 tags present in both XAML and handler; button styles (`GreenBtn`/`ActionBtn`/`GroupBorder`/`SectionLabel`) confirmed.
- ⚠️ Not `dotnet build`-verified (Linux sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016esKUrmFzJMaVVd1nzCVjr)_