### PR TITLE
MEP Systems — Phase A: data-driven System Type Materializer

### DIFF
--- a/StingTools/Commands/Mep/MepSystemTypeCommands.cs
+++ b/StingTools/Commands/Mep/MepSystemTypeCommands.cs
@@ -1,0 +1,198 @@
+// StingTools — MEP System Type commands (Phase A: System Type Materializer).
+//
+//   MEP_BuildSystemTypes    — create any missing duct/pipe system types from
+//                             STING_MEP_SYSTEM_TYPES.json (+ project override),
+//                             stamping abbreviation + graphics on NEW types only.
+//   MEP_RestyleSystemTypes  — same, but also re-applies the baseline graphics to
+//                             EXISTING types (use when you want the corporate
+//                             colours back after a project hand-tuned them).
+//   MEP_InspectSystemTypes  — read-only: which definitions exist in the model vs
+//                             which are still to be built; cross-refs classification.
+//   MEP_ReloadSystemTypes   — drop the registry cache so an edit to the baseline or
+//                             project override is picked up without restarting Revit.
+
+using System;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Mechanical;
+using Autodesk.Revit.DB.Plumbing;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Mep;
+using StingTools.UI;
+
+namespace StingTools.Commands.Mep
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepBuildSystemTypesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+            => MepSystemTypeRunner.Run(commandData, ref message, overwriteGraphics: false);
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepRestyleSystemTypesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+            => MepSystemTypeRunner.Run(commandData, ref message, overwriteGraphics: true);
+    }
+
+    internal static class MepSystemTypeRunner
+    {
+        public static Result Run(ExternalCommandData commandData, ref string message, bool overwriteGraphics)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                var rules = MepSystemTypeRegistry.Get(doc);
+                int enabled = rules.Enabled.Count();
+                if (enabled == 0)
+                {
+                    TaskDialog.Show("STING MEP",
+                        "No enabled MEP system-type definitions found in STING_MEP_SYSTEM_TYPES.json " +
+                        "(or the project override). Nothing to build.");
+                    return Result.Cancelled;
+                }
+
+                MepSystemTypeResult res;
+                using (var t = new Transaction(doc,
+                    overwriteGraphics ? "STING Restyle MEP System Types" : "STING Build MEP System Types"))
+                {
+                    t.Start();
+                    res = MepSystemTypeMaterializer.Materialize(doc, rules, overwriteGraphics);
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create(
+                    overwriteGraphics ? "MEP — Restyle System Types" : "MEP — Build System Types");
+                panel.SetSubtitle(
+                    $"{res.Created} created · {res.Updated} updated · {res.Skipped} skipped · {res.Failed} failed " +
+                    $"(of {enabled} enabled definitions)");
+
+                panel.AddSection("SUMMARY")
+                     .Metric("Created",  res.Created.ToString())
+                     .Metric("Updated",  res.Updated.ToString())
+                     .Metric("Skipped",  res.Skipped.ToString())
+                     .Metric("Failed",   res.Failed.ToString());
+
+                panel.AddSection("SYSTEM TYPES");
+                foreach (var r in res.Rows)
+                    panel.Text($"{Glyph(r.Action)} {r.Name,-30} {r.Discipline,-5} {r.Classification,-20} {r.Note}");
+
+                if (res.Warnings.Count > 0)
+                {
+                    panel.AddSection($"WARNINGS ({res.Warnings.Count})");
+                    foreach (var w in res.Warnings.Take(40)) panel.Text(w);
+                }
+
+                panel.AddSection("NEXT");
+                panel.Text("These types carry the Revit system CLASSIFICATION the 19 MEP filters in " +
+                           "STING_AEC_FILTERS.json match on (RBS_SYSTEM_CLASSIFICATION_PARAM) — run " +
+                           "AecFilters_Create + apply a coordination View Style Pack to see them colour up.");
+                panel.Text("Assign ducts/pipes to these types (or route new runs) so the System Browser " +
+                           "and the colour filters have data to act on.");
+                panel.Show();
+
+                StingLog.Info($"MEP system types: created={res.Created} updated={res.Updated} " +
+                              $"skipped={res.Skipped} failed={res.Failed} overwrite={overwriteGraphics}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepBuildSystemTypesCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        private static string Glyph(MepTypeAction a) => a switch
+        {
+            MepTypeAction.Created => "✚",
+            MepTypeAction.Updated => "↻",
+            MepTypeAction.Skipped => "–",
+            MepTypeAction.Failed  => "✖",
+            _ => " "
+        };
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepInspectSystemTypesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                var rules = MepSystemTypeRegistry.Get(doc);
+
+                var mechNames = new FilteredElementCollector(doc).OfClass(typeof(MechanicalSystemType))
+                    .Cast<MechanicalSystemType>().Select(t => t.Name)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var pipeNames = new FilteredElementCollector(doc).OfClass(typeof(PipingSystemType))
+                    .Cast<PipingSystemType>().Select(t => t.Name)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                int present = 0, missing = 0;
+                var panel = StingResultPanel.Create("MEP — System Type Inventory");
+
+                panel.AddSection("DEFINITIONS");
+                foreach (var d in rules.All)
+                {
+                    bool exists = d.IsDuct ? mechNames.Contains(d.Name)
+                                : d.IsPipe ? pipeNames.Contains(d.Name) : false;
+                    if (!d.Enabled) { panel.Text($"  (disabled) {d.Name}"); continue; }
+                    if (exists) present++; else missing++;
+                    panel.Text($"{(exists ? "✓" : "·")} {d.Name,-30} {d.Discipline,-5} " +
+                               $"{d.Classification,-20} abbr={d.Abbreviation,-6} sys={d.StingSysCode}");
+                }
+
+                panel.SetSubtitle(
+                    $"{present} present · {missing} to build · " +
+                    $"{mechNames.Count} duct + {pipeNames.Count} pipe system types in model");
+
+                if (missing > 0)
+                    panel.AddSection("ACTION").Text($"{missing} definition(s) not yet in the model — run MEP_BuildSystemTypes.");
+                panel.Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepInspectSystemTypesCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepReloadSystemTypesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                MepSystemTypeRegistry.Reload();
+                TaskDialog.Show("STING MEP",
+                    "MEP system-type registry reloaded — corporate baseline + project override re-read on next use.");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepReloadSystemTypesCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/Core/Mep/MepSystemTypeMaterializer.cs
+++ b/StingTools/Core/Mep/MepSystemTypeMaterializer.cs
@@ -1,0 +1,219 @@
+// StingTools — MEP System Type Materializer (Phase A).
+//
+// Turns MepSystemTypeRules (loaded from STING_MEP_SYSTEM_TYPES.json + project
+// override) into live Revit system types:
+//   duct -> MechanicalSystemType.Create(doc, classification, name)
+//   pipe -> PipingSystemType.Create(doc, classification, name)
+// then stamps Abbreviation + graphic overrides (LineColor / LineWeight /
+// LinePatternId / MaterialId).
+//
+// Idempotent: matches existing types by name (never duplicates). New types are
+// always graphically stamped; existing types are only restamped when the caller
+// passes overwriteGraphics = true (so a project's hand-tuned colours survive a
+// re-run unless the user explicitly asks to re-apply the baseline).
+//
+// CALLER OWNS THE ACTIVE TRANSACTION — same contract as AecFilterFactory.FindOrCreate.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Mechanical;
+using Autodesk.Revit.DB.Plumbing;
+
+namespace StingTools.Core.Mep
+{
+    public enum MepTypeAction { Created, Updated, Skipped, Failed }
+
+    public sealed class MepSystemTypeRow
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Discipline { get; set; } = "";
+        public string Classification { get; set; } = "";
+        public MepTypeAction Action { get; set; }
+        public string Note { get; set; } = "";
+    }
+
+    public sealed class MepSystemTypeResult
+    {
+        public List<MepSystemTypeRow> Rows { get; } = new List<MepSystemTypeRow>();
+        public List<string> Warnings { get; } = new List<string>();
+
+        public int Created => Rows.Count(r => r.Action == MepTypeAction.Created);
+        public int Updated => Rows.Count(r => r.Action == MepTypeAction.Updated);
+        public int Skipped => Rows.Count(r => r.Action == MepTypeAction.Skipped);
+        public int Failed  => Rows.Count(r => r.Action == MepTypeAction.Failed);
+    }
+
+    public static class MepSystemTypeMaterializer
+    {
+        /// <summary>
+        /// Create/update every enabled definition. Requires an open transaction.
+        /// </summary>
+        public static MepSystemTypeResult Materialize(
+            Document doc, MepSystemTypeRules rules, bool overwriteGraphics)
+        {
+            var result = new MepSystemTypeResult();
+            if (doc == null || rules == null) { result.Warnings.Add("No document / rules."); return result; }
+
+            // Index existing types once.
+            var mechByName = new FilteredElementCollector(doc).OfClass(typeof(MechanicalSystemType))
+                .Cast<MechanicalSystemType>()
+                .GroupBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+            var pipeByName = new FilteredElementCollector(doc).OfClass(typeof(PipingSystemType))
+                .Cast<PipingSystemType>()
+                .GroupBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var def in rules.Enabled)
+            {
+                var row = new MepSystemTypeRow
+                {
+                    Id = def.Id, Name = def.Name, Discipline = def.Discipline,
+                    Classification = def.Classification
+                };
+                result.Rows.Add(row);
+
+                if (string.IsNullOrWhiteSpace(def.Name) || (!def.IsDuct && !def.IsPipe))
+                {
+                    row.Action = MepTypeAction.Skipped;
+                    row.Note = "missing name or unknown discipline (expect 'duct' or 'pipe')";
+                    continue;
+                }
+
+                if (!Enum.TryParse<MEPSystemClassification>(def.Classification, true, out var cls))
+                {
+                    row.Action = MepTypeAction.Skipped;
+                    row.Note = $"classification '{def.Classification}' not valid in this Revit version";
+                    result.Warnings.Add($"{def.Name}: classification '{def.Classification}' not recognised — skipped.");
+                    continue;
+                }
+
+                try
+                {
+                    MEPSystemType st;
+                    bool created = false;
+
+                    if (def.IsDuct)
+                    {
+                        if (!mechByName.TryGetValue(def.Name, out var mt))
+                        {
+                            mt = MechanicalSystemType.Create(doc, cls, def.Name);
+                            mechByName[def.Name] = mt;
+                            created = true;
+                        }
+                        st = mt;
+                    }
+                    else
+                    {
+                        if (!pipeByName.TryGetValue(def.Name, out var pt))
+                        {
+                            pt = PipingSystemType.Create(doc, cls, def.Name);
+                            pipeByName[def.Name] = pt;
+                            created = true;
+                        }
+                        st = pt;
+                    }
+
+                    bool stampGraphics = created || overwriteGraphics;
+                    int applied = ApplyGraphics(doc, st, def, stampGraphics, result.Warnings);
+
+                    row.Action = created ? MepTypeAction.Created : MepTypeAction.Updated;
+                    row.Note = created
+                        ? $"created ({applied} graphic prop(s) set)"
+                        : (stampGraphics ? $"updated ({applied} graphic prop(s) re-applied)"
+                                         : "exists — graphics left untouched (no overwrite)");
+                }
+                catch (Exception ex)
+                {
+                    row.Action = MepTypeAction.Failed;
+                    row.Note = ex.Message;
+                    result.Warnings.Add($"{def.Name}: {ex.Message}");
+                    StingLog.Warn($"MepSystemTypeMaterializer: '{def.Name}' failed — {ex.Message}");
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Stamp Abbreviation + graphic overrides. Each property is set
+        /// independently so one read-only/edge-case property never aborts the rest.
+        /// Returns the count of properties successfully applied.
+        /// </summary>
+        private static int ApplyGraphics(
+            Document doc, MEPSystemType st, MepSystemTypeDef def, bool stamp, List<string> warnings)
+        {
+            if (st == null || !stamp) return 0;
+            int n = 0;
+
+            if (!string.IsNullOrWhiteSpace(def.Abbreviation))
+                if (TrySet(() => st.Abbreviation = def.Abbreviation, def.Name, "Abbreviation", warnings)) n++;
+
+            if (def.LineColor != null && def.LineColor.Length >= 3)
+            {
+                var c = new Color(Clamp(def.LineColor[0]), Clamp(def.LineColor[1]), Clamp(def.LineColor[2]));
+                if (TrySet(() => st.LineColor = c, def.Name, "LineColor", warnings)) n++;
+            }
+
+            if (def.LineWeight >= 1 && def.LineWeight <= 16)
+                if (TrySet(() => st.LineWeight = def.LineWeight, def.Name, "LineWeight", warnings)) n++;
+
+            if (!string.IsNullOrWhiteSpace(def.LinePattern))
+            {
+                var pid = ResolveLinePattern(doc, def.LinePattern);
+                if (pid != null && pid != ElementId.InvalidElementId)
+                {
+                    if (TrySet(() => st.LinePatternId = pid, def.Name, "LinePatternId", warnings)) n++;
+                }
+                else warnings?.Add($"{def.Name}: line pattern '{def.LinePattern}' not found — left default.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(def.Material))
+            {
+                var mid = ResolveMaterial(doc, def.Material);
+                if (mid != null && mid != ElementId.InvalidElementId)
+                {
+                    if (TrySet(() => st.MaterialId = mid, def.Name, "MaterialId", warnings)) n++;
+                }
+                else warnings?.Add($"{def.Name}: material '{def.Material}' not found — left default.");
+            }
+
+            return n;
+        }
+
+        private static bool TrySet(Action setter, string typeName, string prop, List<string> warnings)
+        {
+            try { setter(); return true; }
+            catch (Exception ex)
+            {
+                warnings?.Add($"{typeName}: could not set {prop} ({ex.Message}).");
+                return false;
+            }
+        }
+
+        private static byte Clamp(int v) => (byte)(v < 0 ? 0 : (v > 255 ? 255 : v));
+
+        private static ElementId ResolveLinePattern(Document doc, string name)
+        {
+            if (string.Equals(name, "Solid", StringComparison.OrdinalIgnoreCase))
+            {
+                try { return LinePatternElement.GetSolidPatternId(); } catch { /* fall through */ }
+            }
+            var lp = new FilteredElementCollector(doc).OfClass(typeof(LinePatternElement))
+                .Cast<LinePatternElement>()
+                .FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+            return lp?.Id ?? ElementId.InvalidElementId;
+        }
+
+        private static ElementId ResolveMaterial(Document doc, string name)
+        {
+            var m = new FilteredElementCollector(doc).OfClass(typeof(Material))
+                .Cast<Material>()
+                .FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+            return m?.Id ?? ElementId.InvalidElementId;
+        }
+    }
+}

--- a/StingTools/Core/Mep/MepSystemTypeRegistry.cs
+++ b/StingTools/Core/Mep/MepSystemTypeRegistry.cs
@@ -1,0 +1,166 @@
+// StingTools — MEP System Type Registry (Phase A: System Type Materializer).
+//
+// Single source of truth for the Revit MEP *system types* STING creates and
+// maintains in a project (duct -> MechanicalSystemType, pipe -> PipingSystemType).
+// Each definition carries the Revit system CLASSIFICATION (which the 19 MEP AEC
+// filters key off via RBS_SYSTEM_CLASSIFICATION_PARAM) plus the STING tag tokens,
+// so materializing them is what makes the system-colour filters + System Browser
+// light up.
+//
+// Layered baseline + project override, mirroring MepSizingRegistry /
+// DrawingTypeRegistry / AecFilterRegistry / ViewStylePackRegistry:
+//   corporate baseline -> Data/STING_MEP_SYSTEM_TYPES.json
+//   project override   -> <project>/_BIM_COORD/mep_system_types.json  (merged by id, project wins)
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Autodesk.Revit.DB;
+
+namespace StingTools.Core.Mep
+{
+    /// <summary>
+    /// One MEP system-type definition (duct or pipe) loaded from
+    /// STING_MEP_SYSTEM_TYPES.json + project override.
+    /// </summary>
+    public class MepSystemTypeDef
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        /// <summary>"duct" (MechanicalSystemType) | "pipe" (PipingSystemType).</summary>
+        public string Discipline { get; set; } = "";
+        /// <summary>MEPSystemClassification enum name (e.g. SupplyAir, DomesticColdWater).</summary>
+        public string Classification { get; set; } = "";
+        public string Abbreviation { get; set; } = "";
+        public string StingSysCode { get; set; } = "";
+        public string StingFuncCode { get; set; } = "";
+
+        /// <summary>[r,g,b] 0..255 → MEPSystemType.LineColor. Null = leave default.</summary>
+        public int[] LineColor { get; set; }
+        /// <summary>1..16 → MEPSystemType.LineWeight. 0 = leave default.</summary>
+        public int LineWeight { get; set; }
+        /// <summary>Line-pattern name → MEPSystemType.LinePatternId. Empty = solid/default.</summary>
+        public string LinePattern { get; set; } = "";
+        /// <summary>Material name → MEPSystemType.MaterialId. Empty = leave default.</summary>
+        public string Material { get; set; } = "";
+
+        public string Uniclass { get; set; } = "";
+        public string Cibse { get; set; } = "";
+        public bool Enabled { get; set; } = true;
+
+        public bool IsDuct => string.Equals(Discipline, "duct", StringComparison.OrdinalIgnoreCase);
+        public bool IsPipe => string.Equals(Discipline, "pipe", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Loaded view of STING_MEP_SYSTEM_TYPES.json + project override.</summary>
+    public class MepSystemTypeRules
+    {
+        /// <summary>Definitions keyed by id (project override merges by id, project wins).</summary>
+        public Dictionary<string, MepSystemTypeDef> ById { get; }
+            = new Dictionary<string, MepSystemTypeDef>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Insertion-ordered list for deterministic materialization + reporting.</summary>
+        public List<MepSystemTypeDef> All { get; } = new List<MepSystemTypeDef>();
+
+        public IEnumerable<MepSystemTypeDef> Enabled => All.Where(d => d.Enabled);
+        public IEnumerable<MepSystemTypeDef> Ducts   => Enabled.Where(d => d.IsDuct);
+        public IEnumerable<MepSystemTypeDef> Pipes   => Enabled.Where(d => d.IsPipe);
+    }
+
+    /// <summary>
+    /// Loader / cache for MepSystemTypeRules. Same layered baseline + project
+    /// override + per-document cache pattern as MepSizingRegistry.
+    /// </summary>
+    public static class MepSystemTypeRegistry
+    {
+        private static readonly ConcurrentDictionary<string, MepSystemTypeRules> _cache
+            = new ConcurrentDictionary<string, MepSystemTypeRules>(StringComparer.OrdinalIgnoreCase);
+
+        public const string DataFileName = "STING_MEP_SYSTEM_TYPES.json";
+        public const string ProjectOverrideRelPath = "_BIM_COORD/mep_system_types.json";
+
+        /// <summary>Resolve the active definitions for a Revit document (cached by project file path).</summary>
+        public static MepSystemTypeRules Get(Document doc)
+        {
+            string key = doc?.PathName ?? "<no-doc>";
+            return _cache.GetOrAdd(key, _ => Load(doc));
+        }
+
+        /// <summary>Force a reload from disk for every cached project.</summary>
+        public static void Reload() => _cache.Clear();
+
+        /// <summary>Force a reload for a single document (e.g. after Save As).</summary>
+        public static void Reload(Document doc)
+        {
+            string key = doc?.PathName ?? "<no-doc>";
+            _cache.TryRemove(key, out _);
+        }
+
+        private static MepSystemTypeRules Load(Document doc)
+        {
+            var rules = new MepSystemTypeRules();
+            try
+            {
+                // 1. Corporate baseline.
+                string basePath = StingTools.Core.StingToolsApp.FindDataFile(DataFileName);
+                if (!string.IsNullOrEmpty(basePath) && File.Exists(basePath))
+                    Apply(JObject.Parse(File.ReadAllText(basePath)), rules);
+
+                // 2. Project override (merge by id, project wins).
+                if (doc != null && !string.IsNullOrEmpty(doc.PathName))
+                {
+                    string projDir = Path.GetDirectoryName(doc.PathName) ?? "";
+                    string projPath = Path.Combine(projDir, ProjectOverrideRelPath);
+                    if (File.Exists(projPath))
+                        Apply(JObject.Parse(File.ReadAllText(projPath)), rules);
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepSystemTypeRegistry.Load failed; using whatever loaded", ex);
+            }
+            return rules;
+        }
+
+        private static void Apply(JObject j, MepSystemTypeRules rules)
+        {
+            if (!(j["systemTypes"] is JArray arr)) return;
+            foreach (var t in arr.OfType<JObject>())
+            {
+                string id = (string)t["id"] ?? "";
+                if (string.IsNullOrWhiteSpace(id)) continue;
+
+                // Merge onto an existing def by id (project override wins field-by-field
+                // only for fields present in the override JSON), else create fresh.
+                if (!rules.ById.TryGetValue(id, out var def))
+                {
+                    def = new MepSystemTypeDef { Id = id };
+                    rules.ById[id] = def;
+                    rules.All.Add(def);
+                }
+
+                def.Name          = (string)t["name"]          ?? def.Name;
+                def.Discipline    = (string)t["discipline"]     ?? def.Discipline;
+                def.Classification= (string)t["classification"] ?? def.Classification;
+                def.Abbreviation  = (string)t["abbreviation"]   ?? def.Abbreviation;
+                def.StingSysCode  = (string)t["stingSysCode"]   ?? def.StingSysCode;
+                def.StingFuncCode = (string)t["stingFuncCode"]  ?? def.StingFuncCode;
+                def.LinePattern   = (string)t["linePattern"]    ?? def.LinePattern;
+                def.Material      = (string)t["material"]       ?? def.Material;
+                def.Uniclass      = (string)t["uniclass"]       ?? def.Uniclass;
+                def.Cibse         = (string)t["cibse"]          ?? def.Cibse;
+                if (t["lineWeight"] != null) def.LineWeight = (int?)t["lineWeight"] ?? def.LineWeight;
+                if (t["enabled"]    != null) def.Enabled    = (bool?)t["enabled"]  ?? def.Enabled;
+
+                if (t["lineColor"] is JArray c && c.Count >= 3)
+                {
+                    try { def.LineColor = new[] { (int)c[0], (int)c[1], (int)c[2] }; }
+                    catch { /* leave previous / null */ }
+                }
+            }
+        }
+    }
+}

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1406,6 +1406,11 @@ namespace StingTools.Core
                 case "CreateDucts": return new Temp.CreateDuctsCommand();
                 case "CreatePipes": return new Temp.CreatePipesCommand();
 
+                // MEP System Type Materializer (Phase A) — chainable in workflows.
+                case "MEP_BuildSystemTypes": return new Commands.Mep.MepBuildSystemTypesCommand();
+                case "MEP_RestyleSystemTypes": return new Commands.Mep.MepRestyleSystemTypesCommand();
+                case "MEP_InspectSystemTypes": return new Commands.Mep.MepInspectSystemTypesCommand();
+
                 // Schedules
                 case "FullAutoPopulate": return new Temp.FullAutoPopulateCommand();
                 case "BatchSchedules": return new Temp.BatchSchedulesCommand();

--- a/StingTools/Data/STING_MEP_SYSTEM_TYPES.json
+++ b/StingTools/Data/STING_MEP_SYSTEM_TYPES.json
@@ -1,0 +1,164 @@
+{
+  "_notes": [
+    "STING MEP System Types — corporate baseline (Phase A: System Type Materializer).",
+    "Single source of truth for the Revit MEP *system types* STING creates/maintains in a project:",
+    "  duct systems  -> MechanicalSystemType.Create(doc, classification, name)",
+    "  pipe systems  -> PipingSystemType.Create(doc, classification, name)",
+    "Materialized idempotently by MEP_BuildSystemTypes (match by name; never duplicates).",
+    "",
+    "Each entry carries the Revit system CLASSIFICATION (the enum the 19 MEP AEC filters in",
+    "STING_AEC_FILTERS.json key off via RBS_SYSTEM_CLASSIFICATION_PARAM) PLUS the STING tag",
+    "tokens (stingSysCode / stingFuncCode). Materializing these is what makes the existing",
+    "system-colour filters and the System Browser light up — the integration hook for the",
+    "Drawing Types / View Style Packs / AEC Filters pipeline.",
+    "",
+    "Layered like every other STING registry:",
+    "  corporate baseline -> Data/STING_MEP_SYSTEM_TYPES.json (this file)",
+    "  project override   -> <project>/_BIM_COORD/mep_system_types.json (merged by id, project wins)",
+    "",
+    "Fields:",
+    "  id             stable key (used to merge project overrides)",
+    "  name           the Revit system-type NAME to create/maintain (the System Browser label)",
+    "  discipline     'duct' (MechanicalSystemType) | 'pipe' (PipingSystemType)",
+    "  classification MEPSystemClassification enum name; unknown values are warned + skipped",
+    "  abbreviation   MEPSystemType.Abbreviation — the prefix Revit uses to auto-name systems",
+    "  stingSysCode   STING SYS token (ties the type back to the ISO 19650 tag grammar)",
+    "  stingFuncCode  STING FUNC token",
+    "  lineColor      [r,g,b] -> MEPSystemType.LineColor graphic override (0..255)",
+    "  lineWeight     1..16   -> MEPSystemType.LineWeight (omit/0 = leave default)",
+    "  linePattern    line-pattern NAME -> MEPSystemType.LinePatternId (omit = solid/default)",
+    "  material       material NAME -> MEPSystemType.MaterialId (omit = leave default)",
+    "  uniclass/cibse reference only (documentation / BOQ calibration)",
+    "  enabled        false to keep a definition on file without materializing it (default true)",
+    "",
+    "Project teams extend / recolour by dropping a mep_system_types.json override — no recompile."
+  ],
+
+  "systemTypes": [
+    {
+      "id": "duct-supply-air", "name": "STING Supply Air", "discipline": "duct",
+      "classification": "SupplyAir", "abbreviation": "SA", "stingSysCode": "HVAC", "stingFuncCode": "SUP",
+      "lineColor": [0, 112, 192], "lineWeight": 5,
+      "uniclass": "Ss_55_30_36", "cibse": "CIBSE-HV01"
+    },
+    {
+      "id": "duct-return-air", "name": "STING Return Air", "discipline": "duct",
+      "classification": "ReturnAir", "abbreviation": "RA", "stingSysCode": "HVAC", "stingFuncCode": "RET",
+      "lineColor": [0, 176, 80], "lineWeight": 4,
+      "uniclass": "Ss_55_30_27", "cibse": "CIBSE-HV02"
+    },
+    {
+      "id": "duct-extract-air", "name": "STING Extract Air", "discipline": "duct",
+      "classification": "ExhaustAir", "abbreviation": "EA", "stingSysCode": "HVAC", "stingFuncCode": "EXT",
+      "lineColor": [255, 128, 0], "lineWeight": 4,
+      "uniclass": "Ss_55_30_27", "cibse": "CIBSE-HV02"
+    },
+    {
+      "id": "duct-fresh-air", "name": "STING Fresh Air", "discipline": "duct",
+      "classification": "SupplyAir", "abbreviation": "FA", "stingSysCode": "HVAC", "stingFuncCode": "SUP",
+      "lineColor": [0, 176, 240], "lineWeight": 4,
+      "uniclass": "Ss_55_30_36", "cibse": "CIBSE-HV03"
+    },
+    {
+      "id": "duct-smoke-extract", "name": "STING Smoke Extract", "discipline": "duct",
+      "classification": "ExhaustAir", "abbreviation": "SMK", "stingSysCode": "HVAC", "stingFuncCode": "EXT",
+      "lineColor": [127, 0, 0], "lineWeight": 5,
+      "uniclass": "Ss_55_30_70", "cibse": "CIBSE-HV04"
+    },
+
+    {
+      "id": "pipe-lthw-flow", "name": "STING LTHW Flow", "discipline": "pipe",
+      "classification": "SupplyHydronic", "abbreviation": "LTHWF", "stingSysCode": "HVAC", "stingFuncCode": "HTG",
+      "lineColor": [192, 0, 0], "lineWeight": 4,
+      "uniclass": "Ss_55_30_10", "cibse": "CIBSE-HT01"
+    },
+    {
+      "id": "pipe-lthw-return", "name": "STING LTHW Return", "discipline": "pipe",
+      "classification": "ReturnHydronic", "abbreviation": "LTHWR", "stingSysCode": "HVAC", "stingFuncCode": "HTG",
+      "lineColor": [255, 80, 80], "lineWeight": 4, "linePattern": "Dash",
+      "uniclass": "Ss_55_30_10", "cibse": "CIBSE-HT01"
+    },
+    {
+      "id": "pipe-chw-flow", "name": "STING CHW Flow", "discipline": "pipe",
+      "classification": "SupplyHydronic", "abbreviation": "CHWF", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
+      "lineColor": [0, 32, 96], "lineWeight": 4,
+      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL01"
+    },
+    {
+      "id": "pipe-chw-return", "name": "STING CHW Return", "discipline": "pipe",
+      "classification": "ReturnHydronic", "abbreviation": "CHWR", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
+      "lineColor": [0, 112, 192], "lineWeight": 4, "linePattern": "Dash",
+      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL01"
+    },
+    {
+      "id": "pipe-condenser-flow", "name": "STING Condenser Water Flow", "discipline": "pipe",
+      "classification": "SupplyHydronic", "abbreviation": "CWF", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
+      "lineColor": [0, 128, 128], "lineWeight": 4,
+      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL02"
+    },
+    {
+      "id": "pipe-condenser-return", "name": "STING Condenser Water Return", "discipline": "pipe",
+      "classification": "ReturnHydronic", "abbreviation": "CWR", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
+      "lineColor": [64, 160, 160], "lineWeight": 4, "linePattern": "Dash",
+      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL02"
+    },
+
+    {
+      "id": "pipe-dcw", "name": "STING Domestic Cold Water", "discipline": "pipe",
+      "classification": "DomesticColdWater", "abbreviation": "DCW", "stingSysCode": "DCW", "stingFuncCode": "DCW",
+      "lineColor": [0, 176, 240], "lineWeight": 4,
+      "uniclass": "Ss_55_70_21", "cibse": "CIBSE-PH01"
+    },
+    {
+      "id": "pipe-dhw", "name": "STING Domestic Hot Water", "discipline": "pipe",
+      "classification": "DomesticHotWater", "abbreviation": "DHW", "stingSysCode": "DHW", "stingFuncCode": "DHW",
+      "lineColor": [255, 0, 0], "lineWeight": 4,
+      "uniclass": "Ss_55_40_25", "cibse": "CIBSE-PH02"
+    },
+    {
+      "id": "pipe-dhwr", "name": "STING DHW Circulation", "discipline": "pipe",
+      "classification": "DomesticHotWater", "abbreviation": "DHWR", "stingSysCode": "DHW", "stingFuncCode": "DHW",
+      "lineColor": [255, 128, 128], "lineWeight": 3, "linePattern": "Dash",
+      "uniclass": "Ss_55_40_25", "cibse": "CIBSE-PH02"
+    },
+
+    {
+      "id": "pipe-soil", "name": "STING Soil and Waste", "discipline": "pipe",
+      "classification": "Sanitary", "abbreviation": "SAN", "stingSysCode": "SAN", "stingFuncCode": "SAN",
+      "lineColor": [102, 51, 0], "lineWeight": 5,
+      "uniclass": "Ss_50_30_70", "cibse": "CIBSE-PH03"
+    },
+    {
+      "id": "pipe-vent", "name": "STING Soil Vent", "discipline": "pipe",
+      "classification": "Vent", "abbreviation": "SVP", "stingSysCode": "SAN", "stingFuncCode": "SAN",
+      "lineColor": [153, 153, 0], "lineWeight": 3,
+      "uniclass": "Ss_50_30_70", "cibse": "CIBSE-PH03"
+    },
+    {
+      "id": "pipe-rainwater", "name": "STING Rainwater", "discipline": "pipe",
+      "classification": "OtherPipe", "abbreviation": "RWD", "stingSysCode": "RWD", "stingFuncCode": "RWD",
+      "lineColor": [0, 153, 153], "lineWeight": 4,
+      "uniclass": "Ss_50_30_67", "cibse": "CIBSE-PH04"
+    },
+
+    {
+      "id": "pipe-fire-wet", "name": "STING Sprinkler (Wet)", "discipline": "pipe",
+      "classification": "FireProtectWet", "abbreviation": "SPR", "stingSysCode": "FP", "stingFuncCode": "FP",
+      "lineColor": [192, 0, 0], "lineWeight": 5,
+      "uniclass": "Ss_55_70_30", "cibse": "CIBSE-FP01"
+    },
+    {
+      "id": "pipe-fire-dry", "name": "STING Sprinkler (Dry)", "discipline": "pipe",
+      "classification": "FireProtectDry", "abbreviation": "SPRD", "stingSysCode": "FP", "stingFuncCode": "FP",
+      "lineColor": [192, 80, 0], "lineWeight": 5, "linePattern": "Dash",
+      "uniclass": "Ss_55_70_30", "cibse": "CIBSE-FP01"
+    },
+
+    {
+      "id": "pipe-natural-gas", "name": "STING Natural Gas", "discipline": "pipe",
+      "classification": "OtherPipe", "abbreviation": "GAS", "stingSysCode": "GAS", "stingFuncCode": "GAS",
+      "lineColor": [255, 192, 0], "lineWeight": 4,
+      "uniclass": "Ss_55_70_38", "cibse": "CIBSE-GS01"
+    }
+  ]
+}

--- a/StingTools/UI/StingHvacCommandHandler.cs
+++ b/StingTools/UI/StingHvacCommandHandler.cs
@@ -133,6 +133,15 @@ namespace StingTools.UI
                     // ── SYS tab ────────────────────────────────────────────
                     case "Hvac_SystemAudit":
                         Run<StingTools.Temp.MEPSystemAuditCommand>(app); break;
+                    // Phase A — MEP System Type Materializer.
+                    case "MEP_BuildSystemTypes":
+                        Run<StingTools.Commands.Mep.MepBuildSystemTypesCommand>(app); break;
+                    case "MEP_RestyleSystemTypes":
+                        Run<StingTools.Commands.Mep.MepRestyleSystemTypesCommand>(app); break;
+                    case "MEP_InspectSystemTypes":
+                        Run<StingTools.Commands.Mep.MepInspectSystemTypesCommand>(app); break;
+                    case "MEP_ReloadSystemTypes":
+                        Run<StingTools.Commands.Mep.MepReloadSystemTypesCommand>(app); break;
                     case "Hvac_AutoFireDamper":
                     case "Routing_AutoFireDamper":
                         Run<StingTools.Commands.RoutingExt.AutoFireDamperCommand>(app); break;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,37 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase A: System Type Materializer)
+
+Closes the gap surfaced by the "can we batch-create MEP systems integrated with
+Drawing Types / Style Packs / Filters?" review: StingTools created MEP *elements*
+but never the system *types* the AEC filters + System Browser key off. Phase A
+makes the duct/pipe system types data-driven, idempotent, and materializable in
+one command — the first half of the create-systems → coordinated-drawing pipeline.
+**Built and verified with `dotnet build` against the Revit 2025 API (0 warnings,
+0 errors)** — not the usual unverified-sandbox caveat.
+
+**New files**
+
+| Path | Role |
+|---|---|
+| `StingTools/Data/STING_MEP_SYSTEM_TYPES.json` | Corporate baseline — 21 canonical duct + pipe system types (air, hydronic, domestic water, drainage/vent, fire, gas) each with `classification` (the `MEPSystemClassification` the 19 MEP filters in `STING_AEC_FILTERS.json` match on via `RBS_SYSTEM_CLASSIFICATION_PARAM`), `abbreviation`, STING `sys`/`func` tag tokens, `lineColor`/`lineWeight`/`linePattern`/`material`. Project override at `<project>/_BIM_COORD/mep_system_types.json`. |
+| `StingTools/Core/Mep/MepSystemTypeRegistry.cs` | Layered baseline + project-override loader (merge by `id`, project wins), per-document cache, `Get`/`Reload`/`Reload(doc)` — mirrors `MepSizingRegistry` exactly. |
+| `StingTools/Core/Mep/MepSystemTypeMaterializer.cs` | Idempotent engine: `duct → MechanicalSystemType.Create(doc, classification, name)`, `pipe → PipingSystemType.Create(...)`, matches existing by name (never duplicates), stamps `Abbreviation` + graphic overrides (`LineColor`/`LineWeight`/`LinePatternId`/`MaterialId`) each in its own try/catch. Caller owns the transaction (same contract as `AecFilterFactory.FindOrCreate`). New types always stamped; existing types restamped only on `overwriteGraphics`. |
+| `StingTools/Commands/Mep/MepSystemTypeCommands.cs` | `MEP_BuildSystemTypes` (create missing + stamp new), `MEP_RestyleSystemTypes` (also re-apply baseline graphics to existing), `MEP_InspectSystemTypes` (read-only present-vs-missing inventory), `MEP_ReloadSystemTypes` (cache drop). `StingResultPanel` reporting with created/updated/skipped/failed + a NEXT section pointing at `AecFilters_Create` + coordination Style Pack. |
+
+**Wiring**: dispatch cases added to `StingHvacCommandHandler` (SYS tab) and to
+`WorkflowEngine.ResolveCommand` so the three build/restyle/inspect commands are
+chainable in workflow presets. `Data/**` auto-copies to the output `data/` dir —
+no `.csproj` change needed.
+
+**Classification safety**: unknown `MEPSystemClassification` names are warned +
+skipped (not thrown), so the JSON degrades gracefully across Revit versions.
+Materializing these types is what lets the existing MEP colour filters and the
+System Browser resolve real data — the integration hook. Phase B (system *instance*
+builder over connector graphs) and Phase C (MEP-discipline-aware drawing routing)
+complete the loop.
+
 #### Completed (Phase 194 — Yes/No-canonical gates — corrects PR #324's Text-canonical choice)
 
 PR #324 (Phase 193) fixed the recurring "Inconsistent Units" error by


### PR DESCRIPTION
## What & why

Answers the review question *"can we batch-create MEP systems integrated with Drawing Types / Style Packs / Filters?"* — **Phase A of 3**. StingTools created MEP *elements* but never the system **types** the 19 MEP AEC filters + the System Browser key off. This makes the duct/pipe system types data-driven, idempotent, and materializable in one command.

## What's in it

- **`Data/STING_MEP_SYSTEM_TYPES.json`** — 21 canonical duct + pipe system types (air, hydronic, domestic water, drainage/vent, fire, gas), each carrying the Revit `MEPSystemClassification` the filters match on, plus abbreviation, STING sys/func tokens, line colour/weight/pattern. Project-overridable at `_BIM_COORD/mep_system_types.json`.
- **`Core/Mep/MepSystemTypeRegistry.cs`** — baseline + project-override loader, per-doc cache (mirrors `MepSizingRegistry`).
- **`Core/Mep/MepSystemTypeMaterializer.cs`** — idempotent `MechanicalSystemType.Create` / `PipingSystemType.Create`, match-by-name (no dupes), stamps abbreviation + graphic overrides, caller owns the transaction.
- **`Commands/Mep/MepSystemTypeCommands.cs`** — `MEP_BuildSystemTypes` / `MEP_RestyleSystemTypes` / `MEP_InspectSystemTypes` / `MEP_ReloadSystemTypes`.
- Wired into `StingHvacCommandHandler` (SYS tab) + `WorkflowEngine.ResolveCommand`.

## Verification

`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors** (the compiler confirmed all five `MEPSystemType` setters + both `Create` overloads). Not the usual unverified-sandbox caveat.

## Design

Pure data + project override (recolour/extend without recompile), idempotent and re-runnable (`Build` preserves project tuning; `Restyle` re-applies the baseline), graceful degradation (unknown classifications warn + skip).

## Stacking

First of 3 stacked PRs: **Phase A** (this) → Phase B (system instances) → Phase C (MEP-aware drawing routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🧪 Live-Revit validation

The full one-pass validation recipe covering **all six phases (A–F)** on a sample model — plus the `WORKFLOW_MEPSystemsValidate.json` preset that runs the whole chain in one go — lives in the tip PR: **#364**. Validate the entire stack there after merging A→F.