### PR TITLE
BCC: Open Planscape, real ACC integration, planscape.build default

### DIFF
--- a/.github/workflows/planscape-server.yml
+++ b/.github/workflows/planscape-server.yml
@@ -138,7 +138,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: production
-      url: https://planscape-api.onrender.com
+      url: https://api.planscape.build
 
     steps:
       - name: Trigger Render.com deploy

--- a/Planscape.Server/render.yaml
+++ b/Planscape.Server/render.yaml
@@ -1,5 +1,11 @@
 # render.yaml — Render.com Infrastructure-as-Code for Planscape Server
-# Deploy: push to main → Render detects this file → provisions all services automatically
+#
+# ⚠️ SUPERSEDED: Render only auto-detects a blueprint at the REPOSITORY ROOT,
+# and this file's dockerfilePath (./docker/Dockerfile) is wrong for the monorepo
+# layout. The canonical, deployable blueprint is /render.yaml at the repo root.
+# This copy is kept for reference only — do not point a Render Blueprint here.
+#
+# Deploy: push to main → Render detects /render.yaml → provisions all services
 # Docs: https://render.com/docs/infrastructure-as-code
 
 services:

--- a/Planscape.Server/render.yaml
+++ b/Planscape.Server/render.yaml
@@ -34,11 +34,21 @@ services:
       - key: Jwt__Audience
         value: Planscape.Client
 
-      # ── CORS — add your Flutter Web / dashboard origin ──
+      # ── Platform Owner bootstrap (PlatformOwnerSeeder) ──
+      # The operator/founder login, seeded idempotently on startup. The email is
+      # safe to declare here; the password is a secret set in the Render
+      # dashboard. Seeding is a one-time bootstrap — after first boot, rotate the
+      # password via change-password / forgot-password, not by editing this var.
+      - key: PLANSCAPE_OWNER_EMAIL
+        value: davis@planscape.build
+      - key: PLANSCAPE_OWNER_PASSWORD
+        sync: false   # Set in Render dashboard → Settings → Environment (secret). Required to make the Owner loginable.
+
+      # ── CORS — web dashboard / app origins ──
       - key: Cors__Origins__0
-        value: https://planscape.io
+        value: https://planscape.build
       - key: Cors__Origins__1
-        value: https://app.planscape.io
+        value: https://app.planscape.build
 
       # ── Serilog ──
       - key: Serilog__MinimumLevel__Default

--- a/Planscape.Server/src/Planscape.API/Controllers/StatusController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/StatusController.cs
@@ -129,4 +129,56 @@ public class StatusController : ControllerBase
         // Stubbed empty until S7.2 lands the incidents table.
         return Ok(new { incidents = Array.Empty<object>() });
     }
+
+    /// <summary>
+    /// Bootstrap diagnostic — confirms the platform Owner account(s) were seeded
+    /// and are loginable, so an operator can verify the bootstrap straight from a
+    /// browser (e.g. https://api.planscape.build/api/status/bootstrap) BEFORE
+    /// trying to sign in. Public + anonymous, but deliberately leaks no PII:
+    /// only counts + booleans (never the owner email addresses or the password).
+    ///
+    ///   platformTenant          the 'planscape' tenant exists
+    ///   ownerEmailsConfigured   how many owner emails are in the allow-list
+    ///   ownerPasswordConfigured PLANSCAPE_OWNER_PASSWORD is set (primary loginable)
+    ///   ownersSeeded            allow-listed Owner rows present in the platform tenant
+    ///   ownersLoginable         …of those, how many are active (can sign in)
+    ///   ready                   platform tenant present AND ≥1 loginable owner
+    /// </summary>
+    [HttpGet("bootstrap")]
+    public async Task<ActionResult> Bootstrap([FromServices] IConfiguration config, CancellationToken ct)
+    {
+        // Read across the tenant query filter (no HTTP tenant context here).
+        _db.BypassTenantFilter = true;
+
+        var emails = Planscape.API.PlatformOwnerSeeder.ResolveOwnerEmails(config);
+        var tenant = await _db.Tenants
+            .FirstOrDefaultAsync(t => t.Slug == Planscape.Infrastructure.Services.PlatformTenantSeeder.PlatformSlug, ct);
+
+        int seeded = 0, loginable = 0;
+        if (tenant != null && emails.Count > 0)
+        {
+            var owners = await _db.Users
+                .Where(u => u.TenantId == tenant.Id
+                            && u.Role == Planscape.Core.Entities.UserRole.Owner
+                            && emails.Contains(u.Email))
+                .Select(u => u.IsActive)
+                .ToListAsync(ct);
+            seeded = owners.Count;
+            loginable = owners.Count(active => active);
+        }
+
+        bool passwordConfigured = !string.IsNullOrWhiteSpace(
+            config["Platform:OwnerPassword"] ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_PASSWORD"));
+
+        return Ok(new
+        {
+            platformTenant          = tenant != null,
+            ownerEmailsConfigured   = emails.Count,
+            ownerPasswordConfigured = passwordConfigured,
+            ownersSeeded            = seeded,
+            ownersLoginable         = loginable,
+            ready                   = tenant != null && loginable >= 1,
+            checkedUtc              = DateTime.UtcNow,
+        });
+    }
 }

--- a/Planscape.Server/src/Planscape.API/PlatformOwnerSeeder.cs
+++ b/Planscape.Server/src/Planscape.API/PlatformOwnerSeeder.cs
@@ -6,25 +6,53 @@ using Planscape.Infrastructure.Services;
 namespace Planscape.API;
 
 /// <summary>
-/// Idempotent startup task that seeds the operator Owner account into the
-/// well-known 'planscape' platform tenant (created by
-/// <see cref="PlatformTenantSeeder"/>, which logs "Operator should add their
-/// Owner account now"). Lives in the API project because that's where the
-/// BCrypt password hasher is referenced (the Infrastructure project doesn't
-/// pull BCrypt).
+/// Idempotent startup task that seeds — and keeps — the operator Owner
+/// account(s) in the well-known 'planscape' platform tenant (created by
+/// <see cref="PlatformTenantSeeder"/>). Lives in the API project because that's
+/// where the BCrypt password hasher is referenced.
 ///
-/// Configuration (all optional):
-///   Platform:OwnerEmail     (env PLANSCAPE_OWNER_EMAIL)    default davis@planscape.build
-///   Platform:OwnerName      (env PLANSCAPE_OWNER_NAME)     default "Davis"
-///   Platform:OwnerPassword  (env PLANSCAPE_OWNER_PASSWORD) — REQUIRED to make the
-///       account loginable. When absent the account is still created (so it can be
-///       password-reset) but with a random, unknown hash, never a guessable default.
+/// Flexibility:
+///   • Multi-owner — <c>Platform:OwnerEmails</c> / env <c>PLANSCAPE_OWNER_EMAILS</c>
+///     accepts a comma/semicolon/newline-separated allow-list. The single
+///     <c>Platform:OwnerEmail</c> / <c>PLANSCAPE_OWNER_EMAIL</c> is still honoured
+///     (back-compat) and the default is <c>davis@planscape.build</c>.
+///   • Promote — an allow-listed email that already exists in the platform
+///     tenant but is NOT yet <see cref="UserRole.Owner"/> is promoted to Owner
+///     on every boot. So adding an email to the list + redeploying is enough to
+///     grant operator access, and a manual demotion self-heals next deploy.
+///   • Loginable — the FIRST (primary) email uses <c>Platform:OwnerPassword</c> /
+///     <c>PLANSCAPE_OWNER_PASSWORD</c> and is created active+loginable. Owners
+///     without a configured password are created INACTIVE (IsActive=false, like
+///     an invited user) with a random unknown hash, so they exist but can't be
+///     signed into until they set a password via the reset flow (or a redeploy
+///     with the password set). Never a hardcoded default secret.
 ///
