### PR TITLE
ACC + CSI integration hardening (supersedes #328)

### DIFF
--- a/StingTools/Clash/AccPullClashesCommand.cs
+++ b/StingTools/Clash/AccPullClashesCommand.cs
@@ -27,6 +27,7 @@ using System.Text;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
 using StingTools.Core;
 using StingTools.Select;
 using StingTools.UI;
@@ -52,10 +53,11 @@ namespace StingTools.Core.Clash
                     "ACC credentials are not configured.\n\n" +
                     "Create %APPDATA%\\Planscape\\acc_credentials.json with at least:\n" +
                     "  ClientId, ClientSecret, RefreshToken, ProjectId\n\n" +
-                    "ProjectId is the ACC coordination container id.");
+                    "ProjectId is the Issues container; set CoordContainerId if the Model " +
+                    "Coordination container differs.");
                 return Result.Cancelled;
             }
-            string containerId = creds.ProjectId;
+            string containerId = creds.CoordContainer;   // falls back to ProjectId
 
             // 1. List model sets and let the user pick.
             List<AccModelSet> sets;
@@ -102,13 +104,14 @@ namespace StingTools.Core.Clash
                 PenetrationMm = c.PenetrationMm,
             }).ToList();
 
-            var scored = ClashTriageEngine.Triage(inputs);   // top-N by score
+            var scoredAll = ClashTriageEngine.TriageAll(inputs);   // full set (CSV + burn-down)
+            var scored = scoredAll.Take(10).ToList();              // top for display + push
             var byId = clashes.GroupBy(c => c.Id).ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
             // 4. Report + CSV.
             var report = new StringBuilder();
             report.AppendLine($"Model set: {chosen.Name}");
-            report.AppendLine($"Clashes pulled: {clashes.Count}   (top {scored.Count} by triage score)");
+            report.AppendLine($"Clashes pulled: {clashes.Count}   (top {scored.Count} shown; CSV has all {scoredAll.Count})");
             report.AppendLine();
             foreach (var s in scored.Take(10))
             {
@@ -116,7 +119,7 @@ namespace StingTools.Core.Clash
                 report.AppendLine($"  {s.Score:F2}  [{s.Category}]  clash {s.ClashId}" +
                                   (c != null ? $"  pen {c.PenetrationMm:F0}mm  {DocShort(c.LeftDocument)} ↔ {DocShort(c.RightDocument)}" : ""));
             }
-            string csv = WriteCsv(doc, chosen, scored, byId);
+            string csv = WriteCsv(doc, chosen, scoredAll, byId);
             if (csv != null) { report.AppendLine(); report.AppendLine("CSV: " + csv); }
 
             // 5. Offer to push the triaged top clashes back to ACC Issues.
@@ -134,24 +137,33 @@ namespace StingTools.Core.Clash
 
             if (res == TaskDialogResult.CommandLink1)
             {
-                int pushed = PushTopIssues(creds, scored.Take(10).ToList(), byId, chosen);
-                TaskDialog.Show("ACC — Pull Clashes", $"Pushed {pushed} clash(es) to ACC Issues.");
+                string sidecar = SidecarPath(doc);
+                var pushedMap = LoadPushed(sidecar);
+                var (pushed, skipped) = PushTopIssues(creds, scored, byId, chosen, pushedMap);
+                SavePushed(sidecar, pushedMap);
+                TaskDialog.Show("ACC — Pull Clashes",
+                    $"Pushed {pushed} new clash(es) to ACC Issues; {skipped} already pushed (skipped).");
             }
 
             StingLog.Info($"ACC_PullClashes: {clashes.Count} clashes, {scored.Count} triaged, set '{chosen.Name}'.");
             return Result.Succeeded;
         }
 
