### PR TITLE
Web coordination app (planscape-web): auth, projects, issues, clashes, 3D viewer, real-time

### DIFF
--- a/.github/workflows/planscape-web.yml
+++ b/.github/workflows/planscape-web.yml
@@ -1,0 +1,40 @@
+name: Planscape Web — Type-check & Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'planscape-web/**'
+      - '.github/workflows/planscape-web.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'planscape-web/**'
+      - '.github/workflows/planscape-web.yml'
+
+defaults:
+  run:
+    working-directory: planscape-web
+
+jobs:
+  build:
+    name: Type-check + Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      # No committed lockfile yet, so npm install (not npm ci) and no cache key.
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASE: https://api.planscape.build

--- a/planscape-web/.env.example
+++ b/planscape-web/.env.example
@@ -3,3 +3,7 @@
 NEXT_PUBLIC_API_BASE=https://api.planscape.build
 # Local dev against the docker-compose stack:
 # NEXT_PUBLIC_API_BASE=http://localhost:5000
+
+# Optional: URL of the 3D viewer (viewer.html). Defaults to
+# ${NEXT_PUBLIC_API_BASE}/viewer.html (the API serves it from wwwroot).
+# NEXT_PUBLIC_VIEWER_URL=https://api.planscape.build/viewer.html

--- a/planscape-web/.env.example
+++ b/planscape-web/.env.example
@@ -1,0 +1,5 @@
+# Base URL of the Planscape API the web app talks to.
+# Production:
+NEXT_PUBLIC_API_BASE=https://api.planscape.build
+# Local dev against the docker-compose stack:
+# NEXT_PUBLIC_API_BASE=http://localhost:5000

--- a/planscape-web/.gitignore
+++ b/planscape-web/.gitignore
@@ -1,0 +1,13 @@
+# dependencies
+node_modules/
+
+# next.js
+.next/
+out/
+build/
+
+# misc
+*.tsbuildinfo
+
+# local env
+.env*.local

--- a/planscape-web/README.md
+++ b/planscape-web/README.md
@@ -1,0 +1,33 @@
+# Planscape Web
+
+Browser app for online BIM coordination, built on the existing Planscape Server API.
+Lives alongside the marketing site (`planscape-site/`); this is the **authenticated
+coordination app** (the rich client that was previously mobile-only).
+
+## Status — slice 1: foundation + auth
+- Next.js 14 (App Router) + TypeScript + Tailwind shell
+- Sign in against `POST /api/auth/login`; bearer token in `localStorage`
+- Protected `/dashboard`; auto-redirect based on session
+
+Coming next: projects & issues → clashes & 3D viewer → real-time (SignalR).
+
+## Run locally
+```bash
+cd planscape-web
+npm install
+cp .env.example .env.local   # set NEXT_PUBLIC_API_BASE
+npm run dev                  # http://localhost:3000
+```
+
+## Config
+`NEXT_PUBLIC_API_BASE` — Planscape API base URL (default `https://api.planscape.build`).
+
+> CORS: this app uses bearer-token auth, so the API must allow this app's origin.
+> `app.planscape.build` is already in the server's `Cors__Origins`. For localhost
+> dev, add `http://localhost:3000` to the server's CORS allow-list or run the API locally.
+
+## Checks
+```bash
+npm run typecheck   # tsc --noEmit
+npm run build       # next build
+```

--- a/planscape-web/app/dashboard/page.tsx
+++ b/planscape-web/app/dashboard/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth';
+
+export default function DashboardPage() {
+  const { ready, user, logout } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (ready && !user) router.replace('/login');
+  }, [ready, user, router]);
+
+  if (!ready || !user) {
+    return <main className="grid min-h-screen place-items-center text-slate-400">Loading…</main>;
+  }
+
+  return (
+    <div className="min-h-screen">
+      <header className="flex items-center justify-between border-b border-slate-200 bg-white px-6 py-3">
+        <span className="font-semibold">Planscape</span>
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-slate-500">{user.email}</span>
+          <button
+            onClick={() => {
+              logout();
+              router.replace('/login');
+            }}
+            className="rounded border border-slate-300 px-3 py-1 transition hover:bg-slate-50"
+          >
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-5xl p-6">
+        <h1 className="text-xl font-semibold">Welcome{user.name ? `, ${user.name}` : ''}</h1>
+        <p className="mt-2 max-w-prose text-slate-500">
+          You&apos;re signed in to the Planscape web app. This is slice&nbsp;1 (foundation + auth).
+          Projects &amp; issues, clashes &amp; the 3D viewer, and real-time updates arrive in the
+          next slices.
+        </p>
+
+        <ul className="mt-6 space-y-2 text-sm text-slate-600">
+          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200">✅ Sign in / session</li>
+          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200 opacity-60">▫️ Projects &amp; Issues — next</li>
+          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200 opacity-60">▫️ Clashes &amp; 3D viewer</li>
+          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200 opacity-60">▫️ Real-time (SignalR)</li>
+        </ul>
+      </main>
+    </div>
+  );
+}

--- a/planscape-web/app/dashboard/page.tsx
+++ b/planscape-web/app/dashboard/page.tsx
@@ -2,53 +2,13 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuth } from '@/lib/auth';
 
-export default function DashboardPage() {
-  const { ready, user, logout } = useAuth();
+// The post-login landing is now /projects. Keep /dashboard as a redirect so any
+// existing links/bookmarks still resolve.
+export default function DashboardRedirect() {
   const router = useRouter();
-
   useEffect(() => {
-    if (ready && !user) router.replace('/login');
-  }, [ready, user, router]);
-
-  if (!ready || !user) {
-    return <main className="grid min-h-screen place-items-center text-slate-400">Loading…</main>;
-  }
-
-  return (
-    <div className="min-h-screen">
-      <header className="flex items-center justify-between border-b border-slate-200 bg-white px-6 py-3">
-        <span className="font-semibold">Planscape</span>
-        <div className="flex items-center gap-3 text-sm">
-          <span className="text-slate-500">{user.email}</span>
-          <button
-            onClick={() => {
-              logout();
-              router.replace('/login');
-            }}
-            className="rounded border border-slate-300 px-3 py-1 transition hover:bg-slate-50"
-          >
-            Sign out
-          </button>
-        </div>
-      </header>
-
-      <main className="mx-auto max-w-5xl p-6">
-        <h1 className="text-xl font-semibold">Welcome{user.name ? `, ${user.name}` : ''}</h1>
-        <p className="mt-2 max-w-prose text-slate-500">
-          You&apos;re signed in to the Planscape web app. This is slice&nbsp;1 (foundation + auth).
-          Projects &amp; issues, clashes &amp; the 3D viewer, and real-time updates arrive in the
-          next slices.
-        </p>
-
-        <ul className="mt-6 space-y-2 text-sm text-slate-600">
-          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200">✅ Sign in / session</li>
-          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200 opacity-60">▫️ Projects &amp; Issues — next</li>
-          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200 opacity-60">▫️ Clashes &amp; 3D viewer</li>
-          <li className="rounded-lg bg-white px-4 py-3 ring-1 ring-slate-200 opacity-60">▫️ Real-time (SignalR)</li>
-        </ul>
-      </main>
-    </div>
-  );
+    router.replace('/projects');
+  }, [router]);
+  return <main className="grid min-h-screen place-items-center text-slate-400">Loading…</main>;
 }

--- a/planscape-web/app/globals.css
+++ b/planscape-web/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/planscape-web/app/layout.tsx
+++ b/planscape-web/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { AuthProvider } from '@/lib/auth';
+
+export const metadata: Metadata = {
+  title: 'Planscape — Coordination',
+  description: 'Planscape online BIM coordination',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-slate-50 text-slate-900 antialiased">
+        <AuthProvider>{children}</AuthProvider>
+      </body>
+    </html>
+  );
+}

--- a/planscape-web/app/login/page.tsx
+++ b/planscape-web/app/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
     setBusy(true);
     try {
       await login(email.trim(), password);
-      router.replace('/dashboard');
+      router.replace('/projects');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Sign-in failed.');
     } finally {

--- a/planscape-web/app/login/page.tsx
+++ b/planscape-web/app/login/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth';
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      await login(email.trim(), password);
+      router.replace('/dashboard');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign-in failed.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="grid min-h-screen place-items-center p-4">
+      <form onSubmit={onSubmit} className="w-full max-w-sm rounded-xl bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="mb-1 text-2xl font-semibold">Planscape</h1>
+        <p className="mb-6 text-sm text-slate-500">Sign in to coordinate online.</p>
+
+        <label className="mb-3 block">
+          <span className="mb-1 block text-sm font-medium">Email</span>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="username"
+            className="w-full rounded border border-slate-300 px-3 py-2 outline-none focus:border-blue-500"
+          />
+        </label>
+
+        <label className="mb-4 block">
+          <span className="mb-1 block text-sm font-medium">Password</span>
+          <input
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            className="w-full rounded border border-slate-300 px-3 py-2 outline-none focus:border-blue-500"
+          />
+        </label>
+
+        {error && <p className="mb-4 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={busy}
+          className="w-full rounded bg-blue-600 px-4 py-2 font-medium text-white transition hover:bg-blue-700 disabled:opacity-60"
+        >
+          {busy ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/planscape-web/app/page.tsx
+++ b/planscape-web/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
 
   useEffect(() => {
     if (!ready) return;
-    router.replace(user ? '/dashboard' : '/login');
+    router.replace(user ? '/projects' : '/login');
   }, [ready, user, router]);
 
   return <main className="grid min-h-screen place-items-center text-slate-400">Loading…</main>;

--- a/planscape-web/app/page.tsx
+++ b/planscape-web/app/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth';
+
+export default function Home() {
+  const { ready, user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!ready) return;
+    router.replace(user ? '/dashboard' : '/login');
+  }, [ready, user, router]);
+
+  return <main className="grid min-h-screen place-items-center text-slate-400">Loading…</main>;
+}

--- a/planscape-web/app/projects/[id]/clashes/[clashId]/page.tsx
+++ b/planscape-web/app/projects/[id]/clashes/[clashId]/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { getClash, updateClash, promoteClashToIssue } from '@/lib/data';
+import type { ClashRecord, ClashStatus } from '@/lib/types';
+
+const STATUSES: ClashStatus[] = ['NEW', 'ACKNOWLEDGED', 'RESOLVED', 'CLOSED'];
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-slate-400">{label}</dt>
+      <dd className="text-sm">{value || '—'}</dd>
+    </div>
+  );
+}
+
+export default function ClashDetailPage() {
+  const params = useParams<{ id: string; clashId: string }>();
+  const projectId = params.id;
+  const clashId = params.clashId;
+  const router = useRouter();
+
+  const [clash, setClash] = useState<ClashRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    getClash(projectId, clashId)
+      .then(setClash)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load clash'));
+  }, [projectId, clashId]);
+
+  async function changeStatus(s: ClashStatus) {
+    if (!clash || clash.status === s) return;
+    const prev = clash.status;
+    setClash({ ...clash, status: s });
+    try {
+      await updateClash(projectId, clashId, { status: s });
+    } catch {
+      setClash({ ...clash, status: prev });
+      setError('Failed to update status');
+    }
+  }
+
+  async function onPromote() {
+    try {
+      const r = await promoteClashToIssue(projectId, clashId);
+      if (r.issueId) {
+        router.push(`/projects/${projectId}/issues/${r.issueId}`);
+      } else {
+        setNotice('Promoted to an issue.');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to promote');
+    }
+  }
+
+  return (
+    <AppShell>
+      <Link href={`/projects/${projectId}/clashes`} className="text-sm text-slate-400 hover:underline">
+        ← Back to clashes
+      </Link>
+
+      {error && <p className="my-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {notice && <p className="my-3 rounded bg-green-50 px-3 py-2 text-sm text-green-700">{notice}</p>}
+      {!clash && !error && <p className="mt-3 text-slate-400">Loading…</p>}
+
+      {clash && (
+        <>
+          <h1 className="mt-1 text-xl font-semibold">
+            {(clash.elementAType || 'Element A')} ↔ {(clash.elementBType || 'Element B')}
+          </h1>
+          <div className="mt-1 text-xs text-slate-400">
+            {clash.severity} · {clash.status}
+            {clash.discipline ? ` · ${clash.discipline}` : ''}
+          </div>
+
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <div className="rounded-lg bg-white p-4 ring-1 ring-slate-200">
+              <h2 className="mb-2 text-sm font-semibold">Geometry</h2>
+              <dl className="space-y-2">
+                <Field label="Overlap volume" value={typeof clash.overlapVolumeMm3 === 'number' ? `${Math.round(clash.overlapVolumeMm3).toLocaleString()} mm³` : '—'} />
+                <Field label="Penetration / distance" value={typeof clash.distanceMm === 'number' ? `${clash.distanceMm.toFixed(1)} mm` : '—'} />
+                <Field label="Centre (x, y, z)" value={`${clash.centreX?.toFixed?.(2)}, ${clash.centreY?.toFixed?.(2)}, ${clash.centreZ?.toFixed?.(2)}`} />
+              </dl>
+            </div>
+            <div className="rounded-lg bg-white p-4 ring-1 ring-slate-200">
+              <h2 className="mb-2 text-sm font-semibold">Elements</h2>
+              <dl className="space-y-2">
+                <Field label="A" value={`${clash.elementAName || clash.elementAType || 'A'} · ${clash.elementAGuid}`} />
+                <Field label="B" value={`${clash.elementBName || clash.elementBType || 'B'} · ${clash.elementBGuid}`} />
+                {clash.resolutionNote && <Field label="Resolution" value={clash.resolutionNote} />}
+              </dl>
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-400">Status</span>
+            <div className="flex flex-wrap gap-2">
+              {STATUSES.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => changeStatus(s)}
+                  className={`rounded-full px-3 py-1 text-xs ${
+                    clash.status === s ? 'bg-blue-600 text-white' : 'bg-white text-slate-600 ring-1 ring-slate-200'
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-5 flex flex-wrap gap-2">
+            <Link
+              href={`/projects/${projectId}/viewer?guid=${encodeURIComponent(clash.elementAGuid)}&x=${clash.centreX}&y=${clash.centreY}&z=${clash.centreZ}`}
+              className="rounded bg-slate-800 px-3 py-2 text-sm font-medium text-white hover:bg-slate-900"
+            >
+              View in model
+            </Link>
+            {clash.issueId ? (
+              <Link
+                href={`/projects/${projectId}/issues/${clash.issueId}`}
+                className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+              >
+                Open linked issue
+              </Link>
+            ) : (
+              <button onClick={onPromote} className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50">
+                Promote to issue
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/clashes/page.tsx
+++ b/planscape-web/app/projects/[id]/clashes/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { listClashes, runClashDetection } from '@/lib/data';
+import type { ClashRecord, ClashStatus } from '@/lib/types';
+
+const FILTERS: (ClashStatus | 'ALL')[] = ['ALL', 'NEW', 'ACKNOWLEDGED', 'RESOLVED', 'CLOSED'];
+
+const severityClass: Record<string, string> = {
+  CRITICAL: 'bg-red-100 text-red-700',
+  MAJOR: 'bg-orange-100 text-orange-700',
+  MINOR: 'bg-slate-100 text-slate-600',
+};
+
+export default function ClashesPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const [clashes, setClashes] = useState<ClashRecord[] | null>(null);
+  const [filter, setFilter] = useState<ClashStatus | 'ALL'>('NEW');
+  const [error, setError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setClashes(null);
+    setError(null);
+    listClashes(projectId, filter === 'ALL' ? {} : { status: filter })
+      .then((r) => setClashes(r.items ?? []))
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load clashes'));
+  }, [projectId, filter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function onRun() {
+    setRunning(true);
+    setNotice(null);
+    try {
+      const r = await runClashDetection(projectId);
+      setNotice(`Detection complete — ${r.found ?? 0} found, ${r.created ?? 0} new, ${r.critical ?? 0} critical.`);
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Clash detection failed');
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+            ← Project
+          </Link>
+          <h1 className="text-xl font-semibold">Clashes</h1>
+        </div>
+        <button
+          onClick={onRun}
+          disabled={running}
+          className="shrink-0 rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          {running ? 'Running…' : 'Run detection'}
+        </button>
+      </div>
+
+      <div className="mb-3 flex flex-wrap gap-2">
+        {FILTERS.map((s) => (
+          <button
+            key={s}
+            onClick={() => setFilter(s)}
+            className={`rounded-full px-3 py-1 text-xs ${
+              filter === s ? 'bg-blue-600 text-white' : 'bg-white text-slate-600 ring-1 ring-slate-200'
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+
+      {notice && <p className="mb-3 rounded bg-green-50 px-3 py-2 text-sm text-green-700">{notice}</p>}
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {!clashes && !error && <p className="text-slate-400">Loading…</p>}
+      {clashes && clashes.length === 0 && <p className="text-slate-500">No clashes.</p>}
+
+      <ul className="space-y-2">
+        {clashes?.map((c) => (
+          <li key={c.id}>
+            <Link
+              href={`/projects/${projectId}/clashes/${c.id}`}
+              className="block rounded-lg bg-white p-3 ring-1 ring-slate-200 transition hover:ring-blue-300"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-medium">
+                  {(c.elementAType || 'Element A')} ↔ {(c.elementBType || 'Element B')}
+                </span>
+                <span className={`shrink-0 rounded px-2 py-0.5 text-xs ${severityClass[c.severity] ?? 'bg-slate-100 text-slate-600'}`}>
+                  {c.severity}
+                </span>
+              </div>
+              <div className="mt-1 text-xs text-slate-400">
+                {c.status}
+                {c.discipline ? ` · ${c.discipline}` : ''}
+                {typeof c.overlapVolumeMm3 === 'number' ? ` · ${Math.round(c.overlapVolumeMm3).toLocaleString()} mm³` : ''}
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
+++ b/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState, type FormEvent } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { getIssue, updateIssue, listComments, addComment } from '@/lib/data';
+import type { BimIssue, IssueComment, IssueStatus } from '@/lib/types';
+
+const STATUSES: IssueStatus[] = ['OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED'];
+
+export default function IssueDetailPage() {
+  const params = useParams<{ id: string; issueId: string }>();
+  const projectId = params.id;
+  const issueId = params.issueId;
+
+  const [issue, setIssue] = useState<BimIssue | null>(null);
+  const [comments, setComments] = useState<IssueComment[]>([]);
+  const [newComment, setNewComment] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getIssue(projectId, issueId)
+      .then(setIssue)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load issue'));
+    listComments(projectId, issueId).then(setComments).catch(() => {});
+  }, [projectId, issueId]);
+
+  async function changeStatus(s: IssueStatus) {
+    if (!issue || issue.status === s) return;
+    const prev = issue.status;
+    setIssue({ ...issue, status: s });
+    try {
+      await updateIssue(projectId, issueId, { status: s });
+    } catch {
+      setIssue({ ...issue, status: prev });
+      setError('Failed to update status');
+    }
+  }
+
+  async function postComment(e: FormEvent) {
+    e.preventDefault();
+    const body = newComment.trim();
+    if (!body) return;
+    setNewComment('');
+    try {
+      const c = await addComment(projectId, issueId, body);
+      setComments((cs) => [...cs, c]);
+    } catch {
+      setError('Failed to add comment');
+      setNewComment(body);
+    }
+  }
+
+  return (
+    <AppShell>
+      <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+        ← Back to issues
+      </Link>
+
+      {error && <p className="my-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {!issue && !error && <p className="mt-3 text-slate-400">Loading…</p>}
+
+      {issue && (
+        <>
+          <h1 className="mt-1 text-xl font-semibold">{issue.title}</h1>
+          <div className="mt-1 text-xs text-slate-400">
+            {issue.type} · {issue.priority}
+            {issue.discipline ? ` · ${issue.discipline}` : ''}
+            {issue.assignee ? ` · ${issue.assignee}` : ''}
+          </div>
+
+          {issue.description && (
+            <p className="mt-4 whitespace-pre-wrap rounded-lg bg-white p-4 text-sm ring-1 ring-slate-200">
+              {issue.description}
+            </p>
+          )}
+
+          <div className="mt-4">
+            <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-slate-400">Status</span>
+            <div className="flex flex-wrap gap-2">
+              {STATUSES.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => changeStatus(s)}
+                  className={`rounded-full px-3 py-1 text-xs ${
+                    issue.status === s ? 'bg-blue-600 text-white' : 'bg-white text-slate-600 ring-1 ring-slate-200'
+                  }`}
+                >
+                  {s.replace('_', ' ')}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <section className="mt-8">
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-400">Comments</h2>
+            <ul className="space-y-2">
+              {comments.length === 0 && <li className="text-sm text-slate-400">No comments yet.</li>}
+              {comments.map((c) => (
+                <li key={c.id} className="rounded-lg bg-white p-3 text-sm ring-1 ring-slate-200">
+                  <div className="mb-1 flex items-center justify-between text-xs text-slate-400">
+                    <span>{c.authorName ?? 'User'}</span>
+                    <span>{c.createdAt ? new Date(c.createdAt).toLocaleString() : ''}</span>
+                  </div>
+                  <p className="whitespace-pre-wrap">{c.body}</p>
+                </li>
+              ))}
+            </ul>
+
+            <form onSubmit={postComment} className="mt-3 flex gap-2">
+              <input
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                placeholder="Add a comment…"
+                className="flex-1 rounded border border-slate-300 px-3 py-2 outline-none focus:border-blue-500"
+              />
+              <button
+                type="submit"
+                disabled={!newComment.trim()}
+                className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+              >
+                Post
+              </button>
+            </form>
+          </section>
+        </>
+      )}
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/issues/new/page.tsx
+++ b/planscape-web/app/projects/[id]/issues/new/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { createIssue } from '@/lib/data';
+import type { IssuePriority } from '@/lib/types';
+
+const PRIORITIES: IssuePriority[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
+const TYPES = ['CLASH', 'RFI', 'DEFECT', 'QUERY', 'OTHER'];
+
+export default function NewIssuePage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const router = useRouter();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [type, setType] = useState('CLASH');
+  const [priority, setPriority] = useState<IssuePriority>('MEDIUM');
+  const [discipline, setDiscipline] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      const issue = await createIssue(projectId, {
+        title: title.trim(),
+        description: description.trim(),
+        type,
+        priority,
+        discipline: discipline.trim(),
+      });
+      router.replace(`/projects/${projectId}/issues/${issue.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create issue');
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AppShell>
+      <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+        ← Back
+      </Link>
+      <h1 className="mb-4 mt-1 text-xl font-semibold">New issue</h1>
+
+      <form onSubmit={onSubmit} className="max-w-xl space-y-4 rounded-lg bg-white p-5 ring-1 ring-slate-200">
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium">Title</span>
+          <input
+            required
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full rounded border border-slate-300 px-3 py-2 outline-none focus:border-blue-500"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium">Description</span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+            className="w-full rounded border border-slate-300 px-3 py-2 outline-none focus:border-blue-500"
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-4">
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium">Type</span>
+            <select value={type} onChange={(e) => setType(e.target.value)} className="w-full rounded border border-slate-300 px-3 py-2">
+              {TYPES.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium">Priority</span>
+            <select
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as IssuePriority)}
+              className="w-full rounded border border-slate-300 px-3 py-2"
+            >
+              {PRIORITIES.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium">Discipline</span>
+          <input
+            value={discipline}
+            onChange={(e) => setDiscipline(e.target.value)}
+            placeholder="e.g. M, E, P, S, A"
+            className="w-full rounded border border-slate-300 px-3 py-2 outline-none focus:border-blue-500"
+          />
+        </label>
+
+        {error && <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={busy || !title.trim()}
+          className="rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          {busy ? 'Creating…' : 'Create issue'}
+        </button>
+      </form>
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import { getProject, listIssues } from '@/lib/data';
+import { useProjectRealtime } from '@/lib/realtime';
 import type { Project, BimIssue, IssueStatus } from '@/lib/types';
 
 const FILTERS: (IssueStatus | 'ALL')[] = ['ALL', 'OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED'];
@@ -23,18 +24,29 @@ export default function ProjectPage() {
   const [issues, setIssues] = useState<BimIssue[] | null>(null);
   const [filter, setFilter] = useState<IssueStatus | 'ALL'>('OPEN');
   const [error, setError] = useState<string | null>(null);
+  const [live, setLive] = useState(false);
 
   useEffect(() => {
     getProject(projectId).then(setProject).catch(() => {});
   }, [projectId]);
 
-  useEffect(() => {
-    setIssues(null);
-    setError(null);
+  const loadIssues = useCallback(() => {
     listIssues(projectId, filter === 'ALL' ? undefined : filter)
       .then(setIssues)
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load issues'));
   }, [projectId, filter]);
+
+  useEffect(() => {
+    setIssues(null);
+    setError(null);
+    loadIssues();
+  }, [loadIssues]);
+
+  // Live updates: refresh the list when an issue changes elsewhere.
+  useProjectRealtime(projectId, (event) => {
+    setLive(true);
+    if (event.startsWith('Issue')) loadIssues();
+  });
 
   return (
     <AppShell>
@@ -45,6 +57,11 @@ export default function ProjectPage() {
           </Link>
           <h1 className="text-xl font-semibold">{project?.name ?? 'Project'}</h1>
           {project?.code && <p className="text-xs text-slate-400">{project.code}</p>}
+          {live && (
+            <span className="mt-1 inline-flex items-center gap-1 text-xs text-green-600">
+              <span className="h-1.5 w-1.5 rounded-full bg-green-500" /> Live
+            </span>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Link

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { getProject, listIssues } from '@/lib/data';
+import type { Project, BimIssue, IssueStatus } from '@/lib/types';
+
+const FILTERS: (IssueStatus | 'ALL')[] = ['ALL', 'OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED'];
+
+const priorityClass: Record<string, string> = {
+  CRITICAL: 'bg-red-100 text-red-700',
+  HIGH: 'bg-orange-100 text-orange-700',
+  MEDIUM: 'bg-amber-100 text-amber-700',
+  LOW: 'bg-slate-100 text-slate-600',
+};
+
+export default function ProjectPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const [project, setProject] = useState<Project | null>(null);
+  const [issues, setIssues] = useState<BimIssue[] | null>(null);
+  const [filter, setFilter] = useState<IssueStatus | 'ALL'>('OPEN');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getProject(projectId).then(setProject).catch(() => {});
+  }, [projectId]);
+
+  useEffect(() => {
+    setIssues(null);
+    setError(null);
+    listIssues(projectId, filter === 'ALL' ? undefined : filter)
+      .then(setIssues)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load issues'));
+  }, [projectId, filter]);
+
+  return (
+    <AppShell>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <Link href="/projects" className="text-sm text-slate-400 hover:underline">
+            ← Projects
+          </Link>
+          <h1 className="text-xl font-semibold">{project?.name ?? 'Project'}</h1>
+          {project?.code && <p className="text-xs text-slate-400">{project.code}</p>}
+        </div>
+        <Link
+          href={`/projects/${projectId}/issues/new`}
+          className="shrink-0 rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          New issue
+        </Link>
+      </div>
+
+      <div className="mb-3 flex flex-wrap gap-2">
+        {FILTERS.map((s) => (
+          <button
+            key={s}
+            onClick={() => setFilter(s)}
+            className={`rounded-full px-3 py-1 text-xs ${
+              filter === s ? 'bg-blue-600 text-white' : 'bg-white text-slate-600 ring-1 ring-slate-200'
+            }`}
+          >
+            {s.replace('_', ' ')}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {!issues && !error && <p className="text-slate-400">Loading…</p>}
+      {issues && issues.length === 0 && <p className="text-slate-500">No issues.</p>}
+
+      <ul className="space-y-2">
+        {issues?.map((i) => (
+          <li key={i.id}>
+            <Link
+              href={`/projects/${projectId}/issues/${i.id}`}
+              className="block rounded-lg bg-white p-3 ring-1 ring-slate-200 transition hover:ring-blue-300"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-medium">{i.title}</span>
+                <span className={`shrink-0 rounded px-2 py-0.5 text-xs ${priorityClass[i.priority] ?? 'bg-slate-100 text-slate-600'}`}>
+                  {i.priority}
+                </span>
+              </div>
+              <div className="mt-1 text-xs text-slate-400">
+                {i.status.replace('_', ' ')}
+                {i.discipline ? ` · ${i.discipline}` : ''}
+                {i.assignee ? ` · ${i.assignee}` : ''}
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -46,12 +46,26 @@ export default function ProjectPage() {
           <h1 className="text-xl font-semibold">{project?.name ?? 'Project'}</h1>
           {project?.code && <p className="text-xs text-slate-400">{project.code}</p>}
         </div>
-        <Link
-          href={`/projects/${projectId}/issues/new`}
-          className="shrink-0 rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          New issue
-        </Link>
+        <div className="flex shrink-0 items-center gap-2">
+          <Link
+            href={`/projects/${projectId}/clashes`}
+            className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            Clashes
+          </Link>
+          <Link
+            href={`/projects/${projectId}/viewer`}
+            className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            3D model
+          </Link>
+          <Link
+            href={`/projects/${projectId}/issues/new`}
+            className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            New issue
+          </Link>
+        </div>
       </div>
 
       <div className="mb-3 flex flex-wrap gap-2">

--- a/planscape-web/app/projects/[id]/viewer/page.tsx
+++ b/planscape-web/app/projects/[id]/viewer/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useSearchParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { listModels, modelFileUrl } from '@/lib/data';
+import { API_BASE } from '@/lib/api';
+import type { ProjectModel } from '@/lib/types';
+
+// useSearchParams needs the page rendered dynamically (no static prerender).
+export const dynamic = 'force-dynamic';
+
+// The existing 3D viewer (Planscape/assets/viewer → API wwwroot). Override with
+// NEXT_PUBLIC_VIEWER_URL if it's hosted elsewhere.
+const VIEWER_URL = process.env.NEXT_PUBLIC_VIEWER_URL || `${API_BASE}/viewer.html`;
+
+export default function ViewerPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const search = useSearchParams();
+  const guid = search.get('guid') || undefined;
+  const wantModel = search.get('model') || undefined;
+
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [models, setModels] = useState<ProjectModel[]>([]);
+  const [activeId, setActiveId] = useState<string | undefined>(wantModel);
+  const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    listModels(projectId)
+      .then((ms) => {
+        setModels(ms);
+        setActiveId((cur) => cur ?? ms[0]?.id);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load models'));
+  }, [projectId]);
+
+  function post(cmd: { type: string; payload?: unknown }) {
+    iframeRef.current?.contentWindow?.postMessage(JSON.stringify(cmd), '*');
+  }
+
+  // Load the active model into the viewer once the iframe is ready, then
+  // deep-link to the clash element (node names carry IFC GUIDs).
+  useEffect(() => {
+    if (!ready || !activeId) return;
+    post({ type: 'load', payload: { url: modelFileUrl(projectId, activeId), modelId: activeId } });
+    if (!guid) return;
+    const t = setTimeout(() => post({ type: 'selectAndZoom', payload: { guid } }), 2500);
+    return () => clearTimeout(t);
+  }, [ready, activeId, projectId, guid]);
+
+  return (
+    <AppShell>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+          ← Project
+        </Link>
+        {models.length > 0 && (
+          <select
+            value={activeId}
+            onChange={(e) => setActiveId(e.target.value)}
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+          >
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+                {m.discipline ? ` (${m.discipline})` : ''}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {models.length === 0 && !error && (
+        <p className="text-slate-500">No models published to this project yet.</p>
+      )}
+
+      <div className="overflow-hidden rounded-lg ring-1 ring-slate-200" style={{ height: '70vh' }}>
+        <iframe
+          ref={iframeRef}
+          src={VIEWER_URL}
+          title="3D model"
+          className="h-full w-full border-0"
+          onLoad={() => setReady(true)}
+          allow="fullscreen"
+        />
+      </div>
+
+      {guid && <p className="mt-2 text-xs text-slate-400">Deep-linked to element {guid}.</p>}
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/page.tsx
+++ b/planscape-web/app/projects/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AppShell } from '@/components/AppShell';
+import { listProjects } from '@/lib/data';
+import type { Project } from '@/lib/types';
+
+export default function ProjectsPage() {
+  const [projects, setProjects] = useState<Project[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listProjects()
+      .then(setProjects)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load projects'));
+  }, []);
+
+  return (
+    <AppShell>
+      <h1 className="mb-4 text-xl font-semibold">Projects</h1>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {!projects && !error && <p className="text-slate-400">Loading…</p>}
+      {projects && projects.length === 0 && <p className="text-slate-500">No projects yet.</p>}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {projects?.map((p) => (
+          <Link
+            key={p.id}
+            href={`/projects/${p.id}`}
+            className="rounded-lg bg-white p-4 ring-1 ring-slate-200 transition hover:ring-blue-300"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="font-medium">{p.name}</span>
+              <span className="text-xs text-slate-400">{p.code}</span>
+            </div>
+            {p.description && <p className="mt-1 line-clamp-2 text-sm text-slate-500">{p.description}</p>}
+          </Link>
+        ))}
+      </div>
+    </AppShell>
+  );
+}

--- a/planscape-web/components/AppShell.tsx
+++ b/planscape-web/components/AppShell.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, type ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/lib/auth';
+
+/** Protected app chrome: gates on auth (redirect to /login), renders the header + content. */
+export function AppShell({ children }: { children: ReactNode }) {
+  const { ready, user, logout } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (ready && !user) router.replace('/login');
+  }, [ready, user, router]);
+
+  if (!ready || !user) {
+    return <main className="grid min-h-screen place-items-center text-slate-400">Loading…</main>;
+  }
+
+  return (
+    <div className="min-h-screen">
+      <header className="flex items-center justify-between border-b border-slate-200 bg-white px-6 py-3">
+        <Link href="/projects" className="font-semibold">
+          Planscape
+        </Link>
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-slate-500">{user.email}</span>
+          <button
+            onClick={() => {
+              logout();
+              router.replace('/login');
+            }}
+            className="rounded border border-slate-300 px-3 py-1 transition hover:bg-slate-50"
+          >
+            Sign out
+          </button>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl p-6">{children}</main>
+    </div>
+  );
+}