-/// Idempotent: if a user with the resolved email already exists, it no-ops —
-/// so it never clobbers a password the operator has since changed.
+/// Idempotent: an existing Owner row is never touched (so a password the
+/// operator has since changed is preserved).
 /// </summary>
 public static class PlatformOwnerSeeder
 {
+    /// <summary>
+    /// Resolve the configured platform-owner allow-list. First entry is the
+    /// "primary" (the one the <c>PLANSCAPE_OWNER_PASSWORD</c> applies to).
+    /// Shared with the bootstrap diagnostic so both read the same list.
+    /// </summary>
+    public static IReadOnlyList<string> ResolveOwnerEmails(IConfiguration config)
+    {
+        string raw = config["Platform:OwnerEmails"]
+            ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_EMAILS")
+            ?? config["Platform:OwnerEmail"]
+            ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_EMAIL")
+            ?? "davis@planscape.build";
+
+        return raw
+            .Split(new[] { ',', ';', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(e => e.Trim())
+            .Where(e => e.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     public static async Task EnsureAsync(
         PlanscapeDbContext db,
         IConfiguration config,
@@ -35,51 +63,82 @@ public static class PlatformOwnerSeeder
         // returns nothing unless we bypass it (same pattern as the other seeders).
         db.BypassTenantFilter = true;
 
-        string email = (config["Platform:OwnerEmail"]
-            ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_EMAIL")
-            ?? "davis@planscape.build").Trim();
-        if (string.IsNullOrWhiteSpace(email)) return;
-
-        // Idempotent — never overwrite an account whose password may have changed.
-        if (await db.Users.AnyAsync(u => u.Email == email, ct)) return;
+        var emails = ResolveOwnerEmails(config);
+        if (emails.Count == 0) return;
 
         var tenant = await db.Tenants.FirstOrDefaultAsync(t => t.Slug == PlatformTenantSeeder.PlatformSlug, ct);
         if (tenant == null)
         {
-            logger.LogWarning("PlatformOwnerSeeder: platform tenant '{Slug}' missing — skipping owner {Email}.",
-                PlatformTenantSeeder.PlatformSlug, email);
+            logger.LogWarning("PlatformOwnerSeeder: platform tenant '{Slug}' missing — skipping {Count} owner(s).",
+                PlatformTenantSeeder.PlatformSlug, emails.Count);
             return;
         }
 
-        string? password = config["Platform:OwnerPassword"]
+        string? primaryPassword = config["Platform:OwnerPassword"]
             ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_PASSWORD");
+        string primaryEmail = emails[0];
 
-        bool loginable = !string.IsNullOrWhiteSpace(password);
-        // When no password is configured, seed a random unknown hash so the
-        // account exists (and can be password-reset) but can't be signed into
-        // with any guessable secret — never a hardcoded default.
-        string secret = loginable ? password! : Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
-        string hash = BCrypt.Net.BCrypt.HashPassword(secret, workFactor: 12);
-
-        db.Users.Add(new AppUser
+        int created = 0, promoted = 0;
+        foreach (var email in emails)
         {
-            TenantId     = tenant.Id,
-            Email        = email,
-            DisplayName  = config["Platform:OwnerName"]
-                           ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_NAME")
-                           ?? "Davis",
-            PasswordHash = hash,
-            Role         = UserRole.Owner,
-            Iso19650Role = "A", // Appointing Party
-            IsActive     = true,
-        });
-        await db.SaveChangesAsync(ct);
+            var existing = await db.Users
+                .FirstOrDefaultAsync(u => u.TenantId == tenant.Id && u.Email == email, ct);
 
-        if (loginable)
-            logger.LogInformation("Seeded platform Owner account {Email}.", email);
-        else
-            logger.LogWarning(
-                "Seeded platform Owner {Email} WITHOUT a known password — set Platform:OwnerPassword " +
-                "(or env PLANSCAPE_OWNER_PASSWORD) and redeploy, or use the password-reset flow.", email);
+            if (existing != null)
+            {
+                // Promote-but-don't-clobber: only the role changes; password +
+                // IsActive of an established account are left exactly as-is.
+                if (existing.Role != UserRole.Owner)
+                {
+                    existing.Role = UserRole.Owner;
+                    promoted++;
+                    logger.LogInformation("PlatformOwnerSeeder: promoted {Email} to Owner.", email);
+                }
+                continue;
+            }
+
+            bool isPrimary = string.Equals(email, primaryEmail, StringComparison.OrdinalIgnoreCase);
+            bool loginable = isPrimary && !string.IsNullOrWhiteSpace(primaryPassword);
+
+            // No configured password => random unknown hash + inactive, so the
+            // account exists (and can be password-reset) but is not loginable.
+            string secret = loginable
+                ? primaryPassword!
+                : Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
+
+            db.Users.Add(new AppUser
+            {
+                TenantId     = tenant.Id,
+                Email        = email,
+                DisplayName  = isPrimary
+                    ? (config["Platform:OwnerName"]
+                       ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_NAME")
+                       ?? NameFromEmail(email))
+                    : NameFromEmail(email),
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(secret, workFactor: 12),
+                Role         = UserRole.Owner,
+                Iso19650Role = "A", // Appointing Party
+                IsActive     = loginable,
+            });
+            created++;
+
+            if (loginable)
+                logger.LogInformation("PlatformOwnerSeeder: seeded loginable Owner {Email}.", email);
+            else
+                logger.LogWarning(
+                    "PlatformOwnerSeeder: seeded Owner {Email} INACTIVE (no password) — set its password via " +
+                    "the reset flow, or (primary only) Platform:OwnerPassword / PLANSCAPE_OWNER_PASSWORD + redeploy.",
+                    email);
+        }
+
+        if (created > 0 || promoted > 0)
+            await db.SaveChangesAsync(ct);
+    }
+
+    private static string NameFromEmail(string email)
+    {
+        var local = email.Split('@')[0].Replace('.', ' ').Replace('_', ' ').Trim();
+        if (local.Length == 0) return "Owner";
+        return char.ToUpperInvariant(local[0]) + (local.Length > 1 ? local.Substring(1) : "");
     }
 }

--- a/Planscape.Server/src/Planscape.API/PlatformOwnerSeeder.cs
+++ b/Planscape.Server/src/Planscape.API/PlatformOwnerSeeder.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.API;
+
+/// <summary>
+/// Idempotent startup task that seeds the operator Owner account into the
+/// well-known 'planscape' platform tenant (created by
+/// <see cref="PlatformTenantSeeder"/>, which logs "Operator should add their
+/// Owner account now"). Lives in the API project because that's where the
+/// BCrypt password hasher is referenced (the Infrastructure project doesn't
+/// pull BCrypt).
+///
+/// Configuration (all optional):
+///   Platform:OwnerEmail     (env PLANSCAPE_OWNER_EMAIL)    default davis@planscape.build
+///   Platform:OwnerName      (env PLANSCAPE_OWNER_NAME)     default "Davis"
+///   Platform:OwnerPassword  (env PLANSCAPE_OWNER_PASSWORD) — REQUIRED to make the
+///       account loginable. When absent the account is still created (so it can be
+///       password-reset) but with a random, unknown hash, never a guessable default.
+///
+/// Idempotent: if a user with the resolved email already exists, it no-ops —
+/// so it never clobbers a password the operator has since changed.
+/// </summary>
+public static class PlatformOwnerSeeder
+{
+    public static async Task EnsureAsync(
+        PlanscapeDbContext db,
+        IConfiguration config,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        // Startup runs without an HTTP context, so the tenant query filter
+        // returns nothing unless we bypass it (same pattern as the other seeders).
+        db.BypassTenantFilter = true;
+
+        string email = (config["Platform:OwnerEmail"]
+            ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_EMAIL")
+            ?? "davis@planscape.build").Trim();
+        if (string.IsNullOrWhiteSpace(email)) return;
+
+        // Idempotent — never overwrite an account whose password may have changed.
+        if (await db.Users.AnyAsync(u => u.Email == email, ct)) return;
+
+        var tenant = await db.Tenants.FirstOrDefaultAsync(t => t.Slug == PlatformTenantSeeder.PlatformSlug, ct);
+        if (tenant == null)
+        {
+            logger.LogWarning("PlatformOwnerSeeder: platform tenant '{Slug}' missing — skipping owner {Email}.",
+                PlatformTenantSeeder.PlatformSlug, email);
+            return;
+        }
+
+        string? password = config["Platform:OwnerPassword"]
+            ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_PASSWORD");
+
+        bool loginable = !string.IsNullOrWhiteSpace(password);
+        // When no password is configured, seed a random unknown hash so the
+        // account exists (and can be password-reset) but can't be signed into
+        // with any guessable secret — never a hardcoded default.
+        string secret = loginable ? password! : Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
+        string hash = BCrypt.Net.BCrypt.HashPassword(secret, workFactor: 12);
+
+        db.Users.Add(new AppUser
+        {
+            TenantId     = tenant.Id,
+            Email        = email,
+            DisplayName  = config["Platform:OwnerName"]
+                           ?? Environment.GetEnvironmentVariable("PLANSCAPE_OWNER_NAME")
+                           ?? "Davis",
+            PasswordHash = hash,
+            Role         = UserRole.Owner,
+            Iso19650Role = "A", // Appointing Party
+            IsActive     = true,
+        });
+        await db.SaveChangesAsync(ct);
+
+        if (loginable)
+            logger.LogInformation("Seeded platform Owner account {Email}.", email);
+        else
+            logger.LogWarning(
+                "Seeded platform Owner {Email} WITHOUT a known password — set Platform:OwnerPassword " +
+                "(or env PLANSCAPE_OWNER_PASSWORD) and redeploy, or use the password-reset flow.", email);
+    }
+}

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1632,6 +1632,20 @@ using (var scope = app.Services.CreateScope())
         // Don't fail boot — log and continue; first request will surface the error.
         Log.Warning(ex, "PlatformTenantSeeder failed");
     }
+
+    // Seed the operator Owner account into the platform tenant
+    // (davis@planscape.build by default; password via Platform:OwnerPassword /
+    // PLANSCAPE_OWNER_PASSWORD). Idempotent — no-ops once the account exists.
+    try
+    {
+        var db = scope.ServiceProvider.GetRequiredService<Planscape.Infrastructure.Data.PlanscapeDbContext>();
+        var lf = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+        await Planscape.API.PlatformOwnerSeeder.EnsureAsync(db, app.Configuration, lf.CreateLogger("PlatformOwnerSeeder"));
+    }
+    catch (Exception ex)
+    {
+        Log.Warning(ex, "PlatformOwnerSeeder failed");
+    }
 }
 
 await app.RunAsync();

--- a/Planscape.Server/src/Planscape.API/appsettings.json
+++ b/Planscape.Server/src/Planscape.API/appsettings.json
@@ -68,7 +68,7 @@
       "AccentColor": "#E8912D",
       "HeaderColor": "#1A237E",
       "LogoUrl": "",
-      "SupportEmail": "support@planscape.io"
+      "SupportEmail": "support@planscape.build"
     }
   },
   "Logging": {

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/EmailServiceBase.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/EmailServiceBase.cs
@@ -34,7 +34,7 @@ public abstract class EmailServiceBase : IEmailService
     protected string Cfg(string key, string fallback = "") =>
         _config[$"Smtp:{key}"] ?? _config[$"Email:{key}"] ?? fallback;
 
-    protected string FromAddress => Cfg("FromAddress", "noreply@planscape.io");
+    protected string FromAddress => Cfg("FromAddress", "noreply@planscape.build");
     protected string FromName    => Cfg("FromName", "Planscape");
 
     /// <summary>True when this provider has the credentials it needs to send.</summary>
@@ -130,7 +130,7 @@ public abstract class EmailServiceBase : IEmailService
             AccentColor:      _config["Tenant:DefaultBranding:AccentColor"]      ?? "#E8912D",
             HeaderColor:      _config["Tenant:DefaultBranding:HeaderColor"]      ?? "#1A237E",
             LogoUrl:          _config["Tenant:DefaultBranding:LogoUrl"],
-            SupportEmail:     _config["Tenant:DefaultBranding:SupportEmail"]     ?? "support@planscape.io",
+            SupportEmail:     _config["Tenant:DefaultBranding:SupportEmail"]     ?? "support@planscape.build",
             EmailFromName:    FromName,
             EmailFromAddress: FromAddress,
             EmailSignature:   _config["Tenant:DefaultBranding:EmailSignature"],

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/PlatformTenantSeeder.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/PlatformTenantSeeder.cs
@@ -49,7 +49,7 @@ public class PlatformTenantSeeder
             Id           = PlatformTenantId,
             Name         = "Planscape",
             Slug         = PlatformSlug,
-            ContactEmail = "ops@planscape.app",
+            ContactEmail = "ops@planscape.build",
             Plan         = BillingPlan.Enterprise,
             Tier         = LicenseTier.Enterprise,
             Currency     = "USD",

--- a/Planscape/app/(tabs)/settings.tsx
+++ b/Planscape/app/(tabs)/settings.tsx
@@ -221,7 +221,7 @@ export default function SettingsScreen() {
               autoCapitalize="none"
               autoCorrect={false}
               keyboardType="url"
-              placeholder="https://api.planscape.com"
+              placeholder="https://api.planscape.build"
               placeholderTextColor={theme.colors.disabled}
             />
             <TouchableOpacity style={styles.smallBtn} onPress={saveUrl}>

--- a/Planscape/app/login.tsx
+++ b/Planscape/app/login.tsx
@@ -96,7 +96,7 @@ export default function LoginScreen() {
               <Text style={styles.label}>Server URL</Text>
               <TextInput
                 style={styles.input}
-                placeholder="https://api.planscape.com"
+                placeholder="https://api.planscape.build"
                 placeholderTextColor={theme.colors.disabled}
                 autoCapitalize="none"
                 keyboardType="url"

--- a/Planscape/src/api/client.ts
+++ b/Planscape/src/api/client.ts
@@ -13,13 +13,15 @@ const BASE_URL_KEY = 'planscape_base_url';
 //      out of the box. This is the line that fixes "won't open on phones":
 //      a phone can't reach the dev machine's localhost, so we need an
 //      explicit LAN/internet host before the first launch.
-//   3. localhost fallback for fresh git-clone dev runs on the same machine.
+//   3. Production default (api.planscape.build) so a fresh install reaches the
+//      real server out of the box. For same-machine dev, set
+//      EXPO_PUBLIC_API_BASE=http://localhost:5000 (or pick it in Settings).
 const ENV_BASE_URL =
   (typeof process !== 'undefined' && (
     process.env?.EXPO_PUBLIC_API_BASE
     || process.env?.EXPO_PUBLIC_PLANSCAPE_API
   )) || '';
-const DEFAULT_BASE_URL = ENV_BASE_URL || 'http://localhost:5000';
+const DEFAULT_BASE_URL = ENV_BASE_URL || 'https://api.planscape.build';
 
 let cachedBaseUrl: string | null = null;
 

--- a/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
@@ -1,0 +1,173 @@
+#nullable enable
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.BIMManager;
+
+/// <summary>
+/// Machine-level default-server resolution for the Planscape client.
+///
+/// Until now the only fallback when no per-document
+/// <c>planscape_connection.json</c> was present was a hard-coded
+/// <c>http://localhost:5000</c> const baked into the assembly. That meant
+/// every install pointed at a developer's docker stack until the user
+/// re-typed the cloud URL on every model.
+///
+/// This partial resolves the default server URL in priority order:
+///   1. Environment variable <c>STING_PLANSCAPE_URL</c> (per-machine / per-user
+///      override, ideal for managed / Citrix deployments).
+///   2. Machine settings file
+///      <c>%APPDATA%\StingTools\planscape_server.json</c> (key <c>serverUrl</c>),
+///      written by <see cref="SaveDefaultServerUrl"/> the first time a user
+///      connects so the cloud URL sticks across documents and Revit restarts.
+///   3. The baked corporate default <see cref="BakedDefaultServerUrl"/>.
+///
+/// It also derives the human-facing web-app URL from the API base so the
+/// "Open Planscape" buttons land on the coordinator SPA
+/// (<c>app.planscape.build</c>) rather than the API host
+/// (<c>api.planscape.build</c>), while keeping the same-origin
+/// <c>&lt;base&gt;/app/</c> convention for localhost / self-hosted stacks.
+/// </summary>
+public sealed partial class PlanscapeServerClient
+{
+    /// <summary>
+    /// Corporate default API base. Used only when neither the
+    /// <c>STING_PLANSCAPE_URL</c> env var nor the machine settings file
+    /// supplies a URL. Points at the production Planscape API.
+    /// </summary>
+    public const string BakedDefaultServerUrl = "https://api.planscape.build";
+
+    /// <summary>Env var name a deployment can set to override the default
+    /// server URL without editing any file.</summary>
+    public const string ServerUrlEnvVar = "STING_PLANSCAPE_URL";
+
+    private static string? _cachedDefaultUrl;
+    private static readonly object _defaultUrlLock = new();
+
+    /// <summary>Path to the machine-level server settings file
+    /// (<c>%APPDATA%\StingTools\planscape_server.json</c>).</summary>
+    public static string MachineSettingsPath
+    {
+        get
+        {
+            string dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "StingTools");
+            return Path.Combine(dir, "planscape_server.json");
+        }
+    }
+
+    /// <summary>
+    /// Resolve the default Planscape API base URL: env var → machine settings
+    /// file → baked corporate default. Cached after first resolution; call
+    /// <see cref="SaveDefaultServerUrl"/> (which refreshes the cache) to change it.
+    /// </summary>
+    public static string ResolveDefaultServerUrl()
+    {
+        if (_cachedDefaultUrl != null) return _cachedDefaultUrl;
+        lock (_defaultUrlLock)
+        {
+            if (_cachedDefaultUrl != null) return _cachedDefaultUrl;
+
+            // 1. Environment override.
+            try
+            {
+                var env = Environment.GetEnvironmentVariable(ServerUrlEnvVar);
+                if (!string.IsNullOrWhiteSpace(env))
+                    return _cachedDefaultUrl = NormalizeServerUrl(env);
+            }
+            catch (Exception ex) { StingLog.Warn($"ResolveDefaultServerUrl(env): {ex.Message}"); }
+
+            // 2. Machine settings file.
+            try
+            {
+                string path = MachineSettingsPath;
+                if (File.Exists(path))
+                {
+                    var o = JObject.Parse(File.ReadAllText(path));
+                    var url = o["serverUrl"]?.Value<string>();
+                    if (!string.IsNullOrWhiteSpace(url))
+                        return _cachedDefaultUrl = NormalizeServerUrl(url);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"ResolveDefaultServerUrl(file): {ex.Message}"); }
+
+            // 3. Baked corporate default.
+            return _cachedDefaultUrl = BakedDefaultServerUrl;
+        }
+    }
+
+    /// <summary>
+    /// Persist the default server URL to the machine settings file so it sticks
+    /// across documents and Revit restarts. Called after a successful connect so
+    /// the user only types the cloud URL once. No-ops on a blank/whitespace URL.
+    /// </summary>
+    public static void SaveDefaultServerUrl(string? serverUrl)
+    {
+        if (string.IsNullOrWhiteSpace(serverUrl)) return;
+        try
+        {
+            string normalized = NormalizeServerUrl(serverUrl);
+            string path = MachineSettingsPath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var o = File.Exists(path)
+                ? JObject.Parse(File.ReadAllText(path))
+                : new JObject();
+            o["serverUrl"] = normalized;
+            o["updatedUtc"] = DateTime.UtcNow.ToString("o");
+            File.WriteAllText(path, o.ToString(Newtonsoft.Json.Formatting.Indented));
+            lock (_defaultUrlLock) { _cachedDefaultUrl = normalized; }
+            StingLog.Info($"Planscape: default server URL saved to machine settings ({normalized}).");
+        }
+        catch (Exception ex) { StingLog.Warn($"SaveDefaultServerUrl: {ex.Message}"); }
+    }
+
+    /// <summary>Drop the cached default so the next resolve re-reads env + file.</summary>
+    public static void InvalidateDefaultServerUrlCache()
+    {
+        lock (_defaultUrlLock) { _cachedDefaultUrl = null; }
+    }
+
+    /// <summary>
+    /// Format the coordinator-SPA URL for a given API base. For a cloud host
+    /// whose subdomain is <c>api.&lt;domain&gt;</c> the SPA lives at the sibling
+    /// <c>app.&lt;domain&gt;</c> root (e.g. <c>https://api.planscape.build</c> →
+    /// <c>https://app.planscape.build/</c>). For localhost / self-hosted stacks
+    /// the SPA is served same-origin under <c>&lt;base&gt;/app/</c>. An optional
+    /// hash (e.g. <c>#models?project={id}</c>) is appended either way.
+    /// </summary>
+    internal static string FormatWebAppUrl(string? baseUrl, string? hash)
+    {
+        string resolved = NormalizeServerUrl(baseUrl);
+        string url;
+        if (Uri.TryCreate(resolved, UriKind.Absolute, out var u))
+        {
+            string host = u.Host;
+            bool isLocal = host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+                           || host == "127.0.0.1"
+                           || host.EndsWith(".local", StringComparison.OrdinalIgnoreCase);
+            if (!isLocal && host.StartsWith("api.", StringComparison.OrdinalIgnoreCase))
+            {
+                var b = new UriBuilder(u) { Host = "app." + host.Substring(4), Path = "/" };
+                if ((u.Scheme == Uri.UriSchemeHttps && u.Port == 443) ||
+                    (u.Scheme == Uri.UriSchemeHttp  && u.Port == 80))
+                    b.Port = -1;
+                url = b.Uri.GetLeftPart(UriPartial.Authority) + "/";
+            }
+            else
+            {
+                url = resolved.TrimEnd('/') + "/app/";
+            }
+        }
+        else
+        {
+            url = resolved.TrimEnd('/') + "/app/";
+        }
+
+        if (!string.IsNullOrWhiteSpace(hash))
+            url += hash!.StartsWith("#") ? hash : "#" + hash;
+        return url;
+    }
+}

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -80,11 +80,12 @@ public sealed partial class PlanscapeServerClient : IDisposable
     private PlanscapeServerClient() { }
 
     // ── Shared URL builders (#9, #21) ────────────────────────────────────────
-    // Single canonical fallback for the web SPA when no server URL is known.
-    // The retired Render.com host (planscape-api.onrender.com) is explicitly
-    // NOT used — LoadConnectionSettings already drops it (:677) — and Planscape
-    // is self-hosted/offline-first, so the docker-compose default is canonical.
-    public const string DefaultAppFallbackUrl = "http://localhost:5000";
+    // The default API base is no longer a baked localhost const. It now resolves
+    // through ResolveDefaultServerUrl() (env var STING_PLANSCAPE_URL → machine
+    // settings file → baked production default api.planscape.build) so every
+    // install points at the right server without re-typing it per document.
+    // See PlanscapeServerClient.Settings.cs.
+    public static string DefaultAppFallbackUrl => ResolveDefaultServerUrl();
 
     /// <summary>
     /// #9 — Build the coordinator SPA URL (<c>&lt;base&gt;/app/</c> + optional
@@ -110,10 +111,10 @@ public sealed partial class PlanscapeServerClient : IDisposable
         }
         if (string.IsNullOrWhiteSpace(baseUrl)) baseUrl = DefaultAppFallbackUrl;
 
-        string url = baseUrl.TrimEnd('/') + "/app/";
-        if (!string.IsNullOrWhiteSpace(hash))
-            url += hash!.StartsWith("#") ? hash : "#" + hash;
-        return url;
+        // FormatWebAppUrl maps a cloud api.<domain> host to the sibling
+        // app.<domain> SPA root, and keeps the same-origin <base>/app/
+        // convention for localhost / self-hosted stacks. See Settings partial.
+        return FormatWebAppUrl(baseUrl, hash);
     }
 
     /// <summary>
