### PR TITLE
planscape-web: notifications bell + model upload UI

### DIFF
--- a/planscape-web/app/layout.tsx
+++ b/planscape-web/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import { AuthProvider } from '@/lib/auth';
+import { NotificationsProvider } from '@/lib/notifications';
 
 export const metadata: Metadata = {
   title: 'Planscape — Coordination',
@@ -12,7 +13,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="min-h-screen bg-slate-50 text-slate-900 antialiased">
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <NotificationsProvider>{children}</NotificationsProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/planscape-web/app/projects/[id]/models/page.tsx
+++ b/planscape-web/app/projects/[id]/models/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { listModels, uploadModel } from '@/lib/data';
+import type { ProjectModel } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const ACCEPT = '.glb,.gltf';
+
+export default function ModelsPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+
+  const [models, setModels] = useState<ProjectModel[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState('');
+  const [discipline, setDiscipline] = useState('');
+
+  function refresh() {
+    listModels(projectId)
+      .then(setModels)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load models'));
+  }
+
+  useEffect(refresh, [projectId]);
+
+  async function onUpload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file) return;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const r = await uploadModel(projectId, file, {
+        name: name.trim() || undefined,
+        discipline: discipline.trim() || undefined,
+      });
+      setNotice(
+        r.converting
+          ? 'Uploaded — a renderable GLB is being generated and will appear shortly.'
+          : r.duplicate
+            ? 'That model was already published (identical bytes).'
+            : 'Model uploaded.',
+      );
+      setFile(null);
+      setName('');
+      setDiscipline('');
+      if (fileRef.current) fileRef.current.value = '';
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+            ← Project
+          </Link>
+          <h1 className="text-xl font-semibold">Models</h1>
+        </div>
+        <Link
+          href={`/projects/${projectId}/viewer`}
+          className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+        >
+          3D model
+        </Link>
+      </div>
+
+      {/* Upload */}
+      <form onSubmit={onUpload} className="mb-6 rounded-lg border border-slate-200 bg-white p-4">
+        <h2 className="mb-3 text-sm font-medium">Publish a model</h2>
+        <div className="flex flex-wrap items-end gap-3">
+          <input
+            ref={fileRef}
+            type="file"
+            accept={ACCEPT}
+            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            className="text-sm"
+          />
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name (optional)"
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+          />
+          <input
+            value={discipline}
+            onChange={(e) => setDiscipline(e.target.value)}
+            placeholder="Discipline (e.g. M)"
+            className="w-32 rounded border border-slate-300 px-2 py-1 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={!file || busy}
+            className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {busy ? 'Uploading…' : 'Upload'}
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-slate-400">
+          GLB/glTF render directly. Export from Revit (BIM tab → Publish Model), or convert IFC to GLB first.
+        </p>
+      </form>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {notice && <p className="mb-3 rounded bg-green-50 px-3 py-2 text-sm text-green-700">{notice}</p>}
+
+      {/* List */}
+      {models.length === 0 ? (
+        <p className="text-slate-500">No models published yet.</p>
+      ) : (
+        <ul className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
+          {models.map((m) => (
+            <li key={m.id} className="flex items-center justify-between px-4 py-3">
+              <div>
+                <span className="text-sm font-medium">{m.name}</span>
+                <span className="ml-2 text-xs text-slate-400">
+                  {m.discipline ? `${m.discipline} · ` : ''}
+                  {m.format ?? ''}
+                  {m.revision ? ` · ${m.revision}` : ''}
+                </span>
+              </div>
+              <Link
+                href={`/projects/${projectId}/viewer?model=${m.id}`}
+                className="text-sm text-blue-600 hover:underline"
+              >
+                View
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -71,6 +71,12 @@ export default function ProjectPage() {
             Clashes
           </Link>
           <Link
+            href={`/projects/${projectId}/models`}
+            className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            Models
+          </Link>
+          <Link
             href={`/projects/${projectId}/viewer`}
             className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
           >

--- a/planscape-web/components/AppShell.tsx
+++ b/planscape-web/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { useEffect, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
+import { NotificationBell } from '@/components/NotificationBell';
 
 /** Protected app chrome: gates on auth (redirect to /login), renders the header + content. */
 export function AppShell({ children }: { children: ReactNode }) {
@@ -25,6 +26,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           Planscape
         </Link>
         <div className="flex items-center gap-3 text-sm">
+          <NotificationBell />
           <span className="text-slate-500">{user.email}</span>
           <button
             onClick={() => {

--- a/planscape-web/components/NotificationBell.tsx
+++ b/planscape-web/components/NotificationBell.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useNotifications } from '@/lib/notifications';
+
+/** Header bell: unread badge + a dropdown of the session's live notifications. */
+export function NotificationBell() {
+  const { notifications, unread, markAllRead, clear } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  function toggle() {
+    const next = !open;
+    setOpen(next);
+    if (next && unread > 0) markAllRead();
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={toggle}
+        aria-label={`Notifications${unread > 0 ? ` (${unread} unread)` : ''}`}
+        className="relative rounded border border-slate-300 px-2 py-1 transition hover:bg-slate-50"
+      >
+        <span aria-hidden>🔔</span>
+        {unread > 0 && (
+          <span className="absolute -right-1 -top-1 grid h-4 min-w-4 place-items-center rounded-full bg-red-600 px-1 text-[10px] font-semibold text-white">
+            {unread > 9 ? '9+' : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 z-20 mt-2 w-80 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg">
+          <div className="flex items-center justify-between border-b border-slate-100 px-3 py-2">
+            <span className="text-sm font-medium">Notifications</span>
+            {notifications.length > 0 && (
+              <button onClick={clear} className="text-xs text-slate-400 hover:underline">
+                Clear
+              </button>
+            )}
+          </div>
+          {notifications.length === 0 ? (
+            <p className="px-3 py-6 text-center text-sm text-slate-400">No notifications yet.</p>
+          ) : (
+            <ul className="max-h-96 divide-y divide-slate-100 overflow-y-auto">
+              {notifications.map((n) => (
+                <li key={n.id} className="px-3 py-2">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-sm font-medium text-slate-800">{n.title}</span>
+                    <time className="shrink-0 text-[10px] text-slate-400" dateTime={n.timestamp}>
+                      {new Date(n.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    </time>
+                  </div>
+                  {n.message && <p className="mt-0.5 text-xs text-slate-500">{n.message}</p>}
+                  {n.channel && (
+                    <span className="mt-1 inline-block rounded bg-slate-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-500">
+                      {n.channel}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -1,4 +1,4 @@
-import { api, API_BASE, getToken } from './api';
+import { api, API_BASE, getToken, setToken, ApiError } from './api';
 import type {
   Project,
   BimIssue,
@@ -94,4 +94,55 @@ export function modelFileUrl(projectId: string, modelId: string): string {
   const token = getToken();
   const base = `${API_BASE}/api/projects/${projectId}/models/${modelId}/file`;
   return token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
+}
+
+export interface UploadModelResult {
+  id?: string;
+  duplicate?: boolean;
+  converting?: boolean;
+  message?: string;
+}
+
+/** Upload a model (GLB/glTF) as multipart/form-data. Uses fetch directly rather
+ *  than the JSON api() wrapper so the browser sets the multipart boundary, and
+ *  bearer auth rides in the header (not the iframe ?access_token= trick). The
+ *  endpoint is role-gated (Admin/Owner/Coordinator) — a 403 surfaces as ApiError. */
+export async function uploadModel(
+  projectId: string,
+  file: File,
+  opts: { name?: string; discipline?: string; description?: string } = {},
+): Promise<UploadModelResult> {
+  const form = new FormData();
+  form.append('File', file, file.name);
+  if (opts.name) form.append('Name', opts.name);
+  if (opts.discipline) form.append('Discipline', opts.discipline);
+  if (opts.description) form.append('Description', opts.description);
+
+  const token = getToken();
+  const headers = new Headers();
+  if (token) headers.set('Authorization', `Bearer ${token}`); // no Content-Type — browser sets the boundary
+
+  const res = await fetch(`${API_BASE}/api/projects/${projectId}/models`, {
+    method: 'POST',
+    headers,
+    body: form,
+  });
+
+  if (res.status === 401) {
+    setToken(null);
+    if (typeof window !== 'undefined' && window.location.pathname !== '/login') window.location.href = '/login';
+    throw new ApiError(401, 'Session expired — please sign in again.');
+  }
+  if (!res.ok) {
+    let message = `Upload failed (HTTP ${res.status})`;
+    try {
+      const b = await res.json();
+      message = b.message || b.error || message;
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return {};
+  return (await res.json()) as UploadModelResult;
 }

--- a/planscape-web/lib/notifications.tsx
+++ b/planscape-web/lib/notifications.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+import { HubConnectionBuilder, LogLevel, type HubConnection } from '@microsoft/signalr';
+import { API_BASE, getToken } from './api';
+import { useAuth } from './auth';
+
+export interface AppNotification {
+  id: string;
+  channel?: string;
+  title: string;
+  message?: string;
+  timestamp: string;
+  read: boolean;
+}
+
+interface NotificationsState {
+  notifications: AppNotification[];
+  unread: number;
+  markAllRead: () => void;
+  clear: () => void;
+}
+
+const NotificationsContext = createContext<NotificationsState | null>(null);
+
+const MAX_KEPT = 50;
+
+/**
+ * One persistent NotificationHub connection for the signed-in user. The hub
+ * auto-joins the caller's `tenant_{id}` + `user_{id}` groups on connect, so a
+ * plain connection (no JoinProject) receives tenant-wide `Notification` events.
+ * Session-scoped: there's no REST inbox endpoint yet, so the list lives in
+ * memory and resets on reload — it's a live feed, not a persisted history.
+ */
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const [notifications, setNotifications] = useState<AppNotification[]>([]);
+  const connRef = useRef<HubConnection | null>(null);
+
+  useEffect(() => {
+    if (!user || !getToken()) return;
+
+    const conn = new HubConnectionBuilder()
+      .withUrl(`${API_BASE}/hubs/notifications`, { accessTokenFactory: () => getToken() ?? '' })
+      .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
+      .configureLogging(LogLevel.Warning)
+      .build();
+    connRef.current = conn;
+
+    conn.on('Notification', (payload: unknown) => {
+      const p = (payload ?? {}) as { channel?: string; title?: string; message?: string; timestamp?: string };
+      const n: AppNotification = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        channel: p.channel,
+        title: p.title || 'Notification',
+        message: p.message,
+        timestamp: p.timestamp || new Date().toISOString(),
+        read: false,
+      };
+      setNotifications((cur) => [n, ...cur].slice(0, MAX_KEPT));
+    });
+
+    conn.start().catch(() => {
+      /* non-fatal — the bell just stays empty if the hub is unreachable */
+    });
+
+    return () => {
+      connRef.current = null;
+      void conn.stop().catch(() => {});
+    };
+  }, [user]);
+
+  const unread = notifications.reduce((n, x) => (x.read ? n : n + 1), 0);
+
+  const value: NotificationsState = {
+    notifications,
+    unread,
+    markAllRead: () => setNotifications((cur) => cur.map((x) => ({ ...x, read: true }))),
+    clear: () => setNotifications([]),
+  };
+
+  return <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>;
+}
+
+/** Safe even outside the provider (returns an inert state) so pages don't crash. */
+export function useNotifications(): NotificationsState {
+  return (
+    useContext(NotificationsContext) ?? {
+      notifications: [],
+      unread: 0,
+      markAllRead: () => {},
+      clear: () => {},
+    }
+  );
+}

--- a/planscape-web/next-env.d.ts
+++ b/planscape-web/next-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 
-// NOTE: This file should not be edited.
-// Committed (rather than gitignored) so `tsc --noEmit` works in CI without a build first.
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## What

**Section-2 ports #2 + #3** in `planscape-web`: a live **notifications bell** and a **model upload UI** — both fully server-backed, both small/high-daily-use.

## Notifications panel (live, session-scoped)
- **`lib/notifications.tsx`** — `NotificationsProvider` opens **one persistent** `NotificationHub` connection for the signed-in user (mounted in the root layout inside `AuthProvider`). The hub **auto-joins `tenant_{id}`/`user_{id}` on connect** (verified in `NotificationHub.OnConnectedAsync`), so a plain connection — no `JoinProject` — receives tenant-wide `Notification` events. Exposes `notifications / unread / markAllRead / clear`.
- **`components/NotificationBell.tsx`** — header bell with unread badge + dropdown (marks read on open, clear, outside-click close).
- Wired into `AppShell` header + root layout.

> **Honest scope:** `NotificationsController` has **no REST inbox/list endpoint** (only subscribe/devices/test), so this is a **live feed held in memory** — it populates as events arrive and resets on reload, not a persisted history. A persisted inbox would need a new server endpoint (noted as follow-up).

## Model upload UI
- **`lib/data.ts`** — `uploadModel()` posts `multipart/form-data` via `fetch` (browser sets the boundary; bearer in the header), mapping 401 / 403 / duplicate / 202.
- **`app/projects/[id]/models`** — new page: publish form (file + name + discipline) + model list with **View** links. Server endpoint is role-gated (Admin/Owner/Coordinator) → a 403 surfaces as an inline error.
- Project page gains a **Models** nav link.

## Verification
- `tsc --noEmit` clean; **`next build` succeeds**.
- Conflict-free with the open #349 federation PR (separate files/pages — this touches the models page, AppShell, layout, notifications lib; #349 touches the viewer page + scene types).

## Caveats
- Notifications are session-live only (no inbox endpoint yet).
- Web can't capture native camera; this PR is model upload, not site-photo capture.
- Not click-tested against a live API (no runnable API in sandbox); built to the verified hub + endpoint contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL)_