-        private static int PushTopIssues(AccCredentials creds, List<ScoredClash> top,
-            Dictionary<string, AccClashRecord> byId, AccModelSet set)
+        // Idempotent push: skip clashes already issued (by stable signature), record the
+        // returned ACC issue id in the sidecar so re-runs don't create duplicate issues.
+        private static (int pushed, int skipped) PushTopIssues(AccCredentials creds, List<ScoredClash> top,
+            Dictionary<string, AccClashRecord> byId, AccModelSet set, Dictionary<string, string> pushedMap)
         {
-            int pushed = 0;
+            int pushed = 0, skipped = 0;
             foreach (var s in top)
             {
                 byId.TryGetValue(s.ClashId, out var c);
+                string sig = c != null ? Signature(c) : s.ClashId;
+                if (pushedMap.ContainsKey(sig)) { skipped++; continue; }
+
                 var issue = new AccIssue
                 {
-                    Title = $"Clash {s.ClashId} [{s.Category}] (STING score {s.Score:F2})",
+                    Title = $"Clash [{s.Category}] (STING score {s.Score:F2})",
                     Description = $"Triaged from ACC Model Coordination set '{set.Name}'.\n" +
                                   $"Score {s.Score:F2} — {s.Rationale}\n" +
                                   (c != null ? $"Penetration {c.PenetrationMm:F0} mm; {c.LeftDocument} ↔ {c.RightDocument}" : ""),
@@ -161,11 +173,54 @@ namespace StingTools.Core.Clash
                 try
                 {
                     var id = AccIssueSync.PushIssueAsync(creds, issue).GetAwaiter().GetResult();
-                    if (!string.IsNullOrEmpty(id)) pushed++;
+                    if (!string.IsNullOrEmpty(id)) { pushed++; pushedMap[sig] = id; }
                 }
                 catch (Exception ex) { StingLog.Warn("ACC push issue: " + ex.Message); }
             }
-            return pushed;
+            return (pushed, skipped);
+        }
+
+        /// <summary>Order-invariant clash signature (object dbid @ document for each side,
+        /// sorted) so an A/B swap between ACC runs maps to the same key — true idempotency.</summary>
+        internal static string Signature(AccClashRecord c)
+        {
+            string a = $"{c.LeftObjectId}@{c.LeftDocument}";
+            string b = $"{c.RightObjectId}@{c.RightDocument}";
+            return string.CompareOrdinal(a, b) <= 0 ? $"{a}|{b}" : $"{b}|{a}";
+        }
+
+        internal static string SidecarPath(Document doc)
+        {
+            string dir = Path.GetDirectoryName(doc?.PathName ?? "");
+            if (string.IsNullOrEmpty(dir))
+                dir = Path.GetDirectoryName(OutputLocationHelper.GetOutputPath(doc, "x.txt")) ?? Path.GetTempPath();
+            string accDir = Path.Combine(dir, "_BIM_COORD", "acc");
+            try { Directory.CreateDirectory(accDir); } catch { }
+            return Path.Combine(accDir, "pushed_clashes.json");
+        }
+
+        internal static Dictionary<string, string> LoadPushed(string path)
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+            try
+            {
+                if (path != null && File.Exists(path))
+                    foreach (var p in JObject.Parse(File.ReadAllText(path)).Properties())
+                        map[p.Name] = (string)p.Value ?? string.Empty;
+            }
+            catch (Exception ex) { StingLog.Warn("ACC pushed_clashes load: " + ex.Message); }
+            return map;
+        }
+
+        internal static void SavePushed(string path, Dictionary<string, string> map)
+        {
+            try
+            {
+                var o = new JObject();
+                foreach (var kv in map) o[kv.Key] = kv.Value;
+                File.WriteAllText(path, o.ToString());
+            }
+            catch (Exception ex) { StingLog.Warn("ACC pushed_clashes save: " + ex.Message); }
         }
 
         private static string WriteCsv(Document doc, AccModelSet set, List<ScoredClash> scored,

--- a/StingTools/Clash/AccSyncIssueStatusCommand.cs
+++ b/StingTools/Clash/AccSyncIssueStatusCommand.cs
@@ -1,0 +1,116 @@
+// AccSyncIssueStatusCommand.cs — ACC → STING issue-closure reconciliation.
+//
+// The other half of the loop: ACC_PullClashes escalates triaged clashes to ACC
+// Issues and records each (clash signature → ACC issue id) in
+// _BIM_COORD/acc/pushed_clashes.json. This command pulls the current ACC issue
+// statuses and reconciles them against that escalation log:
+//   - counts how many escalated clashes are now CLOSED in ACC,
+//   - UNTRACKS the closed ones (removes them from the dedup map) so that if the
+//     same clash recurs in a later pull it is re-raised rather than silently
+//     skipped,
+//   - reports what is still open / not found, and writes a closure CSV.
+//
+// Note on identity: ACC clashes and STING's own clash kernel (clashes.json) use
+// different id spaces (ACC object dbIds vs Revit ElementIds), so this reconciles
+// the ESCALATION log (what STING raised in ACC), not the STING clash store —
+// which is the accurate thing to do. Read-only; network I/O only.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.V6;
+
+namespace StingTools.Core.Clash
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class AccSyncIssueStatusCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            var creds = AccIssueSync.LoadCredentials();
+            if (string.IsNullOrEmpty(creds.ClientId) || string.IsNullOrEmpty(creds.RefreshToken) ||
+                string.IsNullOrEmpty(creds.ProjectId))
+            {
+                TaskDialog.Show("ACC — Sync Issue Status", "ACC credentials are not configured (acc_credentials.json).");
+                return Result.Cancelled;
+            }
+
+            string sidecar = AccPullClashesCommand.SidecarPath(doc);
+            var pushedMap = AccPullClashesCommand.LoadPushed(sidecar);
+            if (pushedMap.Count == 0)
+            {
+                TaskDialog.Show("ACC — Sync Issue Status",
+                    "No escalated clashes are tracked yet.\n\nRun ACC Pull Clashes and push some to ACC Issues first.");
+                return Result.Succeeded;
+            }
+
+            List<AccIssue> issues;
+            try { issues = AccIssueSync.PullIssuesAsync(creds).GetAwaiter().GetResult(); }
+            catch (Exception ex) { StingLog.Error("ACC SyncIssueStatus pull", ex); TaskDialog.Show("ACC", "Issue pull failed: " + ex.Message); return Result.Failed; }
+
+            var statusById = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var i in issues)
+                if (!string.IsNullOrEmpty(i.Id)) statusById[i.Id] = i.Status;
+
+            int closed = 0, open = 0, missing = 0;
+            var rows = new List<string> { "Signature,IssueId,Status,Action" };
+            var toUntrack = new List<string>();
+            foreach (var kv in pushedMap)
+            {
+                if (!statusById.TryGetValue(kv.Value, out string st))
+                {
+                    missing++;
+                    rows.Add($"{Csv(kv.Key)},{Csv(kv.Value)},NOT_FOUND,keep");
+                    continue;
+                }
+                if (AccIssueSync.IsClosedStatus(st))
+                {
+                    closed++;
+                    toUntrack.Add(kv.Key);
+                    rows.Add($"{Csv(kv.Key)},{Csv(kv.Value)},{Csv(st)},untrack");
+                }
+                else { open++; rows.Add($"{Csv(kv.Key)},{Csv(kv.Value)},{Csv(st)},keep"); }
+            }
+
+            foreach (var sig in toUntrack) pushedMap.Remove(sig);   // closed → re-raise on recurrence
+            AccPullClashesCommand.SavePushed(sidecar, pushedMap);
+
+            string csvPath = null;
+            try
+            {
+                csvPath = OutputLocationHelper.GetOutputPath(doc, $"STING_ACC_IssueSync_{DateTime.Now:yyyyMMdd}.csv");
+                File.WriteAllLines(csvPath, rows, Encoding.UTF8);
+            }
+            catch (Exception ex) { StingLog.Warn("ACC IssueSync CSV: " + ex.Message); }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Escalated clashes tracked: {closed + open + missing}");
+            sb.AppendLine($"Now CLOSED in ACC:         {closed}  (untracked — will re-raise if they recur)");
+            sb.AppendLine($"Still open:                {open}");
+            sb.AppendLine($"Issue not found:           {missing}  (kept; may have been deleted in ACC)");
+            sb.AppendLine($"Still tracked after sync:  {pushedMap.Count}");
+            if (csvPath != null) { sb.AppendLine(); sb.AppendLine("CSV: " + csvPath); }
+
+            new TaskDialog("ACC — Sync Issue Status")
+            {
+                MainInstruction = $"{closed} escalated clash(es) resolved in ACC",
+                MainContent = sb.ToString()
+            }.Show();
+            StingLog.Info($"ACC_SyncIssueStatus: closed={closed} open={open} missing={missing} tracked={pushedMap.Count}");
+            return Result.Succeeded;
+        }
+
+        private static string Csv(string s) => "\"" + (s ?? "").Replace("\"", "\"\"") + "\"";
+    }
+}

