### PR TITLE
MEP Systems — Phase B: System Instance Builder

### DIFF
--- a/StingTools/Commands/Mep/MepSystemInstanceCommands.cs
+++ b/StingTools/Commands/Mep/MepSystemInstanceCommands.cs
@@ -1,0 +1,108 @@
+// StingTools — MEP System Instance command (Phase B).
+//
+//   MEP_BuildSystems — walk the connector graph, group connected MEP networks,
+//   assign the STING (Phase A) system type + a meaningful name + STING params
+//   to each, and best-effort create a MechanicalSystem / PipingSystem for orphan
+//   networks that have a detectable source equipment. Scope = current selection
+//   when present, else the whole project.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Mep;
+using StingTools.UI;
+
+namespace StingTools.Commands.Mep
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepBuildSystemsCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                ICollection<ElementId> sel = null;
+                try { sel = ctx.UIDoc?.Selection?.GetElementIds(); } catch { }
+                bool scopedToSelection = sel != null && sel.Count > 0;
+
+                MepSystemBuildResult res;
+                using (var t = new Transaction(doc, "STING Build MEP Systems"))
+                {
+                    t.Start();
+                    res = MepSystemInstanceBuilder.Build(doc, scopedToSelection ? sel : null,
+                                                         attemptCreateOrphans: true);
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create("MEP — Build System Instances");
+                panel.SetSubtitle(
+                    $"{res.Networks} network(s) · {res.Typed} typed · {res.Created} created · " +
+                    $"{res.Stamped} stamped · {res.Skipped} skipped · {res.Failed} failed " +
+                    $"({(scopedToSelection ? "selection" : "whole project")})");
+
+                panel.AddSection("SUMMARY")
+                     .Metric("Networks found",      res.Networks.ToString())
+                     .Metric("Existing systems typed", res.Typed.ToString())
+                     .Metric("New systems created",  res.Created.ToString())
+                     .Metric("Members-only stamped", res.Stamped.ToString())
+                     .Metric("Orphans skipped",      res.Skipped.ToString())
+                     .Metric("Failed",               res.Failed.ToString());
+
+                if (res.CrossStamp != null)
+                {
+                    panel.AddSection("CROSS-STAMP (HVC_/PLM_/ELC_)")
+                         .Metric("Ducts",    res.CrossStamp.DuctsStamped.ToString())
+                         .Metric("Pipes",    res.CrossStamp.PipesStamped.ToString())
+                         .Metric("Circuits", res.CrossStamp.CircuitsStamped.ToString())
+                         .Metric("Fixtures", res.CrossStamp.FixturesStamped.ToString());
+                }
+
+                panel.AddSection("NETWORKS");
+                foreach (var r in res.Rows.Take(60))
+                    panel.Text($"{Glyph(r.Outcome)} {r.Domain,-4} {r.Members,4} el  " +
+                               $"{r.Classification,-20} {r.SystemName,-10} {r.Note}");
+
+                if (res.Warnings.Count > 0)
+                {
+                    panel.AddSection($"WARNINGS ({res.Warnings.Count})");
+                    foreach (var w in res.Warnings.Take(40)) panel.Text(w);
+                }
+
+                panel.AddSection("NEXT");
+                panel.Text("Systems now carry the STING type + classification — run AecFilters_Create " +
+                           "and apply a coordination View Style Pack to colour them, then produce MEP " +
+                           "drawings (Phase C: discipline + classification routing).");
+                panel.Show();
+
+                StingLog.Info($"MEP build systems: networks={res.Networks} typed={res.Typed} " +
+                              $"created={res.Created} stamped={res.Stamped} skipped={res.Skipped}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepBuildSystemsCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        private static string Glyph(MepSystemBuildOutcome o) => o switch
+        {
+            MepSystemBuildOutcome.Typed   => "◉",
+            MepSystemBuildOutcome.Created => "✚",
+            MepSystemBuildOutcome.Stamped => "✎",
+            MepSystemBuildOutcome.Skipped => "–",
+            MepSystemBuildOutcome.Failed  => "✖",
+            _ => " "
+        };
+    }
+}

