### PR TITLE
Wire ModelsController → IFC→GLB converter sidecar (#343 follow-up)

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -32,6 +32,7 @@ public class ModelsController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
     private readonly IFileStorageService _storage;
+    private readonly IConverterClient _converter;
     private readonly ILogger<ModelsController> _logger;
 
     // Upload cap — glTF can be large but anything over this is almost certainly
@@ -41,10 +42,12 @@ public class ModelsController : ControllerBase
     public ModelsController(
         PlanscapeDbContext db,
         IFileStorageService storage,
+        IConverterClient converter,
         ILogger<ModelsController> logger)
     {
         _db = db;
         _storage = storage;
+        _converter = converter;
         _logger = logger;
     }
 
@@ -97,21 +100,23 @@ public class ModelsController : ControllerBase
 
         var format = InferFormat(req.File.FileName);
         // #1 (Empty 3D viewer) — the web viewer is GLTFLoader-only
-        // (viewer.html:782) and this endpoint serves the stored bytes verbatim
-        // (no conversion on the publish path; the converter sidecar's handlers
-        // are not yet written). Publishing IFC/RVT/OBJ/FBX therefore produced a
-        // "successful publish" that rendered an empty canvas. Reject non-glTF at
-        // the boundary so successful publish ⇒ viewable. The plugin's primary
-        // path already exports GLB (PublishModelCommand → RevitGltfExporter); to
-        // keep an IFC-first workflow, wire the converter to emit a GLB
-        // derivative and relax this check (also requires Converter__ApiBearer,
-        // finding #5).
-        if (format is not (ModelFormat.Glb or ModelFormat.Gltf))
+        // (viewer.html:782) and this endpoint serves the stored bytes verbatim.
+        // Publishing IFC/RVT/OBJ/FBX would produce a "successful publish" that
+        // renders an empty canvas, so non-glTF is rejected at the boundary —
+        // EXCEPT IFC when a converter sidecar is configured: then the IFC is
+        // stored as the source and a GLB derivative is generated asynchronously
+        // (the sidecar publishes the GLB back as a normal, renderable model).
+        // The plugin's primary path still exports GLB directly
+        // (PublishModelCommand → RevitGltfExporter).
+        bool willConvertIfc = format == ModelFormat.Ifc && _converter.IsConfigured;
+        if (format is not (ModelFormat.Glb or ModelFormat.Gltf) && !willConvertIfc)
             return BadRequest(new
             {
                 error = "unsupported_viewer_format",
                 format = format.ToString(),
-                message = "Only GLB/glTF are renderable by the viewer. Export/convert IFC/RVT/OBJ/FBX to GLB before publishing."
+                message = format == ModelFormat.Ifc
+                    ? "IFC upload needs the converter sidecar configured (Converter:BaseUrl). Export to GLB from Revit, or enable the converter."
+                    : "Only GLB/glTF are renderable by the viewer. Export/convert IFC/RVT/OBJ/FBX to GLB before publishing."
             });
         var project = await _db.Projects.AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id == projectId, ct);
@@ -274,6 +279,23 @@ public class ModelsController : ControllerBase
         }
         _logger.LogInformation("Model uploaded — {ModelId} {Format} {Size} bytes for project {ProjectId}",
             row.Id, row.Format, row.FileSizeBytes, projectId);
+
+        // IFC with a configured converter — kick off async IFC→GLB conversion.
+        // The IFC is retained as the source row; the sidecar publishes the
+        // renderable GLB back through this same endpoint as a separate model.
+        if (willConvertIfc)
+        {
+            Hangfire.BackgroundJob.Enqueue<Planscape.Infrastructure.Services.IfcToGlbConversionJob>(
+                j => j.ExecuteAsync(row.Id, CancellationToken.None));
+            _logger.LogInformation("Queued IFC→GLB conversion for model {ModelId}", row.Id);
+            return Accepted(new
+            {
+                id = row.Id,
+                format = row.Format.ToString(),
+                converting = true,
+                message = "IFC stored. A renderable GLB derivative is being generated and will appear as a separate model shortly."
+            });
+        }
 
         return CreatedAtAction(nameof(Get), new { projectId, modelId = row.Id }, ToMetaDto(row));
     }

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -292,6 +292,10 @@ else
 {
     builder.Services.AddScoped<Planscape.Core.Interfaces.IFileStorageService, Planscape.Infrastructure.Storage.LocalFileStorageService>();
 }
+// #4 follow-up — IFC→GLB converter sidecar client + conversion job. No-ops
+// gracefully when Converter:BaseUrl is unset (IsConfigured == false).
+builder.Services.AddScoped<Planscape.Core.Interfaces.IConverterClient, Planscape.Infrastructure.Services.ConverterClient>();
+builder.Services.AddScoped<Planscape.Infrastructure.Services.IfcToGlbConversionJob>();
 // Phase 175 audit P1-15-tx — atomic per-key counter (transmittals,
 // future RFIs / NCRs). Scoped because it shares the request DbContext.
 builder.Services.AddScoped<Planscape.Infrastructure.Services.ISequenceCounterService,

--- a/Planscape.Server/src/Planscape.Core/Interfaces/IConverterClient.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/IConverterClient.cs
@@ -3,9 +3,16 @@ namespace Planscape.Core.Interfaces;
 /// <summary>
 /// Thin client for the converter sidecar (Planscape.Server/src/converter-sidecar).
 /// The sidecar exposes <c>POST /ifc-to-glb</c> which pulls the IFC from a