--- a/StingTools/Core/Classification/CsiMasterFormat.cs
+++ b/StingTools/Core/Classification/CsiMasterFormat.cs
@@ -110,11 +110,14 @@ namespace StingTools.Core.Classification
             return bestScore >= 0 ? best : null;
         }
 
-        /// <summary>Canonical key for a CSI section number (trim, collapse spaces, upper).</summary>
+        /// <summary>Canonical key for a CSI section number. Removes ALL whitespace (and
+        /// upper-cases) so spaced "23 05 00" and unspaced "230500" reconcile to the same
+        /// key — SpecLink exports spaced, models often store unspaced. Dots are preserved,
+        /// so a child section "23 05 00.13" stays distinct from its parent.</summary>
         public static string NormalizeSection(string s)
         {
             if (string.IsNullOrWhiteSpace(s)) return "";
-            return Regex.Replace(s.Trim().ToUpperInvariant(), "\\s+", " ");
+            return Regex.Replace(s.Trim().ToUpperInvariant(), "\\s+", "");
         }
 
         public class CsiTocEntry { public string Section; public string Title; }

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1775,6 +1775,7 @@ namespace StingTools.Core
                 case "ClashSessionClear":       return new Core.Clash.ClashSessionClearCommand();
                 case "ClashMatrixEdit":         return new Core.Clash.ClashMatrixEditCommand();
                 case "ACC_PullClashes":         return new Core.Clash.AccPullClashesCommand();
