### PR TITLE
Phased tagging: TAG1_ONLY flag + Scaffold Tiers command

### DIFF
--- a/StingTools/Core/ParamRegistry.cs
+++ b/StingTools/Core/ParamRegistry.cs
@@ -3246,6 +3246,10 @@ namespace StingTools.Core
         public static int WriteContainers(Element el, string[] tokenValues, string categoryName,
             bool overwrite = true, string skipParam = null)
         {
+            // KUT phased tagging: TAG1-only mode writes ASS_TAG_1 + tokens and defers the
+            // discipline containers for colleagues to complete later. Central guard so every
+            // caller (RunFullPipeline, token writers, auto-tagger) honours it uniformly.
+            if (TagConfig.Tag1Only) return 0;
             if (tokenValues == null || tokenValues.Length < 8) return 0;
             int written = 0;
 

--- a/StingTools/Core/TagConfig.Tag7.cs
+++ b/StingTools/Core/TagConfig.Tag7.cs
@@ -1633,6 +1633,8 @@ namespace StingTools.Core
         /// </summary>
         public static int WriteTag7All(Document doc, Element el, string categoryName, string[] tokenValues, bool overwrite = true)
         {
+            // KUT phased tagging: TAG1-only mode defers the TAG7 narrative to the team.
+            if (Tag1Only) return 0;
             if (tokenValues == null || tokenValues.Length < 8) return 0;
             var tag7 = BuildTag7Sections(doc, el, categoryName, tokenValues);
             int written = 0;

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -197,6 +197,14 @@ namespace StingTools.Core
         /// <summary>AL-05: Minimum compliance % gate after batch tag operations. 0 = disabled. Loaded from project_config.json COMPLIANCE_GATE_PCT.</summary>
         public static int ComplianceGatePct { get; internal set; } = 0;
 
+        /// <summary>KUT phased tagging: when true, every tag-write path populates the
+        /// 8 source tokens + ASS_TAG_1_TXT (the ISO 19650 first line) only, and SKIPS the
+        /// discipline containers (ASS_TAG_2..7) + the TAG7 narrative — so colleagues can
+        /// complete those tiers later while coordination proceeds. Enforced centrally in
+        /// ParamRegistry.WriteContainers + TagConfig.WriteTag7All. Loaded from
+        /// project_config.json TAG1_ONLY. Default false (full pipeline).</summary>
+        public static bool Tag1Only { get; internal set; } = false;
+
         /// <summary>HC-001: Configurable proximity radius in feet for CopyTokensFromNearest. Default 10 ft.</summary>
         public static double ProximityRadiusFt { get; internal set; } = 10.0;
 
@@ -617,7 +625,7 @@ namespace StingTools.Core
                     "DISC_MAP","SYS_MAP","PROD_MAP","FUNC_MAP","LOC_CODES","ZONE_CODES","TAG_FORMAT",
                     "TAG_PREFIX","TAG_SUFFIX","CATEGORY_SKIP","CATEGORY_FORCE_SYS","SEQ_SCHEME",
                     "SEQ_INCLUDE_ZONE","SEQ_INCLUDE_LOC","SEQ_LEVEL_RESET","STATUS_DEFAULT","REV_DEFAULT",
-                    "VALIDATE_STRICT_MODE","LOC_PATTERNS","ZONE_PATTERNS","COMPLIANCE_GATE_PCT",
+                    "VALIDATE_STRICT_MODE","LOC_PATTERNS","ZONE_PATTERNS","COMPLIANCE_GATE_PCT","TAG1_ONLY",
                     "SEPARATOR_HISTORY","AUTO_RUN_WORKFLOW_ON_OPEN","ACTIVE_PRESET",
                     "CATEGORY_TOKEN_OVERRIDES","tag3DFamilyPath",
                     "AUTO_TAGGER_ENABLED","AUTO_TAGGER_VISUAL","AUTO_TAGGER_STALE_MARKER",
@@ -916,6 +924,14 @@ namespace StingTools.Core
                 {
                     if (gateObj is long gl) ComplianceGatePct = (int)gl;
                     else if (int.TryParse(gateObj?.ToString(), out int gi)) ComplianceGatePct = gi;
+                }
+
+                // KUT phased tagging — TAG1-only mode (defer containers + TAG7 narrative)
+                Tag1Only = false;
+                if (data.TryGetValue("TAG1_ONLY", out object t1Obj))
+                {
+                    if (t1Obj is bool t1b) Tag1Only = t1b;
+                    else if (bool.TryParse(t1Obj?.ToString(), out bool t1p)) Tag1Only = t1p;
                 }
 
                 // Phase 40: Configurable cost rates filename
@@ -1355,6 +1371,7 @@ namespace StingTools.Core
                     ["CATEGORY_SKIP"] = CategorySkipList.ToList(),
                     ["CATEGORY_FORCE_SYS"] = CategoryForceSys,
                     ["COMPLIANCE_GATE_PCT"] = ComplianceGatePct,
+                    ["TAG1_ONLY"] = Tag1Only,
                     ["SEPARATOR_HISTORY"] = SeparatorHistory,
                     ["AUTO_RUN_WORKFLOW_ON_OPEN"] = AutoRunWorkflowOnOpen ?? "",
                     ["CATEGORY_TOKEN_OVERRIDES"] = CategoryTokenOverrides,

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1390,6 +1390,7 @@ namespace StingTools.Core
             {
                 // Setup
                 case "LoadParams": return new Tags.LoadSharedParamsCommand();
+                case "ScaffoldTiers": return new Tags.ScaffoldTiersCommand();
                 case "MasterSetup": return new Temp.MasterSetupCommand();
                 case "ProjectSetup": return new Temp.ProjectSetupCommand();
 

--- a/StingTools/Tags/ScaffoldTiersCommand.cs
+++ b/StingTools/Tags/ScaffoldTiersCommand.cs
@@ -1,0 +1,78 @@
+using System;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+
+namespace StingTools.Tags
+{
+    // ─────────────────────────────────────────────────────────────────────────
+    // Scaffold Tiers — one-click "ready-to-fill" model for colleagues.
+    //
+    // Sets up the full tier framework so a coordinator can hand the model to the
+    // team to complete labels manually while the job proceeds:
+    //   1. Bind every tier/container (8 tokens + ASS_TAG_2..7 + the discipline
+    //      containers + TAG7 A-F) via LoadSharedParams — the fields now exist on
+    //      every element, empty, ready to fill.
+    //   2. Reveal all 10 paragraph tiers (SetParagraphDepth T10, warnings off) so
+    //      colleagues can see and complete every tier.
+    //   3. Leave the segment mask at its default (all 8 segments visible).
+    //
+    // Pairs with TAG1_ONLY=true in project_config.json: the coordinator's own
+    // tagging pass writes only ASS_TAG_1 (the ISO 19650 first line) and leaves the
+    // tiers for the team. Read/written only through the existing, verified commands.
+    // ─────────────────────────────────────────────────────────────────────────
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ScaffoldTiersCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(commandData);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            // 1. Bind all tiers/containers (reuse the verified shared-parameter binder).
+            string bindMsg = "";
+            Result bind;
+            try { bind = new LoadSharedParamsCommand().Execute(commandData, ref bindMsg, elements); }
+            catch (Exception ex)
+            {
+                StingLog.Error("ScaffoldTiers bind", ex);
+                TaskDialog.Show("Scaffold Tiers", "Parameter binding failed:\n" + ex.Message);
+                return Result.Failed;
+            }
+            if (bind == Result.Cancelled) return Result.Cancelled;
+
+            // 2. Reveal all 10 paragraph tiers on every type (warnings off).
+            int typesUpdated = 0;
+            try
+            {
+                using (var t = new Transaction(doc, "STING Scaffold Tiers — depth T10"))
+                {
+                    t.Start();
+                    typesUpdated = TagStyleEngine.SetParagraphDepth(doc, 10, warnVisible: false);
+                    t.Commit();
+                }
+            }
+            catch (Exception ex) { StingLog.Warn("ScaffoldTiers depth: " + ex.Message); }
+
+            // 3. Segment mask left at default (all 8 segments visible) — no write needed.
+
+            new TaskDialog("Scaffold Tiers")
+            {
+                MainInstruction = "Model scaffolded — ready for colleagues to fill labels",
+                MainContent =
+                    "1. All tag tiers/containers bound (8 tokens + ASS_TAG_2..7 + discipline containers + TAG7 A-F).\n" +
+                    $"2. Paragraph depth set to T10 (all tiers visible) on {typesUpdated} type(s).\n" +
+                    "3. Segment mask left at default (all 8 segments).\n\n" +
+                    "Colleagues complete labels via element Properties or the Excel round-trip " +
+                    "(Export to Excel → fill → Import from Excel).\n\n" +
+                    "Tip: set TAG1_ONLY = true via the Configure command (project_config.json) for your own " +
+                    "coordination pass — your tagging then writes only ASS_TAG_1 and leaves the tiers for the team."
+            }.Show();
+            StingLog.Info($"ScaffoldTiers: bound params + paragraph depth T10 on {typesUpdated} type(s).");
+            return Result.Succeeded;
+        }
+    }
+}

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -1463,6 +1463,7 @@ namespace StingTools.UI
 
                     // ── Setup ──
                     case "LoadSharedParams": RunCommand<Tags.LoadSharedParamsCommand>(app); break;
+                    case "ScaffoldTiers": RunCommand<Tags.ScaffoldTiersCommand>(app); break;
                     case "PurgeSharedParams": RunCommand<Tags.PurgeSharedParamsCommand>(app); break;
                     case "ConfigEditor": RunCommand<Tags.ConfigEditorCommand>(app); break;
                     case "GuidedDataEditor": RunCommand<Tags.GuidedDataEditorCommand>(app); break;

--- a/project-templates/KUT/README.md
+++ b/project-templates/KUT/README.md
@@ -113,6 +113,23 @@ parameter set via `IoTDeviceRegistry`; live read-back stays an FM add-on.
 
 ---
 
+## 4b. Phased tagging (TAG1-only + Scaffold Tiers)
+
+Run the ISO tag now, complete the rest later, in parallel with the team:
+
+- **`Scaffold Tiers`** (one click) binds every tier/container (8 tokens + `ASS_TAG_2..7`
+  + discipline containers + TAG7 A–F), reveals all 10 paragraph tiers (`SetParagraphDepth`
+  T10), and leaves the segment mask at default — a ready-to-fill model for colleagues.
+- **`TAG1_ONLY: true`** in `project_config.json` (set via the Configure command) makes every
+  tagging path write only the 8 tokens + `ASS_TAG_1_TXT` (the ISO 19650 first line) and
+  **skip** the containers + TAG7 narrative — enforced centrally in
+  `ParamRegistry.WriteContainers` + `TagConfig.WriteTag7All`. Default `false` (full pipeline).
+- Colleagues complete the deferred tiers via element **Properties** or the **Excel
+  round-trip** (Export → fill → Import). Gates stay green because `required_containers`
+  is `["ASS_TAG_1_TXT"]` — the deferred tiers are tracked non-blockingly.
+
+---
+
 ## 5. Deployment checklist
 
 1. Copy `_BIM_COORD/` into the temple project folder.


### PR DESCRIPTION
## What & why

Lets a coordinator run the ISO 19650 **first line now** and hand the full tier framework to colleagues to complete **later, in parallel** — the workflow requested for the KUT job.

## (a) `TAG1_ONLY` flag
- `TagConfig.Tag1Only`, loaded from `project_config.json` (`TAG1_ONLY`), serialised + added to known-keys. Default `false` (full pipeline unchanged).
- When `true`, every tag-write path writes the 8 tokens + `ASS_TAG_1_TXT` only and **skips** the discipline containers + TAG7 narrative. Enforced with **two central guards** so all callers (`RunFullPipeline`, token writers, auto-tagger) honour it uniformly:
  - `ParamRegistry.WriteContainers` → early-return when `Tag1Only`
  - `TagConfig.WriteTag7All` → early-return when `Tag1Only`
- `ASS_TAG_1` itself (`BuildAndWriteTag`) is untouched.

## (b) `Scaffold Tiers` command (`ScaffoldTiers`)
One click → ready-to-fill model for colleagues:
1. Bind all tiers/containers (reuses `LoadSharedParams`).
2. Reveal all 10 paragraph tiers (`TagStyleEngine.SetParagraphDepth` T10, warnings off).
3. Leave the segment mask at default (all 8 segments).

Wired in `WorkflowEngine.ResolveCommand` + `StingCommandHandler`. Colleagues complete labels via Properties or the Excel round-trip.

## Notes
- Gates stay green on `ASS_TAG_1` alone (`required_containers = ["ASS_TAG_1_TXT"]`); deferred tiers tracked non-blockingly.
- README (`project-templates/KUT/`) documents the phased workflow.
- Independent of the hardening PRs (#328…); branched off `main`. No dock button added (avoids XAML conflict with #327 / Phase 4) — reachable via command tag + workflow now.

## Verification
- Partial-class (`TagConfig.Tag7`), namespaces (`StingTools.Core`/`.Tags`), and `SetParagraphDepth(Document,int,bool)` signature confirmed against source; tags wired with no dupes.
- ⚠️ Not `dotnet build`-verified (Linux sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016esKUrmFzJMaVVd1nzCVjr)_