--- a/StingTools/Core/Mep/MepSystemInstanceBuilder.cs
+++ b/StingTools/Core/Mep/MepSystemInstanceBuilder.cs
@@ -1,0 +1,402 @@
+// StingTools — MEP System Instance Builder (Phase B).
+//
+// Walks the MEP connector graph (same traversal as MepSystemTracerCommand),
+// groups elements into connected networks, and for each network:
+//
+//   1. If Revit has already formed it into a MechanicalSystem / PipingSystem
+//      (the common case once equipment + ductwork are connected):
+//        - assign the matching STING (Phase A) system TYPE via ChangeTypeId,
+//        - give it a meaningful name  <abbreviation>-<NN>,
+//        - stamp ParamRegistry.MEP_SYS_NAME on every member.
+//      This is the reliable, high-value path — it makes the Phase A system
+//      types + the 19 MEP colour filters actually get used.
+//
+//   2. If it is an ORPHAN network (no MEPSystem yet) but has a detectable
+//      source-equipment connector, BEST-EFFORT create one via
+//      doc.Create.NewMechanicalSystem / NewPipingSystem + MEPSystem.Add,
+//      then type / name / stamp it. Networks that don't satisfy Revit's
+//      "valid source + consistent flow direction + tree" requirement are
+//      REPORTED, not forced — the members still get their STING params.
+//
+//   3. Final pass: MepCrossStampOrchestrator populates HVC_* / PLM_* / ELC_*
+//      from the now-correct native flow/voltage parameters.
+//
+// CALLER OWNS THE ACTIVE TRANSACTION.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Mechanical;
+using Autodesk.Revit.DB.Plumbing;
+using StingTools.Core;
+
+namespace StingTools.Core.Mep
+{
+    public enum MepSystemBuildOutcome { Typed, Created, Stamped, Skipped, Failed }
+
+    public sealed class MepSystemBuildRow
+    {
+        public string Network { get; set; } = "";
+        public int Members { get; set; }
+        public string Domain { get; set; } = "";
+        public string Classification { get; set; } = "";
+        public string SystemName { get; set; } = "";
+        public MepSystemBuildOutcome Outcome { get; set; }
+        public string Note { get; set; } = "";
+    }
+
+    public sealed class MepSystemBuildResult
+    {
+        public List<MepSystemBuildRow> Rows { get; } = new List<MepSystemBuildRow>();
+        public List<string> Warnings { get; } = new List<string>();
+        public int Networks { get; set; }
+        public MepCrossStampResult CrossStamp { get; set; }
+
+        public int Typed   => Rows.Count(r => r.Outcome == MepSystemBuildOutcome.Typed);
+        public int Created => Rows.Count(r => r.Outcome == MepSystemBuildOutcome.Created);
+        public int Stamped => Rows.Count(r => r.Outcome == MepSystemBuildOutcome.Stamped);
+        public int Skipped => Rows.Count(r => r.Outcome == MepSystemBuildOutcome.Skipped);
+        public int Failed  => Rows.Count(r => r.Outcome == MepSystemBuildOutcome.Failed);
+    }
+
+    public static class MepSystemInstanceBuilder
+    {
+        /// <summary>
+        /// Build / type / name / stamp MEP systems for the connected networks
+        /// reachable from <paramref name="seedIds"/> (or the whole project when
+        /// seedIds is null/empty). Requires an open transaction.
+        /// </summary>
+        public static MepSystemBuildResult Build(
+            Document doc, ICollection<ElementId> seedIds, bool attemptCreateOrphans)
+        {
+            var result = new MepSystemBuildResult();
+            if (doc == null) { result.Warnings.Add("No document."); return result; }
+
+            // Index STING (Phase A) system-type elements by classification.
+            var rules = MepSystemTypeRegistry.Get(doc);
+            var mechTypeByClass = BuildTypeIndex<MechanicalSystemType>(doc);
+            var pipeTypeByClass = BuildTypeIndex<PipingSystemType>(doc);
+
+            // Per-classification running counter for system names.
+            var nameSeq = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            // Seeds: explicit selection, else every duct + pipe in the project.
+            var seeds = (seedIds != null && seedIds.Count > 0)
+                ? seedIds.ToList()
+                : new FilteredElementCollector(doc)
+                    .WherePasses(new ElementMulticategoryFilter(new[]
+                    {
+                        BuiltInCategory.OST_DuctCurves,
+                        BuiltInCategory.OST_PipeCurves
+                    }))
+                    .WhereElementIsNotElementType()
+                    .ToElementIds().ToList();
+
+            var globalVisited = new HashSet<long>();
+            foreach (var seed in seeds)
+            {
+                if (globalVisited.Contains(seed.Value)) continue;
+
+                var network = new List<ElementId>();
+                WalkConnectorGraph(doc, seed, globalVisited, network);
+                if (network.Count == 0) continue;
+                result.Networks++;
+
+                try { ProcessNetwork(doc, network, rules, mechTypeByClass, pipeTypeByClass,
+                                     nameSeq, attemptCreateOrphans, result); }
+                catch (Exception ex)
+                {
+                    result.Warnings.Add($"Network @ {seed}: {ex.Message}");
+                    StingLog.Warn($"MepSystemInstanceBuilder network {seed}: {ex.Message}");
+                }
+            }
+
+            // HVC_/PLM_/ELC_ stamping from native flow params (reuses the
+            // existing cross-stamp engine; runs in the same transaction).
+            try { result.CrossStamp = MepCrossStampOrchestrator.AnalyseModel(doc); }
+            catch (Exception ex) { result.Warnings.Add($"Cross-stamp: {ex.Message}"); }
+
+            return result;
+        }
+
+        // ── per-network processing ──────────────────────────────────────────
+
+        private static void ProcessNetwork(
+            Document doc, List<ElementId> network, MepSystemTypeRules rules,
+            Dictionary<MEPSystemClassification, ElementId> mechTypeByClass,
+            Dictionary<MEPSystemClassification, ElementId> pipeTypeByClass,
+            Dictionary<string, int> nameSeq, bool attemptCreateOrphans,
+            MepSystemBuildResult result)
+        {
+            var els = network.Select(doc.GetElement).Where(e => e != null).ToList();
+
+            // Domain: a connected network is single-domain (duct connectors don't
+            // join pipe connectors). Decide by which MEPCurve kind is present.
+            bool hasDuct = els.Any(e => e is Duct);
+            bool hasPipe = els.Any(e => e is Pipe);
+            if (!hasDuct && !hasPipe) return; // fittings-only fragment — skip silently
+
+            string domain = hasDuct ? "duct" : "pipe";
+            var row = new MepSystemBuildRow { Network = network[0].ToString(), Members = network.Count, Domain = domain };
+            result.Rows.Add(row);
+
+            // Existing MEPSystem? Any member MEPCurve that already belongs to one.
+            MEPSystem existing = els.OfType<MEPCurve>()
+                .Select(c => { try { return c.MEPSystem; } catch { return null; } })
+                .FirstOrDefault(s => s != null);
+
+            MEPSystem system = existing;
+            bool created = false;
+
+            if (system == null)
+            {
+                if (!attemptCreateOrphans)
+                {
+                    StampMembers(doc, els, null, row);
+                    row.Outcome = MepSystemBuildOutcome.Stamped;
+                    row.Note = "orphan network (no system) — members stamped; enable create to build a system";
+                    return;
+                }
+                system = TryCreateSystem(doc, els, hasDuct, row, result.Warnings, out created);
+                if (system == null)
+                {
+                    // Could not create — still stamp members so tags/params land.
+                    StampMembers(doc, els, null, row);
+                    row.Outcome = MepSystemBuildOutcome.Skipped;
+                    if (string.IsNullOrEmpty(row.Note))
+                        row.Note = "no valid source-equipment connector to anchor a system";
+                    return;
+                }
+            }
+
+            // Resolve classification from the system's current type.
+            MEPSystemClassification cls = MEPSystemClassification.UndefinedSystemClassification;
+            try
+            {
+                var curType = doc.GetElement(system.GetTypeId()) as MEPSystemType;
+                if (curType != null) cls = curType.SystemClassification;
+            }
+            catch (Exception ex) { result.Warnings.Add($"{row.Network}: classification read: {ex.Message}"); }
+            row.Classification = cls.ToString();
+
+            // Assign the STING (Phase A) system type for this classification.
+            var typeIndex = hasDuct ? mechTypeByClass : pipeTypeByClass;
+            if (typeIndex.TryGetValue(cls, out var stingTypeId) && stingTypeId != system.GetTypeId())
+            {
+                try { system.ChangeTypeId(stingTypeId); }
+                catch (Exception ex) { result.Warnings.Add($"{row.Network}: ChangeTypeId: {ex.Message}"); }
+            }
+
+            // Name it <abbreviation>-<NN> from the matching Phase A definition.
+            var def = rules.Enabled.FirstOrDefault(d =>
+                string.Equals(d.Classification, cls.ToString(), StringComparison.OrdinalIgnoreCase) &&
+                (hasDuct ? d.IsDuct : d.IsPipe));
+            string abbr = def?.Abbreviation;
+            if (string.IsNullOrWhiteSpace(abbr))
+                try { abbr = (doc.GetElement(system.GetTypeId()) as MEPSystemType)?.Abbreviation; } catch { }
+            if (string.IsNullOrWhiteSpace(abbr)) abbr = hasDuct ? "DUCT" : "PIPE";
+
+            int seq = nameSeq.TryGetValue(abbr, out var n) ? n + 1 : 1;
+            nameSeq[abbr] = seq;
+            string sysName = $"{abbr}-{seq:D2}";
+            row.SystemName = sysName;
+
+            TrySetSystemName(system, sysName, result.Warnings, row.Network);
+            StampMembers(doc, els, sysName, row);
+
+            row.Outcome = created ? MepSystemBuildOutcome.Created : MepSystemBuildOutcome.Typed;
+            if (string.IsNullOrEmpty(row.Note))
+                row.Note = created ? "system created + typed + named" : "existing system typed + named";
+        }
+
+        // ── orphan creation (best-effort) ───────────────────────────────────
+
+        private static MEPSystem TryCreateSystem(
+            Document doc, List<Element> els, bool isDuct, MepSystemBuildRow row,
+            List<string> warnings, out bool created)
+        {
+            created = false;
+            var wantedDomain = isDuct ? Domain.DomainHvac : Domain.DomainPiping;
+
+            // Gather equipment / terminal connectors of the right domain that are
+            // free to be added to a new system.
+            var equipConns = new List<Connector>();
+            foreach (var fi in els.OfType<FamilyInstance>())
+            {
+                ConnectorSet cs = null;
+                try { cs = fi.MEPModel?.ConnectorManager?.Connectors; } catch { }
+                if (cs == null) continue;
+                foreach (Connector c in cs)
+                {
+                    try { if (c != null && c.Domain == wantedDomain) equipConns.Add(c); }
+                    catch { }
+                }
+            }
+            if (equipConns.Count < 2)
+            {
+                row.Note = "fewer than two equipment/terminal connectors — cannot anchor a system";
+                return null;
+            }
+
+            // Base = a source connector (flow Out), else the first equipment connector.
+            Connector baseConn = equipConns.FirstOrDefault(c =>
+            {
+                try { return c.Direction == FlowDirectionType.Out; } catch { return false; }
+            }) ?? equipConns[0];
+
+            var members = new ConnectorSet();
+            foreach (var c in equipConns)
+                if (!ReferenceEquals(c, baseConn)) { try { members.Insert(c); } catch { } }
+            if (members.IsEmpty)
+            {
+                row.Note = "no non-base connectors to serve";
+                return null;
+            }
+
+            try
+            {
+                if (isDuct)
+                {
+                    var dst = MapDuctSystemType(baseConn);
+                    var ms = doc.Create.NewMechanicalSystem(baseConn, members, dst);
+                    created = ms != null;
+                    return ms;
+                }
+                else
+                {
+                    var pst = MapPipeSystemType(baseConn);
+                    var ps = doc.Create.NewPipingSystem(baseConn, members, pst);
+                    created = ps != null;
+                    return ps;
+                }
+            }
+            catch (Exception ex)
+            {
+                row.Note = $"create failed: {ex.Message}";
+                warnings.Add($"{row.Network}: NewMEPSystem: {ex.Message}");
+                return null;
+            }
+        }
+
+        // ── helpers ─────────────────────────────────────────────────────────
+
+        private static void StampMembers(Document doc, List<Element> els, string sysName, MepSystemBuildRow row)
+        {
+            if (string.IsNullOrEmpty(sysName))
+            {
+                // Fall back to whatever Revit already calls the system.
+                sysName = els.OfType<MEPCurve>()
+                    .Select(c => { try { return c.MEPSystem?.Name; } catch { return null; } })
+                    .FirstOrDefault(s => !string.IsNullOrEmpty(s)) ?? "";
+            }
+            if (string.IsNullOrEmpty(sysName)) return;
+            foreach (var el in els)
+            {
+                try { ParameterHelpers.SetString(el, ParamRegistry.MEP_SYS_NAME, sysName, overwrite: true); }
+                catch { }
+            }
+        }
+
+        private static void TrySetSystemName(MEPSystem system, string name, List<string> warnings, string netId)
+        {
+            // System name is normally the computed abbreviation+number. Setting
+            // RBS_SYSTEM_NAME_PARAM renames it where the model allows it.
+            try
+            {
+                var p = system.get_Parameter(BuiltInParameter.RBS_SYSTEM_NAME_PARAM);
+                if (p != null && !p.IsReadOnly && p.StorageType == StorageType.String)
+                    p.Set(name);
+            }
+            catch (Exception ex) { warnings.Add($"{netId}: name '{name}': {ex.Message}"); }
+        }
+
+        private static Dictionary<MEPSystemClassification, ElementId> BuildTypeIndex<T>(Document doc)
+            where T : MEPSystemType
+        {
+            var dict = new Dictionary<MEPSystemClassification, ElementId>();
+            foreach (var t in new FilteredElementCollector(doc).OfClass(typeof(T)).Cast<T>())
+            {
+                MEPSystemClassification cls;
+                try { cls = t.SystemClassification; } catch { continue; }
+                // Prefer a STING (Phase A) type when several share a classification.
+                bool isSting = (t.Name ?? "").StartsWith("STING", StringComparison.OrdinalIgnoreCase);
+                if (!dict.ContainsKey(cls) || isSting) dict[cls] = t.Id;
+            }
+            return dict;
+        }
+
+        // Map a connector's classification onto the DuctSystemType / PipeSystemType
+        // enums NewMechanicalSystem / NewPipingSystem require. The enum member names
+        // mostly mirror MEPSystemClassification, so parse-by-name with a safe default.
+        private static DuctSystemType MapDuctSystemType(Connector baseConn)
+        {
+            try
+            {
+                var sys = baseConn.MEPSystem as MechanicalSystem;
+                if (sys != null) return sys.SystemType;
+            }
+            catch { }
+            // Supply by default for an "Out" source, return otherwise.
+            try { return baseConn.Direction == FlowDirectionType.In ? DuctSystemType.ReturnAir : DuctSystemType.SupplyAir; }
+            catch { return DuctSystemType.SupplyAir; }
+        }
+
+        private static PipeSystemType MapPipeSystemType(Connector baseConn)
+        {
+            try
+            {
+                var sys = baseConn.MEPSystem as PipingSystem;
+                if (sys != null) return sys.SystemType;
+            }
+            catch { }
+            try { return baseConn.Direction == FlowDirectionType.In ? PipeSystemType.ReturnHydronic : PipeSystemType.SupplyHydronic; }
+            catch { return PipeSystemType.OtherPipe; }
+        }
+
+        // BFS over the connector graph — same shape as MepSystemTracerCommand.
+        private static void WalkConnectorGraph(
+            Document doc, ElementId start, HashSet<long> visited, List<ElementId> ordered)
+        {
+            var queue = new Queue<ElementId>();
+            queue.Enqueue(start);
+            while (queue.Count > 0)
+            {
+                var id = queue.Dequeue();
+                if (!visited.Add(id.Value)) continue;
+                ordered.Add(id);
+
+                Element el = null;
+                try { el = doc.GetElement(id); } catch { }
+                if (el == null) continue;
+
+                ConnectorSet set = ResolveConnectors(el);
+                if (set == null) continue;
+                foreach (Connector c in set)
+                {
+                    if (c == null) continue;
+                    ConnectorSet others = null;
+                    try { others = c.AllRefs; } catch { }
+                    if (others == null) continue;
+                    foreach (Connector other in others)
+                    {
+                        if (other?.Owner == null) continue;
+                        if (other.Owner.Id.Value == id.Value) continue;
+                        queue.Enqueue(other.Owner.Id);
+                    }
+                }
+            }
+        }
+
+        private static ConnectorSet ResolveConnectors(Element el)
+        {
+            try
+            {
+                if (el is MEPCurve mep) return mep.ConnectorManager?.Connectors;
+                if (el is FamilyInstance fi && fi.MEPModel != null) return fi.MEPModel.ConnectorManager?.Connectors;
+            }
+            catch { }
+            return null;
+        }
+    }
+}

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1410,6 +1410,7 @@ namespace StingTools.Core
                 case "MEP_BuildSystemTypes": return new Commands.Mep.MepBuildSystemTypesCommand();
                 case "MEP_RestyleSystemTypes": return new Commands.Mep.MepRestyleSystemTypesCommand();
                 case "MEP_InspectSystemTypes": return new Commands.Mep.MepInspectSystemTypesCommand();
