### PR TITLE
Add KUT BEP template + ready-to-fill MIDP spreadsheet

### DIFF
--- a/GUIDES/KUT_BEP_TEMPLATE.md
+++ b/GUIDES/KUT_BEP_TEMPLATE.md
@@ -1,0 +1,306 @@
+# BIM Execution Plan (BEP) — Kampala Uganda Temple (KUT)
+
+> **Template type:** ISO 19650-2 BIM Execution Plan (combined pre- and post-appointment).
+> **How to use:** Replace every `[FILL: …]` placeholder. Delete guidance shown in *italics/blockquotes* once filled. Where a section says **"STINGTOOLS generates this"**, attach or reference the generated artefact instead of hand-writing it.
+> **Owner:** Lead Appointed Party (Symbion Consulting). **Drafted/maintained by:** BIM/Information Manager (Planscape — Mayanja Davis).
+> **Status:** `[FILL: Draft / Issued]`  ·  **Revision:** `[FILL: P01]`  ·  **Date:** `[FILL: yyyy-mm-dd]`
+
+---
+
+## Document control
+
+| Field | Value |
+|---|---|
+| Project | Kampala Uganda Temple (KUT) |
+| Project number | `[FILL]` |
+| Appointing Party (Client) | The Church |
+| Lead Appointed Party | Symbion Consulting |
+| Information Manager | Planscape Consulting Engineers Ltd — Mayanja Davis |
+| BEP type | `[FILL: Pre-appointment / Post-appointment]` |
+| Revision | `[FILL: P01]` |
+| Author | `[FILL]` |
+| Checked / Approved | `[FILL]` |
+| Date | `[FILL]` |
+
+### Revision history
+| Rev | Date | Author | Summary of change |
+|---|---|---|---|
+| P01 | `[FILL]` | `[FILL]` | First issue |
+| | | | |
+
+---
+
+## 1. Introduction & project information
+
+### 1.1 Purpose of this BEP
+*This BEP sets out how the project team will produce, manage, exchange and hand over information for KUT in accordance with ISO 19650 and the Appointing Party's Exchange Information Requirements (EIR).*
+
+### 1.2 Project details
+| Item | Detail |
+|---|---|
+| Project name | Kampala Uganda Temple |
+| Location | `[FILL: address, Kampala, Uganda]` |
+| Description | `[FILL: temple + ancillary buildings, GFA, storeys]` |
+| Procurement route | `[FILL: traditional / design-bid-build / …]` |
+| Contract form | `[FILL]` |
+| Programme | 49 months (Phase 2 = 11; Phase 3 = 38) — see §9 / MIDP |
+| Key dates | `[FILL: appointment, Deliverable B, C, D, completion]` |
+
+### 1.3 Project BIM objectives & uses
+*State why BIM is used and the measurable goals. Edit to suit.*
+| # | BIM objective | BIM use | Success measure |
+|---|---|---|---|
+| 1 | Coordinated, clash-free design | 3D coordination / clash detection | 0 unresolved high-priority clashes at each data drop |
+| 2 | Reliable quantities & cost | Quantity take-off (BOQ/NRM2) | BOQ from model at B/C |
+| 3 | Efficient documentation | Drawing production | Drawings auto-produced to corporate standard |
+| 4 | Smooth FF&E + handover | FF&E spec + COBie + O&M | COBie + O&M delivered at D |
+| 5 | Operational readiness / twin | BMS integration (Niagara) | Model reconciled to live points at handover |
+| 6 | `[FILL]` | `[FILL]` | `[FILL]` |
+
+---
+
+## 2. Roles, responsibilities & authorities
+
+### 2.1 Information management roles (ISO 19650)
+| Role | Organisation | Name | Contact |
+|---|---|---|---|
+| Appointing Party | The Church | `[FILL]` | `[FILL]` |
+| Lead Appointed Party | Symbion Consulting | `[FILL]` | `[FILL]` |
+| Information Manager | Planscape | Mayanja Davis | davis@planscape.build |
+| BIM Coordinator(s) | `[FILL]` | `[FILL]` | `[FILL]` |
+| Task Team Manager — Architecture | `[FILL]` | `[FILL]` | `[FILL]` |
+| Task Team Manager — Structure | `[FILL]` | `[FILL]` | `[FILL]` |
+| Task Team Manager — MEP | `[FILL]` | `[FILL]` | `[FILL]` |
+| Task Team Manager — `[FILL]` | `[FILL]` | `[FILL]` | `[FILL]` |
+
+### 2.2 Responsibility matrix (RACI) — summary
+*R=Responsible, A=Accountable, C=Consulted, I=Informed. Expand per deliverable in the MIDP/TIDPs.*
+| Activity | Info Mgr | Lead AP | Arch | Struct | MEP | QS | Contractor |
+|---|---|---|---|---|---|---|---|
+| Maintain CDE | A/R | A | I | I | I | I | C |
+| Set standards & template | R | A | C | C | C | I | I |
+| Produce discipline models | C | A | R | R | R | I | I |
+| Run clash & coordination | R | A | C | C | C | I | C |
+| Approve data drops | C | A/R | C | C | C | C | I |
+| FF&E (Fohlio) | C | A | R | I | C | C | I |
+| Handover (COBie/O&M) | R | A | C | C | C | I | C |
+
+---
+
+## 3. Information requirements (response to the EIR)
+
+### 3.1 Organisational/Project/Asset information requirements
+| Requirement source | Reference | How we satisfy it |
+|---|---|---|
+| EIR (client) | `[FILL: doc ref]` | This BEP + MIDP |
+| Project Information Requirements (PIR) | `[FILL]` | `[FILL]` |
+| Asset Information Requirements (AIR) | `[FILL]` | COBie + O&M + Niagara at handover |
+
+### 3.2 Level of Information Need (LOIN) by stage
+*Geometry (LOD) + alphanumeric data + documentation, per stage. See `lod_matrix.json`.*
+| Stage | LOD (geometry) | Data (alphanumeric) | Documentation |
+|---|---|---|---|
+| 2.1 BOD | 200 | Basic identity/spatial | BOD report |
+| 2.2 Dev Design (B) | 300 | Discipline params + classification | 50% drawings, schedules |
+| 2.3 Tech Design (C) | 350 | Full specification data | 100% set, BOQ |
+| 3.1/3.2 Construction/FF&E | 400 | Manufacturer/installation data | Shop/fab info, FF&E specs |
+| 3.3 Close-out (D) | 500 | Verified as-built + O&M | COBie, O&M, as-builts |
+
+---
+
+## 4. Standards, methods & procedures
+
+### 4.1 Standards adopted
+| Topic | Standard |
+|---|---|
+| Information management | ISO 19650-1/-2/-3/-5 |
+| Classification | `[FILL: Uniclass 2015 / other]` |
+| Naming | ISO 19650 field-based (see §4.2) |
+| Quantities/cost | `[FILL: NRM2 / other]` |
+| Handover | COBie 2.4 |
+| Security | ISO 19650-5 (see §8) |
+
+### 4.2 File / container naming convention
+`[Project]-[Originator]-[Volume/System]-[Level]-[Type]-[Role]-[Number]`
+Example: `KUT-PLNS-ZZ-XX-M3-A-0001`
+| Field | Codes |
+|---|---|
+| Project | `KUT` |
+| Originator | `[FILL: PLNS, SYM, …per firm]` |
+| Volume/System | `[FILL: ZZ, Z1…]` |
+| Level | `[FILL: GF, 01, ZZ]` |
+| Type | `[FILL: M3, DR, SH, SP…]` |
+| Role | A, S, M, E, P, FP, G, Z |
+| Number | 0001… |
+
+### 4.3 CDE states & suitability codes
+`WIP → SHARED (S0–S4) → PUBLISHED (A1/B1) → ARCHIVED` · Revisions `P0x` (preliminary) / `C0x` (contractual).
+| Code | Meaning |
+|---|---|
+| S0–S4 | Shared (WIP / coordination / information / review / stage approval) |
+| A1…An | Published — authorised |
+| B1…Bn | Published — with comments |
+
+### 4.4 Modelling standards (non-negotiables)
+- Shared coordinate system / project base point: `[FILL: define once at mobilisation — never change]`
+- Units: **millimetres**. Levels/grids: `[FILL: naming]`.
+- Controlled family library only — no rogue families, no CAD-as-model.
+- Worksets strategy: `[FILL]`.
+- Tag/data completeness checked (STINGTOOLS) before every Share.
+- Zero unresolved high-priority clashes at each data drop.
+
+---
+
+## 5. Common Data Environment (CDE)
+
+| Item | Detail |
+|---|---|
+| CDE platform | Autodesk Construction Cloud (ACC) |
+| Folder structure | WIP / Shared / Published / Archived |
+| Access control | `[FILL: per ISO 19650-5, role-based]` |
+| Issue/approval workflow | ACC Issues + Reviews; STINGTOOLS BCF push |
+| Transmittals | STINGTOOLS / ACC — formal record of every issue |
+| Interoperability/viewer | Speckle (internal live data + web viewer) |
+| Backup/retention | `[FILL]` |
+
+---
+
+## 6. Software, exchange formats & coordinate system
+
+### 6.1 Software & versions
+| Function | Software | Version |
+|---|---|---|
+| Authoring | Autodesk Revit | `[FILL: 2025/2026/2027]` |
+| CDE / coordination | Autodesk Construction Cloud | current |
+| Automation / QA | STINGTOOLS | current |
+| Interoperability / viewer | Speckle | current |
+| FF&E / O&M | Fohlio | current |
+| BMS / operations | Tridium Niagara | `[FILL]` |
+
+### 6.2 Exchange formats
+| Purpose | Format |
+|---|---|
+| Native models | RVT |
+| Open exchange | IFC `[FILL: 2x3 / 4]` |
+| Coordination | NWC / IFC / ACC models |
+| Drawings | PDF (+ DWG if required) |
+| Quantities | XLSX (NRM2) |
+| Handover | COBie 2.4 (XLSX), O&M (Fohlio export) |
+
+### 6.3 Coordinate system
+`[FILL: agreed survey datum, project base point, true north, shared coordinates origin]` — defined at mobilisation, locked thereafter.
+
+---
+
+## 7. Collaboration & coordination process
+
+### 7.1 The coordination cycle
+`Teams Share (WIP→Shared) → Clash (ACC + STINGTOOLS) → Coordination meeting → Issues assigned & tracked → Weekly model-health report`
+| Cadence | Activity |
+|---|---|
+| Daily | Authoring, auto-tagging, WIP saves |
+| Weekly | Share, clash, coordination meeting, issue tracking |
+| Monthly | KPI/model-health report, data-quality audit, MIDP review |
+| Per stage | Formal data drop + transmittal + client review |
+
+### 7.2 Clash management
+| Item | Detail |
+|---|---|
+| Tools | ACC Model Coordination + STINGTOOLS clash; BCF to ACC Issues |
+| Clash matrix | `[FILL: which disciplines clash vs which]` |
+| Priority/tolerance | `[FILL: e.g., hard clash 0 mm; clearance rules]` |
+| Acceptance | 0 unresolved high-priority clashes at each data drop |
+| Reporting | Clash/coordination report (STINGTOOLS export) |
+
+### 7.3 Coordination meetings
+| Meeting | Frequency | Chair | Attendees | Output |
+|---|---|---|---|---|
+| BIM coordination | Weekly | Info Mgr | Discipline leads | Issue list, actions |
+| Design review | `[FILL]` | Lead AP | All | Decisions log |
+
+---
+
+## 8. Security-minded approach (ISO 19650-5)
+*Temple project — treat as sensitive.*
+| Item | Approach |
+|---|---|
+| Access control | Role-based CDE permissions; least privilege |
+| Sensitive information | `[FILL: what is restricted, e.g., security/MEP/ritual spaces]` |
+| Data handling | `[FILL: storage, transfer, NDAs]` |
+| Breach procedure | `[FILL]` |
+
+---
+
+## 9. Information delivery planning (MIDP / TIDP)
+
+- **TIDPs:** each task team submits a TIDP (deliverables + dates + LOD + responsible). Collected at mobilisation, updated each stage.
+- **MIDP:** the Information Manager aggregates TIDPs into the Master Information Delivery Plan (see companion `KUT_MIDP_TEMPLATE.csv`). Baselined at mobilisation; reissued at each stage and data drop.
+- **Data drops:** Deliverable B (M4), Deliverable C (M8), Deliverable D (M45).
+
+| Milestone | Stage | LOD | Planned (rel. month) |
+|---|---|---|---|
+| BOD | 2.1 | 200 | M1 |
+| Deliverable B (Dev Design) | 2.2 | 300 | M4 |
+| Deliverable C (Tech Design) | 2.3 | 350 | M8 |
+| Tender issue / award | 2.4 | — | M9–M11 |
+| Construction (ongoing) | 3.1 | 400 | M12–M43 |
+| FF&E | 3.2 | 400 | M40–M43 |
+| Deliverable D (Close-out) | 3.3 | 500 | M45 |
+
+---
+
+## 10. Quality assurance & model validation
+| Check | Tool | When |
+|---|---|---|
+| Naming compliance | STINGTOOLS / ACC | Before every Share |
+| Tag/data completeness (≥95%) | STINGTOOLS audit | Before every Share |
+| Clash-free (high-priority) | ACC + STINGTOOLS | Before every data drop |
+| Coordinate/level integrity | Revit/STINGTOOLS | Weekly |
+| Deliverables vs MIDP | MIDP review | Monthly |
+| Model health / KPI | STINGTOOLS KPI dashboard | Monthly |
+
+---
+
+## 11. FF&E, handover & operations
+| Item | Approach |
+|---|---|
+| FF&E | Fohlio — file/Add-in round-trip now (`Fohlio_Export/ImportFinishes`); live API later. See playbook Part 4. |
+| Quantities/cost | STINGTOOLS BOQ (NRM2) |
+| Handover data | COBie 2.4 (STINGTOOLS) + O&M (Fohlio) |
+| Digital twin / BMS | Niagara bridge (`Niagara_ExportPoints` / `Niagara_Reconcile`) at commissioning/handover |
+| As-built | Model updated to LOD 500 at Deliverable D |
+
+---
+
+## 12. Training & competence
+| Audience | Training | When |
+|---|---|---|
+| All task teams | Half-day kickoff (CDE, naming, LOD, clash, STINGTOOLS) | Mobilisation |
+| Discipline leads | TIDP + data requirements | Mobilisation + each stage |
+| FM/Operator | COBie/O&M/Niagara requirements | Pre-handover |
+
+*See playbook Part 9 for the full kickoff pack.*
+
+---
+
+## 13. Risks & mitigation
+| Risk | Likelihood | Impact | Mitigation | Owner |
+|---|---|---|---|---|
+| Uncoordinated information | `[FILL]` | High | CDE governance + weekly clash + automated QA | Info Mgr |
+| Late deliverables | `[FILL]` | High | MIDP tracking + monthly RAG | Info Mgr |
+| Fohlio API delay | Medium | Low | Use file/Add-in route now (Option A) | Info Mgr |
+| Inconsistent standards | `[FILL]` | Medium | STINGTOOLS enforces standards | Info Mgr |
+| `[FILL]` | | | | |
+
+---
+
+## 14. Appendices
+- A: EIR (client) — `[attach]`
+- B: MIDP — `KUT_MIDP_TEMPLATE.csv`
+- C: TIDPs (per discipline) — `[attach]`
+- D: Responsibility matrix (full) — `[attach]`
+- E: Clash matrix — `[attach]`
+- F: Standards references / KUT overlay — `project-templates/KUT/_BIM_COORD/`
+
+---
+*BEP template — keep under revision control; reissue when standards, team, programme or scope change.*

