### PR TITLE
planscape-web: documents register + members + cross-project search

### DIFF
--- a/planscape-web/app/projects/[id]/documents/page.tsx
+++ b/planscape-web/app/projects/[id]/documents/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { listDocuments, documentDownloadUrl } from '@/lib/data';
+import type { ProjectDocument } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const CDE = ['ALL', 'WIP', 'SHARED', 'PUBLISHED', 'ARCHIVE'] as const;
+
+const cdeClass: Record<string, string> = {
+  WIP: 'bg-slate-100 text-slate-600',
+  SHARED: 'bg-amber-100 text-amber-700',
+  PUBLISHED: 'bg-green-100 text-green-700',
+  ARCHIVE: 'bg-slate-200 text-slate-500',
+  SUPERSEDED: 'bg-red-50 text-red-600',
+  WITHDRAWN: 'bg-red-50 text-red-600',
+};
+
+function fmtSize(b?: number): string {
+  if (!b) return '';
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(0)} KB`;
+  return `${(b / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export default function DocumentsPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const [docs, setDocs] = useState<ProjectDocument[] | null>(null);
+  const [cde, setCde] = useState<(typeof CDE)[number]>('ALL');
+  const [search, setSearch] = useState('');
+  const [query, setQuery] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setDocs(null);
+    setError(null);
+    listDocuments(projectId, {
+      cdeStatus: cde === 'ALL' ? undefined : cde,
+      search: query || undefined,
+    })
+      .then(setDocs)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load documents'));
+  }, [projectId, cde, query]);
+
+  useEffect(load, [load]);
+
+  return (
+    <AppShell>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+            ← Project
+          </Link>
+          <h1 className="text-xl font-semibold">Documents</h1>
+        </div>
+      </div>
+
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        {CDE.map((s) => (
+          <button
+            key={s}
+            onClick={() => setCde(s)}
+            className={`rounded-full px-3 py-1 text-xs ${
+              cde === s ? 'bg-blue-600 text-white' : 'bg-white text-slate-600 ring-1 ring-slate-200'
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            setQuery(search.trim());
+          }}
+          className="ml-auto"
+        >
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search documents…"
+            className="rounded border border-slate-300 px-2 py-1 text-sm"
+          />
+        </form>
+      </div>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {!docs && !error && <p className="text-slate-400">Loading…</p>}
+      {docs && docs.length === 0 && <p className="text-slate-500">No documents.</p>}
+
+      {docs && docs.length > 0 && (
+        <ul className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
+          {docs.map((d) => (
+            <li key={d.id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium">{d.fileName}</span>
+                  <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${cdeClass[d.cdeStatus] ?? 'bg-slate-100 text-slate-600'}`}>
+                    {d.cdeStatus}
+                  </span>
+                </div>
+                <div className="mt-0.5 text-xs text-slate-400">
+                  {d.documentType ? `${d.documentType} · ` : ''}
+                  {d.suitabilityCode ? `${d.suitabilityCode} · ` : ''}
+                  {d.revision ? `${d.revision} · ` : ''}
+                  {d.discipline ? `${d.discipline} · ` : ''}
+                  {fmtSize(d.fileSizeBytes)}
+                  {d.scanStatus && d.scanStatus !== 'CLEAN' && d.scanStatus !== 'SKIPPED' ? ` · ${d.scanStatus}` : ''}
+                </div>
+              </div>
+              <a
+                href={documentDownloadUrl(projectId, d.id)}
+                className="shrink-0 text-sm text-blue-600 hover:underline"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Download
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/members/page.tsx
+++ b/planscape-web/app/projects/[id]/members/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { listMembers, inviteMember, updateMemberRole, removeMember } from '@/lib/data';
+import type { ProjectMember } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const PROJECT_ROLES = ['Viewer', 'Contributor', 'Coordinator', 'Manager', 'Owner', 'Admin'];
+
+export default function MembersPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const [members, setMembers] = useState<ProjectMember[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [email, setEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState('Contributor');
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(() => {
+    listMembers(projectId)
+      .then(setMembers)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load members'));
+  }, [projectId]);
+
+  useEffect(load, [load]);
+
+  async function onInvite(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email.trim()) return;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const r = await inviteMember(projectId, { email: email.trim(), projectRole: inviteRole });
+      setNotice(
+        r.emailSent
+          ? `Invite emailed to ${email.trim()}.`
+          : r.isPending
+            ? `Invited ${email.trim()} (pending — email not configured, share the link from the server).`
+            : `${email.trim()} added.`,
+      );
+      setEmail('');
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invite failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRoleChange(m: ProjectMember, role: string) {
+    setMembers((cur) => cur?.map((x) => (x.id === m.id ? { ...x, projectRole: role } : x)) ?? null);
+    try {
+      await updateMemberRole(projectId, m.id, { projectRole: role });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to change role');
+      load();
+    }
+  }
+
+  async function onRemove(m: ProjectMember) {
+    if (!confirm(`Remove ${m.displayName} from the project?`)) return;
+    setMembers((cur) => cur?.filter((x) => x.id !== m.id) ?? null);
+    try {
+      await removeMember(projectId, m.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove member');
+      load();
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-4">
+        <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+          ← Project
+        </Link>
+        <h1 className="text-xl font-semibold">Members</h1>
+      </div>
+
+      {/* Invite */}
+      <form onSubmit={onInvite} className="mb-4 flex flex-wrap items-end gap-2 rounded-lg border border-slate-200 bg-white p-4">
+        <label className="block">
+          <span className="text-sm text-slate-600">Invite by email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="person@firm.com"
+            className="mt-1 block w-64 rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <select
+          value={inviteRole}
+          onChange={(e) => setInviteRole(e.target.value)}
+          className="rounded border border-slate-300 px-2 py-1.5 text-sm"
+        >
+          {PROJECT_ROLES.map((r) => (
+            <option key={r}>{r}</option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          disabled={busy || !email.trim()}
+          className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {busy ? 'Inviting…' : 'Invite'}
+        </button>
+      </form>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {notice && <p className="mb-3 rounded bg-green-50 px-3 py-2 text-sm text-green-700">{notice}</p>}
+      {!members && !error && <p className="text-slate-400">Loading…</p>}
+      {members && members.length === 0 && <p className="text-slate-500">No members.</p>}
+
+      {members && members.length > 0 && (
+        <ul className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
+          {members.map((m) => (
+            <li key={m.id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{m.displayName}</div>
+                <div className="truncate text-xs text-slate-400">
+                  {m.email}
+                  {m.iso19650Role ? ` · ${m.iso19650Role}` : ''}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <select
+                  value={PROJECT_ROLES.includes(m.projectRole) ? m.projectRole : ''}
+                  onChange={(e) => onRoleChange(m, e.target.value)}
+                  className="rounded border border-slate-300 px-2 py-1 text-xs"
+                >
+                  {!PROJECT_ROLES.includes(m.projectRole) && <option value="">{m.projectRole || '—'}</option>}
+                  {PROJECT_ROLES.map((r) => (
+                    <option key={r}>{r}</option>
+                  ))}
+                </select>
+                <button
+                  onClick={() => onRemove(m)}
+                  className="rounded border border-slate-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="mt-2 text-xs text-slate-400">Managing members requires a Manager+ project role.</p>
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -65,6 +65,18 @@ export default function ProjectPage() {
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Link
+            href={`/projects/${projectId}/documents`}
+            className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            Documents
+          </Link>
+          <Link
+            href={`/projects/${projectId}/members`}
+            className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            Members
+          </Link>
+          <Link
             href={`/projects/${projectId}/clashes`}
             className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
           >

--- a/planscape-web/app/search/page.tsx
+++ b/planscape-web/app/search/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { search as runSearch } from '@/lib/data';
+import type { SearchResult } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const typeBadge: Record<string, string> = {
+  issue: 'bg-blue-100 text-blue-700',
+  document: 'bg-amber-100 text-amber-700',
+  meeting: 'bg-green-100 text-green-700',
+  tag: 'bg-slate-100 text-slate-600',
+};
+
+function hrefFor(r: SearchResult): string {
+  switch (r.type) {
+    case 'issue':
+      return `/projects/${r.projectId}/issues/${r.id}`;
+    case 'meeting':
+      return `/projects/${r.projectId}/meetings/${r.id}`;
+    case 'document':
+      return `/projects/${r.projectId}/documents`;
+    default:
+      return `/projects/${r.projectId}`;
+  }
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<AppShell><p className="text-slate-400">Loading…</p></AppShell>}>
+      <SearchInner />
+    </Suspense>
+  );
+}
+
+function SearchInner() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const q = params.get('q') || '';
+
+  const [input, setInput] = useState(q);
+  const [results, setResults] = useState<SearchResult[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const doSearch = useCallback((term: string) => {
+    if (term.trim().length < 2) {
+      setResults(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    runSearch(term.trim())
+      .then((r) => setResults(r.results))
+      .catch((e) => setError(e instanceof Error ? e.message : 'Search failed'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    setInput(q);
+    doSearch(q);
+  }, [q, doSearch]);
+
+  return (
+    <AppShell>
+      <h1 className="mb-3 text-xl font-semibold">Search</h1>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          router.push(`/search?q=${encodeURIComponent(input.trim())}`);
+        }}
+        className="mb-4"
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Search issues, documents, meetings, tags…"
+          autoFocus
+          className="w-full max-w-xl rounded border border-slate-300 px-3 py-2 text-sm"
+        />
+      </form>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {loading && <p className="text-slate-400">Searching…</p>}
+      {!loading && q.trim().length >= 2 && results && results.length === 0 && (
+        <p className="text-slate-500">No matches for “{q}”.</p>
+      )}
+      {q.trim().length > 0 && q.trim().length < 2 && (
+        <p className="text-slate-400">Type at least 2 characters.</p>
+      )}
+
+      {results && results.length > 0 && (
+        <ul className="space-y-2">
+          {results.map((r) => (
+            <li key={`${r.type}-${r.id}`}>
+              <Link
+                href={hrefFor(r)}
+                className="flex items-center justify-between gap-3 rounded-lg bg-white p-3 ring-1 ring-slate-200 transition hover:ring-blue-300"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{r.label}</div>
+                  <div className="truncate text-xs text-slate-400">
+                    {r.detail}
+                    {r.projectName ? ` · ${r.projectName}` : ''}
+                  </div>
+                </div>
+                <span className={`shrink-0 rounded px-2 py-0.5 text-[10px] uppercase ${typeBadge[r.type] ?? 'bg-slate-100 text-slate-600'}`}>
+                  {r.type}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </AppShell>
+  );
+}

--- a/planscape-web/components/AppShell.tsx
+++ b/planscape-web/components/AppShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/lib/auth';
@@ -9,6 +9,7 @@ import { useAuth } from '@/lib/auth';
 export function AppShell({ children }: { children: ReactNode }) {
   const { ready, user, logout } = useAuth();
   const router = useRouter();
+  const [q, setQ] = useState('');
 
   useEffect(() => {
     if (ready && !user) router.replace('/login');
@@ -25,6 +26,20 @@ export function AppShell({ children }: { children: ReactNode }) {
           Planscape
         </Link>
         <div className="flex items-center gap-3 text-sm">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (q.trim().length >= 2) router.push(`/search?q=${encodeURIComponent(q.trim())}`);
+            }}
+          >
+            <input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search…"
+              aria-label="Search"
+              className="w-40 rounded border border-slate-300 px-2 py-1 text-sm focus:w-56"
+            />
+          </form>
           <span className="text-slate-500">{user.email}</span>
           <button
             onClick={() => {

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -7,6 +7,11 @@ import type {
   ClashListResponse,
   ClashDetectionResult,
   ProjectModel,
+  ProjectDocument,
+  DocumentListResponse,
+  ProjectMember,
+  Iso19650Role,
+  SearchResponse,
 } from './types';
 
 // ── Projects ──
@@ -94,4 +99,64 @@ export function modelFileUrl(projectId: string, modelId: string): string {
   const token = getToken();
   const base = `${API_BASE}/api/projects/${projectId}/models/${modelId}/file`;
   return token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
+}
+
+// ── Documents (CDE) ──
+export async function listDocuments(
+  projectId: string,
+  opts: { cdeStatus?: string; discipline?: string; documentType?: string; search?: string } = {},
+): Promise<ProjectDocument[]> {
+  const params = new URLSearchParams();
+  if (opts.cdeStatus) params.set('cdeStatus', opts.cdeStatus);
+  if (opts.discipline) params.set('discipline', opts.discipline);
+  if (opts.documentType) params.set('documentType', opts.documentType);
+  if (opts.search) params.set('search', opts.search);
+  const qs = params.toString();
+  const raw = await api<DocumentListResponse | ProjectDocument[]>(
+    `/api/projects/${projectId}/documents${qs ? `?${qs}` : ''}`,
+  );
+  return Array.isArray(raw) ? raw : (raw.items ?? []);
+}
+
+/** Authenticated download URL — token as a query param (global ?access_token=
+ *  auth), so a plain anchor download carries the bearer. */
+export function documentDownloadUrl(projectId: string, docId: string): string {
+  const token = getToken();
+  const base = `${API_BASE}/api/projects/${projectId}/documents/${docId}/download`;
+  return token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
+}
+
+// ── Project members ──
+export function listMembers(projectId: string): Promise<ProjectMember[]> {
+  return api<ProjectMember[]>(`/api/projects/${projectId}/members`);
+}
+
+export function listProjectRoles(projectId: string): Promise<Iso19650Role[]> {
+  return api<Iso19650Role[]>(`/api/projects/${projectId}/members/roles`);
+}
+
+export function inviteMember(
+  projectId: string,
+  body: { email: string; displayName?: string; projectRole?: string; iso19650Role?: string },
+): Promise<{ message?: string; isPending?: boolean; emailSent?: boolean }> {
+  return api(`/api/projects/${projectId}/members/invite`, { method: 'POST', body: JSON.stringify(body) });
+}
+
+export function updateMemberRole(
+  projectId: string,
+  memberId: string,
+  body: { projectRole?: string; iso19650Role?: string },
+): Promise<{ id: string; projectRole: string; iso19650Role?: string }> {
+  return api(`/api/projects/${projectId}/members/${memberId}`, { method: 'PUT', body: JSON.stringify(body) });
+}
+
+export function removeMember(projectId: string, memberId: string): Promise<void> {
+  return api(`/api/projects/${projectId}/members/${memberId}`, { method: 'DELETE' });
+}
+
+// ── Cross-project search ──
+export function search(q: string, types?: string[], limit = 25): Promise<SearchResponse> {
+  const params = new URLSearchParams({ q, limit: String(limit) });
+  if (types && types.length) params.set('type', types.join(','));
+  return api<SearchResponse>(`/api/search?${params.toString()}`);
 }

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -90,3 +90,60 @@ export interface ProjectModel {
   revision?: string;
   uploadedAt?: string;
 }
+
+// ── Documents (CDE) ──
+export interface ProjectDocument {
+  id: string;
+  fileName: string;
+  description?: string | null;
+  documentType?: string;
+  cdeStatus: string; // WIP | SHARED | PUBLISHED | ARCHIVE | SUPERSEDED | WITHDRAWN | OBSOLETE
+  suitabilityCode?: string; // S0–S7 | CR | AB
+  revision?: string | null;
+  discipline?: string | null;
+  originator?: string | null;
+  fileSizeBytes?: number;
+  uploadedBy?: string;
+  uploadedAt?: string;
+  scanStatus?: string; // PENDING | CLEAN | INFECTED | SKIPPED
+}
+
+export interface DocumentListResponse {
+  items: ProjectDocument[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+// ── Project members ──
+export interface ProjectMember {
+  id: string; // member row id
+  userId: string;
+  email: string;
+  displayName: string;
+  projectRole: string; // Viewer | Contributor | Coordinator | Manager | Owner | Admin
+  iso19650Role?: string;
+  joinedAt?: string | null;
+  invitedBy?: string | null;
+}
+
+export interface Iso19650Role {
+  code: string;
+  label: string;
+}
+
+// ── Cross-project search ──
+export interface SearchResult {
+  type: 'tag' | 'issue' | 'document' | 'meeting';
+  id: string;
+  label: string;
+  detail: string;
+  projectId: string;
+  projectName: string;
+}
+
+export interface SearchResponse {
+  query: string;
+  count: number;
+  results: SearchResult[];
+}

--- a/planscape-web/next-env.d.ts
+++ b/planscape-web/next-env.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 
-// NOTE: This file should not be edited.
-// Committed (rather than gitignored) so `tsc --noEmit` works in CI without a build first.
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## What

**Section-2 ports #5–7** in `planscape-web`, batched: **documents register**, **project members**, and **cross-project search**. Mostly read + the key actions; all server-backed.

## Documents (CDE register)
- **`lib/data.ts`** — `listDocuments` (cdeStatus/discipline/type/search filters; tolerant of `{items}`|array) + `documentDownloadUrl` (uses the global `?access_token=` query auth, same as model files, so a plain anchor download carries the bearer).
- **`app/projects/[id]/documents`** — list with **CDE filter chips** (WIP/SHARED/PUBLISHED/ARCHIVE) + search, per-doc CDE state / suitability / revision / discipline / size + **Download**.

## Members
- **`lib/data.ts`** — `listMembers / listProjectRoles / inviteMember / updateMemberRole / removeMember`.
- **`app/projects/[id]/members`** — roster + **invite-by-email** + **role select** + **remove**. Management is **Manager+** gated server-side → a 403 surfaces as an inline error.

## Cross-project search
- **`lib/data.ts`** — `search(q, types?, limit)` → `/api/search` (tenant-scoped, cross-project).
- **`app/search`** — query box + grouped results (issue / document / meeting / tag), each deep-linked to the right page. Wrapped in `Suspense` for the `useSearchParams` CSR bailout.
- **AppShell** gains a global header **search box** → `/search?q=`.
- Project page gains **Documents** + **Members** nav links.

## Verification
- Types (`ProjectDocument` / `DocumentListResponse` / `ProjectMember` / `Iso19650Role` / `SearchResult` / `SearchResponse`) verified against the controllers + mobile `endpoints.ts`.
- `tsc --noEmit` clean; **`next build` succeeds**.

## Caveats / scope
- Documents is **list + download**; upload (presign + AV scan) and CDE state transitions are deferred (heavier, role/approval-gated) — noted for a follow-up.
- Transmittals UI not included in this batch (server contract captured; easy follow-up).
- Not click-tested against a live API; built to verified contracts.
- Expected trivial nav-block merge conflicts with the other open `planscape-web` PRs (#349/#350/#351) — all resolve to keeping every link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL)_