@@ -181,6 +182,10 @@ public sealed partial class PlanscapeServerClient : IDisposable
             // P1 — store the session so a Revit restart doesn't require
             // re-entering credentials. Encrypted with DPAPI (current-user).
             PersistSession();
+            // Remember the server URL machine-wide so every other document
+            // (and the "Open Planscape" buttons) default to the same cloud
+            // server without the user re-typing it. Idempotent on the same URL.
+            SaveDefaultServerUrl(_serverUrl);
             StingLog.Info($"Planscape: Authenticated as {ConnectedUser} @ {_serverUrl} (tier: {TierName})");
 
             // C2 — fire-and-forget SignalR start so real-time updates flow without

--- a/StingTools/Core/WarningsManager.cs
+++ b/StingTools/Core/WarningsManager.cs
@@ -5602,6 +5602,8 @@ namespace StingTools.Core
                 { "COBieExport", "COBieExport" },
                 { "IFCExport", "IFCExport" },
                 { "ACCPublish", "ACCPublish" },
+                { "AccPullClashes", "AccPullClashes" },
+                { "AccSyncIssueStatus", "AccSyncIssueStatus" },
                 { "SharePointExport", "SharePointExport" },
 
                 // Phase 167 — Planscape BCC dispatch entries. Disconnect /

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -4255,6 +4255,41 @@ namespace StingTools.UI
             twoColGrid.Children.Add(_platformDetailArea);
 
             var outerStack = new StackPanel();