+                case "ACC_SyncIssueStatus":     return new Core.Clash.AccSyncIssueStatusCommand();
                 case "BatchSystemPush":         return new Tags.BatchSystemPushCommand();
                 case "ExportSheetRegister":     return new Docs.ExportSheetRegisterCommand();
                 case "COBieHandoverExport":     return new Docs.COBieHandoverExportCommand();

--- a/StingTools/V6/AccIssueSync.cs
+++ b/StingTools/V6/AccIssueSync.cs
@@ -38,6 +38,15 @@ namespace StingTools.V6
         public DateTime AccessTokenExpiry { get; set; }
         public string HubId { get; set; } = string.Empty;
         public string ProjectId { get; set; } = string.Empty;
+        /// <summary>ACC Model-Coordination container id. Often differs from the Issues/ProjectId container. Falls back to ProjectId when empty.</summary>
+        public string CoordContainerId { get; set; } = string.Empty;
+        /// <summary>Default ACC issue type id used when an issue carries none — required by the ACC Issues API.</summary>
+        public string IssueTypeId { get; set; } = string.Empty;
+        /// <summary>Multiply ACC clash 'dist' by this to get millimetres (default 1000 = metres). Set per the model's clash-result units.</summary>
+        public double DistToMm { get; set; } = 1000.0;
+
+        /// <summary>Coordination container, falling back to the Issues/ProjectId container when unset.</summary>
+        public string CoordContainer => string.IsNullOrEmpty(CoordContainerId) ? ProjectId : CoordContainerId;
 
         public bool IsStale => string.IsNullOrEmpty(AccessToken) || DateTime.UtcNow >= AccessTokenExpiry.AddMinutes(-5);
     }
@@ -107,14 +116,18 @@ namespace StingTools.V6
         public static async Task<string> PushIssueAsync(AccCredentials creds, AccIssue issue)
         {
             if (!await EnsureAuthAsync(creds).ConfigureAwait(false)) return null;
+            string issueType = !string.IsNullOrEmpty(issue.IssueType) ? issue.IssueType : creds.IssueTypeId;
             var body = new JObject
             {
                 ["title"]               = issue.Title,
                 ["description"]         = issue.Description,
                 ["status"]              = issue.Status,
-                ["issue_type_id"]       = issue.IssueType,
                 ["location_description"]= issue.LocationDescription,
             };
+            // ACC requires a valid issue_type_id. Only send it when we have one;
+            // omitting an empty value is safer than posting "" (which ACC rejects).
+            if (!string.IsNullOrEmpty(issueType)) body["issue_type_id"] = issueType;
+            else StingLog.Warn("AccIssueSync.PushIssue: no issue_type_id — set IssueTypeId in acc_credentials.json; ACC may reject.");
             var req = new HttpRequestMessage(HttpMethod.Post,
                 $"{IssuesUrl}/containers/{creds.ProjectId}/issues")
             { Content = new StringContent(body.ToString(), Encoding.UTF8, "application/json") };
@@ -141,31 +154,60 @@ namespace StingTools.V6
             return null;
         }
 
-        /// <summary>Pull the latest issue set from ACC.</summary>
-        public static async Task<List<AccIssue>> PullIssuesAsync(AccCredentials creds, int pageSize = 100)
+        /// <summary>Pull the full issue set from ACC, following pagination (offset
+        /// loop) so large projects aren't truncated at the first page. 429s retried
+        /// per page with back-off; stops at the first short page or maxPages cap.</summary>
+        public static async Task<List<AccIssue>> PullIssuesAsync(AccCredentials creds, int pageSize = 100, int maxPages = 200)
         {
             var list = new List<AccIssue>();
             if (!await EnsureAuthAsync(creds).ConfigureAwait(false)) return list;
-            var req = new HttpRequestMessage(HttpMethod.Get,
-                $"{IssuesUrl}/containers/{creds.ProjectId}/issues?limit={pageSize}");
-            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", creds.AccessToken);
-            var resp = await _http.SendAsync(req).ConfigureAwait(false);
-            if (!resp.IsSuccessStatusCode) return list;
-            var j = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
-            foreach (var t in j["results"] ?? new JArray())
+
+            int offset = 0;
+            for (int page = 0; page < maxPages; page++)
             {
-                list.Add(new AccIssue
+                JObject j = null;
+                for (int attempt = 0; attempt < 4 && j == null; attempt++)
                 {
-                    Id                  = (string)t["id"] ?? string.Empty,
-                    Title               = (string)t["title"] ?? string.Empty,
-                    Description         = (string)t["description"] ?? string.Empty,
-                    Status              = (string)t["status"] ?? "open",
-                    IssueType           = (string)t["issue_type_id"] ?? string.Empty,
-                    AssignedToUserId    = (string)t["assigned_to"] ?? string.Empty,
-                    LocationDescription = (string)t["location_description"] ?? string.Empty,
-                });
+                    var req = new HttpRequestMessage(HttpMethod.Get,
+                        $"{IssuesUrl}/containers/{creds.ProjectId}/issues?limit={pageSize}&offset={offset}");
+                    req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", creds.AccessToken);
+                    var resp = await _http.SendAsync(req).ConfigureAwait(false);
+                    if ((int)resp.StatusCode == 429) { await Task.Delay(TimeSpan.FromSeconds(1 << attempt)).ConfigureAwait(false); continue; }
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        StingLog.Warn($"AccIssueSync.PullIssues {(int)resp.StatusCode} at offset {offset}");
+                        return list;
+                    }
+                    j = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
+                }
+                if (j == null) break;
+
+                var results = j["results"] as JArray ?? new JArray();
+                foreach (var t in results)
+                {
+                    list.Add(new AccIssue
+                    {
+                        Id                  = (string)t["id"] ?? string.Empty,
+                        Title               = (string)t["title"] ?? string.Empty,
+                        Description         = (string)t["description"] ?? string.Empty,
+                        Status              = (string)t["status"] ?? "open",
+                        IssueType           = (string)t["issue_type_id"] ?? string.Empty,
+                        AssignedToUserId    = (string)t["assigned_to"] ?? string.Empty,
+                        LocationDescription = (string)t["location_description"] ?? string.Empty,
+                    });
+                }
+                if (results.Count < pageSize) break;   // last page
+                offset += pageSize;
             }
             return list;
+        }
+
+        /// <summary>True when an ACC issue status represents a closed/resolved state.</summary>
+        public static bool IsClosedStatus(string status)
+        {
+            if (string.IsNullOrEmpty(status)) return false;
+            string s = status.ToLowerInvariant();
+            return s.Contains("closed") || s.Contains("resolved") || s.Contains("not_an_issue") || s.Contains("void");
         }
 
         public static string CredentialsPath => Path.Combine(

--- a/StingTools/V6/AccModelCoordSync.cs
+++ b/StingTools/V6/AccModelCoordSync.cs
@@ -72,7 +72,9 @@ namespace StingTools.V6
         public long RightObjectId { get; set; }        // rvid (dbId)
         public string LeftDocument { get; set; } = string.Empty;
         public string RightDocument { get; set; } = string.Empty;
-        public double PenetrationMm => Math.Abs(DistanceM) * 1000.0;
+        /// <summary>Factor converting DistanceM → mm (from AccCredentials.DistToMm; default 1000 = metres).</summary>
+        public double DistToMm { get; set; } = 1000.0;
+        public double PenetrationMm => Math.Abs(DistanceM) * DistToMm;
     }
 
     public static class AccModelCoordSync
@@ -83,20 +85,31 @@ namespace StingTools.V6
         private const string ModelSetBase = Host + "/bim360/modelset/v3";
         private const string ClashBase    = Host + "/bim360/clash/v3";
 
-        // ── Model sets ──
+        // ── Model sets (paginated; dedupes by id so an offset-ignoring endpoint can't loop) ──
         public static async Task<List<AccModelSet>> ListModelSetsAsync(AccCredentials creds, string containerId)
         {
             var list = new List<AccModelSet>();
             if (string.IsNullOrEmpty(containerId)) return list;
-            var json = await GetJsonAsync(creds, $"{ModelSetBase}/containers/{containerId}/modelsets").ConfigureAwait(false);
-            var arr = json?["modelSets"] as JArray ?? json?["results"] as JArray ?? json as JArray;
-            if (arr == null) return list;
-            foreach (var m in arr)
-                list.Add(new AccModelSet
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            const int pageSize = 100;
+            int offset = 0;
+            for (int page = 0; page < 50; page++)
+            {
+                var json = await GetJsonAsync(creds,
+                    $"{ModelSetBase}/containers/{containerId}/modelsets?limit={pageSize}&offset={offset}").ConfigureAwait(false);
+                var arr = json?["modelSets"] as JArray ?? json?["results"] as JArray ?? json as JArray;
+                if (arr == null || arr.Count == 0) break;
+                int added = 0;
+                foreach (var m in arr)
                 {
-                    Id   = (string)(m["modelSetId"] ?? m["id"]) ?? string.Empty,
-                    Name = (string)(m["name"] ?? m["title"]) ?? "(unnamed model set)",
-                });
+                    string id = (string)(m["modelSetId"] ?? m["id"]) ?? string.Empty;
+                    if (string.IsNullOrEmpty(id) || !seen.Add(id)) continue;
+                    list.Add(new AccModelSet { Id = id, Name = (string)(m["name"] ?? m["title"]) ?? "(unnamed model set)" });
+                    added++;
+                }
+                if (arr.Count < pageSize || added == 0) break;  // last page, or endpoint ignored offset
+                offset += pageSize;
+            }
             return list;
         }
 
@@ -136,9 +149,9 @@ namespace StingTools.V6
             }
 
             // 3. download + gunzip the scope files
-            var clashScope    = await DownloadScopeAsync(clashUrl).ConfigureAwait(false);
-            var instanceScope = await DownloadScopeAsync(instanceUrl).ConfigureAwait(false);
-            var documentScope = documentUrl != null ? await DownloadScopeAsync(documentUrl).ConfigureAwait(false) : null;
+            var clashScope    = await DownloadScopeAsync(clashUrl, creds).ConfigureAwait(false);
+            var instanceScope = await DownloadScopeAsync(instanceUrl, creds).ConfigureAwait(false);
+            var documentScope = documentUrl != null ? await DownloadScopeAsync(documentUrl, creds).ConfigureAwait(false) : null;
             if (clashScope == null || instanceScope == null) return result;
 
             // 4. join. instances are keyed by cid (== clash id); first instance per cid wins.
@@ -172,6 +185,7 @@ namespace StingTools.V6
                     RightObjectId = ParseLong(ins?["rvid"]),
                     LeftDocument  = ldid != null && docNameById.TryGetValue(ldid, out var ln) ? ln : (ldid ?? ""),
                     RightDocument = rdid != null && docNameById.TryGetValue(rdid, out var rn) ? rn : (rdid ?? ""),
+                    DistToMm      = creds.DistToMm,
                 });
             }
             return result;
@@ -218,13 +232,17 @@ namespace StingTools.V6
             return null;
         }
 
-        /// <summary>Download a pre-signed scope resource and gunzip it to JSON.
-        /// Pre-signed URLs carry their own auth, so no bearer header is sent.</summary>
-        private static async Task<JObject> DownloadScopeAsync(string url)
+        /// <summary>Download a scope resource and gunzip it to JSON. Pre-signed S3/
+        /// CloudFront URLs carry their own auth; API-hosted resources (developer.api.
+        /// autodesk.com) need the bearer, so we attach it when the host matches.</summary>
+        private static async Task<JObject> DownloadScopeAsync(string url, AccCredentials creds)
         {
             try
             {
-                using var resp = await _http.GetAsync(url).ConfigureAwait(false);
+                using var req = new HttpRequestMessage(HttpMethod.Get, url);
+                if (url.StartsWith(Host, StringComparison.OrdinalIgnoreCase) && creds != null && !string.IsNullOrEmpty(creds.AccessToken))
+                    req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", creds.AccessToken);
+                using var resp = await _http.SendAsync(req).ConfigureAwait(false);
                 if (!resp.IsSuccessStatusCode) { StingLog.Warn($"ACC scope download {(int)resp.StatusCode}"); return null; }
                 var bytes = await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 string text = TryGunzip(bytes) ?? Encoding.UTF8.GetString(bytes);


### PR DESCRIPTION
## What & why

Owns the **ACC + CSI** accuracy/hardening in one branch — the gaps #328/Phase 2 covered **plus the net-new accuracy items** from the deep review. **Supersedes #328** (close it once this is reviewed).

## ACC — correctness
| Gap | Fix |
|---|---|
| 1 | **Idempotency** — `ACC_PullClashes` records an **order-invariant** clash signature (`objId@doc`, sorted) → ACC issue id in `_BIM_COORD/acc/pushed_clashes.json`; re-runs skip already-pushed clashes (no duplicate ACC issues) |
| 2 | **`issue_type_id`** — `PushIssue` uses `AccCredentials.IssueTypeId`; omits the field when unset (ACC rejects empty) and warns |
| 3 | **`CoordContainerId`** — separate coordination container (falls back to `ProjectId`) |
| 4 | **dist units** — `AccCredentials.DistToMm` (default 1000) drives `PenetrationMm` |
| 5 | **bearer-on-download** — scope GET attaches the bearer for API-hosted resources (pre-signed URLs ignore it) |
| 9 | **TriageAll for CSV** — full scored set in CSV/burn-down; top-10 for display |

## ACC — net-new accuracy
- **Pagination** 🔴 — `PullIssues` + `ListModelSets` follow offset pages (modelsets dedupe by id so an offset-ignoring endpoint can't loop). Large projects no longer truncate at 100 / first page.
- **Bidirectional status sync** — new **`ACC_SyncIssueStatus`**: reconciles ACC issue closures against the escalation log, **untracks closed clashes so recurrences re-raise**, writes a closure CSV.

## CSI — net-new accuracy
- **`NormalizeSection`** strips **all** whitespace so `23 05 00` ≡ `230500` (SpecLink spaced vs model unspaced) — kills false spec gaps; dots preserved (child sections stay distinct).
- **CSV row-length guard** (`f.Length < 6`) — already present; verified, no change.

## Fohlio (5th net-new)
One-way currency ("vs last import") is **inherent to file-based sync** — only the live REST tier (needs an API key) closes it. Documented; not codeable here.

## Verification
- Internally consistent (download calls 2-arg, `TriageAll`, push signature/sidecar helpers all line up); namespaces/signatures checked against source.
- ⚠️ Not `dotnet build`-verified (Linux sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016esKUrmFzJMaVVd1nzCVjr)_