### PR TITLE
IFC→GLB conversion in the converter-sidecar (IfcConvert)

### DIFF
--- a/Planscape.Server/src/converter-sidecar/Dockerfile
+++ b/Planscape.Server/src/converter-sidecar/Dockerfile
@@ -12,11 +12,27 @@
 # Run:
 #   docker run --rm -p 7700:7700 -e API_BASE=https://api.planscape.app planscape/converter-sidecar:latest
 
-FROM node:20-alpine
+# Debian (glibc) base so the prebuilt IfcConvert binary runs — the
+# ifcopenshell-builds binaries are glibc, not musl, so node:alpine can't run them.
+FROM node:20-bookworm-slim
 
-# IfcOpenShell is brought in via a separate stage when needed for IFC →
-# glTF; v1 only handles GLB chunking so the image stays light.
-RUN apk add --no-cache curl python3 make g++
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl unzip ca-certificates python3 make g++ \
+ && rm -rf /var/lib/apt/lists/*
+
+# IfcConvert (IfcOpenShell) for the /ifc-to-glb endpoint. ifcopenshell-builds
+# uses content-hashed filenames, so the URL drifts per release — override at
+# build time with --build-arg IFCCONVERT_URL=<current linux64 IfcConvert zip>
+# (see https://github.com/IfcOpenShell/IfcOpenShell releases). The install is
+# NON-FATAL: if it fails, the image still serves GLB chunking and /ifc-to-glb
+# returns 501 until a working URL is supplied.
+ARG IFCCONVERT_URL=https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.8.0-linux64.zip
+RUN (curl -fsSL "$IFCCONVERT_URL" -o /tmp/ifc.zip \
+      && unzip -o /tmp/ifc.zip -d /usr/local/bin \
+      && chmod +x /usr/local/bin/IfcConvert \
+      && rm -f /tmp/ifc.zip \
+      && IfcConvert --version) \
+   || echo "WARN: IfcConvert not installed (set IFCCONVERT_URL) — /ifc-to-glb will return 501"
 
 WORKDIR /app
 COPY package.json server.js /app/

--- a/Planscape.Server/src/converter-sidecar/server.js
+++ b/Planscape.Server/src/converter-sidecar/server.js
@@ -6,6 +6,11 @@
 //     each chunk back to /api/scene-nodes (tenant-scoped storage),
 //     returns the manifest the SceneNode rows are minted from.
 //
+// POST /ifc-to-glb
+//   { sourceUrl: string, projectId: uuid, fileName?: string, discipline?: string }
+//   → downloads the IFC, runs IfcConvert (IfcOpenShell) to produce a GLB,
+//     publishes it back as a renderable ProjectModel, returns { modelId }.
+//
 // POST /health
 //   → 200 OK
 //
@@ -20,6 +25,12 @@ import { draco, prune, dedup, weld } from '@gltf-transform/functions';
 import draco3d from 'draco3dgltf';
 import fetch from 'node-fetch';
 import crypto from 'crypto';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { mkdtemp, writeFile, readFile, rm } from 'fs/promises';
+const execFileP = promisify(execFile);
 
 const PORT = process.env.PORT || 7700;
 const API_BASE = process.env.API_BASE || 'http://api:8080';
@@ -30,6 +41,67 @@ const app = express();
 app.use(express.json({ limit: '10mb' }));
 
 app.get('/health', (_req, res) => res.json({ ok: true }));
+
+// IFC → GLB via IfcConvert (IfcOpenShell). Downloads the IFC, converts to a
+// binary glTF, then publishes the GLB back as a renderable ProjectModel so the
+// web/mobile viewer (GLTFLoader) can open it. RVT is out of scope — route those
+// through the Revit plugin's own GLB export or APS Model Derivative.
+app.post('/ifc-to-glb', async (req, res) => {
+  if (CONVERTER_TOKEN && req.headers['x-converter-token'] !== CONVERTER_TOKEN) {
+    return res.status(401).json({ error: 'unauthorised' });
+  }
+  const { sourceUrl, projectId, fileName, discipline } = req.body || {};
+  if (!sourceUrl || !projectId) {
+    return res.status(400).json({ error: 'sourceUrl and projectId are required' });
+  }
+
+  const work = await mkdtemp(path.join(os.tmpdir(), 'ifc-'));
+  const inPath = path.join(work, 'src.ifc');
+  const outPath = path.join(work, 'out.glb');
+  const baseName = (fileName || 'model').replace(/\.[^.]+$/, '');
+  const outName = `${baseName}.glb`;
+  try {
+    // 1. Pull the IFC.
+    const srcResp = await fetch(sourceUrl);
+    if (!srcResp.ok) throw new Error(`source fetch failed: HTTP ${srcResp.status}`);
+    await writeFile(inPath, Buffer.from(await srcResp.arrayBuffer()));
+
+    // 2. Convert. --use-element-guids keeps IFC GlobalIds as glTF node names so
+    //    the element-map / clash highlighting lines up with the source IFC.
+    try {
+      await execFileP('IfcConvert', ['--use-element-guids', '-y', inPath, outPath], {
+        maxBuffer: 64 * 1024 * 1024,
+      });
+    } catch (convErr) {
+      const missing = convErr && (convErr.code === 'ENOENT');
+      return res.status(missing ? 501 : 500).json({
+        error: missing
+          ? 'IfcConvert not installed in this image — rebuild the sidecar with IFCCONVERT_URL set.'
+          : `IfcConvert failed: ${String(convErr)}`,
+      });
+    }
+
+    // 3. Publish the GLB as a renderable ProjectModel.
+    const glb = await readFile(outPath);
+    const fd = new FormData();
+    fd.append('File', new Blob([glb], { type: 'model/gltf-binary' }), outName);
+    fd.append('Name', outName);
+    if (discipline) fd.append('Discipline', discipline);
+    const pubResp = await fetch(`${API_BASE}/api/projects/${projectId}/models`, {
+      method: 'POST',
+      headers: API_BEARER ? { Authorization: `Bearer ${API_BEARER}` } : {},
+      body: fd,
+    });
+    if (!pubResp.ok) throw new Error(`publish failed: HTTP ${pubResp.status} ${await pubResp.text()}`);
+    const row = await pubResp.json();
+    res.json({ ok: true, modelId: row.id ?? row.modelId ?? null, name: outName, glbBytes: glb.length });
+  } catch (err) {
+    console.error('ifc-to-glb failed', err);
+    res.status(500).json({ error: String(err) });
+  } finally {
+    await rm(work, { recursive: true, force: true }).catch(() => {});
+  }
+});
 
 app.post('/chunk', async (req, res) => {
   if (CONVERTER_TOKEN && req.headers['x-converter-token'] !== CONVERTER_TOKEN) {


### PR DESCRIPTION
**#4 of the "all" program** (own branch, per your call). Adds IFC→GLB conversion so the viewer can open IFC, not just pre-exported GLB.

## What
The `converter-sidecar` only chunked GLBs. It now also converts **IFC → renderable GLB** via **IfcConvert (IfcOpenShell)** — the standard, battle-tested CLI — rather than hand-assembling geometry:
- **`POST /ifc-to-glb`** — download IFC → `IfcConvert --use-element-guids` (keeps IFC GlobalIds as glTF node names so element-map/clash highlighting lines up) → publish the GLB back as a `ProjectModel` via `/api/projects/{id}/models`. Token-guarded like `/chunk`; missing binary → `501`.
- **Dockerfile** — switched to `node:20-bookworm-slim` (glibc, required to run the prebuilt IfcConvert) and installs IfcConvert via the `IFCCONVERT_URL` build arg. Install is **non-fatal**: a bad URL leaves GLB chunking working and `/ifc-to-glb` returning 501.

## Deliberately scoped (follow-up, needs deploy to test)
- Wire `ModelsController` to accept an IFC upload, store it, call `/ifc-to-glb` with its file URL (`Converter:BaseUrl` / `Converter:Token` config), and skip non-GLB formats in the viewer. This touches an EF/viewer surface and can't be validated until the sidecar is deployed, so it's a separate PR.
- **RVT is out of scope** — route those through the Revit plugin's existing GLB export or APS Model Derivative.

## Caveats
- Built to documented IfcOpenShell/APS signatures; **not run against a live IFC or a deployed sidecar**.
- `IFCCONVERT_URL` defaults to a representative version — verify the current linux64 IfcConvert zip URL at deploy (ifcopenshell-builds uses content-hashed filenames). The sidecar Docker image isn't built in PR CI, so this can't break PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL)_