--- a/GUIDES/KUT_MIDP_TEMPLATE.csv
+++ b/GUIDES/KUT_MIDP_TEMPLATE.csv
@@ -1,0 +1,51 @@
+Ref,Discipline,Originator,Deliverable,Type,Stage,LOD,Format,Suitability,CDE State,Planned Rel Month,Planned Date,Actual Date,Responsible,TIDP Ref,RAG,Notes
+Z-000,BIM/Info Mgmt,PLNS,BIM Execution Plan (BEP),Document,Mobilisation,NA,DOCX/PDF,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,Baseline at mobilisation
+Z-001,BIM/Info Mgmt,PLNS,Master Information Delivery Plan (MIDP),Document,Mobilisation,NA,XLSX/CSV,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,Aggregated from all TIDPs
+Z-002,BIM/Info Mgmt,PLNS,Responsibility matrix (RACI),Document,Mobilisation,NA,XLSX,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,
+Z-003,BIM/Info Mgmt,PLNS,Federated coordination model,Model,2.1 BOD,200,NWC/IFC,S1,Shared,M1,,,BIM Coordinator,TIDP-Z,,First federation
+A-100,Architecture,FILL,Architectural model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,Arch lead,TIDP-A,,Massing + generic
+S-100,Structure,FILL,Structural model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,Struct lead,TIDP-S,,Generic frame
+M-100,Mechanical,FILL,Mechanical (HVAC) model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,MEP lead,TIDP-M,,Generic systems
+E-100,Electrical,FILL,Electrical model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,MEP lead,TIDP-E,,Generic systems
+P-100,Public Health,FILL,Plumbing/drainage model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,MEP lead,TIDP-P,,Generic systems
+Z-110,BIM/Info Mgmt,PLNS,Basis of Design (BOD) report,Document,2.1 BOD,200,DOCX/PDF,S3,Shared,M1,,,Lead AP,TIDP-Z,,Design intent
+A-200,Architecture,FILL,Architectural model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,Arch lead,TIDP-A,,Developed design
+A-201,Architecture,FILL,GA plans/sections/elevations (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S2,Shared,M4,,,Arch lead,TIDP-A,,
+A-202,Architecture,FILL,Door/window schedules,Schedule,2.2 Deliverable B,300,PDF/XLSX,S2,Shared,M4,,,Arch lead,TIDP-A,,
+A-203,Architecture,FILL,Room data sheets (key spaces),Document,2.2 Deliverable B,300,PDF,S2,Shared,M4,,,Arch lead,TIDP-A,,STINGTOOLS RDS
+S-200,Structure,FILL,Structural model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,Struct lead,TIDP-S,,
+S-201,Structure,FILL,General arrangement drawings (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S2,Shared,M4,,,Struct lead,TIDP-S,,
+M-200,Mechanical,FILL,Mechanical model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,MEP lead,TIDP-M,,
+M-201,Mechanical,FILL,HVAC layouts (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S2,Shared,M4,,,MEP lead,TIDP-M,,
+E-200,Electrical,FILL,Electrical model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,MEP lead,TIDP-E,,
+E-201,Electrical,FILL,Power/lighting layouts (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S2,Shared,M4,,,MEP lead,TIDP-E,,
+P-200,Public Health,FILL,Plumbing/drainage model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,MEP lead,TIDP-P,,
+Z-210,BIM/Info Mgmt,PLNS,Clash/coordination report,Document,2.2 Deliverable B,300,PDF/BCF,S2,Shared,M4,,,BIM Coordinator,TIDP-Z,,Zero high-priority clashes
+Z-211,BIM/Info Mgmt,PLNS,Federated model,Model,2.2 Deliverable B,300,NWC/IFC,S2,Shared,M4,,,BIM Coordinator,TIDP-Z,,
+Z-212,QS/Cost,FILL,Bill of Quantities (preliminary),Schedule,2.2 Deliverable B,300,XLSX,S2,Shared,M4,,,QS,TIDP-Z,,STINGTOOLS BOQ/NRM2
+A-300,Architecture,FILL,Architectural model,Model,2.3 Deliverable C,350,RVT/IFC,S4,Shared,M8,,,Arch lead,TIDP-A,,Technical design
+A-301,Architecture,FILL,Full drawing set (100%) + details,Drawing,2.3 Deliverable C,350,PDF/DWG,S4,Shared,M8,,,Arch lead,TIDP-A,,
+S-300,Structure,FILL,Structural model,Model,2.3 Deliverable C,350,RVT/IFC,S4,Shared,M8,,,Struct lead,TIDP-S,,Connections resolved
+S-301,Structure,FILL,Structural drawing set (100%),Drawing,2.3 Deliverable C,350,PDF/DWG,S4,Shared,M8,,,Struct lead,TIDP-S,,
+M-300,Mechanical,FILL,Mechanical model,Model,2.3 Deliverable C,350,RVT/IFC,S4,Shared,M8,,,MEP lead,TIDP-M,,
+M-301,Mechanical,FILL,HVAC drawing set (100%),Drawing,2.3 Deliverable C,350,PDF/DWG,S4,Shared,M8,,,MEP lead,TIDP-M,,
+E-300,Electrical,FILL,Electrical model + drawings (100%),Model/Drawing,2.3 Deliverable C,350,RVT/PDF,S4,Shared,M8,,,MEP lead,TIDP-E,,
+P-300,Public Health,FILL,Plumbing model + drawings (100%),Model/Drawing,2.3 Deliverable C,350,RVT/PDF,S4,Shared,M8,,,MEP lead,TIDP-P,,
+FP-300,Fire,FILL,Fire strategy + model,Model/Document,2.3 Deliverable C,350,RVT/PDF,S4,Shared,M8,,,Fire lead,TIDP-FP,,
+Z-310,QS/Cost,FILL,Bill of Quantities (tender),Schedule,2.3 Deliverable C,350,XLSX,S4,Shared,M8,,,QS,TIDP-Z,,
+Z-311,BIM/Info Mgmt,PLNS,Specifications,Document,2.3 Deliverable C,350,PDF,S4,Shared,M8,,,Lead AP,TIDP-Z,,
+FF-300,FF&E,FILL,FF&E specifications (initial),Schedule,2.3 Deliverable C,350,Fohlio/PDF,S4,Shared,M8,,,FF&E lead,TIDP-FF,,Fohlio Option A
+Z-400,BIM/Info Mgmt,PLNS,Tender documents,Document,2.4 Tender,NA,PDF,A1,Published,M9,,,Lead AP,TIDP-Z,,
+Z-401,BIM/Info Mgmt,PLNS,Conformed set / construction documentation,Drawing,2.5 Conformed,350,PDF/DWG,A1,Published,M11,,,Lead AP,TIDP-Z,,Post-award addenda
+ALL-500,All disciplines,FILL,Construction-stage models (LOD 400),Model,3.1 Construction,400,RVT/IFC,A1,Published,M12-M43,,,Task teams,TIDP-ALL,,Ongoing; revisions tracked
+Z-510,BIM/Info Mgmt,PLNS,RFI/submittal register,Document,3.1 Construction,400,XLSX,S2,Shared,M12-M43,,,Info Mgr,TIDP-Z,,ACC Issues
+Z-511,BIM/Info Mgmt,PLNS,Monthly model-health/KPI report,Document,3.1 Construction,400,PDF/HTML,S2,Shared,M12-M43,,,Info Mgr,TIDP-Z,,STINGTOOLS KPI dashboard
+M-520,Mechanical,FILL,BMS points export (Niagara),Document,3.1 Construction,400,CSV,S2,Shared,M40,,,MEP lead,TIDP-M,,Niagara_ExportPoints
+FF-600,FF&E,FILL,FF&E final schedule + procurement,Schedule,3.2 FF&E,400,Fohlio/XLSX,A1,Published,M43,,,FF&E lead,TIDP-FF,,
+A-700,Architecture,FILL,As-built architectural model,Model,3.3 Deliverable D,500,RVT/IFC,A1,Published,M45,,,Arch lead,TIDP-A,,Verified as-built
+S-700,Structure,FILL,As-built structural model,Model,3.3 Deliverable D,500,RVT/IFC,A1,Published,M45,,,Struct lead,TIDP-S,,
+M-700,MEP,FILL,As-built MEP model,Model,3.3 Deliverable D,500,RVT/IFC,A1,Published,M45,,,MEP lead,TIDP-M,,
+Z-700,BIM/Info Mgmt,PLNS,COBie handover dataset,Schedule,3.3 Deliverable D,500,XLSX,A1,Published,M45,,,Info Mgr,TIDP-Z,,STINGTOOLS COBie 2.4
+Z-701,BIM/Info Mgmt,PLNS,O&M / asset data pack,Document,3.3 Deliverable D,500,Fohlio/PDF,A1,Published,M45,,,Info Mgr,TIDP-Z,,
+Z-702,BIM/Info Mgmt,PLNS,Digital twin baseline (model reconciled to BMS),Document,3.3 Deliverable D,500,CSV/PDF,A1,Published,M45,,,Info Mgr,TIDP-Z,,Niagara_Reconcile
+Z-703,BIM/Info Mgmt,PLNS,Final handover transmittal + archive,Document,3.3 Deliverable D,500,PDF,A1,Archived,M45,,,Info Mgr,TIDP-Z,,


### PR DESCRIPTION
## What

Two companion deliverables to the KUT BIM Manager playbook, both under `GUIDES/`:

### `KUT_BEP_TEMPLATE.md` — fuller ISO 19650-2 BIM Execution Plan
14 sections + appendices, with fillable `[FILL: …]` placeholders:
document control & revision history · roles/RACI · EIR response + LOIN by stage · standards/naming/CDE suitability codes · CDE · software/formats/coordinate system · collaboration + clash process · ISO 19650-5 security · MIDP/TIDP planning · QA & model validation · FF&E/handover/digital-twin · training · risks. Cross-references the playbook and the MIDP.

### `KUT_MIDP_TEMPLATE.csv` — ready-to-fill Master Information Delivery Plan
17 columns × 50 pre-seeded rows (validated well-formed, 51×17 incl. header). Spans every discipline across **BOD → Deliverable B → C → Tender → Construction → FF&E → Deliverable D**, with LOD, suitability, CDE state, planned relative month, responsible, TIDP ref, RAG, and notes. Opens directly in Excel / Google Sheets.

Columns: `Ref, Discipline, Originator, Deliverable, Type, Stage, LOD, Format, Suitability, CDE State, Planned Rel Month, Planned Date, Actual Date, Responsible, TIDP Ref, RAG, Notes`

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016esKUrmFzJMaVVd1nzCVjr)_