--- a/planscape-web/lib/api.ts
+++ b/planscape-web/lib/api.ts
@@ -1,0 +1,60 @@
+// Minimal fetch wrapper for the Planscape API: attaches the bearer token,
+// normalises errors, and bounces to /login on 401. Bearer-token auth (not
+// cookies), so cross-origin calls need the API's CORS allow-list to include
+// this app's origin (app.planscape.build is allow-listed; for localhost dev,
+// add it to Cors__Origins on the server or run the API locally).
+
+const TOKEN_KEY = 'planscape_token';
+
+export const API_BASE = (process.env.NEXT_PUBLIC_API_BASE || 'https://api.planscape.build').replace(/\/$/, '');
+
+export function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string | null): void {
+  if (typeof window === 'undefined') return;
+  if (token) window.localStorage.setItem(TOKEN_KEY, token);
+  else window.localStorage.removeItem(TOKEN_KEY);
+}
+
+export class ApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = getToken();
+  const headers = new Headers(init.headers);
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  if (init.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+
+  const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
+
+  if (res.status === 401) {
+    setToken(null);
+    if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+      window.location.href = '/login';
+    }
+    throw new ApiError(401, 'Session expired — please sign in again.');
+  }
+
+  if (!res.ok) {
+    let message = `Request failed (HTTP ${res.status})`;
+    try {
+      const body = await res.json();
+      message = body.message || body.error || message;
+    } catch {
+      /* non-JSON error body — keep the generic message */
+    }
+    throw new ApiError(res.status, message);
+  }
+
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}