-/// presigned <c>sourceUrl</c>, runs IfcConvert, and publishes the GLB back via
-/// <c>POST /api/projects/{id}/models</c> (so the GLB lands as a normal,
-/// renderable ProjectModel — no extra controller work on the callback).
+/// presigned <c>sourceUrl</c>, runs IfcConvert, and STREAMS the GLB back in the
+/// response body (with an <c>X-Glb-Sha256</c> + <c>X-Glb-Bytes</c> header).
+///
+/// The caller (IfcToGlbConversionJob) then stores the GLB itself via
+/// <see cref="IFileStorageService.SaveScopedAsync"/> and creates the
+/// ProjectModel row with correct tenancy — so the sidecar needs NO callback
+/// into the authed API and NO shared platform bearer with cross-tenant project
+/// access. This is the sustainable shape: one credential surface, correct
+/// tenant attribution, and the GLB bytes never transit the API web process
+/// (the conversion job runs on the worker).
 ///
 /// Configured via <c>Converter:BaseUrl</c> + <c>Converter:Token</c> (env
 /// <c>Converter__BaseUrl</c> / <c>Converter__Token</c>). When unset,
@@ -18,12 +25,36 @@ public interface IConverterClient
 
     /// <summary>
     /// Ask the sidecar to convert an IFC (fetchable at <paramref name="sourceUrl"/>)
-    /// to GLB and publish it to the given project. Returns the sidecar's result
-    /// (ok + optional new GLB model id) — never throws for an HTTP error, so a
-    /// failed conversion doesn't crash the enqueuing job.
+    /// to GLB and stream it back. The returned <see cref="ConverterGlbResult"/>
+    /// owns the open response — the caller MUST dispose it. Never throws for an
+    /// HTTP/transport error; failures surface via <see cref="ConverterGlbResult.Success"/>.
     /// </summary>
-    Task<ConverterResult> ConvertIfcToGlbAsync(
-        string sourceUrl, Guid projectId, string fileName, string? discipline, CancellationToken ct = default);
+    Task<ConverterGlbResult> ConvertIfcToGlbAsync(
+        string sourceUrl, string fileName, string? discipline, CancellationToken ct = default);
 }
 
-public record ConverterResult(bool Success, Guid? GlbModelId = null, string? Error = null);
+/// <summary>
+/// Result of an IFC→GLB conversion. Holds the open GLB response stream when
+/// <see cref="Success"/>; dispose to release the underlying HTTP response.
+/// </summary>
+public sealed class ConverterGlbResult : IDisposable
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+
+    /// <summary>The GLB bytes (only when <see cref="Success"/>). Read once, then dispose.</summary>
+    public Stream? Glb { get; init; }
+    /// <summary>SHA-256 of the GLB (hex), supplied by the sidecar so the caller hashes in zero passes.</summary>
+    public string? Sha256 { get; init; }
+    /// <summary>GLB size in bytes.</summary>
+    public long Bytes { get; init; }
+
+    private IDisposable? _owner;
+
+    public static ConverterGlbResult Fail(string error) => new() { Success = false, Error = error };
+
+    public static ConverterGlbResult Ok(Stream glb, string? sha256, long bytes, IDisposable owner) =>
+        new() { Success = true, Glb = glb, Sha256 = sha256, Bytes = bytes, _owner = owner };
+
+    public void Dispose() => _owner?.Dispose();
+}

--- a/Planscape.Server/src/Planscape.Core/Interfaces/IConverterClient.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/IConverterClient.cs
@@ -1,0 +1,29 @@
+namespace Planscape.Core.Interfaces;
+
+/// <summary>
+/// Thin client for the converter sidecar (Planscape.Server/src/converter-sidecar).
+/// The sidecar exposes <c>POST /ifc-to-glb</c> which pulls the IFC from a
+/// presigned <c>sourceUrl</c>, runs IfcConvert, and publishes the GLB back via
+/// <c>POST /api/projects/{id}/models</c> (so the GLB lands as a normal,
+/// renderable ProjectModel — no extra controller work on the callback).
+///
+/// Configured via <c>Converter:BaseUrl</c> + <c>Converter:Token</c> (env
+/// <c>Converter__BaseUrl</c> / <c>Converter__Token</c>). When unset,
+/// <see cref="IsConfigured"/> is false and callers skip conversion gracefully.
+/// </summary>
+public interface IConverterClient
+{
+    /// <summary>True when Converter:BaseUrl is configured.</summary>
+    bool IsConfigured { get; }
+
+    /// <summary>
+    /// Ask the sidecar to convert an IFC (fetchable at <paramref name="sourceUrl"/>)
+    /// to GLB and publish it to the given project. Returns the sidecar's result
+    /// (ok + optional new GLB model id) — never throws for an HTTP error, so a
+    /// failed conversion doesn't crash the enqueuing job.
+    /// </summary>
+    Task<ConverterResult> ConvertIfcToGlbAsync(
+        string sourceUrl, Guid projectId, string fileName, string? discipline, CancellationToken ct = default);
+}
+
+public record ConverterResult(bool Success, Guid? GlbModelId = null, string? Error = null);

--- a/Planscape.Server/src/Planscape.Core/Interfaces/IFileStorageService.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/IFileStorageService.cs
@@ -70,6 +70,19 @@ public interface IFileStorageService
         string objectKey, string contentType, TimeSpan validFor, long maxBytes, CancellationToken ct = default);
 
     /// <summary>
+    /// Generate a short-lived presigned GET URL for an object so an external,
+    /// unauthenticated worker can pull the bytes directly (no API proxy, no
+    /// bearer). Used by the IFC→GLB converter sidecar, which fetches its
+    /// <c>sourceUrl</c> with a plain GET. Background jobs run without a tenant
+    /// context, so they pass <paramref name="bypassTenantCheck"/>.
+    /// Throws <see cref="NotSupportedException"/> on backends that can't
+    /// presign (local filesystem in dev) — callers must handle that and skip
+    /// conversion rather than crash.
+    /// </summary>
+    Task<string> GetPresignedGetUrlAsync(
+        string objectKey, TimeSpan validFor, CancellationToken ct = default, bool bypassTenantCheck = false);
+
+    /// <summary>
     /// Move (server-side copy + delete) an object from one key to
     /// another inside the same bucket. Used by the ClamAV scanner
     /// to promote <c>uploads/raw/...</c> → <c>safe/...</c> after the

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ConverterClient.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ConverterClient.cs
@@ -1,0 +1,85 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using Planscape.Core.Interfaces;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// Default <see cref="IConverterClient"/> — talks to the converter sidecar's
+/// <c>POST /ifc-to-glb</c> endpoint over HTTP. See <see cref="IConverterClient"/>
+/// for the contract; this implementation reads <c>Converter:BaseUrl</c> /
+/// <c>Converter:Token</c> from config and posts the JSON the sidecar expects
+/// (<c>{ sourceUrl, projectId, fileName, discipline }</c> + <c>x-converter-token</c>).
+///
+/// CAVEAT: built to the sidecar contract but not yet exercised against a
+/// deployed sidecar. The sidecar publishes the GLB back through the authed
+/// models endpoint using its own <c>API_BEARER</c>, so that token must belong
+/// to a user with Admin/Owner/Coordinator role + project access (set at deploy).
+/// </summary>
+public class ConverterClient : IConverterClient
+{
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly IConfiguration _config;
+    private readonly ILogger<ConverterClient> _logger;
+
+    public ConverterClient(IHttpClientFactory httpFactory, IConfiguration config, ILogger<ConverterClient> logger)
+    {
+        _httpFactory = httpFactory;
+        _config = config;
+        _logger = logger;
+    }
+
+    private string BaseUrl => (_config["Converter:BaseUrl"] ?? "").TrimEnd('/');
+    private string Token   => _config["Converter:Token"] ?? "";
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(BaseUrl);
+
+    public async Task<ConverterResult> ConvertIfcToGlbAsync(
+        string sourceUrl, Guid projectId, string fileName, string? discipline, CancellationToken ct = default)
+    {
+        if (!IsConfigured)
+            return new ConverterResult(false, Error: "Converter:BaseUrl not configured.");
+
+        var body = new JObject
+        {
+            ["sourceUrl"] = sourceUrl,
+            ["projectId"] = projectId.ToString(),
+            ["fileName"] = fileName,
+            ["discipline"] = discipline ?? "",
+        };
+
+        try
+        {
+            var http = _httpFactory.CreateClient();
+            http.Timeout = TimeSpan.FromMinutes(10); // IfcConvert on a large model is slow
+            using var req = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/ifc-to-glb")
+            {
+                Content = new StringContent(body.ToString(), Encoding.UTF8, "application/json")
+            };
+            if (!string.IsNullOrWhiteSpace(Token))
+                req.Headers.TryAddWithoutValidation("x-converter-token", Token);
+
+            var resp = await http.SendAsync(req, ct);
+            string respBody = await resp.Content.ReadAsStringAsync(ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("ConverterClient /ifc-to-glb HTTP {Status}: {Body}", (int)resp.StatusCode, Trim(respBody));
+                return new ConverterResult(false, Error: $"converter HTTP {(int)resp.StatusCode}");
+            }
+
+            var j = JObject.Parse(respBody);
+            Guid? modelId = Guid.TryParse((string?)j["modelId"], out var g) ? g : null;
+            return new ConverterResult(true, modelId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "ConverterClient /ifc-to-glb failed");
+            return new ConverterResult(false, Error: ex.Message);
+        }
+    }
+
+    private static string Trim(string s) => string.IsNullOrEmpty(s) ? "" : (s.Length > 300 ? s.Substring(0, 300) : s);
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ConverterClient.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ConverterClient.cs
@@ -9,15 +9,19 @@ namespace Planscape.Infrastructure.Services;
 
 /// <summary>
 /// Default <see cref="IConverterClient"/> — talks to the converter sidecar's
-/// <c>POST /ifc-to-glb</c> endpoint over HTTP. See <see cref="IConverterClient"/>
-/// for the contract; this implementation reads <c>Converter:BaseUrl</c> /
-/// <c>Converter:Token</c> from config and posts the JSON the sidecar expects
-/// (<c>{ sourceUrl, projectId, fileName, discipline }</c> + <c>x-converter-token</c>).
+/// <c>POST /ifc-to-glb</c> endpoint over HTTP and streams the GLB back. See
+/// <see cref="IConverterClient"/> for the contract; this implementation reads
+/// <c>Converter:BaseUrl</c> / <c>Converter:Token</c> from config and posts the
+/// JSON the sidecar expects (<c>{ sourceUrl, fileName, discipline }</c> +
+/// <c>x-converter-token</c>).
+///
+/// Uses <see cref="HttpCompletionOption.ResponseHeadersRead"/> so the GLB body
+/// is NOT buffered in memory — the caller streams it straight to storage. The
+/// SHA-256 + byte-count come back as response headers so the caller never has
+/// to re-read the stream to hash it.
 ///
 /// CAVEAT: built to the sidecar contract but not yet exercised against a
-/// deployed sidecar. The sidecar publishes the GLB back through the authed
-/// models endpoint using its own <c>API_BEARER</c>, so that token must belong
-/// to a user with Admin/Owner/Coordinator role + project access (set at deploy).
+/// deployed sidecar.
 /// </summary>
 public class ConverterClient : IConverterClient
 {
@@ -37,49 +41,65 @@ public class ConverterClient : IConverterClient
 
     public bool IsConfigured => !string.IsNullOrWhiteSpace(BaseUrl);
 
-    public async Task<ConverterResult> ConvertIfcToGlbAsync(
-        string sourceUrl, Guid projectId, string fileName, string? discipline, CancellationToken ct = default)
+    public async Task<ConverterGlbResult> ConvertIfcToGlbAsync(
+        string sourceUrl, string fileName, string? discipline, CancellationToken ct = default)
     {
         if (!IsConfigured)
-            return new ConverterResult(false, Error: "Converter:BaseUrl not configured.");
+            return ConverterGlbResult.Fail("Converter:BaseUrl not configured.");
 
         var body = new JObject
         {
             ["sourceUrl"] = sourceUrl,
-            ["projectId"] = projectId.ToString(),
             ["fileName"] = fileName,
             ["discipline"] = discipline ?? "",
         };
 
+        HttpResponseMessage? resp = null;
         try
         {
             var http = _httpFactory.CreateClient();
             http.Timeout = TimeSpan.FromMinutes(10); // IfcConvert on a large model is slow
-            using var req = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/ifc-to-glb")
+            var req = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/ifc-to-glb")
             {
                 Content = new StringContent(body.ToString(), Encoding.UTF8, "application/json")
             };
             if (!string.IsNullOrWhiteSpace(Token))
                 req.Headers.TryAddWithoutValidation("x-converter-token", Token);
 
-            var resp = await http.SendAsync(req, ct);
-            string respBody = await resp.Content.ReadAsStringAsync(ct);
+            // ResponseHeadersRead — get headers (incl. the hash) without buffering the GLB body.
+            resp = await http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
             if (!resp.IsSuccessStatusCode)
             {
-                _logger.LogWarning("ConverterClient /ifc-to-glb HTTP {Status}: {Body}", (int)resp.StatusCode, Trim(respBody));
-                return new ConverterResult(false, Error: $"converter HTTP {(int)resp.StatusCode}");
+                string err = await SafeReadAsync(resp, ct);
+                _logger.LogWarning("ConverterClient /ifc-to-glb HTTP {Status}: {Body}", (int)resp.StatusCode, err);
+                resp.Dispose();
+                return ConverterGlbResult.Fail($"converter HTTP {(int)resp.StatusCode}");
             }
 
-            var j = JObject.Parse(respBody);
-            Guid? modelId = Guid.TryParse((string?)j["modelId"], out var g) ? g : null;
-            return new ConverterResult(true, modelId);
+            string? sha = FirstHeader(resp, "X-Glb-Sha256");
+            long bytes = long.TryParse(FirstHeader(resp, "X-Glb-Bytes"), out var b) ? b : 0;
+            var stream = await resp.Content.ReadAsStreamAsync(ct);
+            // Hand ownership of the response (and thus the stream) to the result.
+            return ConverterGlbResult.Ok(stream, sha, bytes, resp);
         }
         catch (Exception ex)
         {
+            resp?.Dispose();
             _logger.LogWarning(ex, "ConverterClient /ifc-to-glb failed");
-            return new ConverterResult(false, Error: ex.Message);
+            return ConverterGlbResult.Fail(ex.Message);
         }
     }
 
-    private static string Trim(string s) => string.IsNullOrEmpty(s) ? "" : (s.Length > 300 ? s.Substring(0, 300) : s);
+    private static string? FirstHeader(HttpResponseMessage resp, string name)
+    {
+        if (resp.Headers.TryGetValues(name, out var v)) return v.FirstOrDefault();
+        if (resp.Content.Headers.TryGetValues(name, out var cv)) return cv.FirstOrDefault();
+        return null;
+    }
+
+    private static async Task<string> SafeReadAsync(HttpResponseMessage resp, CancellationToken ct)
+    {
+        try { var s = await resp.Content.ReadAsStringAsync(ct); return s.Length > 300 ? s.Substring(0, 300) : s; }
+        catch { return ""; }
+    }
 }

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
@@ -12,19 +12,23 @@ namespace Planscape.Infrastructure.Services;
 /// IFC is uploaded and a converter is configured.
 ///
 /// Flow: load the IFC row → presign a short-lived GET URL for its bytes →
-/// hand that URL to the sidecar (<see cref="IConverterClient.ConvertIfcToGlbAsync"/>),
-/// which downloads, runs IfcConvert, and POSTs the GLB back to the models
-/// endpoint as a normal (renderable) ProjectModel.
+/// ask the sidecar to convert + STREAM the GLB back → store that GLB ourselves
+/// (<see cref="IFileStorageService.SaveScopedAsync"/>) and insert a new
+/// renderable ProjectModel row with the SAME tenant/project as the source IFC.
+///
+/// Why we store it here rather than letting the sidecar POST it back to the
+/// authed /models endpoint: a single shared platform bearer would need
+/// Admin/Owner/Coordinator + project membership across EVERY tenant, which is
+/// fragile and over-privileged. Storing in the job keeps one credential surface,
+/// attributes the derivative to the right tenant, and keeps the GLB bytes off
+/// the API web process (this job runs on the "heavy" worker queue).
 ///
 /// Runs without a tenant context (Hangfire), so it bypasses the tenant filter
-/// for the lookup and the tenant-prefix check for the presign. The IFC row's
-/// own TenantId/ProjectId are used verbatim — no cross-tenant leakage because
-/// the job is only ever enqueued with a freshly-inserted row's id.
+/// for the lookup, the tenant-prefix check for the presign, and stamps TenantId
+/// explicitly on the new row. Best-effort — a sidecar error is logged, never
+/// thrown, so a failed convert leaves the IFC stored (and re-uploadable).
 ///
-/// CAVEAT: not yet exercised against a deployed sidecar. Conversion is
-/// best-effort — a sidecar error is logged + stamped on the row, never thrown,
-/// so a failed convert leaves the IFC stored (and re-uploadable) rather than
-/// erroring the user's upload.
+/// CAVEAT: not yet exercised against a deployed sidecar.
 /// </summary>
 public class IfcToGlbConversionJob
 {
@@ -92,15 +96,83 @@ public class IfcToGlbConversionJob
             return;
         }
 
-        var result = await _converter.ConvertIfcToGlbAsync(
-            sourceUrl, ifc.ProjectId, ifc.FileName, ifc.Discipline, ct);
-
-        if (result.Success)
-            _logger.LogInformation(
-                "IfcToGlbConversionJob: converted IFC {ModelId} → GLB {GlbId} for project {ProjectId}",
-                modelId, result.GlbModelId, ifc.ProjectId);
-        else
+        using var result = await _converter.ConvertIfcToGlbAsync(sourceUrl, ifc.FileName, ifc.Discipline, ct);
+        if (!result.Success || result.Glb == null)
+        {
             _logger.LogWarning(
                 "IfcToGlbConversionJob: conversion of IFC {ModelId} failed: {Error}", modelId, result.Error);
+            return;
+        }
+
+        // Dedup on the GLB hash (sidecar supplies it before we read the body) so a
+        // re-run doesn't pile up identical derivatives.
+        if (!string.IsNullOrEmpty(result.Sha256))
+        {
+            bool exists = await _db.ProjectModels.AnyAsync(
+                m => m.TenantId == ifc.TenantId && m.ProjectId == ifc.ProjectId
+                  && m.ContentHash == result.Sha256 && m.DeletedAt == null, ct);
+            if (exists)
+            {
+                _logger.LogInformation(
+                    "IfcToGlbConversionJob: GLB for IFC {ModelId} already exists (hash {Hash}); skipping", modelId, result.Sha256);
+                return;
+            }
+        }
+
+        var glbName = Path.GetFileNameWithoutExtension(ifc.FileName) + ".glb";
+
+        // Spool the (non-seekable, unknown-length) HTTP stream to a temp file so
+        // the S3 SDK gets a seekable stream with a known Content-Length — and so
+        // we don't hold the whole GLB in RAM. Then store + record the real size.
+        string tmp = Path.Combine(Path.GetTempPath(), $"sting-ifc-glb-{Guid.NewGuid():N}.glb");
+        string key;
+        long sizeBytes;
+        try
+        {
+            await using (var tmpWrite = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+                await result.Glb.CopyToAsync(tmpWrite, ct);
+            sizeBytes = new FileInfo(tmp).Length;
+
+            await using var tmpRead = new FileStream(tmp, FileMode.Open, FileAccess.Read, FileShare.Read);
+            key = await _storage.SaveScopedAsync(ifc.TenantId, ifc.ProjectId, glbName, tmpRead, ct);
+        }
+        finally
+        {
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort temp cleanup */ }
+        }
+
+        var row = new ProjectModel
+        {
+            TenantId = ifc.TenantId,
+            ProjectId = ifc.ProjectId,
+            Name = string.IsNullOrWhiteSpace(ifc.Name) ? Path.GetFileNameWithoutExtension(glbName) : ifc.Name,
+            Description = $"Converted from IFC {ifc.FileName}",
+            Discipline = ifc.Discipline,
+            FileName = glbName,
+            Format = ModelFormat.Glb,
+            StoragePath = key,
+            ContentHash = result.Sha256,
+            FileSizeBytes = sizeBytes > 0 ? sizeBytes : result.Bytes,
+            Units = string.IsNullOrWhiteSpace(ifc.Units) ? "mm" : ifc.Units,
+            Revision = ifc.Revision,
+            UploadedBy = "IFC→GLB converter",
+            UploadedAt = DateTime.UtcNow,
+        };
+        _db.ProjectModels.Add(row);
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+            _logger.LogInformation(
+                "IfcToGlbConversionJob: converted IFC {ModelId} → GLB {GlbId} ({Bytes} bytes) for project {ProjectId}",
+                modelId, row.Id, row.FileSizeBytes, ifc.ProjectId);
+        }
+        catch (DbUpdateException)
+        {
+            // A concurrent conversion won the unique (TenantId, ProjectId, ContentHash)
+            // index — the derivative already exists, so this run is a no-op.
+            _db.Entry(row).State = EntityState.Detached;
+            _logger.LogInformation(
+                "IfcToGlbConversionJob: GLB for IFC {ModelId} inserted concurrently; skipping", modelId);
+        }
     }
 }

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
@@ -48,6 +48,10 @@ public class IfcToGlbConversionJob
         _logger = logger;
     }
 