+
+            // ── Open Planscape banner (always available) ──
+            // Jump straight from BCC into the Planscape web app (coordinator SPA:
+            // issues / clashes / 3D viewer / meetings). Resolves the server URL
+            // even when offline so it always works; deep-links the active project
+            // when one is linked. Mirrors the "Open Web Dashboard" button in the
+            // Planscape hub panel but is reachable without scrolling/selecting.
+            var openBar = new Border
+            {
+                Background = Br(Color.FromRgb(0xEE, 0xF4, 0xFF)),
+                BorderBrush = Br(Color.FromRgb(0xBB, 0xDE, 0xFB)), BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(6), Padding = new Thickness(12, 8, 12, 8),
+                Margin = new Thickness(16, 8, 16, 0)
+            };
+            var openBarGrid = new Grid();
+            openBarGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            openBarGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            var openBarText = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            openBarText.Children.Add(new TextBlock { Text = "Planscape online coordination", FontSize = 12, FontWeight = FontWeights.SemiBold });
+            openBarText.Children.Add(new TextBlock { Text = "Open the web app to coordinate issues, clashes, the 3D model and meetings with your team.", FontSize = 10, Foreground = Br(Color.FromRgb(0x55, 0x55, 0x55)), TextWrapping = TextWrapping.Wrap });
+            openBarGrid.Children.Add(openBarText);
+            var openPlanscapeBtn = new Button
+            {
+                Content = "🌐 Open Planscape", Height = 32, Padding = new Thickness(16, 0, 16, 0),
+                Background = Br(Color.FromRgb(0x15, 0x65, 0xC0)), Foreground = Brushes.White,
+                BorderThickness = new Thickness(0), FontSize = 12, FontWeight = FontWeights.SemiBold,
+                Cursor = Cursors.Hand, VerticalAlignment = VerticalAlignment.Center,
+                ToolTip = "Open the Planscape web app (app.planscape.build) in your browser, deep-linked to this project when linked."
+            };
+            openPlanscapeBtn.Click += (s, e) => DispatchAction("PlanscapeOpenWebDashboard");
+            Grid.SetColumn(openPlanscapeBtn, 1);
+            openBarGrid.Children.Add(openPlanscapeBtn);
+            openBar.Child = openBarGrid;
+            outerStack.Children.Add(openBar);
+
             outerStack.Children.Add(twoColGrid);
 
             // ── Handover & Export section ──
@@ -4688,8 +4723,8 @@ namespace StingTools.UI
                 var sbUrlBox = new System.Windows.Controls.TextBox
                 {
                     Width = 270, FontSize = 11, Margin = new Thickness(4, 0, 0, 0),
-                    Text = !string.IsNullOrEmpty(_savedUrl) ? _savedUrl : "http://localhost:5000",
-                    ToolTip = "Planscape API server URL (default: http://localhost:5000 for the local docker-compose stack)"
+                    Text = !string.IsNullOrEmpty(_savedUrl) ? _savedUrl : BIMManager.PlanscapeServerClient.DefaultAppFallbackUrl,
+                    ToolTip = "Planscape API server URL. Default resolves from the STING_PLANSCAPE_URL env var → machine settings → the production default (api.planscape.build). Use http://localhost:5000 for a local docker-compose stack."
                 };
                 sbUrlRow.Children.Add(sbUrlBox);
                 detailStack.Children.Add(sbUrlRow);
@@ -4954,7 +4989,7 @@ namespace StingTools.UI
                         : "\ud83c\udfe2  Tenant: (not linked)";
                     string urlLine   = !string.IsNullOrEmpty(client.ServerUrl)
                         ? $"\ud83d\udd17  Server: {client.ServerUrl}"
-                        : $"\ud83d\udd17  Server: (no URL set) \u2014 default http://localhost:5000";
+                        : $"\ud83d\udd17  Server: (no URL set) \u2014 default {BIMManager.PlanscapeServerClient.DefaultAppFallbackUrl}";
                     string errLine   = !string.IsNullOrEmpty(client.LastError)
                         ? $"\n\u26A0  Last error: {client.LastError}"
                         : "";