--- a/planscape-web/lib/auth.tsx
+++ b/planscape-web/lib/auth.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { API_BASE, getToken, setToken } from './api';
+
+export interface AuthUser {
+  email: string;
+  name?: string;
+  tenantId?: string;
+}
+
+interface AuthState {
+  /** True once the initial token restore from localStorage has run. */
+  ready: boolean;
+  user: AuthUser | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthState | null>(null);
+
+/** Decode the (unverified) JWT payload for display only — never for trust. */
+function decodeJwt(token: string): AuthUser | null {
+  try {
+    const part = token.split('.')[1];
+    if (!part) return null;
+    const json = atob(part.replace(/-/g, '+').replace(/_/g, '/'));
+    const p = JSON.parse(json) as Record<string, string>;
+    return {
+      email: p.email || p.sub || p.unique_name || 'user',
+      name: p.name || p.given_name,
+      tenantId: p.tenant || p.tenantId || p.tid,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [ready, setReady] = useState(false);
+  const [user, setUser] = useState<AuthUser | null>(null);
+
+  useEffect(() => {
+    const t = getToken();
+    if (t) setUser(decodeJwt(t));
+    setReady(true);
+  }, []);
+
+  async function login(email: string, password: string): Promise<void> {
+    const res = await fetch(`${API_BASE}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!res.ok) {
+      let message = 'Sign-in failed.';
+      try {
+        const body = await res.json();
+        message = body.message || body.error || message;
+      } catch {
+        /* keep generic */
+      }
+      throw new Error(message);
+    }
+    const data = (await res.json()) as { accessToken?: string; token?: string };
+    const token = data.accessToken || data.token;
+    if (!token) throw new Error('Sign-in succeeded but no token was returned.');
+    setToken(token);
+    setUser(decodeJwt(token));
+  }
+
+  function logout(): void {
+    setToken(null);
+    setUser(null);
+  }
+
+  return <AuthContext.Provider value={{ ready, user, login, logout }}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider');
+  return ctx;
+}

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -1,6 +1,15 @@
-import { api } from './api';
-import type { Project, BimIssue, IssueComment } from './types';
+import { api, API_BASE, getToken } from './api';
+import type {
+  Project,
+  BimIssue,
+  IssueComment,
+  ClashRecord,
+  ClashListResponse,
+  ClashDetectionResult,
+  ProjectModel,
+} from './types';
 
+// ── Projects ──
 export function listProjects(): Promise<Project[]> {
   return api<Project[]>('/api/projects');
 }
@@ -9,6 +18,7 @@ export function getProject(id: string): Promise<Project> {
   return api<Project>(`/api/projects/${id}`);
 }
 
+// ── Issues ──
 export async function listIssues(projectId: string, status?: string): Promise<BimIssue[]> {
   const qs = status ? `?status=${encodeURIComponent(status)}` : '';
   // The server may return a flat array or an { items } envelope — handle both.
@@ -22,17 +32,11 @@ export function getIssue(projectId: string, issueId: string): Promise<BimIssue> 
 }
 
 export function createIssue(projectId: string, body: Partial<BimIssue>): Promise<BimIssue> {
-  return api<BimIssue>(`/api/projects/${projectId}/issues`, {
-    method: 'POST',
-    body: JSON.stringify(body),
-  });
+  return api<BimIssue>(`/api/projects/${projectId}/issues`, { method: 'POST', body: JSON.stringify(body) });
 }
 
 export function updateIssue(projectId: string, issueId: string, body: Partial<BimIssue>): Promise<BimIssue> {
-  return api<BimIssue>(`/api/projects/${projectId}/issues/${issueId}`, {
-    method: 'PUT',
-    body: JSON.stringify(body),
-  });
+  return api<BimIssue>(`/api/projects/${projectId}/issues/${issueId}`, { method: 'PUT', body: JSON.stringify(body) });
 }
 
 export function listComments(projectId: string, issueId: string): Promise<IssueComment[]> {
@@ -44,4 +48,50 @@ export function addComment(projectId: string, issueId: string, body: string): Pr
     method: 'POST',
     body: JSON.stringify({ body }),
   });
+}
+
+// ── Clashes ──
+export function listClashes(
+  projectId: string,
+  opts: { status?: string; severity?: string } = {},
+): Promise<ClashListResponse> {
+  const params = new URLSearchParams();
+  if (opts.status) params.set('status', opts.status);
+  if (opts.severity) params.set('severity', opts.severity);
+  const qs = params.toString();
+  return api<ClashListResponse>(`/api/projects/${projectId}/clashes${qs ? `?${qs}` : ''}`);
+}
+
+export function getClash(projectId: string, clashId: string): Promise<ClashRecord> {
+  return api<ClashRecord>(`/api/projects/${projectId}/clashes/${clashId}`);
+}
+
+export function updateClash(projectId: string, clashId: string, body: Partial<ClashRecord>): Promise<ClashRecord> {
+  return api<ClashRecord>(`/api/projects/${projectId}/clashes/${clashId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+export function runClashDetection(projectId: string): Promise<ClashDetectionResult> {
+  return api<ClashDetectionResult>(`/api/projects/${projectId}/clashes/run`, { method: 'POST' });
+}
+
+export function promoteClashToIssue(projectId: string, clashId: string): Promise<{ issueId?: string }> {
+  return api<{ issueId?: string }>(`/api/projects/${projectId}/clashes/${clashId}/promote-to-issue`, {
+    method: 'POST',
+  });
+}
+
+// ── Models / viewer ──
+export function listModels(projectId: string): Promise<ProjectModel[]> {
+  return api<ProjectModel[]>(`/api/projects/${projectId}/models`);
+}
+
+/** Authenticated GLB URL — the token rides as a query param because the viewer
+ *  iframe fetches the geometry itself and can't set an Authorization header. */
+export function modelFileUrl(projectId: string, modelId: string): string {
+  const token = getToken();
+  const base = `${API_BASE}/api/projects/${projectId}/models/${modelId}/file`;
+  return token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
 }

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -1,0 +1,47 @@
+import { api } from './api';
+import type { Project, BimIssue, IssueComment } from './types';
+
+export function listProjects(): Promise<Project[]> {
+  return api<Project[]>('/api/projects');
+}
+
+export function getProject(id: string): Promise<Project> {
+  return api<Project>(`/api/projects/${id}`);
+}
+
+export async function listIssues(projectId: string, status?: string): Promise<BimIssue[]> {
+  const qs = status ? `?status=${encodeURIComponent(status)}` : '';
+  // The server may return a flat array or an { items } envelope — handle both.
+  const raw = await api<BimIssue[] | { items: BimIssue[] }>(`/api/projects/${projectId}/issues${qs}`);
+  if (Array.isArray(raw)) return raw;
+  return raw.items ?? [];
+}
+
+export function getIssue(projectId: string, issueId: string): Promise<BimIssue> {
+  return api<BimIssue>(`/api/projects/${projectId}/issues/${issueId}`);
+}
+
+export function createIssue(projectId: string, body: Partial<BimIssue>): Promise<BimIssue> {
+  return api<BimIssue>(`/api/projects/${projectId}/issues`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function updateIssue(projectId: string, issueId: string, body: Partial<BimIssue>): Promise<BimIssue> {
+  return api<BimIssue>(`/api/projects/${projectId}/issues/${issueId}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+}
+
+export function listComments(projectId: string, issueId: string): Promise<IssueComment[]> {
+  return api<IssueComment[]>(`/api/projects/${projectId}/issues/${issueId}/comments`);
+}
+
+export function addComment(projectId: string, issueId: string, body: string): Promise<IssueComment> {
+  return api<IssueComment>(`/api/projects/${projectId}/issues/${issueId}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body }),
+  });
+}

--- a/planscape-web/lib/realtime.ts
+++ b/planscape-web/lib/realtime.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { HubConnectionBuilder, LogLevel } from '@microsoft/signalr';
+import { API_BASE, getToken } from './api';
+
+export type RealtimeHandler = (event: string, payload: unknown) => void;
+
+// NotificationHub events the web app reacts to (mirrors the mobile client).
+const EVENTS = [
+  'IssueCreated',
+  'IssueUpdated',
+  'IssueDeleted',
+  'IssueCommentAdded',
+  'CommentAdded',
+  'ComplianceChanged',
+  'ComplianceSnapshotAdded',
+  'Notification',
+  'ClashUpdated',
+];
+
+/**
+ * Live updates for a project via the NotificationHub. Connects with the bearer
+ * token (SignalR appends it as access_token), joins the project group, and calls
+ * `onEvent(event, payload)` for each relevant broadcast. Best-effort: if the hub
+ * is unreachable the UI still works via manual refresh.
+ */
+export function useProjectRealtime(projectId: string | undefined, onEvent: RealtimeHandler): void {
+  const handlerRef = useRef(onEvent);
+  handlerRef.current = onEvent;
+
+  useEffect(() => {
+    if (!projectId || !getToken()) return;
+
+    const conn = new HubConnectionBuilder()
+      .withUrl(`${API_BASE}/hubs/notifications`, { accessTokenFactory: () => getToken() ?? '' })
+      .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
+      .configureLogging(LogLevel.Warning)
+      .build();
+
+    for (const e of EVENTS) {
+      conn.on(e, (payload: unknown) => handlerRef.current(e, payload));
+    }
+
+    let joined = false;
+    let disposed = false;
+    conn
+      .start()
+      .then(() => conn.invoke('JoinProject', projectId))
+      .then(() => {
+        joined = true;
+      })
+      .catch(() => {
+        /* non-fatal — UI degrades to manual refresh */
+      });
+
+    return () => {
+      disposed = true;
+      void (async () => {
+        try {
+          if (joined) await conn.invoke('LeaveProject').catch(() => {});
+        } finally {
+          await conn.stop().catch(() => {});
+        }
+      })();
+      void disposed;
+    };
+  }, [projectId]);
+}

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -1,0 +1,39 @@
+export interface Project {
+  id: string;
+  code: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  phase?: string;
+  status?: string;
+  compliancePercent?: number;
+  ragStatus?: string;
+  openIssueCount?: number;
+}
+
+export type IssuePriority = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
+export type IssueStatus = 'OPEN' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED';
+
+export interface BimIssue {
+  id: string;
+  code?: string;
+  title: string;
+  description: string;
+  type: string;
+  priority: IssuePriority;
+  status: IssueStatus;
+  assignee: string;
+  assigneeEmail?: string;
+  discipline: string;
+  createdAt: string;
+  dueDate?: string;
+}
+
+export interface IssueComment {
+  id: string;
+  body: string;
+  authorName?: string;
+  authorUserId?: string;
+  source?: string;
+  createdAt: string;
+}

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -37,3 +37,56 @@ export interface IssueComment {
   source?: string;
   createdAt: string;
 }
+
+// ── Clashes ──
+export type ClashSeverity = 'CRITICAL' | 'MAJOR' | 'MINOR';
+export type ClashStatus = 'NEW' | 'ACKNOWLEDGED' | 'RESOLVED' | 'CLOSED';
+
+export interface ClashRecord {
+  id: string;
+  status: ClashStatus;
+  severity: ClashSeverity;
+  discipline?: string;
+  kind?: string;
+  elementAGuid: string;
+  elementAName?: string;
+  elementAType?: string;
+  elementBGuid: string;
+  elementBName?: string;
+  elementBType?: string;
+  centreX: number;
+  centreY: number;
+  centreZ: number;
+  overlapVolumeMm3: number;
+  distanceMm?: number;
+  assignedTo?: string;
+  resolutionNote?: string;
+  issueId?: string;
+  detectedAt?: string;
+}
+
+export interface ClashListResponse {
+  total: number;
+  aggregates?: {
+    byStatus?: Array<{ status: string; count: number }>;
+    bySeverity?: Array<{ severity: string; count: number }>;
+  };
+  items: ClashRecord[];
+}
+
+export interface ClashDetectionResult {
+  scannedPairs?: number;
+  found?: number;
+  created?: number;
+  critical?: number;
+}
+
+// ── Models ──
+export interface ProjectModel {
+  id: string;
+  name: string;
+  discipline?: string;
+  format?: string;
+  revision?: string;
+  uploadedAt?: string;
+}

--- a/planscape-web/next-env.d.ts
+++ b/planscape-web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.
+// Committed (rather than gitignored) so `tsc --noEmit` works in CI without a build first.

--- a/planscape-web/next.config.js
+++ b/planscape-web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/planscape-web/package.json
+++ b/planscape-web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "planscape-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Planscape online BIM coordination — browser app (auth → projects → issues → clashes → 3D viewer → real-time).",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "postcss": "8.4.39",
+    "tailwindcss": "3.4.7",
+    "typescript": "5.5.3"
+  }
+}

--- a/planscape-web/package.json
+++ b/planscape-web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@microsoft/signalr": "8.0.7",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/planscape-web/postcss.config.js
+++ b/planscape-web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/planscape-web/tailwind.config.ts
+++ b/planscape-web/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/planscape-web/tsconfig.json
+++ b/planscape-web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
The browser coordination app — the headline gap from the original review (the rich client was mobile-only). New top-level **`planscape-web/`** (Next.js 14 App Router + TS + Tailwind), built on the existing API. All four planned slices:

### Slice 1 — foundation + auth
`lib/api.ts` (bearer token, 401→/login), `lib/auth.tsx` (login via `/api/auth/login`, token in localStorage), `/login`, session redirects, and a `planscape-web.yml` CI workflow (`tsc --noEmit` + `next build`).

### Slice 2 — projects + issues
`/projects` (cards) · `/projects/[id]` (issue list + status filter) · `/projects/[id]/issues/new` (create) · `/projects/[id]/issues/[issueId]` (detail, optimistic status PUT, comments).

### Slice 3 — clashes + 3D viewer
`/projects/[id]/clashes` (list, status filter, run-detection) · `/clashes/[clashId]` (geometry + elements, status PATCH, promote-to-issue, **View in model**) · `/projects/[id]/viewer` (embeds the existing `viewer.html` via iframe, model picker, drives it with its real `postMessage` bridge — `load` + `selectAndZoom` — deep-linking a clash to its element).

### Slice 4 — real-time
`lib/realtime.ts` `useProjectRealtime` (SignalR NotificationHub, token via `accessTokenFactory`, JoinProject, auto-reconnect). The project page live-refreshes its issue list on `Issue*` events with a **Live** indicator.

## Flow
sign in → projects → issues (create/comment/transition) → clashes (resolve/promote) → 3D model (deep-link) → live updates.

## Caveats
- Built to the API/viewer contracts; the only validation is `planscape-web.yml` (`tsc` + `next build`) — not yet click-tested against a live API.
- Bearer-token auth → API CORS must allow this origin (`app.planscape.build` is allow-listed; add `http://localhost:3000` for dev).
- Viewer embed uses `viewer.html`'s documented postMessage bridge; the load + `selectAndZoom` timing may need a small tweak once run against a deployed API + a published model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL