### PR TITLE
KUT hardening Phase 1 — ACC issue push correctness (Gaps 1–2)

### DIFF
--- a/StingTools/Clash/AccPullClashesCommand.cs
+++ b/StingTools/Clash/AccPullClashesCommand.cs
@@ -27,6 +27,7 @@ using System.Text;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
 using StingTools.Core;
 using StingTools.Select;
 using StingTools.UI;
@@ -134,38 +135,103 @@ namespace StingTools.Core.Clash
 
             if (res == TaskDialogResult.CommandLink1)
             {
-                int pushed = PushTopIssues(creds, scored.Take(10).ToList(), byId, chosen);
-                TaskDialog.Show("ACC — Pull Clashes", $"Pushed {pushed} clash(es) to ACC Issues.");
+                int pushed = PushTopIssues(doc, creds, scored.Take(10).ToList(), byId, chosen, out int skipped);
+                TaskDialog.Show("ACC — Pull Clashes",
+                    $"Pushed {pushed} new clash(es) to ACC Issues." +
+                    (skipped > 0 ? $"\nSkipped {skipped} already pushed (idempotent — see _BIM_COORD/acc/pushed_clashes.json)." : ""));
             }
 
             StingLog.Info($"ACC_PullClashes: {clashes.Count} clashes, {scored.Count} triaged, set '{chosen.Name}'.");
             return Result.Succeeded;
         }
 
-        private static int PushTopIssues(AccCredentials creds, List<ScoredClash> top,
-            Dictionary<string, AccClashRecord> byId, AccModelSet set)
+        // N-G1: idempotent push. A sidecar maps a STABLE clash signature
+        // (leftObjectId|rightObjectId|leftDoc|rightDoc — NOT the volatile ACC
+        // clash id, which can churn between tests) to the ACC issue id it
+        // created, so re-running pushes 0 new issues when nothing changed.
+        private static int PushTopIssues(Document doc, AccCredentials creds, List<ScoredClash> top,
+            Dictionary<string, AccClashRecord> byId, AccModelSet set, out int skipped)
         {
+            skipped = 0;
             int pushed = 0;
+            string sidecar = PushedSidecarPath(doc);
+            var pushedMap = LoadPushedMap(sidecar);
+            bool dirty = false;
+
             foreach (var s in top)
             {
                 byId.TryGetValue(s.ClashId, out var c);
+                if (c == null) continue;
+                string sig = ClashSignature(c);
+                if (pushedMap.ContainsKey(sig)) { skipped++; continue; }   // already pushed
+
                 var issue = new AccIssue
                 {
                     Title = $"Clash {s.ClashId} [{s.Category}] (STING score {s.Score:F2})",
                     Description = $"Triaged from ACC Model Coordination set '{set.Name}'.\n" +
                                   $"Score {s.Score:F2} — {s.Rationale}\n" +
-                                  (c != null ? $"Penetration {c.PenetrationMm:F0} mm; {c.LeftDocument} ↔ {c.RightDocument}" : ""),
+                                  $"Penetration {c.PenetrationMm:F0} mm; {c.LeftDocument} ↔ {c.RightDocument}",
                     Status = "open",
                     LocationDescription = set.Name,
                 };
                 try
                 {
                     var id = AccIssueSync.PushIssueAsync(creds, issue).GetAwaiter().GetResult();
-                    if (!string.IsNullOrEmpty(id)) pushed++;
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        pushedMap[sig] = id;
+                        dirty = true;
+                        pushed++;
+                    }
                 }
                 catch (Exception ex) { StingLog.Warn("ACC push issue: " + ex.Message); }
             }
+
+            if (dirty) SavePushedMap(sidecar, pushedMap);
             return pushed;
+        }
+
+        // Stable signature: object dbIds + source document names. Deliberately
+        // NOT the ACC clash id (it is per-test and not stable across re-runs).
+        private static string ClashSignature(AccClashRecord c)
+            => $"{c.LeftObjectId}|{c.RightObjectId}|{c.LeftDocument}|{c.RightDocument}";
+
+        private static string PushedSidecarPath(Document doc)
+        {
+            string projDir = string.IsNullOrEmpty(doc?.PathName) ? null : Path.GetDirectoryName(doc.PathName);
+            // Fall back to the standard output location for unsaved/cloud models.
+            string baseDir = !string.IsNullOrEmpty(projDir)
+                ? Path.Combine(projDir, "_BIM_COORD", "acc")
+                : Path.Combine(Path.GetDirectoryName(OutputLocationHelper.GetOutputPath(doc, "x.txt")) ?? Path.GetTempPath(), "_BIM_COORD", "acc");
+            return Path.Combine(baseDir, "pushed_clashes.json");
+        }
+
+        private static Dictionary<string, string> LoadPushedMap(string path)
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+            try
+            {
+                if (path != null && File.Exists(path))
+                {
+                    var j = JObject.Parse(File.ReadAllText(path));
+                    foreach (var p in j.Properties())
+                        map[p.Name] = (string)p.Value ?? string.Empty;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn("ACC pushed_clashes load: " + ex.Message); }
+            return map;
+        }
+
+        private static void SavePushedMap(string path, Dictionary<string, string> map)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                var j = new JObject();
+                foreach (var kv in map) j[kv.Key] = kv.Value;
+                File.WriteAllText(path, j.ToString());
+            }
+            catch (Exception ex) { StingLog.Warn("ACC pushed_clashes save: " + ex.Message); }
         }
 
         private static string WriteCsv(Document doc, AccModelSet set, List<ScoredClash> scored,

--- a/StingTools/V6/AccIssueSync.cs
+++ b/StingTools/V6/AccIssueSync.cs
@@ -39,6 +39,12 @@ namespace StingTools.V6
         public string HubId { get; set; } = string.Empty;
         public string ProjectId { get; set; } = string.Empty;
 
+        // N-G2: ACC rejects an issue create with an empty issue_type_id. When
+        // unset, AccIssueSync.EnsureIssueTypeAsync fetches the project's issue
+        // types once and caches a Clash/default type (+ first subtype) here.
+        public string IssueTypeId { get; set; } = string.Empty;
+        public string IssueSubtypeId { get; set; } = string.Empty;
+
         public bool IsStale => string.IsNullOrEmpty(AccessToken) || DateTime.UtcNow >= AccessTokenExpiry.AddMinutes(-5);
     }
 
@@ -103,18 +109,78 @@ namespace StingTools.V6
             finally { _tokenLock.Release(); }
         }
 
+        /// <summary>
+        /// N-G2: Resolve a usable issue_type_id for the container. Order:
+        /// already-cached <see cref="AccCredentials.IssueTypeId"/> → fetch the
+        /// project's issue types once (GET issue-types) and pick a
+        /// Clash/Coordination type (else the first), caching the id (+ first
+        /// subtype). Idempotent; cached on the credentials + persisted.
+        /// </summary>
+        public static async Task<bool> EnsureIssueTypeAsync(AccCredentials creds)
+        {
+            if (!string.IsNullOrEmpty(creds.IssueTypeId)) return true;
+            if (!await EnsureAuthAsync(creds).ConfigureAwait(false)) return false;
+            try
+            {
+                var req = new HttpRequestMessage(HttpMethod.Get,
+                    $"{IssuesUrl}/containers/{creds.ProjectId}/issue-types?include=subtypes&limit=200");
+                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", creds.AccessToken);
+                var resp = await _http.SendAsync(req).ConfigureAwait(false);
+                if (!resp.IsSuccessStatusCode)
+                {
+                    StingLog.Warn($"AccIssueSync.EnsureIssueType returned {(int)resp.StatusCode}");
+                    return false;
+                }
+                var j = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
+                var results = j["results"] as JArray ?? new JArray();
+                if (results.Count == 0) { StingLog.Warn("AccIssueSync.EnsureIssueType: container returned no issue types."); return false; }
+
+                JToken chosen = null;
+                foreach (var t in results)
+                {
+                    string title = ((string)t["title"] ?? string.Empty).ToLowerInvariant();
+                    if (title.Contains("clash") || title.Contains("coordination")) { chosen = t; break; }
+                }
+                chosen ??= results[0];
+                creds.IssueTypeId = (string)chosen["id"] ?? string.Empty;
+                var subs = chosen["subtypes"] as JArray;
+                if (subs != null && subs.Count > 0)
+                    creds.IssueSubtypeId = (string)subs[0]["id"] ?? string.Empty;
+                SaveCredentials(creds);
+                StingLog.Info($"AccIssueSync: resolved issue type '{(string)chosen["title"]}' ({creds.IssueTypeId}).");
+                return !string.IsNullOrEmpty(creds.IssueTypeId);
+            }
+            catch (Exception ex) { StingLog.Error("AccIssueSync.EnsureIssueType failed", ex); return false; }
+        }
+
         /// <summary>Push a STING-originated issue to ACC.</summary>
         public static async Task<string> PushIssueAsync(AccCredentials creds, AccIssue issue)
         {
             if (!await EnsureAuthAsync(creds).ConfigureAwait(false)) return null;
+
+            // N-G2: an empty issue_type_id is rejected by ACC. Prefer an explicit
+            // type on the issue, else the credentials' configured/cached type,
+            // else fetch + cache one from the project.
+            string typeId = !string.IsNullOrEmpty(issue.IssueType) ? issue.IssueType : creds.IssueTypeId;
+            if (string.IsNullOrEmpty(typeId))
+            {
+                await EnsureIssueTypeAsync(creds).ConfigureAwait(false);
+                typeId = creds.IssueTypeId;
+            }
+            if (string.IsNullOrEmpty(typeId))
+                StingLog.Warn("AccIssueSync.PushIssue: no issue_type_id resolved — ACC will reject. " +
+                              "Set IssueTypeId in acc_credentials.json or ensure the container exposes issue types.");
+
             var body = new JObject
             {
                 ["title"]               = issue.Title,
                 ["description"]         = issue.Description,
                 ["status"]              = issue.Status,
-                ["issue_type_id"]       = issue.IssueType,
+                ["issue_type_id"]       = typeId,
                 ["location_description"]= issue.LocationDescription,
             };
+            if (!string.IsNullOrEmpty(creds.IssueSubtypeId))
+                body["issue_subtype_id"] = creds.IssueSubtypeId;
             var req = new HttpRequestMessage(HttpMethod.Post,
                 $"{IssuesUrl}/containers/{creds.ProjectId}/issues")
             { Content = new StringContent(body.ToString(), Encoding.UTF8, "application/json") };


### PR DESCRIPTION
**Draft — verify in Revit/ACC before merge.** Phase 1 of 4 (must-fix correctness; ACC issue push is broken without these).

## Gaps closed
- **Gap 1 — ACC issue push not idempotent.** `AccPullClashesCommand.PushTopIssues` created a new ACC Issue every run → duplicates. Now keeps `<project>/_BIM_COORD/acc/pushed_clashes.json` mapping a **stable** signature `leftObjectId|rightObjectId|leftDoc|rightDoc` (not the volatile ACC clash id) → created issue id; already-pushed signatures are skipped, returned ids recorded, skipped count surfaced in the dialog.
- **Gap 2 — `issue_type_id` empty.** ACC rejects an empty type. Added `IssueTypeId` (+ optional `IssueSubtypeId`) to `AccCredentials`; new `EnsureIssueTypeAsync` fetches the container issue types once (`GET issues/v1/containers/{id}/issue-types?include=subtypes`), caches a Clash/Coordination type (else first) + first subtype, persists to `acc_credentials.json`. `PushIssueAsync` resolves type (explicit → cached → fetched) and sends `issue_subtype_id` when known.

## Files
- `StingTools/V6/AccIssueSync.cs`
- `StingTools/Clash/AccPullClashesCommand.cs`

No new params / JSON / commandTags / dock buttons. **Release build: 0 errors, 0 warnings** (built against Revit 2025 API on Windows).

## Verify in Revit/ACC
1. With a valid `%APPDATA%\Planscape\acc_credentials.json`, run **ACC_PullClashes** → Push → confirm a **2xx** create.
2. Re-run with no new clashes → **0 new, N skipped**; `_BIM_COORD/acc/pushed_clashes.json` populated.
3. Confirm `IssueTypeId` gets cached into `acc_credentials.json` after the first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)