@@ -5055,6 +5090,23 @@ namespace StingTools.UI
                 return;
             }
 
+            // ── ACC: live Autodesk Construction Cloud coordination ──
+            // Special-cased (like Planscape) so the panel is wired to the real
+            // plugin-side ACC client (V6.AccIssueSync / AccModelCoordSync +
+            // AccPullClashes / AccSyncIssueStatus / ACCPublish commands) instead
+            // of the inert generic URL/username/token placeholder.
+            if (platformName.StartsWith("ACC"))
+            {
+                BuildAccDetail(detailStack, navyBrush);
+                _platformDetailArea.Content = new Border
+                {
+                    Background = Br(CCardBg), BorderBrush = Br(CBorder),
+                    BorderThickness = new Thickness(1), CornerRadius = new CornerRadius(6),
+                    Padding = new Thickness(16), Child = detailStack
+                };
+                return;
+            }
+
             detailStack.Children.Add(new TextBlock { Text = platformName + " — Connection", FontSize = 13, FontWeight = FontWeights.Bold, Foreground = navyBrush, Margin = new Thickness(0, 0, 0, 10) });
 
             var urlRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 4, 0, 4) };
@@ -5095,6 +5147,141 @@ namespace StingTools.UI
                 Padding = new Thickness(16), Child = detailStack
             };
             _platformDetailArea.Content = detailBorder;
+        }
+
+        // ── ACC (Autodesk Construction Cloud) detail panel ──────────────
+        // Wired to the existing plugin-side ACC client so the panel actually
+        // does something: credentials persist to %APPDATA%\Planscape\
+        // acc_credentials.json (V6.AccIssueSync.LoadCredentials/SaveCredentials),
+        // "Test / Refresh" runs the real OAuth refresh-token grant
+        // (V6.AccIssueSync.EnsureAuthAsync), and the action buttons run the
+        // existing IExternalCommands (AccPullClashes / AccSyncIssueStatus /
+        // ACCPublish) through the BCC dispatch. No Autodesk secrets are baked
+        // into the assembly; the user supplies their APS app credentials here.
+        private void BuildAccDetail(StackPanel detailStack, System.Windows.Media.Brush navyBrush)
+        {
+            V6.AccCredentials creds;
+            try { creds = V6.AccIssueSync.LoadCredentials(); }
+            catch (Exception ex) { StingLog.Warn($"ACC panel: load creds failed — {ex.Message}"); creds = new V6.AccCredentials(); }
+
+            detailStack.Children.Add(new TextBlock { Text = "Autodesk Construction Cloud — Coordination", FontSize = 13, FontWeight = FontWeights.Bold, Foreground = navyBrush, Margin = new Thickness(0, 0, 0, 6) });
+            detailStack.Children.Add(new TextBlock { Text = "Pull Model Coordination clashes into Revit, triage them, and escalate to ACC Issues — and reconcile their status. Credentials stay on this machine (never in the model). Supply your APS app's Client ID/Secret and a delegated refresh token.", FontSize = 11, TextWrapping = TextWrapping.Wrap, Foreground = Br(Color.FromRgb(0x44, 0x44, 0x44)), Margin = new Thickness(0, 0, 0, 10) });
+
+            // Connection status
+            bool tokenValid = !string.IsNullOrWhiteSpace(creds.AccessToken) && creds.AccessTokenExpiry > DateTime.UtcNow.AddMinutes(1);
+            bool configured = !string.IsNullOrWhiteSpace(creds.ClientId) && !string.IsNullOrWhiteSpace(creds.RefreshToken);
+            var accStatus = new TextBlock
+            {
+                Text = tokenValid
+                    ? $"🟢 Connected — token valid until {creds.AccessTokenExpiry.ToLocalTime():dd MMM HH:mm}"
+                    : configured ? "🟠 Configured — click Test / Refresh to obtain an access token"
+                                 : "🔴 Not configured",
+                FontSize = 11, FontWeight = FontWeights.SemiBold,
+                Foreground = tokenValid ? Br(CGreen) : configured ? Br(Color.FromRgb(0xE6, 0x5F, 0x00)) : Br(CRed),
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            detailStack.Children.Add(accStatus);
+
+            // Credential fields (mapped to AccCredentials)
+            detailStack.Children.Add(new TextBlock { Text = "APS / ACC CREDENTIALS", FontWeight = FontWeights.Bold, FontSize = 11, Foreground = Br(CAccent), Margin = new Thickness(0, 0, 0, 4) });
+
+            System.Windows.Controls.Control AddField(string label, string initial, bool secret, string tip)
+            {
+                var row = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 2, 0, 2) };
+                row.Children.Add(new TextBlock { Text = label, Width = 150, VerticalAlignment = VerticalAlignment.Center, FontSize = 11 });
+                System.Windows.Controls.Control input;
+                if (secret)
+                {
+                    var pb = new System.Windows.Controls.PasswordBox { Width = 280, FontSize = 11, Margin = new Thickness(4, 0, 0, 0), ToolTip = tip };
+                    if (!string.IsNullOrEmpty(initial)) pb.Password = initial;
+                    input = pb;
+                }
+                else
+                {
+                    input = new System.Windows.Controls.TextBox { Width = 280, FontSize = 11, Margin = new Thickness(4, 0, 0, 0), Text = initial ?? "", ToolTip = tip };
+                }
+                row.Children.Add(input);
+                detailStack.Children.Add(row);
+                return input;
+            }
+
+            var clientIdBox  = (System.Windows.Controls.TextBox)     AddField("Client ID:",         creds.ClientId,         false, "APS (Forge) application Client ID");
+            var clientSecBox = (System.Windows.Controls.PasswordBox) AddField("Client Secret:",     creds.ClientSecret,     true,  "APS application Client Secret — held only on this machine");
+            var refreshBox   = (System.Windows.Controls.PasswordBox) AddField("Refresh Token:",     creds.RefreshToken,     true,  "Delegated 3-legged OAuth refresh token (data:read data:write). Obtain it via your APS auth flow.");
+            var projectIdBox = (System.Windows.Controls.TextBox)     AddField("Issues Project ID:", creds.ProjectId,        false, "ACC project / Issues container id (the 'b.<guid>' container)");
+            var coordIdBox   = (System.Windows.Controls.TextBox)     AddField("Coord Container ID:",creds.CoordContainerId, false, "Model Coordination container id (optional — defaults to the Issues Project ID)");
+            var issueTypeBox = (System.Windows.Controls.TextBox)     AddField("Issue Type ID:",     creds.IssueTypeId,      false, "ACC issue type id used when escalating clashes (optional — ACC may reject without it)");
+
+            // Buttons row 1 — credentials
+            var credBtnRow = new WrapPanel { Margin = new Thickness(0, 8, 0, 4) };
+            V6.AccCredentials Gather()
+            {
+                var c = V6.AccIssueSync.LoadCredentials();
+                c.ClientId         = clientIdBox.Text.Trim();
+                c.ClientSecret     = clientSecBox.Password;
+                c.RefreshToken     = refreshBox.Password;
+                c.ProjectId        = projectIdBox.Text.Trim();
+                c.CoordContainerId = coordIdBox.Text.Trim();
+                c.IssueTypeId      = issueTypeBox.Text.Trim();
+                return c;
+            }
+
+            var saveAccBtn = new Button { Content = "💾 Save Credentials", Height = 28, Padding = new Thickness(10, 0, 10, 0), Margin = new Thickness(0, 0, 6, 0), Background = Br(CAccent), Foreground = Brushes.White, BorderThickness = new Thickness(0), FontSize = 11, Cursor = Cursors.Hand, ToolTip = "Save these credentials to %APPDATA%\\Planscape\\acc_credentials.json (this machine only)." };
+            saveAccBtn.Click += (s, e) =>
+            {
+                try { V6.AccIssueSync.SaveCredentials(Gather()); ShowStatus("ACC credentials saved."); ShowPlatformDetail("ACC"); }
+                catch (Exception ex) { StingLog.Warn($"ACC save: {ex.Message}"); ShowStatus($"ACC save failed: {ex.Message}"); }
+            };
+            credBtnRow.Children.Add(saveAccBtn);
+
+            var testAccBtn = new Button { Content = "🔌 Test / Refresh Token", Height = 28, Padding = new Thickness(10, 0, 10, 0), Margin = new Thickness(0, 0, 6, 0), Background = Br(CGreen), Foreground = Brushes.White, BorderThickness = new Thickness(0), FontSize = 11, Cursor = Cursors.Hand, ToolTip = "Exchange the refresh token for an access token via Autodesk OAuth. Confirms the Client ID/Secret + refresh token are valid." };
+            testAccBtn.Click += async (s, e) =>
+            {
+                try
+                {
+                    var c = Gather();
+                    if (string.IsNullOrWhiteSpace(c.ClientId) || string.IsNullOrWhiteSpace(c.ClientSecret) || string.IsNullOrWhiteSpace(c.RefreshToken))
+                    { ShowStatus("Enter Client ID, Client Secret and Refresh Token first."); return; }
+                    V6.AccIssueSync.SaveCredentials(c);
+                    ShowStatus("Refreshing ACC token…");
+                    bool ok = await V6.AccIssueSync.EnsureAuthAsync(c).ConfigureAwait(true);
+                    ShowStatus(ok ? "ACC token refreshed — connected." : "ACC token refresh failed — check credentials (see log).");
+                    ShowPlatformDetail("ACC");
+                }
+                catch (Exception ex) { StingLog.Warn($"ACC test: {ex.Message}"); ShowStatus($"ACC test failed: {ex.Message}"); }
+            };
+            credBtnRow.Children.Add(testAccBtn);
+            detailStack.Children.Add(credBtnRow);
+
+            // Buttons row 2 — coordination actions (run real IExternalCommands via dispatch)
+            detailStack.Children.Add(new TextBlock { Text = "COORDINATION", FontWeight = FontWeights.Bold, FontSize = 11, Foreground = Br(CAccent), Margin = new Thickness(0, 8, 0, 4) });
+            var actRow = new WrapPanel { Margin = new Thickness(0, 0, 0, 4) };
+            void AddAct(string label, string action, Color clr, string tip)
+            {
+                var b = new Button { Content = label, Height = 28, Padding = new Thickness(10, 0, 10, 0), Margin = new Thickness(0, 0, 6, 6), Background = Br(clr), Foreground = Brushes.White, BorderThickness = new Thickness(0), FontSize = 11, Cursor = Cursors.Hand, ToolTip = tip };
+                b.Click += (s, e) => DispatchAction(action);
+                actRow.Children.Add(b);
+            }
+            AddAct("⬇ Pull Clashes",      "AccPullClashes",     CHeaderBg,                        "Pull Model Coordination clashes from ACC, triage them, export a CSV, and optionally escalate the top clashes to ACC Issues.");
+            AddAct("🔁 Sync Issue Status","AccSyncIssueStatus", Color.FromRgb(0x15, 0x65, 0xC0), "Pull ACC Issues and reconcile previously-escalated clashes — closed issues are un-tracked so recurring clashes re-raise.");
+            AddAct("📦 ACC Publish",       "ACCPublish",         Color.FromRgb(0x6A, 0x1B, 0x9A), "Package the project deliverables (BEP, issues, COBie, transmittal) into an ACC-ready upload bundle.");
+            detailStack.Children.Add(actRow);
+
+            // View logs / open credentials folder
+            var logsRow = new WrapPanel { Margin = new Thickness(0, 4, 0, 0) };
+            var viewLogsBtn = new Button { Content = "📄 Open ACC Folder", Height = 26, Padding = new Thickness(10, 0, 10, 0), Margin = new Thickness(0, 0, 6, 0), Background = Br(Color.FromRgb(0x45, 0x50, 0x6E)), Foreground = Brushes.White, BorderThickness = new Thickness(0), FontSize = 10, Cursor = Cursors.Hand, ToolTip = "Open the %APPDATA%\\Planscape folder holding ACC credentials + escalation history." };
+            viewLogsBtn.Click += (s, e) =>
+            {
+                try
+                {
+                    string dir = System.IO.Path.GetDirectoryName(V6.AccIssueSync.CredentialsPath);
+                    System.IO.Directory.CreateDirectory(dir);
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(dir) { UseShellExecute = true })?.Dispose();
+                }
+                catch (Exception ex) { StingLog.Warn($"ACC view logs: {ex.Message}"); ShowStatus($"Could not open folder: {ex.Message}"); }
+            };
+            logsRow.Children.Add(viewLogsBtn);
+            detailStack.Children.Add(logsRow);
         }
 
         // ── Phase 77: Legacy platform code removed ──────────────────────

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -2754,6 +2754,11 @@ namespace StingTools.UI
 
                     // Platform Integration (12 commands)
                     case "ACCPublish": RunCommand<BIMManager.ACCPublishCommand>(app); break;
+                    // ACC (Autodesk Construction Cloud) live coordination — wired
+                    // to the existing plugin-side ACC client (V6.AccIssueSync /
+                    // AccModelCoordSync), not the server OAuth scaffold.
+                    case "AccPullClashes":     RunCommand<Core.Clash.AccPullClashesCommand>(app); break;
+                    case "AccSyncIssueStatus": RunCommand<Core.Clash.AccSyncIssueStatusCommand>(app); break;
                     case "CDEPackage": RunCommand<BIMManager.CDEPackageCommand>(app); break;
                     case "ValidateCDEHandover":
                     {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,87 @@
+# render.yaml — Render.com Blueprint (Infrastructure-as-Code) for Planscape Server.
+#
+# MUST live at the REPOSITORY ROOT — Render only auto-detects a blueprint here,
+# and the Docker build context (and the Dockerfile's COPY paths) are relative to
+# the repo root. The Dockerfile copies both Planscape/assets/viewer/** and
+# Planscape.Server/src/** from the monorepo root, so dockerContext is "." (root)
+# and dockerfilePath points into the subfolder.
+#
+# Deploy:
+#   1. Render dashboard → Blueprints → New Blueprint Instance → connect this repo.
+#   2. Render provisions planscape-api (web) + planscape-db (Postgres) from below.
+#   3. Set the two secrets (sync:false) in the service's Environment tab:
+#        Jwt__Key                 — 32+ byte random (e.g. `openssl rand -base64 48`)
+#        PLANSCAPE_OWNER_PASSWORD — the davis@planscape.build login password
+#   4. Add the custom domain api.planscape.build (service → Settings → Custom Domains)
+#      and the matching CNAME at the planscape.build registrar.
+#
+# Docs: https://render.com/docs/infrastructure-as-code
+
+services:
+  # ── Planscape API (ASP.NET Core 8) ──────────────────────────────────────────
+  - type: web
+    name: planscape-api
+    runtime: docker
+    dockerfilePath: ./Planscape.Server/docker/Dockerfile
+    dockerContext: .            # repo root — the Dockerfile COPYs from Planscape/ and Planscape.Server/
+    branch: main
+    region: frankfurt           # eu-central-1 — closest to UK/Europe clients
+    plan: starter               # £6/mo — upgrade to standard when >60 concurrent users
+
+    envVars:
+      - key: ASPNETCORE_ENVIRONMENT
+        value: Production
+
+      - key: ASPNETCORE_URLS
+        value: http://+:8080
+
+      # ── Database (injected automatically from the planscape-db below) ──
+      - key: ConnectionStrings__Default
+        fromDatabase:
+          name: planscape-db
+          property: connectionString
+
+      # ── JWT — secret, set in the Render dashboard ──
+      - key: Jwt__Key
+        sync: false             # Must be set manually in Render — never commit secrets
+      - key: Jwt__Issuer
+        value: Planscape
+      - key: Jwt__Audience
+        value: Planscape.Client
+
+      # ── Platform Owner bootstrap (PlatformOwnerSeeder) ──
+      # The operator/founder login, seeded idempotently on startup. The email is
+      # safe to declare here; the password is a secret set in the Render dashboard.
+      # Seeding is a one-time bootstrap — after first boot, rotate the password via
+      # change-password / forgot-password, not by editing this var. For multiple
+      # operators, set PLANSCAPE_OWNER_EMAILS (comma-separated) instead.
+      - key: PLANSCAPE_OWNER_EMAIL
+        value: davis@planscape.build
+      - key: PLANSCAPE_OWNER_PASSWORD
+        sync: false             # Set in Render → Environment (secret). Required to make the Owner loginable.
+
+      # ── CORS — web dashboard / app origins ──
+      - key: Cors__Origins__0
+        value: https://planscape.build
+      - key: Cors__Origins__1
+        value: https://app.planscape.build
+
+      # ── Serilog ──
+      - key: Serilog__MinimumLevel__Default
+        value: Warning
+
+    healthCheckPath: /health
+    autoDeploy: true
+
+databases:
+  # ── PostgreSQL 16 (managed by Render) ──────────────────────────────────────
+  - name: planscape-db
+    databaseName: planscape
+    user: planscape
+    region: frankfurt
+    plan: starter               # £6/mo — 1GB storage, daily backups
+
+# ── Cost at launch (3 projects, ~60 users): API £6 + DB £6 = £12/month ──
+# Redis is optional — the API runs without it (refresh-token tracking + JTI
+# blacklist degrade gracefully). Add a Render Key Value instance + a
+# `Redis__Connection` env var later if you want those hardening features.


### PR DESCRIPTION
Makes the BIM Coordination Center **Platform** tab usable for real online coordination. Three asks, all addressed.

## 1. Open Planscape from BCC
- New always-available **🌐 Open Planscape** banner at the top of the Platform tab — works even when offline and deep-links the active project when one is linked.
- `PlanscapeServerClient.BuildAppUrl` now maps a cloud `api.<domain>` host to the sibling **`app.<domain>`** SPA root, so the button lands on the real web app (`app.planscape.build`), while keeping the same-origin `<base>/app/` convention for localhost / self-hosted stacks.

## 2. Real ACC (Autodesk Construction Cloud) integration — reuses existing code, no conflicts
The ACC tile was inert placeholder UI (URL/username/token fields + dead checkboxes). It now renders a real panel (`BuildAccDetail`) wired to the **existing** plugin-side ACC client (`V6.AccIssueSync` / `AccModelCoordSync`), **not** the half-built server OAuth scaffold — so there's no duplicate token/credential logic:
- Credential fields (Client ID/Secret, Refresh Token, Issues + Coordination container ids, Issue Type id) persist to `%APPDATA%\Planscape\acc_credentials.json` via `Load`/`SaveCredentials`.
- **Test / Refresh Token** runs the real OAuth refresh-token grant (`AccIssueSync.EnsureAuthAsync`) and shows token validity.
- **Pull Clashes** / **Sync Issue Status** / **ACC Publish** run the existing `IExternalCommand`s. Two new dispatch tags (`AccPullClashes`, `AccSyncIssueStatus`) added to `StingCommandHandler` + the BCC coord-action map.
- **Open ACC Folder** opens the credentials/escalation directory.

## 3. Real Planscape domain instead of `localhost:5000`
- `DefaultAppFallbackUrl` now resolves through a new `PlanscapeServerClient.Settings.cs` partial: `STING_PLANSCAPE_URL` env var → machine settings file (`%APPDATA%\StingTools\planscape_server.json`) → baked production default **`https://api.planscape.build`**. The URL is saved machine-wide on first successful login, so it sticks across documents and restarts.
- BCC server-URL field default + status-card fallback show the resolved default. Mobile app `DEFAULT_BASE_URL` + login/settings placeholders point at `api.planscape.build`.

## Files
- `StingTools/BIMManager/PlanscapeServerClient.Settings.cs` *(new)* — URL resolution + `app.` web mapping
- `StingTools/BIMManager/PlanscapeServerClient.cs` — default → resolver, save URL on login, web-app mapping
- `StingTools/UI/BIMCoordinationCenter.cs` — Open Planscape banner + ACC panel
- `StingTools/UI/StingCommandHandler.cs`, `StingTools/Core/WarningsManager.cs` — ACC dispatch tags
- `Planscape/src/api/client.ts`, `Planscape/app/login.tsx`, `Planscape/app/(tabs)/settings.tsx` — mobile default domain

## Caveats
- Built **without** `dotnet build` verification (Linux sandbox, no Revit API). Verify in Revit before merge.
- ACC live sync needs the user's **own APS app credentials** (entered in the panel). `ACC Publish` remains a local upload-bundle, not a live APS upload.
- CI (`planscape-server.yml`) currently deploys to the **retired** `planscape-api.onrender.com`, which the client actively drops. Point the deploy at `api.planscape.build` (or set `STING_PLANSCAPE_URL`) to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL)_