+                case "MEP_BuildSystems": return new Commands.Mep.MepBuildSystemsCommand();
 
                 // Schedules
                 case "FullAutoPopulate": return new Temp.FullAutoPopulateCommand();

--- a/StingTools/UI/StingHvacCommandHandler.cs
+++ b/StingTools/UI/StingHvacCommandHandler.cs
@@ -142,6 +142,9 @@ namespace StingTools.UI
                         Run<StingTools.Commands.Mep.MepInspectSystemTypesCommand>(app); break;
                     case "MEP_ReloadSystemTypes":
                         Run<StingTools.Commands.Mep.MepReloadSystemTypesCommand>(app); break;
+                    // Phase B — MEP System Instance Builder.
+                    case "MEP_BuildSystems":
+                        Run<StingTools.Commands.Mep.MepBuildSystemsCommand>(app); break;
                     case "Hvac_AutoFireDamper":
                     case "Routing_AutoFireDamper":
                         Run<StingTools.Commands.RoutingExt.AutoFireDamperCommand>(app); break;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,35 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase B: System Instance Builder)
+
+Builds on Phase A: walks the MEP connector graph (same traversal as
+`MepSystemTracerCommand`), groups elements into connected networks, and for each
+network assigns the STING (Phase A) system **type**, a meaningful **name**
+(`<abbreviation>-NN`), and stamps `ParamRegistry.MEP_SYS_NAME` on every member —
+then runs `MepCrossStampOrchestrator` to populate `HVC_*`/`PLM_*`/`ELC_*` from the
+native flow/voltage params. **Built + verified with `dotnet build` against the
+Revit 2025 API (0 warnings, 0 errors)** — including the live `NewMechanicalSystem`
+/ `NewPipingSystem` / `ChangeTypeId` / `DuctSystemType` / `PipeSystemType` calls.
+
+**New files**
+
+| Path | Role |
+|---|---|
+| `StingTools/Core/Mep/MepSystemInstanceBuilder.cs` | Connector-graph network grouping + per-network type/name/stamp. Reliable path: networks Revit has already systemized get the STING type + name + params. Best-effort path: orphan networks with a detectable source-equipment connector get a real `MechanicalSystem`/`PipingSystem` via `doc.Create.NewMechanicalSystem`/`NewPipingSystem`. Networks that don't satisfy Revit's source/flow/tree requirement are **reported, not forced** (members still stamped). Caller owns the transaction. |
+| `StingTools/Commands/Mep/MepSystemInstanceCommands.cs` | `MEP_BuildSystems` — scope = selection when present, else whole project; `StingResultPanel` reports networks / typed / created / stamped / skipped / failed + the HVC/PLM/ELC cross-stamp counts. |
+
+**Wiring**: `StingHvacCommandHandler` (SYS tab) + `WorkflowEngine.ResolveCommand`.
+
+**Honest scope**: `NewMechanicalSystem`/`NewPipingSystem` require a valid source
+equipment + consistent flow direction + tree topology; on rough/imported models
+that often isn't satisfiable, so creation is best-effort and the high-value,
+reliable work is typing + naming + stamping the systems Revit already formed.
+Electrical circuits (`ElectricalSystem`) use a different power-connector mechanism
+and are out of Phase B scope. Phase C wires discipline + classification into
+`DrawingDispatcher` to close the create→drawing loop. **Runtime behaviour of the
+orphan-creation path should still be verified against a live Revit model.**
+
 #### Completed (MEP Systems — Phase A: System Type Materializer)
 
 Closes the gap surfaced by the "can we batch-create MEP systems integrated with


