### PR TITLE
Phase 196 — tag-creation inject path: pre-skip type conflicts + failure swallower

### DIFF
--- a/StingTools/Tags/FamilyLabelAuthor.cs
+++ b/StingTools/Tags/FamilyLabelAuthor.cs
@@ -267,7 +267,9 @@ namespace StingTools.Tags
                 FamilyManager fm = fdoc.FamilyManager;
                 using (Transaction tx = new Transaction(fdoc, "STING AuthorLabels — bind tier params"))
                 {
+                    TagParamInjector.InstallSwallower(tx); // Phase 196 — before Start
                     tx.Start();
+                    var idx = TagParamInjector.BuildIndex(fdoc);
                     foreach (string name in paramNames)
                     {
                         ExternalDefinition ext = FindSharedDefinition(defFile, name);
@@ -276,15 +278,17 @@ namespace StingTools.Tags
                             result.Warnings.Add($"Shared param '{name}' not in {Path.GetFileName(opts.SharedParamFile)}");
                             continue;
                         }
-                        if (HasParameter(fm, name)) continue;
-                        try
+                        // Phase 196: pre-skip TEXT↔YESNO conflicts so a stale MR file
+                        // can't raise the unrecoverable "cannot be added" modal here.
+                        switch (TagParamInjector.EnsureFamilyParam(fm, ext, idx, GroupTypeId.General, true))
                         {
-                            fm.AddParameter(ext, GroupTypeId.General, true); // instance
-                            added++;
-                        }
-                        catch (Exception ex)
-                        {
-                            result.Warnings.Add($"AddParameter('{name}') failed: {ex.Message}");
+                            case TagParamInjector.InjectResult.Added:
+                                added++;
+                                break;
+                            case TagParamInjector.InjectResult.SkippedConflict:
+                                result.Warnings.Add($"'{name}': type conflict with the family's existing definition — kept existing (TEXT↔YESNO drift)");
+                                break;
+                            // SkippedExists / Failed: no-op (Failed already logged by the injector).
                         }
                     }
                     tx.Commit();

--- a/StingTools/Tags/FamilyParamCreatorCommand.cs
+++ b/StingTools/Tags/FamilyParamCreatorCommand.cs
@@ -323,43 +323,32 @@ namespace StingTools.Tags
                         fm.GetParameters().Select(p => p.Definition.Name),
                         StringComparer.OrdinalIgnoreCase);
 
+                    // Phase 196: index existing SharedParameterElements once; route
+                    // every add through the shared conflict-tolerant injector so a
+                    // TEXT↔YESNO gate drift is skipped, never thrown as a modal. The
+                    // commit-time swallower is installed on the caller's transaction
+                    // (ProcessFamily / ProcessFamilyDocument).
+                    var injIdx = TagParamInjector.BuildIndex(famDoc);
                     foreach (string paramName in paramNames)
                     {
-                        try
+                        if (existingNames.Contains(paramName)) { skipped++; continue; }
+
+                        ExternalDefinition extDef = null;
+                        foreach (DefinitionGroup group in defFile.Groups)
                         {
-                            if (existingNames.Contains(paramName))
-                            {
-                                skipped++;
-                                continue;
-                            }
+                            extDef = group.Definitions
+                                .Cast<ExternalDefinition>()
+                                .FirstOrDefault(d => d.Name == paramName);
+                            if (extDef != null) break;
+                        }
+                        if (extDef == null) { skipped++; continue; }
 
-                            // Find the definition in shared param file
-                            ExternalDefinition extDef = null;
-                            foreach (DefinitionGroup group in defFile.Groups)
-                            {
-                                extDef = group.Definitions
-                                    .Cast<ExternalDefinition>()
-                                    .FirstOrDefault(d => d.Name == paramName);
-                                if (extDef != null) break;
-                            }
-
-                            if (extDef == null)
-                            {
-                                skipped++;
-                                continue;
-                            }
-
-                            bool isInstance = paramName != ParamRegistry.TAG_POS;
-                            fm.AddParameter(extDef,
-                                GroupTypeId.General,
-                                isInstance);
+                        bool isInstance = paramName != ParamRegistry.TAG_POS;
+                        if (TagParamInjector.EnsureFamilyParam(fm, extDef, injIdx, GroupTypeId.General, isInstance)
+                                == TagParamInjector.InjectResult.Added)
                             added++;
-                        }
-                        catch (Exception ex)
-                        {
-                            StingLog.Warn($"InjectSharedParams '{paramName}': {ex.Message}");
-                            skipped++;
-                        }
+                        else
+                            skipped++; // SkippedExists / SkippedConflict / Failed (logged by the injector)
                     }
                 }
                 finally
