### PR TITLE
planscape-web polish: doc upload/transitions, transmittals, photos, issue assignment

### DIFF
--- a/planscape-web/app/projects/[id]/documents/page.tsx
+++ b/planscape-web/app/projects/[id]/documents/page.tsx
@@ -1,15 +1,23 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
-import { listDocuments, documentDownloadUrl } from '@/lib/data';
+import { listDocuments, documentDownloadUrl, uploadDocument, transitionDocument } from '@/lib/data';
 import type { ProjectDocument } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
 const CDE = ['ALL', 'WIP', 'SHARED', 'PUBLISHED', 'ARCHIVE'] as const;
+
+// First valid forward transition per CDE state + the suitability it implies
+// (server enforces the full matrix; this is the common-path shortcut).
+const NEXT_STATE: Record<string, { to: string; suitability: string; label: string } | undefined> = {
+  WIP: { to: 'SHARED', suitability: 'S2', label: 'Share' },
+  SHARED: { to: 'PUBLISHED', suitability: 'S4', label: 'Publish' },
+  PUBLISHED: { to: 'ARCHIVE', suitability: 'S7', label: 'Archive' },
+};
 
 const cdeClass: Record<string, string> = {
   WIP: 'bg-slate-100 text-slate-600',
@@ -35,6 +43,11 @@ export default function DocumentsPage() {
   const [search, setSearch] = useState('');
   const [query, setQuery] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [discipline, setDiscipline] = useState('');
+  const [busy, setBusy] = useState(false);
 
   const load = useCallback(() => {
     setDocs(null);
@@ -49,6 +62,40 @@ export default function DocumentsPage() {
 
   useEffect(load, [load]);
 
+  async function onUpload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file) return;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await uploadDocument(projectId, file, { discipline: discipline.trim() || undefined });
+      setNotice('Document uploaded (WIP).');
+      setFile(null);
+      setDiscipline('');
+      if (fileRef.current) fileRef.current.value = '';
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onTransition(d: ProjectDocument) {
+    const n = NEXT_STATE[d.cdeStatus];
+    if (!n) return;
+    setError(null);
+    setNotice(null);
+    try {
+      await transitionDocument(projectId, d.id, { newState: n.to, suitabilityCode: n.suitability });
+      setNotice(`${d.fileName} → ${n.to}.`);
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Transition failed');
+    }
+  }
+
   return (
     <AppShell>
       <div className="mb-4 flex items-center justify-between gap-3">
@@ -59,6 +106,28 @@ export default function DocumentsPage() {
           <h1 className="text-xl font-semibold">Documents</h1>
         </div>
       </div>
+
+      <form onSubmit={onUpload} className="mb-3 flex flex-wrap items-end gap-2 rounded-lg border border-slate-200 bg-white p-3">
+        <input
+          ref={fileRef}
+          type="file"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="text-sm"
+        />
+        <input
+          value={discipline}
+          onChange={(e) => setDiscipline(e.target.value)}
+          placeholder="Discipline (e.g. A)"
+          className="w-32 rounded border border-slate-300 px-2 py-1 text-sm"
+        />
+        <button
+          type="submit"
+          disabled={!file || busy}
+          className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {busy ? 'Uploading…' : 'Upload (WIP)'}
+        </button>
+      </form>
 
       <div className="mb-3 flex flex-wrap items-center gap-2">
         {CDE.map((s) => (
@@ -89,6 +158,7 @@ export default function DocumentsPage() {
       </div>
 
       {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {notice && <p className="mb-3 rounded bg-green-50 px-3 py-2 text-sm text-green-700">{notice}</p>}
       {!docs && !error && <p className="text-slate-400">Loading…</p>}
       {docs && docs.length === 0 && <p className="text-slate-500">No documents.</p>}
 
@@ -112,14 +182,24 @@ export default function DocumentsPage() {
                   {d.scanStatus && d.scanStatus !== 'CLEAN' && d.scanStatus !== 'SKIPPED' ? ` · ${d.scanStatus}` : ''}
                 </div>
               </div>
-              <a
-                href={documentDownloadUrl(projectId, d.id)}
-                className="shrink-0 text-sm text-blue-600 hover:underline"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Download
-              </a>
+              <div className="flex shrink-0 items-center gap-2">
+                {NEXT_STATE[d.cdeStatus] && (
+                  <button
+                    onClick={() => onTransition(d)}
+                    className="rounded border border-slate-300 px-2 py-1 text-xs hover:bg-slate-50"
+                  >
+                    {NEXT_STATE[d.cdeStatus]!.label}
+                  </button>
+                )}
+                <a
+                  href={documentDownloadUrl(projectId, d.id)}
+                  className="text-sm text-blue-600 hover:underline"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Download
+                </a>
+              </div>
             </li>
           ))}
         </ul>

--- a/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
+++ b/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
@@ -18,13 +18,38 @@ export default function IssueDetailPage() {
   const [comments, setComments] = useState<IssueComment[]>([]);
   const [newComment, setNewComment] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [assignee, setAssignee] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [savingAssign, setSavingAssign] = useState(false);
 
   useEffect(() => {
     getIssue(projectId, issueId)
-      .then(setIssue)
+      .then((i) => {
+        setIssue(i);
+        setAssignee(i.assignee ?? '');
+        setDueDate(i.dueDate ? i.dueDate.slice(0, 10) : '');
+      })
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load issue'));
     listComments(projectId, issueId).then(setComments).catch(() => {});
   }, [projectId, issueId]);
+
+  async function saveAssignment() {
+    if (!issue) return;
+    setSavingAssign(true);
+    setError(null);
+    try {
+      const body: Partial<BimIssue> = {
+        assignee: assignee.trim(),
+        dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
+      };
+      const updated = await updateIssue(projectId, issueId, body);
+      setIssue(updated);
+    } catch {
+      setError('Failed to save assignment');
+    } finally {
+      setSavingAssign(false);
+    }
+  }
 
   async function changeStatus(s: IssueStatus) {
     if (!issue || issue.status === s) return;
@@ -91,6 +116,34 @@ export default function IssueDetailPage() {
                 </button>
               ))}
             </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-end gap-3 rounded-lg bg-white p-3 ring-1 ring-slate-200">
+            <label className="block">
+              <span className="text-xs font-medium uppercase tracking-wide text-slate-400">Assignee</span>
+              <input
+                value={assignee}
+                onChange={(e) => setAssignee(e.target.value)}
+                placeholder="name or email"
+                className="mt-1 block w-56 rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-medium uppercase tracking-wide text-slate-400">Due date</span>
+              <input
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="mt-1 block rounded border border-slate-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+            <button
+              onClick={saveAssignment}
+              disabled={savingAssign}
+              className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50 disabled:opacity-50"
+            >
+              {savingAssign ? 'Saving…' : 'Save'}
+            </button>
           </div>
 
           <section className="mt-8">

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -71,6 +71,18 @@ export default function ProjectPage() {
             Documents
           </Link>
           <Link
+            href={`/projects/${projectId}/transmittals`}
+            className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            Transmittals
+          </Link>
+          <Link
+            href={`/projects/${projectId}/photos`}
+            className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
+          >
+            Photos
+          </Link>
+          <Link
             href={`/projects/${projectId}/members`}
             className="rounded border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50"
           >

--- a/planscape-web/app/projects/[id]/photos/page.tsx
+++ b/planscape-web/app/projects/[id]/photos/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { listSitePhotos, photoFileUrl, approvePhoto, rejectPhoto } from '@/lib/data';
+import type { SitePhoto } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const REASONS = ['ALL', 'Progress', 'Issue', 'Defect', 'Safety', 'AsBuilt', 'Reference'] as const;
+
+export default function PhotosPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const [photos, setPhotos] = useState<SitePhoto[] | null>(null);
+  const [reason, setReason] = useState<(typeof REASONS)[number]>('ALL');
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setPhotos(null);
+    listSitePhotos(projectId, { reason: reason === 'ALL' ? undefined : reason })
+      .then(setPhotos)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load photos'));
+  }, [projectId, reason]);
+
+  useEffect(load, [load]);
+
+  async function onApprove(p: SitePhoto) {
+    const caption = prompt('Caption (required, min 3 chars):', p.caption ?? '');
+    if (caption == null) return;
+    setError(null);
+    setNotice(null);
+    try {
+      await approvePhoto(projectId, p.id, caption);
+      setNotice('Photo approved.');
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Approve failed');
+    }
+  }
+
+  async function onReject(p: SitePhoto) {
+    const reasonText = prompt('Rejection reason:');
+    if (!reasonText) return;
+    setError(null);
+    setNotice(null);
+    try {
+      await rejectPhoto(projectId, p.id, reasonText);
+      setNotice('Photo rejected.');
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Reject failed');
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-4">
+        <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+          ← Project
+        </Link>
+        <h1 className="text-xl font-semibold">Site photos</h1>
+      </div>
+
+      <div className="mb-3 flex flex-wrap gap-2">
+        {REASONS.map((r) => (
+          <button
+            key={r}
+            onClick={() => setReason(r)}
+            className={`rounded-full px-3 py-1 text-xs ${
+              reason === r ? 'bg-blue-600 text-white' : 'bg-white text-slate-600 ring-1 ring-slate-200'
+            }`}
+          >
+            {r}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {notice && <p className="mb-3 rounded bg-green-50 px-3 py-2 text-sm text-green-700">{notice}</p>}
+      {!photos && !error && <p className="text-slate-400">Loading…</p>}
+      {photos && photos.length === 0 && (
+        <p className="text-slate-500">No photos. Capture happens on the mobile app; review them here.</p>
+      )}
+
+      {photos && photos.length > 0 && (
+        <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+          {photos.map((p) => (
+            <li key={p.id} className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={photoFileUrl(projectId, p.id)}
+                alt={p.caption ?? p.reason ?? 'Site photo'}
+                className="h-32 w-full bg-slate-100 object-cover"
+                loading="lazy"
+              />
+              <div className="p-2">
+                <div className="flex items-center justify-between gap-1 text-[10px] text-slate-400">
+                  <span>{p.reason}</span>
+                  <span>{p.audience}</span>
+                </div>
+                {p.caption && <p className="mt-0.5 truncate text-xs text-slate-600">{p.caption}</p>}
+                <div className="mt-1 text-[10px] text-slate-400">
+                  {p.capturedByName ?? ''}
+                  {p.capturedAt ? ` · ${new Date(p.capturedAt).toLocaleDateString()}` : ''}
+                </div>
+                {(p.audience === 'PendingReview' || p.audience === 'Internal') && (
+                  <div className="mt-2 flex gap-1">
+                    <button
+                      onClick={() => onApprove(p)}
+                      className="flex-1 rounded bg-green-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-green-700"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      onClick={() => onReject(p)}
+                      className="flex-1 rounded border border-slate-300 px-2 py-1 text-[11px] text-red-600 hover:bg-red-50"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/[id]/transmittals/page.tsx
+++ b/planscape-web/app/projects/[id]/transmittals/page.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { listTransmittals, createTransmittal, transmittalAction } from '@/lib/data';
+import type { Transmittal } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const statusClass: Record<string, string> = {
+  DRAFT: 'bg-slate-100 text-slate-600',
+  SENT: 'bg-blue-100 text-blue-700',
+  ACKNOWLEDGED: 'bg-amber-100 text-amber-700',
+  RESPONDED: 'bg-green-100 text-green-700',
+};
+
+// Allowed next action per status (DRAFT→send, SENT→acknowledge, ACKNOWLEDGED→respond).
+const nextAction: Record<string, 'send' | 'acknowledge' | 'respond' | undefined> = {
+  DRAFT: 'send',
+  SENT: 'acknowledge',
+  ACKNOWLEDGED: 'respond',
+};
+const actionLabel: Record<string, string> = { send: 'Send', acknowledge: 'Acknowledge', respond: 'Respond' };
+
+export default function TransmittalsPage() {
+  const params = useParams<{ id: string }>();
+  const projectId = params.id;
+  const [items, setItems] = useState<Transmittal[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [recipient, setRecipient] = useState('');
+  const [notes, setNotes] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(() => {
+    listTransmittals(projectId)
+      .then(setItems)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load transmittals'));
+  }, [projectId]);
+
+  useEffect(load, [load]);
+
+  async function onCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!recipient.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await createTransmittal(projectId, { recipient: recipient.trim(), notes: notes.trim() || undefined });
+      setRecipient('');
+      setNotes('');
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create transmittal');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onAction(t: Transmittal) {
+    const action = nextAction[t.status];
+    if (!action) return;
+    const body = action === 'respond' ? { responseNotes: prompt('Response notes (optional)') || undefined } : undefined;
+    try {
+      await transmittalAction(projectId, t.id, action, body);
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Action failed');
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-4">
+        <Link href={`/projects/${projectId}`} className="text-sm text-slate-400 hover:underline">
+          ← Project
+        </Link>
+        <h1 className="text-xl font-semibold">Transmittals</h1>
+      </div>
+
+      <form onSubmit={onCreate} className="mb-4 flex flex-wrap items-end gap-2 rounded-lg border border-slate-200 bg-white p-4">
+        <label className="block">
+          <span className="text-sm text-slate-600">Recipient</span>
+          <input
+            value={recipient}
+            onChange={(e) => setRecipient(e.target.value)}
+            placeholder="Name / organisation"
+            className="mt-1 block w-56 rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block flex-1">
+          <span className="text-sm text-slate-600">Notes (optional)</span>
+          <input
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            className="mt-1 block w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={busy || !recipient.trim()}
+          className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {busy ? 'Creating…' : 'New transmittal'}
+        </button>
+      </form>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+      {!items && !error && <p className="text-slate-400">Loading…</p>}
+      {items && items.length === 0 && <p className="text-slate-500">No transmittals.</p>}
+
+      {items && items.length > 0 && (
+        <ul className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
+          {items.map((t) => (
+            <li key={t.id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{t.transmittalCode}</span>
+                  <span className={`rounded px-1.5 py-0.5 text-[10px] ${statusClass[t.status] ?? 'bg-slate-100 text-slate-600'}`}>
+                    {t.status}
+                  </span>
+                </div>
+                <div className="mt-0.5 truncate text-xs text-slate-400">
+                  To {t.recipient}
+                  {t.notes ? ` · ${t.notes}` : ''}
+                </div>
+              </div>
+              {nextAction[t.status] && (
+                <button
+                  onClick={() => onAction(t)}
+                  className="shrink-0 rounded border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50"
+                >
+                  {actionLabel[nextAction[t.status]!]}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </AppShell>
+  );
+}

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -19,6 +19,8 @@ import type {
   ProjectMember,
   Iso19650Role,
   SearchResponse,
+  Transmittal,
+  SitePhoto,
 } from './types';
 
 // ── Projects ──
@@ -374,4 +376,126 @@ export function search(q: string, types?: string[], limit = 25): Promise<SearchR
   const params = new URLSearchParams({ q, limit: String(limit) });
   if (types && types.length) params.set('type', types.join(','));
   return api<SearchResponse>(`/api/search?${params.toString()}`);
+}
+
+// ── Document upload + CDE transition ──
+/** Multipart document upload (file + ISO 19650 metadata). Role-gated server-side. */
+export async function uploadDocument(
+  projectId: string,
+  file: File,
+  meta: { documentType?: string; discipline?: string; revision?: string; description?: string } = {},
+): Promise<ProjectDocument> {
+  const form = new FormData();
+  form.append('file', file, file.name);
+  if (meta.documentType) form.append('documentType', meta.documentType);
+  if (meta.discipline) form.append('discipline', meta.discipline);
+  if (meta.revision) form.append('revision', meta.revision);
+  if (meta.description) form.append('description', meta.description);
+
+  const token = getToken();
+  const headers = new Headers();
+  if (token) headers.set('Authorization', `Bearer ${token}`); // browser sets multipart boundary
+
+  const res = await fetch(`${API_BASE}/api/projects/${projectId}/documents/upload`, {
+    method: 'POST',
+    headers,
+    body: form,
+  });
+  if (res.status === 401) {
+    setToken(null);
+    if (typeof window !== 'undefined' && window.location.pathname !== '/login') window.location.href = '/login';
+    throw new ApiError(401, 'Session expired — please sign in again.');
+  }
+  if (!res.ok) {
+    let message = `Upload failed (HTTP ${res.status})`;
+    try {
+      const b = await res.json();
+      message = b.message || b.error || message;
+    } catch {
+      /* non-JSON */
+    }
+    throw new ApiError(res.status, message);
+  }
+  return (await res.json()) as ProjectDocument;
+}
+
+/** CDE state transition (WIP→SHARED→PUBLISHED→ARCHIVE…). Role/suitability/approval
+ *  gated server-side — a 400/403 surfaces as ApiError with the reason. */
+export function transitionDocument(
+  projectId: string,
+  docId: string,
+  body: { newState: string; suitabilityCode?: string; revision?: string },
+): Promise<ProjectDocument> {
+  return api<ProjectDocument>(`/api/projects/${projectId}/documents/${docId}/state`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Transmittals ──
+export async function listTransmittals(projectId: string): Promise<Transmittal[]> {
+  const raw = await api<{ transmittals?: Transmittal[] } | Transmittal[]>(
+    `/api/projects/${projectId}/transmittals`,
+  );
+  if (Array.isArray(raw)) return raw;
+  return raw.transmittals ?? [];
+}
+
+export function createTransmittal(
+  projectId: string,
+  body: { recipient: string; notes?: string; documentIds?: string[] },
+): Promise<Transmittal> {
+  return api<Transmittal>(`/api/projects/${projectId}/transmittals`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function transmittalAction(
+  projectId: string,
+  txId: string,
+  action: 'send' | 'acknowledge' | 'respond',
+  body?: { responseNotes?: string },
+): Promise<Transmittal> {
+  return api<Transmittal>(`/api/projects/${projectId}/transmittals/${txId}/${action}`, {
+    method: 'PUT',
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ── Site photos ──
+export async function listSitePhotos(
+  projectId: string,
+  opts: { reason?: string; audience?: string } = {},
+): Promise<SitePhoto[]> {
+  const params = new URLSearchParams();
+  if (opts.reason) params.set('reason', opts.reason);
+  if (opts.audience) params.set('audience', opts.audience);
+  const qs = params.toString();
+  const raw = await api<{ items?: SitePhoto[] } | SitePhoto[]>(
+    `/api/projects/${projectId}/photos${qs ? `?${qs}` : ''}`,
+  );
+  if (Array.isArray(raw)) return raw;
+  return raw.items ?? [];
+}
+
+/** Authenticated photo bytes URL (original or redacted), token via query. */
+export function photoFileUrl(projectId: string, photoId: string): string {
+  const token = getToken();
+  const base = `${API_BASE}/api/projects/${projectId}/photos/${photoId}/file`;
+  return token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
+}
+
+export function approvePhoto(projectId: string, photoId: string, caption: string): Promise<unknown> {
+  return api(`/api/projects/${projectId}/photos/${photoId}/approve`, {
+    method: 'POST',
+    body: JSON.stringify({ caption }),
+  });
+}
+
+export function rejectPhoto(projectId: string, photoId: string, reason: string): Promise<unknown> {
+  return api(`/api/projects/${projectId}/photos/${photoId}/reject`, {
+    method: 'POST',
+    body: JSON.stringify({ reason }),
+  });
 }

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -249,3 +249,37 @@ export interface SearchResponse {
   count: number;
   results: SearchResult[];
 }
+
+// ── Transmittals ──
+export interface Transmittal {
+  id: string;
+  transmittalCode: string;
+  recipient: string;
+  status: string; // DRAFT | SENT | ACKNOWLEDGED | RESPONDED
+  notes?: string | null;
+  createdBy?: string;
+  createdAt?: string;
+  sentAt?: string | null;
+  acknowledgedAt?: string | null;
+  respondedAt?: string | null;
+  responseNotes?: string | null;
+}
+
+// ── Site photos ──
+export interface SitePhoto {
+  id: string;
+  projectId: string;
+  reason?: string;
+  audience?: string; // Internal | PendingReview | Approved | ClientPortal | Withdrawn
+  blurStatus?: string;
+  watermarkApplied?: boolean;
+  caption?: string | null;
+  capturedAt?: string;
+  capturedByName?: string | null;
+  levelCode?: string | null;
+  zoneCode?: string | null;
+  discipline?: string | null;
+  approvedAt?: string | null;
+  rejectedAt?: string | null;
+  rejectedReason?: string | null;
+}


### PR DESCRIPTION
## What

The **remaining section-2 polish** in `planscape-web`, all server-backed. Branched off the just-merged `main`, so conflict-free.

## Documents — upload + CDE transitions
- `uploadDocument` (multipart `POST /documents/upload`) + `transitionDocument` (`PUT /documents/{id}/state`).
- Documents page gains an **upload form** (lands as WIP) and a **per-doc forward CDE transition** button (WIP→SHARED→PUBLISHED→ARCHIVE with the implied suitability S2/S4/S7). The server enforces the full transition matrix / role / approval gates — 400/403 surface inline.

## Transmittals — new page `/projects/[id]/transmittals`
- `listTransmittals / createTransmittal / transmittalAction`.
- List + create (recipient + notes) + status-driven action button (DRAFT→**Send**, SENT→**Acknowledge**, ACKNOWLEDGED→**Respond**).

## Site photos — new page `/projects/[id]/photos`
- `listSitePhotos / photoFileUrl / approvePhoto / rejectPhoto`.
- Gallery grid (redacted/original bytes via `?access_token=`) + reason filter + **approve** (caption) / **reject** (reason). Capture stays native (mobile); the web does review/approval.

## Issues — assignee + due-date editing
- Issue detail page gains an **Assignee** + **Due date** editor (`updateIssue`).

## Plumbing
- Project nav gains **Transmittals** + **Photos** links. Types added: `Transmittal`, `SitePhoto`.
- `tsc --noEmit` clean; **`next build` succeeds**.

## Caveats
- Document upload uses the multipart path (skips AV scan, marked `scanStatus=SKIPPED` server-side); the presign+scan path is heavier and deferred.
- CDE transition button does the common forward path; non-standard transitions (rework, withdraw, supersede) aren't exposed yet.
- Photo capture is native-only (browsers can't reliably access the site camera) — web handles gallery + review.
- Not click-tested against a live API; built to verified contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL)_