### PR TITLE
planscape-web UX: project create, compliance RAG, error boundary, pagination

### DIFF
--- a/planscape-web/app/error.tsx
+++ b/planscape-web/app/error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+// Global error boundary — App Router renders this on an uncaught render/runtime
+// error in a route subtree, instead of a blank screen.
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="grid min-h-screen place-items-center bg-slate-50 p-6">
+      <div className="max-w-md rounded-lg border border-slate-200 bg-white p-6 text-center">
+        <h1 className="text-lg font-semibold">Something went wrong</h1>
+        <p className="mt-2 text-sm text-slate-500">{error.message || 'An unexpected error occurred.'}</p>
+        <button
+          onClick={reset}
+          className="mt-4 rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/planscape-web/app/not-found.tsx
+++ b/planscape-web/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="grid min-h-screen place-items-center bg-slate-50 p-6">
+      <div className="max-w-md rounded-lg border border-slate-200 bg-white p-6 text-center">
+        <h1 className="text-lg font-semibold">Page not found</h1>
+        <p className="mt-2 text-sm text-slate-500">That page doesn’t exist or you don’t have access.</p>
+        <Link
+          href="/projects"
+          className="mt-4 inline-block rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Back to projects
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/planscape-web/app/projects/[id]/documents/page.tsx
+++ b/planscape-web/app/projects/[id]/documents/page.tsx
@@ -48,6 +48,13 @@ export default function DocumentsPage() {
   const [file, setFile] = useState<File | null>(null);
   const [discipline, setDiscipline] = useState('');
   const [busy, setBusy] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+
+  const PAGE_SIZE = 50;
+  const filters = () => ({
+    cdeStatus: cde === 'ALL' ? undefined : cde,
+    search: query || undefined,
+  });
 
   const load = useCallback(() => {
     setDocs(null);
@@ -55,12 +62,29 @@ export default function DocumentsPage() {
     listDocuments(projectId, {
       cdeStatus: cde === 'ALL' ? undefined : cde,
       search: query || undefined,
+      page: 1,
+      pageSize: PAGE_SIZE,
     })
-      .then(setDocs)
+      .then((d) => {
+        setDocs(d);
+        setHasMore(d.length === PAGE_SIZE);
+      })
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load documents'));
   }, [projectId, cde, query]);
 
   useEffect(load, [load]);
+
+  async function loadMore() {
+    if (!docs) return;
+    const page = Math.floor(docs.length / PAGE_SIZE) + 1;
+    try {
+      const more = await listDocuments(projectId, { ...filters(), page, pageSize: PAGE_SIZE });
+      setDocs([...docs, ...more]);
+      setHasMore(more.length === PAGE_SIZE);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load more');
+    }
+  }
 
   async function onUpload(e: React.FormEvent) {
     e.preventDefault();
@@ -203,6 +227,17 @@ export default function DocumentsPage() {
             </li>
           ))}
         </ul>
+      )}
+
+      {hasMore && (
+        <div className="mt-3 text-center">
+          <button
+            onClick={loadMore}
+            className="rounded border border-slate-300 px-4 py-2 text-sm hover:bg-slate-50"
+          >
+            Load more
+          </button>
+        </div>
       )}
     </AppShell>
   );

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
+import { RagBadge } from '@/components/RagBadge';
 import { getProject, listIssues } from '@/lib/data';
 import { useProjectRealtime } from '@/lib/realtime';
 import type { Project, BimIssue, IssueStatus } from '@/lib/types';
@@ -55,7 +56,10 @@ export default function ProjectPage() {
           <Link href="/projects" className="text-sm text-slate-400 hover:underline">
             ← Projects
           </Link>
-          <h1 className="text-xl font-semibold">{project?.name ?? 'Project'}</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-semibold">{project?.name ?? 'Project'}</h1>
+            {project && <RagBadge rag={project.ragStatus} percent={project.compliancePercent} />}
+          </div>
           {project?.code && <p className="text-xs text-slate-400">{project.code}</p>}
           {live && (
             <span className="mt-1 inline-flex items-center gap-1 text-xs text-green-600">

--- a/planscape-web/app/projects/new/page.tsx
+++ b/planscape-web/app/projects/new/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { AppShell } from '@/components/AppShell';
+import { createProject } from '@/lib/data';
+
+export const dynamic = 'force-dynamic';
+
+export default function NewProjectPage() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+  const [description, setDescription] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const p = await createProject({
+        name: name.trim(),
+        code: code.trim() || undefined,
+        description: description.trim() || undefined,
+      });
+      router.push(`/projects/${p.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create project');
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="mb-4">
+        <Link href="/projects" className="text-sm text-slate-400 hover:underline">
+          ← Projects
+        </Link>
+        <h1 className="text-xl font-semibold">New project</h1>
+      </div>
+
+      {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+
+      <form onSubmit={submit} className="max-w-lg space-y-3 rounded-lg border border-slate-200 bg-white p-4">
+        <label className="block">
+          <span className="text-sm text-slate-600">Name</span>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-slate-600">Code (optional — auto-derived if blank)</span>
+          <input
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="e.g. KLA-OFFICE"
+            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-slate-600">Description (optional)</span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-sm"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={busy || !name.trim()}
+          className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {busy ? 'Creating…' : 'Create project'}
+        </button>
+      </form>
+    </AppShell>
+  );
+}

--- a/planscape-web/app/projects/page.tsx
+++ b/planscape-web/app/projects/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { AppShell } from '@/components/AppShell';
+import { RagBadge } from '@/components/RagBadge';
 import { listProjects } from '@/lib/data';
 import type { Project } from '@/lib/types';
 
@@ -18,7 +19,15 @@ export default function ProjectsPage() {
 
   return (
     <AppShell>
-      <h1 className="mb-4 text-xl font-semibold">Projects</h1>
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Projects</h1>
+        <Link
+          href="/projects/new"
+          className="rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          New project
+        </Link>
+      </div>
 
       {error && <p className="mb-3 rounded bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
       {!projects && !error && <p className="text-slate-400">Loading…</p>}
@@ -33,9 +42,15 @@ export default function ProjectsPage() {
           >
             <div className="flex items-center justify-between gap-3">
               <span className="font-medium">{p.name}</span>
-              <span className="text-xs text-slate-400">{p.code}</span>
+              <div className="flex shrink-0 items-center gap-2">
+                <RagBadge rag={p.ragStatus} percent={p.compliancePercent} />
+                <span className="text-xs text-slate-400">{p.code}</span>
+              </div>
             </div>
             {p.description && <p className="mt-1 line-clamp-2 text-sm text-slate-500">{p.description}</p>}
+            {typeof p.openIssueCount === 'number' && (
+              <p className="mt-1 text-xs text-slate-400">{p.openIssueCount} open issue(s)</p>
+            )}
           </Link>
         ))}
       </div>

--- a/planscape-web/components/RagBadge.tsx
+++ b/planscape-web/components/RagBadge.tsx
@@ -1,0 +1,19 @@
+/** Compliance RAG chip. Renders nothing when there's no signal. */
+export function RagBadge({ rag, percent }: { rag?: string; percent?: number }) {
+  if (!rag && percent == null) return null;
+  const key = (rag || '').toUpperCase();
+  const cls =
+    key === 'GREEN'
+      ? 'bg-green-100 text-green-700'
+      : key === 'AMBER'
+        ? 'bg-amber-100 text-amber-700'
+        : key === 'RED'
+          ? 'bg-red-100 text-red-700'
+          : 'bg-slate-100 text-slate-600';
+  const label = percent != null ? `${Math.round(percent)}%` : key || '—';
+  return (
+    <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`} title={key ? `Compliance: ${key}` : undefined}>
+      {label}
+    </span>
+  );
+}

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -32,6 +32,15 @@ export function getProject(id: string): Promise<Project> {
   return api<Project>(`/api/projects/${id}`);
 }
 
+export function createProject(body: {
+  name: string;
+  code?: string;
+  description?: string;
+  phase?: string;
+}): Promise<Project> {
+  return api<Project>('/api/projects', { method: 'POST', body: JSON.stringify(body) });
+}
+
 // ── Issues ──
 export async function listIssues(projectId: string, status?: string): Promise<BimIssue[]> {
   const qs = status ? `?status=${encodeURIComponent(status)}` : '';
@@ -321,13 +330,15 @@ export function getLiveKitToken(
 // ── Documents (CDE) ──
 export async function listDocuments(
   projectId: string,
-  opts: { cdeStatus?: string; discipline?: string; documentType?: string; search?: string } = {},
+  opts: { cdeStatus?: string; discipline?: string; documentType?: string; search?: string; page?: number; pageSize?: number } = {},
 ): Promise<ProjectDocument[]> {
   const params = new URLSearchParams();
   if (opts.cdeStatus) params.set('cdeStatus', opts.cdeStatus);
   if (opts.discipline) params.set('discipline', opts.discipline);
   if (opts.documentType) params.set('documentType', opts.documentType);
   if (opts.search) params.set('search', opts.search);
+  if (opts.page) params.set('page', String(opts.page));
+  if (opts.pageSize) params.set('pageSize', String(opts.pageSize));
   const qs = params.toString();
   const raw = await api<DocumentListResponse | ProjectDocument[]>(
     `/api/projects/${projectId}/documents${qs ? `?${qs}` : ''}`,


### PR DESCRIPTION
## What

**Section-2 UX completeness** — fills the gaps where the data already existed but the UI didn't surface or act on it.

- **Project create** — `createProject()` + `/projects/new` form + a **New project** button on the projects list. (The web could only *list* projects before.)
- **Compliance RAG** — a `RagBadge` component (GREEN/AMBER/RED + %) shown on the **projects list** and the **project header**. `Project.compliancePercent` / `ragStatus` were carried in the type but never displayed; the list also now shows `openIssueCount`.
- **Resilience** — `app/error.tsx` global error boundary + `app/not-found.tsx`, replacing blank screens on render errors / bad routes.
- **Pagination** — `listDocuments` now takes `page`/`pageSize`; the documents page gets a **Load more** button (stops when a page returns `< pageSize`). The same pattern can extend to issues/photos.

## Verification
`tsc --noEmit` clean; **`next build` succeeds**.

## Notes
- Branched off the merged `main`; independent of the test-suite PR (#354) — they touch different files.
- Pagination is applied to documents (the explicitly server-paginated list); issues/photos can adopt the identical pattern in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7MtkT34dMsiksNzuNiVxL)_