### PR DESCRIPTION
## What & why

**Phase B of 3** (stacked on #359). Builds on Phase A's system *types* by creating/typing/naming the system **instances**. Walks the MEP connector graph (same traversal as `MepSystemTracerCommand`), groups elements into connected networks, and per network:

- **Reliable path** — networks Revit has already systemized get the STING (Phase A) system **type** (`ChangeTypeId`), a meaningful **name** (`<abbreviation>-NN`), and `MEP_SYS_NAME` stamped on every member. This is what makes the Phase A types + the colour filters actually get *used*.
- **Best-effort path** — orphan networks with a detectable source-equipment connector get a real `MechanicalSystem`/`PipingSystem` via `doc.Create.NewMechanicalSystem`/`NewPipingSystem`. Networks that don't satisfy Revit's source/flow/tree requirement are **reported, not forced** (members still stamped).
- **Final pass** — runs the existing `MepCrossStampOrchestrator` to populate `HVC_*`/`PLM_*`/`ELC_*` from native flow/voltage params.

## What's in it

- **`Core/Mep/MepSystemInstanceBuilder.cs`** — network grouping + per-network type/name/stamp + orphan creation. Caller owns the transaction.
- **`Commands/Mep/MepSystemInstanceCommands.cs`** — `MEP_BuildSystems` (scope = selection when present, else whole project) with a full `StingResultPanel` breakdown.
- Wired into `StingHvacCommandHandler` + `WorkflowEngine.ResolveCommand`.

## Verification

`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors** — including the live `NewMechanicalSystem` / `NewPipingSystem` / `ChangeTypeId` / `DuctSystemType` / `PipeSystemType` calls.

## Honest scope

`NewMechanicalSystem`/`NewPipingSystem` require a valid source equipment + consistent flow direction + tree topology; on rough/imported models that often isn't satisfiable, so orphan creation is best-effort and the high-value reliable work is typing + naming + stamping the systems Revit already formed. Electrical circuits (`ElectricalSystem`) use a different power-connector mechanism and are out of scope. **The orphan-creation path should still be verified against a live Revit model.**

## Stacking

Phase A (#359) → **Phase B** (this) → Phase C (MEP-aware drawing routing). Base is `claude/mep-systems-phase-a`; review/merge after #359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🧪 Live-Revit validation

The full one-pass validation recipe covering **all six phases (A–F)** on a sample model — plus the `WORKFLOW_MEPSystemsValidate.json` preset that runs the whole chain in one go — lives in the tip PR: **#364**. Validate the entire stack there after merging A→F.