+    // "heavy" queue is worker-only (see Program.cs Hangfire server config) — keep
+    // the up-to-10-min IfcConvert round-trip off the API's 2 default-queue workers
+    // so it can't starve compliance / notification / platform-sync jobs.
+    [Hangfire.Queue("heavy")]
     [Hangfire.AutomaticRetry(Attempts = 2, OnAttemptsExceeded = Hangfire.AttemptsExceededAction.Delete)]
     public async Task ExecuteAsync(Guid modelId, CancellationToken ct = default)
     {
@@ -68,6 +72,11 @@ public class IfcToGlbConversionJob
         if (ifc.Format != ModelFormat.Ifc)
         {
             _logger.LogInformation("IfcToGlbConversionJob: model {ModelId} is {Format}, not IFC; skipping", modelId, ifc.Format);
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(ifc.StoragePath))
+        {
+            _logger.LogWarning("IfcToGlbConversionJob: model {ModelId} has no StoragePath; skipping", modelId);
             return;
         }
 

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// Background job that converts a stored IFC ProjectModel into a renderable GLB
+/// derivative via the converter sidecar. Enqueued by ModelsController when an
+/// IFC is uploaded and a converter is configured.
+///
+/// Flow: load the IFC row → presign a short-lived GET URL for its bytes →
+/// hand that URL to the sidecar (<see cref="IConverterClient.ConvertIfcToGlbAsync"/>),
+/// which downloads, runs IfcConvert, and POSTs the GLB back to the models
+/// endpoint as a normal (renderable) ProjectModel.
+///
+/// Runs without a tenant context (Hangfire), so it bypasses the tenant filter
+/// for the lookup and the tenant-prefix check for the presign. The IFC row's
+/// own TenantId/ProjectId are used verbatim — no cross-tenant leakage because
+/// the job is only ever enqueued with a freshly-inserted row's id.
+///
+/// CAVEAT: not yet exercised against a deployed sidecar. Conversion is
+/// best-effort — a sidecar error is logged + stamped on the row, never thrown,
+/// so a failed convert leaves the IFC stored (and re-uploadable) rather than
+/// erroring the user's upload.
+/// </summary>
+public class IfcToGlbConversionJob
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly IFileStorageService _storage;
+    private readonly IConverterClient _converter;
+    private readonly ILogger<IfcToGlbConversionJob> _logger;
+
+    // Long enough for the sidecar to finish a big IfcConvert before the URL dies.
+    private static readonly TimeSpan SourceUrlTtl = TimeSpan.FromMinutes(30);
+
+    public IfcToGlbConversionJob(
+        PlanscapeDbContext db,
+        IFileStorageService storage,
+        IConverterClient converter,
+        ILogger<IfcToGlbConversionJob> logger)
+    {
+        _db = db;
+        _storage = storage;
+        _converter = converter;
+        _logger = logger;
+    }
+
+    [Hangfire.AutomaticRetry(Attempts = 2, OnAttemptsExceeded = Hangfire.AttemptsExceededAction.Delete)]
+    public async Task ExecuteAsync(Guid modelId, CancellationToken ct = default)
+    {
+        if (!_converter.IsConfigured)
+        {
+            _logger.LogInformation("IfcToGlbConversionJob: converter not configured; skipping {ModelId}", modelId);
+            return;
+        }
+
+        _db.BypassTenantFilter = true;
+        var ifc = await _db.ProjectModels
+            .FirstOrDefaultAsync(m => m.Id == modelId && m.DeletedAt == null, ct);
+        if (ifc == null)
+        {
+            _logger.LogWarning("IfcToGlbConversionJob: model {ModelId} not found", modelId);
+            return;
+        }
+        if (ifc.Format != ModelFormat.Ifc)
+        {
+            _logger.LogInformation("IfcToGlbConversionJob: model {ModelId} is {Format}, not IFC; skipping", modelId, ifc.Format);
+            return;
+        }
+
+        string sourceUrl;
+        try
+        {
+            sourceUrl = await _storage.GetPresignedGetUrlAsync(ifc.StoragePath, SourceUrlTtl, ct, bypassTenantCheck: true);
+        }
+        catch (NotSupportedException)
+        {
+            _logger.LogWarning(
+                "IfcToGlbConversionJob: storage backend can't presign (local FS dev?); cannot convert {ModelId}", modelId);
+            return;
+        }
+
+        var result = await _converter.ConvertIfcToGlbAsync(
+            sourceUrl, ifc.ProjectId, ifc.FileName, ifc.Discipline, ct);
+
+        if (result.Success)
+            _logger.LogInformation(
+                "IfcToGlbConversionJob: converted IFC {ModelId} → GLB {GlbId} for project {ProjectId}",
+                modelId, result.GlbModelId, ifc.ProjectId);
+        else
+            _logger.LogWarning(
+                "IfcToGlbConversionJob: conversion of IFC {ModelId} failed: {Error}", modelId, result.Error);
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Storage/LocalFileStorageService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Storage/LocalFileStorageService.cs
@@ -115,6 +115,16 @@ public class LocalFileStorageService : IFileStorageService
             "LocalFileStorageService cannot generate presigned URLs. Use S3 storage in production or POST the bytes through the API.");
 
     /// <summary>
+    /// Local filesystem can't presign — the converter sidecar runs in another
+    /// container and can't read this volume. Callers catch this and skip
+    /// IFC→GLB conversion in dev (S3/MinIO is required for the sidecar path).
+    /// </summary>
+    public Task<string> GetPresignedGetUrlAsync(
+        string objectKey, TimeSpan validFor, CancellationToken ct = default, bool bypassTenantCheck = false)
+        => throw new NotSupportedException(
+            "LocalFileStorageService cannot generate presigned URLs. Use S3/MinIO storage for the IFC→GLB converter path.");
+
+    /// <summary>
     /// Phase 175 — server-side move via filesystem rename.
     /// </summary>
     public Task MoveAsync(string sourceKey, string destKey, CancellationToken ct = default, bool bypassTenantCheck = false)

--- a/Planscape.Server/src/Planscape.Infrastructure/Storage/S3FileStorageService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Storage/S3FileStorageService.cs
@@ -250,6 +250,26 @@ public class S3FileStorageService : IFileStorageService, IAsyncDisposable
     }
 
     /// <summary>
