### PR TITLE
MEP Systems — Phase C: MEP-aware drawing coordination

### DIFF
--- a/StingTools/Commands/Mep/MepCoordinationCommands.cs
+++ b/StingTools/Commands/Mep/MepCoordinationCommands.cs
@@ -1,0 +1,155 @@
+// StingTools — MEP Coordination commands (Phase C).
+//
+//   MEP_ApplyMepCoordination — turn the ACTIVE view into a coordinated MEP drawing:
+//     resolve the MEP coordination/plan DrawingType (view template + style pack via
+//     DrawingDispatcher), apply its presentation, then overlay the system-classification
+//     colour filters so each system reads in its discipline colour. Closes the loop:
+//     create systems (A) → stamp classification (B) → coordinated MEP drawing (C).
+//
+//   MEP_InspectMepCoordination — read-only dry run: which classifications are present,
+//     which AEC filter each resolves to, and which DrawingType would be applied.
+
+using System;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Drawing;
+using StingTools.Core.Mep;
+using StingTools.UI;
+
+namespace StingTools.Commands.Mep
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepApplyMepCoordinationCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+                var view = doc.ActiveView;
+                if (view == null) { message = "No active view."; return Result.Failed; }
+
+                DrawingType dt = ResolveMepDrawingType(doc);
+
+                MepCoordResult res;
+                using (var t = new Transaction(doc, "STING Apply MEP Coordination"))
+                {
+                    t.Start();
+                    if (dt != null)
+                    {
+                        try { DrawingTypePresentation.Apply(doc, view, dt, runAnnotation: false); }
+                        catch (Exception ex) { StingLog.Warn($"MEP coord: presentation apply: {ex.Message}"); }
+                    }
+                    res = MepCoordinationEngine.ApplyToView(doc, view);
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create("MEP — Apply Coordination to View");
+                panel.SetSubtitle(
+                    $"'{view.Name}' · {res.Applied} system filter(s) applied · {res.Unmatched} unmatched" +
+                    (dt != null ? $" · DrawingType '{dt.Id}'" : " · no DrawingType matched"));
+
+                panel.AddSection("DRAWING TYPE");
+                panel.Text(dt != null
+                    ? $"{dt.Id}  ({dt.Discipline}/{dt.Purpose}) — template + style pack applied"
+                    : "No MEP coordination/plan DrawingType resolved — filters applied without a template.");
+
+                panel.AddSection("SYSTEM CLASSIFICATIONS");
+                foreach (var r in res.Rows)
+                    panel.Text($"{(r.Applied ? "✓" : "·")} {r.Classification,-22} {r.FilterName,-30} {r.Note}");
+
+                if (res.Warnings.Count > 0)
+                {
+                    panel.AddSection($"WARNINGS ({res.Warnings.Count})");
+                    foreach (var w in res.Warnings.Take(40)) panel.Text(w);
+                }
+                panel.Show();
+
+                StingLog.Info($"MEP coordination: view='{view.Name}' applied={res.Applied} unmatched={res.Unmatched} dt={dt?.Id}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepApplyMepCoordinationCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        internal static DrawingType ResolveMepDrawingType(Document doc)
+        {
+            try
+            {
+                return DrawingDispatcher.Resolve(doc, "M", "*", "Coordination")
+                    ?? DrawingDispatcher.Resolve(doc, "*", "*", "MEP")
+                    ?? DrawingDispatcher.CandidatesForDiscipline(doc, "M")
+                        .FirstOrDefault(d => d.Purpose == DrawingPurpose.Coordination
+                                          || d.Purpose == DrawingPurpose.Plan);
+            }
+            catch (Exception ex) { StingLog.Warn($"MEP coord: DrawingType resolve: {ex.Message}"); return null; }
+        }
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepInspectMepCoordinationCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                var present = MepCoordinationEngine.PresentClassifications(doc);
+                var defs = AecFilterRegistry.ListAll(doc);
+                var dt = MepApplyMepCoordinationCommand.ResolveMepDrawingType(doc);
+
+                var panel = StingResultPanel.Create("MEP — Coordination Inspect (dry run)");
+                panel.SetSubtitle($"{present.Count} system classification(s) present · " +
+                                  (dt != null ? $"DrawingType '{dt.Id}'" : "no DrawingType matched"));
+
+                panel.AddSection("CLASSIFICATION → FILTER");
+                if (present.Count == 0)
+                    panel.Text("No duct/pipe members carry a classification yet — run MEP_BuildSystems (Phase B).");
+                foreach (var cls in present)
+                {
+                    var def = defs.FirstOrDefault(d => RuleHas(d?.Rule, cls));
+                    panel.Text($"{(def != null ? "✓" : "·")} {cls,-22} {(def != null ? def.Name : "(no matching AEC filter)")}");
+                }
+
+                panel.AddSection("DRAWING TYPE");
+                panel.Text(dt != null
+                    ? $"{dt.Id}  ({dt.Discipline}/{dt.Purpose})  pack='{dt.ViewStylePackId}'"
+                    : "No MEP coordination/plan DrawingType resolved.");
+                panel.Text("Run MEP_ApplyMepCoordination on the target view to apply the template + colours.");
+                panel.Show();
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepInspectMepCoordinationCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        private static bool RuleHas(AecFilterRule rule, string value)
+        {
+            if (rule == null) return false;
+            if (rule.IsLeaf)
+                return string.Equals(rule.Param, "RBS_SYSTEM_CLASSIFICATION_PARAM", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals((rule.Value ?? "").Trim(), value, StringComparison.OrdinalIgnoreCase);
+            if (rule.Rules != null)
+                foreach (var c in rule.Rules) if (RuleHas(c, value)) return true;
+            return false;
+        }
+    }
+}

--- a/StingTools/Core/Mep/MepCoordinationEngine.cs
+++ b/StingTools/Core/Mep/MepCoordinationEngine.cs
@@ -1,0 +1,212 @@
+// StingTools — MEP Coordination Engine (Phase C).
+//
+// Closes the create-systems → coordinated-drawing loop. Reads the MEP system
+// CLASSIFICATIONS actually present in the model (the same RBS_SYSTEM_CLASSIFICATION
+// the Phase A types carry and Phase B stamps onto elements), resolves the matching
+// corporate AEC filter from STING_AEC_FILTERS.json (auto-matched by the live
+// classification value — no manual enum map to drift), lazy-creates it via
+// AecFilterFactory, and applies it to a view with the filter's own colour override.
+//
+// The result: a view where Supply Air is GSA-blue, Return Air green, CHW navy …
+// driven end-to-end by one classification chain (Phase A colour on the type →
+// Phase B classification on the element → Phase C filter override on the view).
+//
+// CALLER OWNS THE ACTIVE TRANSACTION (for ApplyToView).
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Autodesk.Revit.DB;
+using StingTools.Core.Drawing;
+
+namespace StingTools.Core.Mep
+{
+    public sealed class MepCoordRow
+    {
+        public string Classification { get; set; } = "";
+        public string FilterName { get; set; } = "";
+        public bool Applied { get; set; }
+        public string Note { get; set; } = "";
+    }
+
+    public sealed class MepCoordResult
+    {
+        public List<MepCoordRow> Rows { get; } = new List<MepCoordRow>();
+        public List<string> Warnings { get; } = new List<string>();
+        public int Applied => Rows.Count(r => r.Applied);
+        public int Unmatched => Rows.Count(r => !r.Applied);
+    }
+
+    public static class MepCoordinationEngine
+    {
+        private const string ClassParam = "RBS_SYSTEM_CLASSIFICATION_PARAM";
+
+        /// <summary>
+        /// Distinct MEP system classification display-strings present in the model,
+        /// read straight off duct + pipe members (e.g. "Supply Air", "Hydronic Return").
+        /// </summary>
+        public static List<string> PresentClassifications(Document doc)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (doc == null) return new List<string>();
+            var collector = new FilteredElementCollector(doc)
+                .WherePasses(new ElementMulticategoryFilter(new[]
+                {
+                    BuiltInCategory.OST_DuctCurves,
+                    BuiltInCategory.OST_PipeCurves
+                }))
+                .WhereElementIsNotElementType();
+            foreach (var el in collector)
+            {
+                try
+                {
+                    var p = el.get_Parameter(BuiltInParameter.RBS_SYSTEM_CLASSIFICATION_PARAM);
+                    var v = p?.AsValueString();
+                    if (!string.IsNullOrWhiteSpace(v)) set.Add(v.Trim());
+                }
+                catch { }
+            }
+            return set.OrderBy(s => s).ToList();
+        }
+
+        /// <summary>
+        /// Apply the system-classification colour filters to <paramref name="view"/>.
+        /// Requires an open transaction. Returns per-classification outcome rows.
+        /// </summary>
+        public static MepCoordResult ApplyToView(Document doc, View view)
+        {
+            var result = new MepCoordResult();
+            if (doc == null || view == null) { result.Warnings.Add("No document / view."); return result; }
+            if (!CanOverride(view))
+            {
+                result.Warnings.Add($"View '{view.Name}' does not allow graphic overrides (schedule / sheet?).");
+                return result;
+            }
+
+            var present = PresentClassifications(doc);
+            if (present.Count == 0)
+            {
+                result.Warnings.Add("No duct/pipe members carry a system classification yet — run Phase B (MEP_BuildSystems) first.");
+                return result;
+            }
+
+            var defs = AecFilterRegistry.ListAll(doc);
+            var solid = ParameterHelpers.GetSolidFillPattern(doc)?.Id;
+            var existing = new HashSet<ElementId>(view.GetFilters());
+
+            foreach (var cls in present)
+            {
+                var row = new MepCoordRow { Classification = cls };
+                result.Rows.Add(row);
+
+                var def = FindFilterForClassification(defs, cls);
+                if (def == null)
+                {
+                    row.Note = "no AEC filter keyed on this classification — add one to STING_AEC_FILTERS.json";
+                    continue;
+                }
+                row.FilterName = def.Name;
+
+                FilterFactoryResult fr;
+                try { fr = AecFilterFactory.FindOrCreate(doc, def); }
+                catch (Exception ex) { row.Note = $"filter create: {ex.Message}"; result.Warnings.Add($"{cls}: {ex.Message}"); continue; }
+                if (fr == null || !fr.Ok) { row.Note = fr?.Error ?? "filter not created"; continue; }
+
+                try
+                {
+                    if (!existing.Contains(fr.Filter.Id)) { view.AddFilter(fr.Filter.Id); existing.Add(fr.Filter.Id); }
+                    var ogs = BuildOverride(def.DefaultOverride, solid);
+                    view.SetFilterOverrides(fr.Filter.Id, ogs);
+                    view.SetFilterVisibility(fr.Filter.Id, true);
+                    row.Applied = true;
+                    row.Note = fr.Created ? "filter created + applied" : "filter applied";
+                }
+                catch (Exception ex)
+                {
+                    row.Note = $"apply: {ex.Message}";
+                    result.Warnings.Add($"{cls}: apply: {ex.Message}");
+                }
+            }
+            return result;
+        }
+
+        // ── helpers ─────────────────────────────────────────────────────────
+
+        private static bool CanOverride(View view)
+        {
+            try { return view != null && !view.IsTemplate && view.AreGraphicsOverridesAllowed(); }
+            catch { return false; }
+        }
+
+        private static AecFilterDefinition FindFilterForClassification(
+            IReadOnlyList<AecFilterDefinition> defs, string classificationValue)
+        {
+            if (defs == null) return null;
+            foreach (var d in defs)
+                if (RuleMatchesClassification(d?.Rule, classificationValue))
+                    return d;
+            return null;
+        }
+
+        private static bool RuleMatchesClassification(AecFilterRule rule, string value)
+        {
+            if (rule == null) return false;
+            if (rule.IsLeaf)
+                return string.Equals(rule.Param, ClassParam, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals((rule.Value ?? "").Trim(), value, StringComparison.OrdinalIgnoreCase);
+            if (rule.Rules != null)
+                foreach (var child in rule.Rules)
+                    if (RuleMatchesClassification(child, value)) return true;
+            return false;
+        }
+
+        private static OverrideGraphicSettings BuildOverride(FilterDefaultOverride ov, ElementId solidFill)
+        {
+            var ogs = new OverrideGraphicSettings();
+            if (ov == null) return ogs;
+
+            var proj = ParseHex(ov.ProjColor);
+            if (proj != null) ogs.SetProjectionLineColor(proj);
+            if (ov.ProjWeight.HasValue && ov.ProjWeight.Value >= 1 && ov.ProjWeight.Value <= 16)
+                ogs.SetProjectionLineWeight(ov.ProjWeight.Value);
+
+            var cut = ParseHex(ov.CutColor);
+            if (cut != null) ogs.SetCutLineColor(cut);
+            if (ov.CutWeight.HasValue && ov.CutWeight.Value >= 1 && ov.CutWeight.Value <= 16)
+                ogs.SetCutLineWeight(ov.CutWeight.Value);
+
+            var surf = ParseHex(ov.SurfFgColor);
+            if (surf != null && solidFill != null)
+            {
+                ogs.SetSurfaceForegroundPatternId(solidFill);
+                ogs.SetSurfaceForegroundPatternColor(surf);
+            }
+            var cutFg = ParseHex(ov.CutFgColor) ?? cut ?? proj;
+            if (cutFg != null && solidFill != null)
+            {
+                ogs.SetCutForegroundPatternId(solidFill);
+                ogs.SetCutForegroundPatternColor(cutFg);
+            }
+            if (ov.Transparency.HasValue && ov.Transparency.Value >= 0 && ov.Transparency.Value <= 100)
+                ogs.SetSurfaceTransparency(ov.Transparency.Value);
+            if (ov.Halftone.HasValue) ogs.SetHalftone(ov.Halftone.Value);
+            return ogs;
+        }
+
+        private static Color ParseHex(string hex)
+        {
+            if (string.IsNullOrWhiteSpace(hex)) return null;
+            hex = hex.Trim().TrimStart('#');
+            if (hex.Length != 6) return null;
+            try
+            {
+                byte r = byte.Parse(hex.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                byte g = byte.Parse(hex.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                byte b = byte.Parse(hex.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                return new Color(r, g, b);
+            }
+            catch { return null; }
+        }
+    }
+}

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1411,6 +1411,8 @@ namespace StingTools.Core
                 case "MEP_RestyleSystemTypes": return new Commands.Mep.MepRestyleSystemTypesCommand();
                 case "MEP_InspectSystemTypes": return new Commands.Mep.MepInspectSystemTypesCommand();
                 case "MEP_BuildSystems": return new Commands.Mep.MepBuildSystemsCommand();
+                case "MEP_ApplyMepCoordination": return new Commands.Mep.MepApplyMepCoordinationCommand();
+                case "MEP_InspectMepCoordination": return new Commands.Mep.MepInspectMepCoordinationCommand();
 
                 // Schedules
                 case "FullAutoPopulate": return new Temp.FullAutoPopulateCommand();

--- a/StingTools/UI/StingHvacCommandHandler.cs
+++ b/StingTools/UI/StingHvacCommandHandler.cs
@@ -145,6 +145,11 @@ namespace StingTools.UI
                     // Phase B — MEP System Instance Builder.
                     case "MEP_BuildSystems":
                         Run<StingTools.Commands.Mep.MepBuildSystemsCommand>(app); break;
+                    // Phase C — MEP-aware drawing coordination.
+                    case "MEP_ApplyMepCoordination":
+                        Run<StingTools.Commands.Mep.MepApplyMepCoordinationCommand>(app); break;
+                    case "MEP_InspectMepCoordination":
+                        Run<StingTools.Commands.Mep.MepInspectMepCoordinationCommand>(app); break;
                     case "Hvac_AutoFireDamper":
                     case "Routing_AutoFireDamper":
                         Run<StingTools.Commands.RoutingExt.AutoFireDamperCommand>(app); break;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,37 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase C: MEP-aware drawing coordination)
+
+Closes the create-systems → coordinated-drawing loop. Reads the MEP system
+**classifications** actually present in the model (the same `RBS_SYSTEM_CLASSIFICATION`
+the Phase A types carry and Phase B stamps onto elements), resolves the matching
+corporate AEC filter from `STING_AEC_FILTERS.json` **auto-matched by the live
+classification value** (no manual enum map to drift), lazy-creates it via
+`AecFilterFactory`, and applies it to a view with the filter's own discipline colour —
+on top of the MEP DrawingType's template + style pack resolved through
+`DrawingDispatcher`. **Built + verified with `dotnet build` against the Revit 2025
+API (0 warnings, 0 errors)** — including the live `View.AddFilter` /
+`SetFilterOverrides` / `DrawingTypePresentation.Apply` calls.
+
+**New files**
+
+| Path | Role |
+|---|---|
+| `StingTools/Core/Mep/MepCoordinationEngine.cs` | `PresentClassifications(doc)` reads distinct system-classification strings straight off duct/pipe members; `ApplyToView(doc, view)` matches each to its `STING_AEC_FILTERS.json` definition (`RBS_SYSTEM_CLASSIFICATION_PARAM equals "<value>"`), `FindOrCreate`s the filter, adds it to the view, and applies the filter's hex colour override (solid surface + projection/cut lines). Caller owns the transaction. |
+| `StingTools/Commands/Mep/MepCoordinationCommands.cs` | `MEP_ApplyMepCoordination` — resolves the MEP coordination/plan DrawingType via `DrawingDispatcher`, applies its presentation to the active view, then overlays the classification colour filters. `MEP_InspectMepCoordination` — read-only dry run: present classifications → resolved filter + DrawingType. |
+
+**Wiring**: `StingHvacCommandHandler` (SYS tab) + `WorkflowEngine.ResolveCommand`.
+
+**The deep integration**: one classification chain end-to-end — Phase A colour on the
+system *type* (project-wide) → Phase B classification stamped on the *element* →
+Phase C filter override on the *view*. Supply Air reads GSA-blue, Return Air green,
+CHW navy, etc., with zero manual per-view setup. Classifications with no matching AEC
+filter are reported (add one to `STING_AEC_FILTERS.json`); flow-vs-return / CHW-vs-LTHW
+splits that share one `MEPSystemClassification` are a known Revit limitation surfaced
+honestly. Full per-discipline view *production* (duplicate/create plans per system) is
+the natural next extension on top of this engine.
+
 #### Completed (MEP Systems — Phase B: System Instance Builder)
 
 Builds on Phase A: walks the MEP connector graph (same traversal as


### PR DESCRIPTION
## What & why

**Phase C of 3** (stacked on #360). Closes the create-systems → coordinated-drawing loop. Reads the MEP system **classifications** present in the model (the same `RBS_SYSTEM_CLASSIFICATION` the Phase A types carry and Phase B stamps onto elements), resolves the matching corporate AEC filter from `STING_AEC_FILTERS.json` **auto-matched by the live classification value** (no manual enum map to drift), lazy-creates it via `AecFilterFactory`, and applies it to a view with the filter's discipline colour — on top of the MEP DrawingType's template + style pack resolved through `DrawingDispatcher`.

## What's in it

- **`Core/Mep/MepCoordinationEngine.cs`** — `PresentClassifications(doc)` + `ApplyToView(doc, view)` (find filter by classification → `FindOrCreate` → `AddFilter` → hex colour override). Caller owns the transaction.
- **`Commands/Mep/MepCoordinationCommands.cs`** — `MEP_ApplyMepCoordination` (resolve DrawingType + apply presentation + classification colours to the active view) and `MEP_InspectMepCoordination` (read-only dry run).
- Wired into `StingHvacCommandHandler` + `WorkflowEngine.ResolveCommand`.

## The deep integration

One classification chain, end-to-end: **Phase A** colour on the system *type* (project-wide) → **Phase B** classification stamped on the *element* → **Phase C** filter override on the *view*. Supply Air reads GSA-blue, Return Air green, CHW navy, etc., with zero manual per-view setup.

## Verification

`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors** — including the live `View.AddFilter` / `SetFilterOverrides` / `DrawingTypePresentation.Apply` / `DrawingDispatcher` calls.

## Honest scope

Classifications with no matching AEC filter are reported (add one to `STING_AEC_FILTERS.json`). Flow-vs-return / CHW-vs-LTHW splits that share one `MEPSystemClassification` are a known Revit limitation, surfaced honestly. Full per-discipline view *production* (duplicate/create plans per system) is the natural next extension on top of this engine.

## Stacking

Phase A (#359) → Phase B (#360) → **Phase C** (this). Base is `claude/mep-systems-phase-b`; review/merge after #359 and #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🧪 Live-Revit validation

The full one-pass validation recipe covering **all six phases (A–F)** on a sample model — plus the `WORKFLOW_MEPSystemsValidate.json` preset that runs the whole chain in one go — lives in the tip PR: **#364**. Validate the entire stack there after merging A→F.