@@ -1023,6 +1012,7 @@ namespace StingTools.Tags
 
                 using (Transaction tx = new Transaction(famDoc, "STING Tag Family Parameter Creator"))
                 {
+                    TagParamInjector.InstallSwallower(tx); // Phase 196 — before Start
                     tx.Start();
 
                     // Pre-injection purge. Scope is set by opts.Purge:
@@ -1472,6 +1462,7 @@ namespace StingTools.Tags
 
                 using (Transaction tx = new Transaction(famDoc, "STING Family Param Inject"))
                 {
+                    TagParamInjector.InstallSwallower(tx); // Phase 196 — before Start
                     tx.Start();
 
                     if (opts.Purge != PurgeMode.None)

--- a/StingTools/Tags/TagFamilyCreatorCommand.cs
+++ b/StingTools/Tags/TagFamilyCreatorCommand.cs
@@ -2245,51 +2245,41 @@ namespace StingTools.Tags
                 // Use provided param list or fallback to basic TagParams
                 var paramsToAdd = paramNames ?? new List<string>(TagFamilyConfig.TagParams);
 
+                int skippedExists = 0, skippedConflict = 0;
                 using (Transaction tx = new Transaction(famDoc, "STING Add Tag Params"))
                 {
+                    // Phase 196: install the conflict swallower BEFORE Start as the
+                    // commit-time safety net (mirrors LoadSharedParamsCommand).
+                    TagParamInjector.InstallSwallower(tx);
                     tx.Start();
 
+                    // Phase 196: index the family doc's existing SharedParameterElements
+                    // once, then pre-skip any GUID/name/type conflict so a stale
+                    // TEXT vs YESNO gate never reaches the unrecoverable Error modal.
+                    var idx = TagParamInjector.BuildIndex(famDoc);
                     foreach (string paramName in paramsToAdd)
                     {
-                        // Find the definition in the shared parameter file
                         ExternalDefinition extDef = FindSharedDefinition(defFile, paramName);
                         if (extDef == null)
                         {
                             StingLog.Warn($"Shared parameter '{paramName}' not found in file");
                             continue;
                         }
-
-                        // Check if already added
-                        bool exists = false;
-                        foreach (FamilyParameter fp in famMan.Parameters)
+                        switch (TagParamInjector.EnsureFamilyParam(famMan, extDef, idx, GroupTypeId.General, true))
                         {
-                            if (fp.Definition.Name == paramName)
-                            {
-                                exists = true;
-                                break;
-                            }
-                        }
-                        if (exists) continue;
-
-                        try
-                        {
-                            famMan.AddParameter(
-                                extDef,
-                                GroupTypeId.General,
-                                true); // isInstance = true (tags display instance values)
-                            added++;
-                        }
-                        catch (Exception ex)
-                        {
-                            StingLog.Warn($"Cannot add param '{paramName}' to family: {ex.Message}");
+                            case TagParamInjector.InjectResult.Added: added++; break;
+                            case TagParamInjector.InjectResult.SkippedExists: skippedExists++; break;
+                            case TagParamInjector.InjectResult.SkippedConflict: skippedConflict++; break;
                         }
                     }
 
                     tx.Commit();
                 }
 
-                StingLog.Info($"Added {added} shared parameters to tag family");
-                return added > 0;
+                StingLog.Info($"AddSharedParameters: added {added}, skipped-exists {skippedExists}, " +
+                              $"skipped-conflict {skippedConflict} (TEXT↔YESNO drift if >0; family kept its definition)");
+                // Treat "all already present" as success too — the family is complete.
+                return added > 0 || skippedExists > 0;
             }
             catch (Exception ex)
             {

--- a/StingTools/Tags/TagParamInjector.cs
+++ b/StingTools/Tags/TagParamInjector.cs
@@ -1,0 +1,157 @@
+// TagParamInjector.cs — shared shared-parameter inject guard for the tag path.
+//
+// Phase 196. CreateTagFamilies (and the sibling family-param inject paths) used
+// to call FamilyManager.AddParameter from the shared-parameter file with no
+// conflict handling. When the loaded MR_PARAMETERS.txt declares a gate param as
+// one type (e.g. Text) but the family/template already holds it as another
+// (e.g. Yes/No), Revit raises an Error-severity failure at commit → the
+// unrecoverable "cannot be added (Text) — conflicts with existing Yes/No" modal.
+//
+// LoadSharedParamsCommand already solved this for the PROJECT: it (a) pre-skips
+// GUID/name/type conflicts before AddParameter (its "step 3b") and (b) installs
+// BindingWarningSwallower as a commit-time safety net. This helper gives every
+// FAMILY-doc inject site the same two protections, scoped to the family
+// document's SharedParameterElements, so all three call sites share identical
+// logic and reuse the same BindingWarningSwallower (StingTools.Tags).
+//
+// Contract: a gate already present in the family as Yes/No is kept; the Text
+// re-add is skipped. The family stays complete + correct and GateToken emits the
+// bare if(GATE, …). No parameter types, data files, GateToken or formulas change.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+
+namespace StingTools.Tags
+{
+    internal static class TagParamInjector
+    {
+        public enum InjectResult { Added, SkippedExists, SkippedConflict, Failed }
+
+        /// <summary>Per-family-document index of existing SharedParameterElements
+        /// keyed by GUID and by name (with data-type id), mirroring
+        /// LoadSharedParamsCommand step 3b but scoped to the family doc.</summary>
+        public sealed class Index
+        {
+            public readonly Dictionary<Guid, (string name, string typeId)> ByGuid = new();
+            public readonly Dictionary<string, (Guid guid, string typeId)> ByName =
+                new(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public static Index BuildIndex(Document famDoc)
+        {
+            var idx = new Index();
+            if (famDoc == null) return idx;
+            try
+            {
+                foreach (var spe in new FilteredElementCollector(famDoc)
+                             .OfClass(typeof(SharedParameterElement)).Cast<SharedParameterElement>())
+                {
+                    try
+                    {
+                        Guid g = spe.GuidValue;
+                        InternalDefinition d = spe.GetDefinition();
+                        string name = d?.Name ?? "";
+                        string typeId = null;
+                        try { typeId = d?.GetDataType()?.TypeId; }
+                        catch (Exception ex) { StingLog.Warn($"TagParamInjector GetDataType '{name}': {ex.Message}"); }
+                        idx.ByGuid[g] = (name, typeId);
+                        if (!string.IsNullOrEmpty(name)) idx.ByName[name] = (g, typeId);
+                    }
+                    catch (Exception ex) { StingLog.Warn($"TagParamInjector inspect SPE: {ex.Message}"); }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"TagParamInjector collect SPEs: {ex.Message}"); }
+            return idx;
+        }
+
+        /// <summary>Add one shared parameter to the family, pre-skipping
+        /// type/name/GUID conflicts (keep the family's existing definition).
+        /// Callers must install <see cref="InstallSwallower"/> on the transaction
+        /// as the commit-time safety net for anything that still slips through.</summary>
+        public static InjectResult EnsureFamilyParam(
+            FamilyManager fm, ExternalDefinition extDef, Index idx, ForgeTypeId group, bool isInstance)
+        {
+            if (fm == null || extDef == null) return InjectResult.Failed;
+
+            // Already a FamilyParameter by name → nothing to do.
+            foreach (FamilyParameter fp in fm.Parameters)
+                if (string.Equals(fp?.Definition?.Name, extDef.Name, StringComparison.OrdinalIgnoreCase))
+                    return InjectResult.SkippedExists;
+
+            if (idx != null && IsConflict(extDef, idx, out string reason))
+            {
+                StingLog.Warn($"TagParamInjector: skip '{extDef.Name}' — {reason}; keeping the family's existing definition.");
+                return InjectResult.SkippedConflict;
+            }
+
+            try { fm.AddParameter(extDef, group, isInstance); return InjectResult.Added; }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagParamInjector AddParameter '{extDef.Name}': {ex.Message}");
+                return InjectResult.Failed;
+            }
+        }
+
+        // Conflict test, mirroring LoadSharedParamsCommand step 3b at family scope.
+        private static bool IsConflict(ExternalDefinition d, Index idx, out string reason)
+        {
+            reason = null;
+            string newTypeId = null;
+            try { newTypeId = d.GetDataType()?.TypeId; }
+            catch (Exception ex) { StingLog.Warn($"TagParamInjector GetDataType def '{d.Name}': {ex.Message}"); }
+
+            bool guidExists = idx.ByGuid.TryGetValue(d.GUID, out var existing);
+            bool nameExists = idx.ByName.TryGetValue(d.Name, out var existingByName);
+            if (!guidExists && !nameExists) return false; // brand-new param — safe to add
+
+            bool typeIndeterminate = guidExists
+                ? (existing.typeId == null || newTypeId == null)
+                : (existingByName.typeId == null || newTypeId == null);
+            bool nameMismatch = guidExists
+                && !string.Equals(existing.name, d.Name, StringComparison.OrdinalIgnoreCase);
+            bool typeMismatch = guidExists
+                ? (!typeIndeterminate && !string.Equals(existing.typeId, newTypeId, StringComparison.Ordinal))
+                : (!typeIndeterminate && !string.Equals(existingByName.typeId, newTypeId, StringComparison.Ordinal));
+            bool nameOwnedByOtherGuid = !guidExists && nameExists && existingByName.guid != d.GUID;
+
+            if (nameMismatch || typeMismatch || typeIndeterminate || nameOwnedByOtherGuid)
+            {
+                if (nameOwnedByOtherGuid) reason = $"name held by a different GUID ({existingByName.guid})";
+                else if (nameMismatch)    reason = $"GUID already held by '{existing.name}'";
+                else if (typeMismatch)    reason = $"family holds type {Short(guidExists ? existing.typeId : existingByName.typeId)}, file has {Short(newTypeId)}";
+                else                      reason = "data type indeterminate on either side";
+                return true;
+            }
+            return false; // same identity already present (not yet a FamilyParameter) — safe to add
+        }
+
+        private static string Short(string t)
+        {
+            if (string.IsNullOrEmpty(t)) return "?";
+            int dot = t.LastIndexOf('.');
+            string s = dot >= 0 && dot < t.Length - 1 ? t.Substring(dot + 1) : t;
+            int dash = s.IndexOf('-');
+            return dash > 0 ? s.Substring(0, dash) : s;
+        }
+
+        /// <summary>Install the shared-parameter-conflict failure swallower on a
+        /// transaction (call BEFORE tx.Start()). Reuses BindingWarningSwallower —
+        /// never forks it — so any Error-severity "shared parameter … conflicts"
+        /// that still reaches commit is dismissed instead of shown as a modal.</summary>
+        public static void InstallSwallower(Transaction tx)
+        {
+            if (tx == null) return;
+            try
+            {
+                var o = tx.GetFailureHandlingOptions();
+                o.SetFailuresPreprocessor(new BindingWarningSwallower());
+                o.SetClearAfterRollback(true);
+                tx.SetFailureHandlingOptions(o);
+            }
+            catch (Exception ex) { StingLog.Warn($"TagParamInjector InstallSwallower: {ex.Message}"); }
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,62 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 196 — tag-creation inject path: pre-skip type conflicts + failure swallower, mirrors LoadSharedParams)
+
+`CreateTagFamilies` could throw the unrecoverable Revit modal **"… cannot be
+added (Text) — conflicts with the existing parameter … (Yes/No)"** (the 141-error
+dialog) whenever the loaded `MR_PARAMETERS.txt` declared a gate param as a
+different data type than the family/template already held. The tag-creation
+inject path called `FamilyManager.AddParameter` from the shared-parameter file
+with **no** conflict handling, whereas `LoadSharedParamsCommand` had long
+handled the same situation gracefully for the project (pre-skip in its "step 3b"
++ a `BindingWarningSwallower` `IFailuresPreprocessor`). This phase gives every
+family-param inject site the same two protections.
+
+**Root cause.** The conflict is an **Error-severity failure raised at commit**,
+not an exception at `AddParameter`, so the existing per-param `try/catch` could
+not prevent the modal. And the conflict lives at the **`SharedParameterElement`
+/ document** level, so the old name-only check against `FamilyManager.Parameters`
+missed it.
+
+**Changes (no parameter types, data files, `GateToken` or formulas touched):**
+
+1. **New `Tags/TagParamInjector.cs`** (`internal static`) factoring the shared
+   logic so the three call sites are identical, not duplicated:
+   - `BuildIndex(famDoc)` — indexes the **family document's**
+     `SharedParameterElement`s by GUID and by name (with
+     `GetDefinition().GetDataType().TypeId`), exactly as LoadSharedParams step 3b
+     does for the project.
+   - `EnsureFamilyParam(fm, extDef, idx, group, isInstance)` → `Added` /
+     `SkippedExists` / `SkippedConflict` / `Failed`. Pre-skips a def whose GUID
+     **or** name already exists in the family with a different data type (or a
+     name held by a different GUID, or an indeterminate type) — keeping the
+     family's existing definition and logging `StingLog.Warn`.
+   - `InstallSwallower(tx)` — sets `BindingWarningSwallower` (reused, **not**
+     forked) via `tx.GetFailureHandlingOptions().SetFailuresPreprocessor(...)`
+     before `tx.Start()` as the commit-time safety net.
+2. **Wired into all three family-param inject sites in the tag path:**
+   `TagFamilyCreatorCommand.AddSharedParameters`,
+   `FamilyParamCreatorCommand.InjectSharedParams` (swallower installed on its two
+   callers' transactions — `ProcessFamily` + `ProcessFamilyDocument`), and
+   `FamilyLabelAuthor.BindSharedParameters` (T4–T10 binding).
+3. **Counts surfaced.** `AddSharedParameters` logs `added / skipped-exists /
+   skipped-conflict` so a stale-TEXT `MR_PARAMETERS.txt` is visible in the log
+   without blocking the user; the label-author path adds a per-param warning on
+   conflict.
+
+**Contract.** A gate already present in the family as Yes/No (from template/seed)
+keeps its Yes/No; the Text re-add is skipped → the family stays complete and
+correct, and `TagConfig.GateToken` emits the bare `if(GATE, …)` for it.
+`CreateTagFamilies` completes with **0 modals** even against a stale TEXT
+`MR_PARAMETERS.txt`.
+
+**Verification.** Release build on Windows (Revit 2025 API) — **0 errors,
+0 warnings**. Built without in-Revit verification in this pass; verify in Revit
+that `CreateTagFamilies` completes with no "cannot be added" modal and produces
+working tag families (gates render, tiers toggle), including against a TEXT
+`MR_PARAMETERS.txt` to prove the resilience.
+
 #### Completed (Phase 194 — Yes/No-canonical gates — corrects PR #324's Text-canonical choice)
 
 PR #324 (Phase 193) fixed the recurring "Inconsistent Units" error by


### PR DESCRIPTION
**Draft — verify in Revit before merge.** Makes `CreateTagFamilies` resilient to shared-parameter **type conflicts**, so it never throws the unrecoverable *"… cannot be added (Text) — conflicts with the existing … (Yes/No)"* modal — regardless of whether the loaded `MR_PARAMETERS.txt` is TEXT or YESNO.

## Root cause
The tag-creation inject path called `FamilyManager.AddParameter` from the shared-param file with **no** conflict handling. The conflict is an **Error-severity failure raised at commit** (not an exception at `AddParameter`), and it lives at the **`SharedParameterElement`/document** level — so the old per-param `try/catch` + name-only `FamilyManager.Parameters` check both missed it. `LoadSharedParamsCommand` already solved the same problem for the project (step-3b pre-skip + `BindingWarningSwallower`); the tag path had neither.

## Fix — both protections, factored into one helper
**New `Tags/TagParamInjector.cs`** (reuses `BindingWarningSwallower`, doesn't fork it):
- `BuildIndex(famDoc)` — indexes the **family doc's** `SharedParameterElement`s by GUID + name (with `GetDataType().TypeId`).
- `EnsureFamilyParam(...)` → `Added` / `SkippedExists` / `SkippedConflict` / `Failed` — pre-skips a def whose GUID **or** name already exists with a different type (or name-held-by-other-GUID / indeterminate type), keeping the family's existing definition.
- `InstallSwallower(tx)` — sets the swallower via `GetFailureHandlingOptions().SetFailuresPreprocessor(...)` **before** `tx.Start()`.

**Wired into all three family-param inject sites:**
- `TagFamilyCreatorCommand.AddSharedParameters` (primary)
- `FamilyParamCreatorCommand.InjectSharedParams` (swallower on its two callers' transactions: `ProcessFamily` + `ProcessFamilyDocument`)
- `FamilyLabelAuthor.BindSharedParameters` (T4–T10 binding)

`AddSharedParameters` logs **added / skipped-exists / skipped-conflict** so a stale-TEXT file is visible in the log without blocking.

## Contract
A gate already present in the family as Yes/No keeps its Yes/No; the Text re-add is skipped → family stays complete + correct, and `TagConfig.GateToken` emits the bare `if(GATE, …)`. **No parameter types, data files, `GateToken`, or formula logic changed.**

## Verify in Revit
- Run **CreateTagFamilies** → completes with **no "cannot be added" modal**; tag families work (gates render, tiers toggle).
- Bonus: point `DataPath` at a **TEXT** `MR_PARAMETERS.txt` and re-run → still 0 modals (proves resilience).

**Release build (Windows, Revit 2025): 0 errors, 0 warnings.** Not in-Revit-verified in this pass (sandbox) — verify before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)