+    /// Presigned GET so the converter sidecar (or any external worker) can pull
+    /// an object's bytes directly. Mirror of <see cref="GetPresignedPutUrlAsync"/>
+    /// with <c>Verb = GET</c>; no headers to pin on a download.
+    /// </summary>
+    public Task<string> GetPresignedGetUrlAsync(
+        string objectKey, TimeSpan validFor, CancellationToken ct = default, bool bypassTenantCheck = false)
+    {
+        EnforceTenantOwnership(objectKey, bypassTenantCheck);
+
+        var req = new GetPreSignedUrlRequest
+        {
+            BucketName = _bucket,
+            Key = objectKey,
+            Verb = HttpVerb.GET,
+            Expires = DateTime.UtcNow.Add(validFor),
+        };
+        return Task.FromResult(_s3.GetPreSignedURL(req));
+    }
+
+    /// <summary>
     /// Phase 175 — server-side copy + delete inside the same bucket.
     /// Used to promote uploads/raw/... → safe/... after AV scan.
     /// </summary>

--- a/Planscape.Server/src/converter-sidecar/server.js
+++ b/Planscape.Server/src/converter-sidecar/server.js
@@ -50,9 +50,12 @@ app.post('/ifc-to-glb', async (req, res) => {
   if (CONVERTER_TOKEN && req.headers['x-converter-token'] !== CONVERTER_TOKEN) {
     return res.status(401).json({ error: 'unauthorised' });
   }
-  const { sourceUrl, projectId, fileName, discipline } = req.body || {};
-  if (!sourceUrl || !projectId) {
-    return res.status(400).json({ error: 'sourceUrl and projectId are required' });
+  // The caller stores the GLB itself, so we only need the source IFC URL +
+  // an output name. (projectId/tenantId are no longer needed here — they were
+  // for the retired POST-back-to-/models path.)
+  const { sourceUrl, fileName, discipline } = req.body || {};
+  if (!sourceUrl) {
+    return res.status(400).json({ error: 'sourceUrl is required' });
   }
 
   const work = await mkdtemp(path.join(os.tmpdir(), 'ifc-'));
@@ -81,20 +84,21 @@ app.post('/ifc-to-glb', async (req, res) => {
       });
     }
 
-    // 3. Publish the GLB as a renderable ProjectModel.
+    // 3. Stream the GLB back to the caller (the API's IfcToGlbConversionJob),
+    //    which stores it with correct tenancy and creates the ProjectModel row.
+    //    We deliberately do NOT POST back into the authed /models endpoint: that
+    //    would require a single shared platform bearer with Admin/Owner/Coordinator
+    //    + project access across every tenant. SHA-256 + byte count ride in
+    //    headers so the API hashes in zero extra passes.
     const glb = await readFile(outPath);
-    const fd = new FormData();
-    fd.append('File', new Blob([glb], { type: 'model/gltf-binary' }), outName);
-    fd.append('Name', outName);
-    if (discipline) fd.append('Discipline', discipline);
-    const pubResp = await fetch(`${API_BASE}/api/projects/${projectId}/models`, {
-      method: 'POST',
-      headers: API_BEARER ? { Authorization: `Bearer ${API_BEARER}` } : {},
-      body: fd,
+    const sha = crypto.createHash('sha256').update(glb).digest('hex');
+    res.set({
+      'Content-Type': 'model/gltf-binary',
+      'X-Glb-Sha256': sha,
+      'X-Glb-Bytes': String(glb.length),
+      'X-Glb-Name': outName,
     });
-    if (!pubResp.ok) throw new Error(`publish failed: HTTP ${pubResp.status} ${await pubResp.text()}`);
-    const row = await pubResp.json();
-    res.json({ ok: true, modelId: row.id ?? row.modelId ?? null, name: outName, glbBytes: glb.length });
+    res.send(glb);
   } catch (err) {
     console.error('ifc-to-glb failed', err);
     res.status(500).json({ error: String(err) });

--- a/render.yaml
+++ b/render.yaml
@@ -71,6 +71,18 @@ services:
       - key: Acc__CallbackUrl
         value: https://api.planscape.build/api/acc/oauth/callback
 
+      # ── Converter sidecar (IFC→GLB) — optional ──
+      # Set Converter__BaseUrl to the deployed converter-sidecar URL to enable
+      # server-side IFC→GLB conversion on model upload. When unset, IFC uploads
+      # are rejected with a "convert to GLB first" message (no behaviour change).
+      # Converter__Token must match the sidecar's CONVERTER_TOKEN. The sidecar
+      # also needs API_BASE (this API) + API_BEARER (an Admin/Owner/Coordinator
+      # token with project access) to publish the GLB back.
+      - key: Converter__BaseUrl
+        sync: false
+      - key: Converter__Token
+        sync: false
+
       # ── CORS — web dashboard / app origins ──
       - key: Cors__Origins__0
         value: https://planscape.build

--- a/render.yaml
+++ b/render.yaml
@@ -75,9 +75,10 @@ services:
       # Set Converter__BaseUrl to the deployed converter-sidecar URL to enable
       # server-side IFC→GLB conversion on model upload. When unset, IFC uploads
       # are rejected with a "convert to GLB first" message (no behaviour change).
-      # Converter__Token must match the sidecar's CONVERTER_TOKEN. The sidecar
-      # also needs API_BASE (this API) + API_BEARER (an Admin/Owner/Coordinator
-      # token with project access) to publish the GLB back.
+      # Converter__Token must match the sidecar's CONVERTER_TOKEN. The /ifc-to-glb
+      # path streams the GLB back to the API (which stores it with correct
+      # tenancy) — it needs NO API_BEARER. (The separate /chunk path still uses
+      # the sidecar's own API_BASE/API_BEARER env.)
       - key: Converter__BaseUrl
         sync: false
       - key: Converter__Token


### PR DESCRIPTION
## What

Closes the follow-up PR #343 deferred: make `ModelsController` **accept IFC uploads** and generate a renderable **GLB derivative** via the converter sidecar, instead of rejecting every non-glTF format at the boundary.

## Flow (sustainable, single-credential)

1. Client uploads `.ifc` → `ModelsController.Upload`
2. If `Converter:BaseUrl` is configured: store the IFC as the source row, enqueue `IfcToGlbConversionJob` (on the **heavy/worker** queue), return **202 Accepted**
3. Job presigns a short-lived **GET** for the IFC bytes → calls the sidecar's `/ifc-to-glb`
4. Sidecar downloads, runs **IfcConvert**, and **streams the GLB back** in the response body with `X-Glb-Sha256` + `X-Glb-Bytes` headers
5. Job stores the GLB itself via `SaveScopedAsync` with the **source IFC's tenant/project**, dedups on the supplied SHA-256, and inserts the renderable GLB row

When `Converter:BaseUrl` is **unset**, IFC keeps its clear "convert to GLB first" rejection — **zero behaviour change** on existing deployments.

## Why the sidecar streams back (vs. POSTing to /models)

The original idea had the sidecar publish the GLB through the authed `/models` endpoint using one shared `API_BEARER` — which would need Admin/Owner/Coordinator **and** project membership across **every** tenant (fragile + over-privileged). Instead the sidecar streams the GLB to the job, which already has correct DB + storage access. Result: **one credential surface, correct tenant attribution, and GLB bytes never transit the API web process** (the job runs on the worker).

## Changes

- **`IFileStorageService.GetPresignedGetUrlAsync`** — the missing seam (sidecar fetches `sourceUrl` unauthenticated). S3/MinIO presigns; local-FS throws `NotSupported` and the job skips gracefully.
- **`IConverterClient` / `ConverterClient`** — POST `{sourceUrl, fileName, discipline}` + `x-converter-token`; returns a disposable `ConverterGlbResult` (open GLB stream + hash + size) via `ResponseHeadersRead` (no buffering). `IsConfigured == false` ⇒ no-op; never throws.
- **`IfcToGlbConversionJob`** (Hangfire, `[Queue("heavy")]`, `BypassTenantFilter`) — presign → convert → spool to temp (seekable stream + known length for the S3 SDK; no 500 MB in RAM) → `SaveScopedAsync` → insert row. Dedups on SHA-256; handles the unique-index race.
- **`ModelsController`** — inject `IConverterClient`, allow IFC through when configured, enqueue + 202.
- **converter-sidecar `server.js`** — `/ifc-to-glb` streams the GLB back with hash headers (no POST-back, no `API_BEARER`); `/chunk` unchanged.
- **`Program.cs`** — register client + job. **`render.yaml`** — document `Converter__BaseUrl` / `Converter__Token`.

## Performance / correctness notes

- Conversion routed to the **worker-only "heavy" queue** so a ~10-min IfcConvert can't occupy one of the API's 2 default-queue workers.
- HTTP GLB stream spooled to a temp file → S3 `PutObject` gets a seekable, known-length stream (avoids "could not determine content length").
- Single-pass hashing (sidecar supplies SHA-256), worker-side only.

## Caveats

- **Scaffold** — built to the sidecar contract, not exercised against a deployed sidecar.
- Requires an **S3/MinIO** storage backend (presigned GET); local-FS dev skips conversion.
- Both the IFC (source) and GLB (derivative) appear as model rows — IFC shows as non-viewable; the GLB is renderable.
- No `dotnet build` verification (Linux sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL