### PR TITLE
MEP Systems — Phase D: hardening (abbrev filters + auto-author + opt-in orphans) + review fixes

### DIFF
--- a/StingTools/Commands/Mep/MepCoordinationCommands.cs
+++ b/StingTools/Commands/Mep/MepCoordinationCommands.cs
@@ -89,7 +89,11 @@ namespace StingTools.Commands.Mep
         {
             try
             {
-                return DrawingDispatcher.Resolve(doc, "M", "*", "Coordination")
+                // "COORD" is the docType the corporate routing table uses for
+                // mep-coord-A1-1to50; try it first so the rule resolves deterministically,
+                // then the longer aliases, then a purpose-based candidate scan.
+                return DrawingDispatcher.Resolve(doc, "M", "*", "COORD")
+                    ?? DrawingDispatcher.Resolve(doc, "M", "*", "Coordination")
                     ?? DrawingDispatcher.Resolve(doc, "*", "*", "MEP")
                     ?? DrawingDispatcher.CandidatesForDiscipline(doc, "M")
                         .FirstOrDefault(d => d.Purpose == DrawingPurpose.Coordination

--- a/StingTools/Commands/Mep/MepCoordinationCommands.cs
+++ b/StingTools/Commands/Mep/MepCoordinationCommands.cs
@@ -60,9 +60,9 @@ namespace StingTools.Commands.Mep
                     ? $"{dt.Id}  ({dt.Discipline}/{dt.Purpose}) — template + style pack applied"
                     : "No MEP coordination/plan DrawingType resolved — filters applied without a template.");
 
-                panel.AddSection("SYSTEM CLASSIFICATIONS");
+                panel.AddSection("SYSTEMS → FILTER");
                 foreach (var r in res.Rows)
-                    panel.Text($"{(r.Applied ? "✓" : "·")} {r.Classification,-22} {r.FilterName,-30} {r.Note}");
+                    panel.Text($"{(r.Applied ? "✓" : "·")} {Label(r),-26} [{r.Source,-13}] {r.FilterName,-28} {r.Note}");
 
                 if (res.Warnings.Count > 0)
                 {
@@ -81,6 +81,9 @@ namespace StingTools.Commands.Mep
                 return Result.Failed;
             }
         }
+
+        private static string Label(MepCoordRow r)
+            => string.IsNullOrEmpty(r.Abbreviation) ? r.Classification : $"{r.Abbreviation} ({r.Classification})";
 
         internal static DrawingType ResolveMepDrawingType(Document doc)
         {
@@ -108,28 +111,37 @@ namespace StingTools.Commands.Mep
                 var doc = ctx?.Doc;
                 if (doc == null) { message = "No active document."; return Result.Failed; }
 
-                var present = MepCoordinationEngine.PresentClassifications(doc);
-                var defs = AecFilterRegistry.ListAll(doc);
+                // Same resolution the Apply command uses (no writes) — keeps the
+                // dry run and the real run perfectly consistent.
+                var plan = MepCoordinationEngine.BuildPlan(doc);
                 var dt = MepApplyMepCoordinationCommand.ResolveMepDrawingType(doc);
 
                 var panel = StingResultPanel.Create("MEP — Coordination Inspect (dry run)");
-                panel.SetSubtitle($"{present.Count} system classification(s) present · " +
+                int resolvable = plan.Count(r => r.Source != "none");
+                panel.SetSubtitle($"{plan.Count} system(s) present · {resolvable} resolvable · " +
                                   (dt != null ? $"DrawingType '{dt.Id}'" : "no DrawingType matched"));
 
-                panel.AddSection("CLASSIFICATION → FILTER");
-                if (present.Count == 0)
-                    panel.Text("No duct/pipe members carry a classification yet — run MEP_BuildSystems (Phase B).");
-                foreach (var cls in present)
+                panel.AddSection("SYSTEM → FILTER (source)");
+                if (plan.Count == 0)
+                    panel.Text("No duct/pipe members carry a system yet — run MEP_BuildSystems (Phase B).");
+                foreach (var r in plan)
                 {
-                    var def = defs.FirstOrDefault(d => RuleHas(d?.Rule, cls));
-                    panel.Text($"{(def != null ? "✓" : "·")} {cls,-22} {(def != null ? def.Name : "(no matching AEC filter)")}");
+                    string label = string.IsNullOrEmpty(r.Abbreviation) ? r.Classification : $"{r.Abbreviation} ({r.Classification})";
+                    bool ok = r.Source != "none";
+                    string filter = ok ? r.FilterName : "(no filter & no Phase A colour)";
+                    panel.Text($"{(ok ? "✓" : "·")} {label,-26} [{r.Source,-13}] {filter}");
                 }
+
+                panel.AddSection("LEGEND");
+                panel.Text("abbreviation = distinguishes services that share a classification (CHWF vs LTHWF) · " +
+                           "classification = corporate STING_AEC_FILTERS.json · synthesised = auto-authored from Phase A colour.");
 
                 panel.AddSection("DRAWING TYPE");
                 panel.Text(dt != null
                     ? $"{dt.Id}  ({dt.Discipline}/{dt.Purpose})  pack='{dt.ViewStylePackId}'"
                     : "No MEP coordination/plan DrawingType resolved.");
-                panel.Text("Run MEP_ApplyMepCoordination on the target view to apply the template + colours.");
+                panel.Text("Generate the abbreviation filters with MEP_GenerateSystemFilters, then " +
+                           "MEP_ApplyMepCoordination on the target view to apply the template + colours.");
                 panel.Show();
                 return Result.Succeeded;
             }
@@ -139,17 +151,6 @@ namespace StingTools.Commands.Mep
                 message = ex.Message;
                 return Result.Failed;
             }
-        }
-
-        private static bool RuleHas(AecFilterRule rule, string value)
-        {
-            if (rule == null) return false;
-            if (rule.IsLeaf)
-                return string.Equals(rule.Param, "RBS_SYSTEM_CLASSIFICATION_PARAM", StringComparison.OrdinalIgnoreCase)
-                    && string.Equals((rule.Value ?? "").Trim(), value, StringComparison.OrdinalIgnoreCase);
-            if (rule.Rules != null)
-                foreach (var c in rule.Rules) if (RuleHas(c, value)) return true;
-            return false;
         }
     }
 }

--- a/StingTools/Commands/Mep/MepSystemFilterCommands.cs
+++ b/StingTools/Commands/Mep/MepSystemFilterCommands.cs
@@ -1,0 +1,135 @@
+// StingTools — MEP System Filter command (Phase D).
+//
+//   MEP_GenerateSystemFilters — turn the Phase A system-type definitions into
+//   abbreviation-keyed AEC filters ("STING - Sys: …"), persist them to the project
+//   override <project>/_BIM_COORD/aec_filters.json (so they become first-class —
+//   visible to the AEC filter registry, View Style Packs, and Drawing Types), and
+//   create the matching ParameterFilterElements in the document so they're usable
+//   immediately. Idempotent (merge by id; FindOrCreate by name).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json;
+using StingTools.Core;
+using StingTools.Core.Drawing;
+using StingTools.Core.Mep;
+using StingTools.UI;
+
+namespace StingTools.Commands.Mep
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepGenerateSystemFiltersCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                var rules = MepSystemTypeRegistry.Get(doc);
+                var defs = MepSystemFilterGenerator.Generate(rules);
+                if (defs.Count == 0)
+                {
+                    TaskDialog.Show("STING MEP",
+                        "No enabled system-type definitions with an abbreviation + colour to generate filters from. " +
+                        "Check STING_MEP_SYSTEM_TYPES.json (or the project override).");
+                    return Result.Cancelled;
+                }
+
+                // 1. Persist to the project AEC-filter override (so packs / drawing types see them).
+                string persistPath = null; int persisted = 0; string persistNote = "";
+                try { persisted = PersistToProject(doc, defs, out persistPath); }
+                catch (Exception ex) { persistNote = ex.Message; StingLog.Warn($"MEP filter persist: {ex.Message}"); }
+                AecFilterRegistry.Reload(doc);
+
+                // 2. Create the ParameterFilterElements in the document.
+                int created = 0, existing = 0, failed = 0;
+                var rows = new List<string>();
+                using (var t = new Transaction(doc, "STING Generate MEP System Filters"))
+                {
+                    t.Start();
+                    foreach (var def in defs)
+                    {
+                        var fr = AecFilterFactory.FindOrCreate(doc, def);
+                        if (fr == null || !fr.Ok) { failed++; rows.Add($"✖ {def.Name}  {fr?.Error}"); continue; }
+                        if (fr.Created) created++; else existing++;
+                        rows.Add($"{(fr.Created ? "✚" : "◉")} {def.Name}");
+                    }
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create("MEP — Generate System Filters");
+                panel.SetSubtitle(
+                    $"{defs.Count} abbreviation-keyed filters · {created} created · {existing} existing · {failed} failed · " +
+                    (persistPath != null ? $"{persisted} written to project override" : "not persisted (unsaved project)"));
+
+                panel.AddSection("SUMMARY")
+                     .Metric("Generated", defs.Count.ToString())
+                     .Metric("Created in model", created.ToString())
+                     .Metric("Already existed", existing.ToString())
+                     .Metric("Failed", failed.ToString())
+                     .Metric("Persisted to override", persistPath != null ? persisted.ToString() : "—",
+                             persistPath != null ? Path.GetFileName(persistPath) : persistNote);
+
+                panel.AddSection("FILTERS");
+                foreach (var r in rows.Take(60)) panel.Text(r);
+
+                panel.AddSection("NEXT");
+                panel.Text("These 'STING - Sys: …' filters key on ASS_MEP_SYS_NAME_TXT begins-with '<abbr>-' so they " +
+                           "distinguish CHWF / LTHWF / CWF etc. — reference them from a View Style Pack, or run " +
+                           "MEP_ApplyMepCoordination to colour the active view automatically.");
+                panel.Show();
+
+                StingLog.Info($"MEP system filters: generated={defs.Count} created={created} existing={existing} persisted={persisted}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepGenerateSystemFiltersCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// Merge the generated definitions (by id) into
+        /// <project>/_BIM_COORD/aec_filters.json. Returns the count written.
+        /// </summary>
+        private static int PersistToProject(Document doc, List<AecFilterDefinition> defs, out string path)
+        {
+            path = null;
+            if (doc == null || string.IsNullOrEmpty(doc.PathName)) return 0; // unsaved — can't persist
+            string dir = Path.GetDirectoryName(doc.PathName);
+            if (string.IsNullOrEmpty(dir)) return 0;
+            string coord = Path.Combine(dir, "_BIM_COORD");
+            Directory.CreateDirectory(coord);
+            path = Path.Combine(coord, "aec_filters.json");
+
+            AecFilterLibrary lib = null;
+            if (File.Exists(path))
+            {
+                try { lib = JsonConvert.DeserializeObject<AecFilterLibrary>(File.ReadAllText(path)); }
+                catch (Exception ex) { StingLog.Warn($"MEP filter persist: existing override unreadable, recreating — {ex.Message}"); }
+            }
+            lib ??= new AecFilterLibrary();
+            lib.Filters ??= new List<AecFilterDefinition>();
+
+            var byId = lib.Filters
+                .Where(f => !string.IsNullOrEmpty(f.Id))
+                .ToDictionary(f => f.Id, StringComparer.OrdinalIgnoreCase);
+            foreach (var d in defs) byId[d.Id] = d;
+            lib.Filters = byId.Values.ToList();
+
+            File.WriteAllText(path, JsonConvert.SerializeObject(lib, Formatting.Indented));
+            return defs.Count;
+        }
+    }
+}

--- a/StingTools/Commands/Mep/MepSystemInstanceCommands.cs
+++ b/StingTools/Commands/Mep/MepSystemInstanceCommands.cs
@@ -22,7 +22,25 @@ namespace StingTools.Commands.Mep
     [Regeneration(RegenerationOption.Manual)]
     public class MepBuildSystemsCommand : IExternalCommand
     {
+        // Default: type / name / stamp the systems Revit already formed (the reliable,
+        // high-value path). Orphan creation (NewMechanicalSystem/NewPipingSystem) is
+        // opt-in via MEP_BuildSystemsForce because it depends on a valid source
+        // equipment + consistent flow direction + tree topology.
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+            => MepBuildSystemsRunner.Run(commandData, ref message, attemptCreateOrphans: false);
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepBuildSystemsForceCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+            => MepBuildSystemsRunner.Run(commandData, ref message, attemptCreateOrphans: true);
+    }
+
+    internal static class MepBuildSystemsRunner
+    {
+        public static Result Run(ExternalCommandData commandData, ref string message, bool attemptCreateOrphans)
         {
             try
             {
@@ -35,11 +53,12 @@ namespace StingTools.Commands.Mep
                 bool scopedToSelection = sel != null && sel.Count > 0;
 
                 MepSystemBuildResult res;
-                using (var t = new Transaction(doc, "STING Build MEP Systems"))
+                using (var t = new Transaction(doc,
+                    attemptCreateOrphans ? "STING Build MEP Systems (force)" : "STING Build MEP Systems"))
                 {
                     t.Start();
                     res = MepSystemInstanceBuilder.Build(doc, scopedToSelection ? sel : null,
-                                                         attemptCreateOrphans: true);
+                                                         attemptCreateOrphans);
                     t.Commit();
                 }
 
@@ -47,7 +66,8 @@ namespace StingTools.Commands.Mep
                 panel.SetSubtitle(
                     $"{res.Networks} network(s) · {res.Typed} typed · {res.Created} created · " +
                     $"{res.Stamped} stamped · {res.Skipped} skipped · {res.Failed} failed " +
-                    $"({(scopedToSelection ? "selection" : "whole project")})");
+                    $"({(scopedToSelection ? "selection" : "whole project")} · " +
+                    $"{(attemptCreateOrphans ? "force-create orphans" : "type/name/stamp only")})");
 
                 panel.AddSection("SUMMARY")
                      .Metric("Networks found",      res.Networks.ToString())
@@ -78,18 +98,19 @@ namespace StingTools.Commands.Mep
                 }
 
                 panel.AddSection("NEXT");
-                panel.Text("Systems now carry the STING type + classification — run AecFilters_Create " +
-                           "and apply a coordination View Style Pack to colour them, then produce MEP " +
-                           "drawings (Phase C: discipline + classification routing).");
+                panel.Text("Systems now carry the STING type + classification + name — run " +
+                           "MEP_GenerateSystemFilters then MEP_ApplyMepCoordination to colour the view by " +
+                           "system (Phase D). Orphan networks with a valid source can be force-built via " +
+                           "MEP_BuildSystemsForce.");
                 panel.Show();
 
                 StingLog.Info($"MEP build systems: networks={res.Networks} typed={res.Typed} " +
-                              $"created={res.Created} stamped={res.Stamped} skipped={res.Skipped}");
+                              $"created={res.Created} stamped={res.Stamped} skipped={res.Skipped} force={attemptCreateOrphans}");
                 return Result.Succeeded;
             }
             catch (Exception ex)
             {
-                StingLog.Error("MepBuildSystemsCommand", ex);
+                StingLog.Error("MepBuildSystemsRunner", ex);
                 message = ex.Message;
                 return Result.Failed;
             }

--- a/StingTools/Core/Mep/MepCoordinationEngine.cs
+++ b/StingTools/Core/Mep/MepCoordinationEngine.cs
@@ -1,15 +1,19 @@
-// StingTools — MEP Coordination Engine (Phase C).
+// StingTools — MEP Coordination Engine (Phase C + Phase D).
 //
-// Closes the create-systems → coordinated-drawing loop. Reads the MEP system
-// CLASSIFICATIONS actually present in the model (the same RBS_SYSTEM_CLASSIFICATION
-// the Phase A types carry and Phase B stamps onto elements), resolves the matching
-// corporate AEC filter from STING_AEC_FILTERS.json (auto-matched by the live
-// classification value — no manual enum map to drift), lazy-creates it via
-// AecFilterFactory, and applies it to a view with the filter's own colour override.
+// Closes the create-systems → coordinated-drawing loop. Reads the MEP systems
+// present in the model and resolves a colour filter for each by priority:
 //
-// The result: a view where Supply Air is GSA-blue, Return Air green, CHW navy …
-// driven end-to-end by one classification chain (Phase A colour on the type →
-// Phase B classification on the element → Phase C filter override on the view).
+//   1. Abbreviation-keyed STING filter (Phase D) — keys on ASS_MEP_SYS_NAME_TXT
+//      begins-with "<abbr>-" (stamped by Phase B). DISTINGUISHES services that
+//      share one MEPSystemClassification (CHWF / LTHWF / CWF are all SupplyHydronic).
+//   2. Corporate classification filter (Phase C) — a STING_AEC_FILTERS.json entry
+//      keyed on RBS_SYSTEM_CLASSIFICATION_PARAM equals "<display>".
+//   3. Auto-authored classification filter (Phase D) — synthesised from the matching
+//      Phase A def's colour so a present system ALWAYS colours, even with no curated
+//      filter.
+//
+// One source of truth throughout: Phase A colour on the type → Phase B classification
+// + name on the element → Phase D filter override on the view.
 //
 // CALLER OWNS THE ACTIVE TRANSACTION (for ApplyToView).
 
@@ -22,10 +26,22 @@ using StingTools.Core.Drawing;
 
 namespace StingTools.Core.Mep
 {
+    /// <summary>A distinct MEP system present in the model.</summary>
+    public sealed class PresentSystem
+    {
+        public string DisplayClassification { get; set; } = ""; // "Supply Air"
+        public string EnumClassification { get; set; } = "";     // "SupplyAir"
+        public string Abbreviation { get; set; } = "";           // "CHWF" (from ASS_MEP_SYS_NAME_TXT prefix)
+        public bool IsDuct { get; set; }
+        public string Key => string.IsNullOrEmpty(Abbreviation) ? "cls:" + DisplayClassification : "abbr:" + Abbreviation;
+    }
+
     public sealed class MepCoordRow
     {
         public string Classification { get; set; } = "";
+        public string Abbreviation { get; set; } = "";
         public string FilterName { get; set; } = "";
+        public string Source { get; set; } = "";   // abbreviation | classification | synthesised | none
         public bool Applied { get; set; }
         public string Note { get; set; } = "";
     }
@@ -42,14 +58,25 @@ namespace StingTools.Core.Mep
     {
         private const string ClassParam = "RBS_SYSTEM_CLASSIFICATION_PARAM";
 
-        /// <summary>
-        /// Distinct MEP system classification display-strings present in the model,
-        /// read straight off duct + pipe members (e.g. "Supply Air", "Hydronic Return").
-        /// </summary>
+        // ── model read ───────────────────────────────────────────────────────
+
+        /// <summary>Distinct system classification display-strings present (back-compat).</summary>
         public static List<string> PresentClassifications(Document doc)
+            => PresentSystems(doc).Select(s => s.DisplayClassification)
+                                  .Where(s => !string.IsNullOrEmpty(s))
+                                  .Distinct(StringComparer.OrdinalIgnoreCase)
+                                  .OrderBy(s => s).ToList();
+
+        /// <summary>
+        /// Distinct MEP systems present on duct + pipe members, each carrying its
+        /// display classification, enum classification, and STING abbreviation
+        /// (the ASS_MEP_SYS_NAME_TXT prefix Phase B stamped).
+        /// </summary>
+        public static List<PresentSystem> PresentSystems(Document doc)
         {
-            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            if (doc == null) return new List<string>();
+            var byKey = new Dictionary<string, PresentSystem>(StringComparer.OrdinalIgnoreCase);
+            if (doc == null) return new List<PresentSystem>();
+
             var collector = new FilteredElementCollector(doc)
                 .WherePasses(new ElementMulticategoryFilter(new[]
                 {
@@ -57,23 +84,67 @@ namespace StingTools.Core.Mep
                     BuiltInCategory.OST_PipeCurves
                 }))
                 .WhereElementIsNotElementType();
+
             foreach (var el in collector)
             {
                 try
                 {
-                    var p = el.get_Parameter(BuiltInParameter.RBS_SYSTEM_CLASSIFICATION_PARAM);
-                    var v = p?.AsValueString();
-                    if (!string.IsNullOrWhiteSpace(v)) set.Add(v.Trim());
+                    string display = el.get_Parameter(BuiltInParameter.RBS_SYSTEM_CLASSIFICATION_PARAM)?.AsValueString()?.Trim() ?? "";
+                    string abbr = AbbrevFromSysName(el.LookupParameter(MepSystemFilterGenerator.SysNameParam)?.AsString());
+                    string enumCls = EnumClassification(doc, el);
+                    if (string.IsNullOrEmpty(display) && string.IsNullOrEmpty(abbr)) continue;
+
+                    var ps = new PresentSystem
+                    {
+                        DisplayClassification = display,
+                        EnumClassification = enumCls,
+                        Abbreviation = abbr,
+                        IsDuct = el is Autodesk.Revit.DB.Mechanical.Duct
+                    };
+                    if (!byKey.ContainsKey(ps.Key)) byKey[ps.Key] = ps;
+                    else
+                    {
+                        // Backfill missing fields from later members.
+                        var ex = byKey[ps.Key];
+                        if (string.IsNullOrEmpty(ex.DisplayClassification)) ex.DisplayClassification = display;
+                        if (string.IsNullOrEmpty(ex.EnumClassification)) ex.EnumClassification = enumCls;
+                    }
                 }
                 catch { }
             }
-            return set.OrderBy(s => s).ToList();
+            return byKey.Values.OrderBy(s => s.IsDuct ? 0 : 1).ThenBy(s => s.DisplayClassification).ToList();
         }
 
+        // ── planning (shared by Apply + Inspect for consistency) ─────────────
+
         /// <summary>
-        /// Apply the system-classification colour filters to <paramref name="view"/>.
-        /// Requires an open transaction. Returns per-classification outcome rows.
+        /// Resolve, without writing, the filter each present system would get and
+        /// from which source. No transaction needed.
         /// </summary>
+        public static List<MepCoordRow> BuildPlan(Document doc)
+        {
+            var rows = new List<MepCoordRow>();
+            if (doc == null) return rows;
+            var rules = MepSystemTypeRegistry.Get(doc);
+            var corporate = AecFilterRegistry.ListAll(doc);
+            foreach (var sys in PresentSystems(doc))
+            {
+                var def = ResolveDef(rules, corporate, sys, out string source);
+                rows.Add(new MepCoordRow
+                {
+                    Classification = sys.DisplayClassification,
+                    Abbreviation = sys.Abbreviation,
+                    FilterName = def?.Name ?? "",
+                    Source = source,
+                    Note = def == null ? "no filter & no Phase A colour for this system" : ""
+                });
+            }
+            return rows;
+        }
+
+        // ── apply ────────────────────────────────────────────────────────────
+
+        /// <summary>Apply the resolved colour filters to <paramref name="view"/>. Requires an open transaction.</summary>
         public static MepCoordResult ApplyToView(Document doc, View view)
         {
             var result = new MepCoordResult();
@@ -84,69 +155,106 @@ namespace StingTools.Core.Mep
                 return result;
             }
 
-            var present = PresentClassifications(doc);
-            if (present.Count == 0)
+            var systems = PresentSystems(doc);
+            if (systems.Count == 0)
             {
-                result.Warnings.Add("No duct/pipe members carry a system classification yet — run Phase B (MEP_BuildSystems) first.");
+                result.Warnings.Add("No duct/pipe members carry a system yet — run MEP_BuildSystems (Phase B) first.");
                 return result;
             }
 
-            var defs = AecFilterRegistry.ListAll(doc);
+            var rules = MepSystemTypeRegistry.Get(doc);
+            var corporate = AecFilterRegistry.ListAll(doc);
             var solid = ParameterHelpers.GetSolidFillPattern(doc)?.Id;
             var existing = new HashSet<ElementId>(view.GetFilters());
 
-            foreach (var cls in present)
+            foreach (var sys in systems)
             {
-                var row = new MepCoordRow { Classification = cls };
+                var row = new MepCoordRow { Classification = sys.DisplayClassification, Abbreviation = sys.Abbreviation };
                 result.Rows.Add(row);
 
-                var def = FindFilterForClassification(defs, cls);
-                if (def == null)
-                {
-                    row.Note = "no AEC filter keyed on this classification — add one to STING_AEC_FILTERS.json";
-                    continue;
-                }
+                var def = ResolveDef(rules, corporate, sys, out string source);
+                row.Source = source;
+                if (def == null) { row.Note = "no filter & no Phase A colour for this system"; continue; }
                 row.FilterName = def.Name;
 
                 FilterFactoryResult fr;
                 try { fr = AecFilterFactory.FindOrCreate(doc, def); }
-                catch (Exception ex) { row.Note = $"filter create: {ex.Message}"; result.Warnings.Add($"{cls}: {ex.Message}"); continue; }
+                catch (Exception ex) { row.Note = $"filter create: {ex.Message}"; result.Warnings.Add($"{def.Name}: {ex.Message}"); continue; }
                 if (fr == null || !fr.Ok) { row.Note = fr?.Error ?? "filter not created"; continue; }
 
                 try
                 {
                     if (!existing.Contains(fr.Filter.Id)) { view.AddFilter(fr.Filter.Id); existing.Add(fr.Filter.Id); }
-                    var ogs = BuildOverride(def.DefaultOverride, solid);
-                    view.SetFilterOverrides(fr.Filter.Id, ogs);
+                    view.SetFilterOverrides(fr.Filter.Id, BuildOverride(def.DefaultOverride, solid));
                     view.SetFilterVisibility(fr.Filter.Id, true);
                     row.Applied = true;
-                    row.Note = fr.Created ? "filter created + applied" : "filter applied";
+                    row.Note = $"{source}: {(fr.Created ? "created + applied" : "applied")}";
                 }
                 catch (Exception ex)
                 {
                     row.Note = $"apply: {ex.Message}";
-                    result.Warnings.Add($"{cls}: apply: {ex.Message}");
+                    result.Warnings.Add($"{def.Name}: apply: {ex.Message}");
                 }
             }
             return result;
         }
 
-        // ── helpers ─────────────────────────────────────────────────────────
+        // ── resolution (the Phase D priority chain) ──────────────────────────
+
+        private static AecFilterDefinition ResolveDef(
+            MepSystemTypeRules rules, IReadOnlyList<AecFilterDefinition> corporate,
+            PresentSystem sys, out string source)
+        {
+            // 1. Abbreviation-keyed STING filter — distinguishes same-classification services.
+            if (!string.IsNullOrEmpty(sys.Abbreviation))
+            {
+                var d = rules?.Enabled.FirstOrDefault(x =>
+                    string.Equals(x.Abbreviation, sys.Abbreviation, StringComparison.OrdinalIgnoreCase)
+                    && x.LineColor != null);
+                if (d != null) { source = "abbreviation"; return MepSystemFilterGenerator.AbbreviationFilter(d); }
+            }
+
+            // 2. Corporate classification filter from STING_AEC_FILTERS.json.
+            if (!string.IsNullOrEmpty(sys.DisplayClassification))
+            {
+                var c = corporate?.FirstOrDefault(f => RuleMatchesClassification(f?.Rule, sys.DisplayClassification));
+                if (c != null) { source = "classification"; return c; }
+            }
+
+            // 3. Auto-author from the matching Phase A def colour.
+            var synth = MepSystemFilterGenerator.SynthesiseForClassification(
+                rules, sys.EnumClassification, sys.DisplayClassification);
+            if (synth != null) { source = "synthesised"; return synth; }
+
+            source = "none";
+            return null;
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────────
+
+        private static string AbbrevFromSysName(string sysName)
+        {
+            if (string.IsNullOrWhiteSpace(sysName)) return "";
+            int dash = sysName.IndexOf('-');
+            return dash > 0 ? sysName.Substring(0, dash).Trim() : "";
+        }
+
+        private static string EnumClassification(Document doc, Element el)
+        {
+            try
+            {
+                var sys = (el as MEPCurve)?.MEPSystem;
+                if (sys == null) return "";
+                var t = doc.GetElement(sys.GetTypeId()) as MEPSystemType;
+                return t?.SystemClassification.ToString() ?? "";
+            }
+            catch { return ""; }
+        }
 
         private static bool CanOverride(View view)
         {
             try { return view != null && !view.IsTemplate && view.AreGraphicsOverridesAllowed(); }
             catch { return false; }
-        }
-
-        private static AecFilterDefinition FindFilterForClassification(
-            IReadOnlyList<AecFilterDefinition> defs, string classificationValue)
-        {
-            if (defs == null) return null;
-            foreach (var d in defs)
-                if (RuleMatchesClassification(d?.Rule, classificationValue))
-                    return d;
-            return null;
         }
 
         private static bool RuleMatchesClassification(AecFilterRule rule, string value)

--- a/StingTools/Core/Mep/MepSystemFilterGenerator.cs
+++ b/StingTools/Core/Mep/MepSystemFilterGenerator.cs
@@ -1,0 +1,152 @@
+// StingTools — MEP System Filter Generator (Phase D).
+//
+// Turns the Phase A system-type definitions into AEC filter definitions so the
+// SAME single source (STING_MEP_SYSTEM_TYPES.json) drives system types, instance
+// names, AND view colours.
+//
+// Two filter shapes:
+//
+//   1. Abbreviation-keyed (preferred) — keys on ASS_MEP_SYS_NAME_TXT begins-with
+//      "<abbr>-". Phase B stamps that param on every member as "<abbr>-NN", so this
+//      DISTINGUISHES services that share one MEPSystemClassification (CHW-flow vs
+//      LTHW-flow vs CW-flow are all SupplyHydronic, but CHWF- / LTHWF- / CWF- differ).
+//      This is the fix for the Phase C "flow/return ambiguity" caveat.
+//
+//   2. Classification-synthesised (fallback / auto-author) — keys on
+//      RBS_SYSTEM_CLASSIFICATION_PARAM equals "<display>". Used when a classification
+//      is present in the model but no corporate AEC filter covers it: the colour
+//      comes from the matching Phase A def so every present system always colours.
+//
+// All generated definitions carry origin="project" and ids prefixed "sting-sys-"
+// so they round-trip cleanly through AecFilterRegistry's project-override merge.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.Drawing;
+
+namespace StingTools.Core.Mep
+{
+    public static class MepSystemFilterGenerator
+    {
+        public const string IdPrefix    = "sting-sys-";
+        public const string SysNameParam = "ASS_MEP_SYS_NAME_TXT"; // == ParamRegistry.MEP_SYS_NAME
+
+        private static readonly string[] DuctCats =
+        {
+            "OST_DuctCurves", "OST_DuctFitting", "OST_DuctAccessory",
+            "OST_DuctTerminal", "OST_FlexDuctCurves", "OST_DuctInsulations"
+        };
+        private static readonly string[] PipeCats =
+        {
+            "OST_PipeCurves", "OST_PipeFitting", "OST_PipeAccessory",
+            "OST_FlexPipeCurves", "OST_PipeInsulations", "OST_Sprinklers", "OST_PlumbingFixtures"
+        };
+
+        /// <summary>
+        /// One abbreviation-keyed AEC filter per enabled Phase A definition that has
+        /// both an abbreviation and a colour. These are the "STING - Sys: …" filters.
+        /// </summary>
+        public static List<AecFilterDefinition> Generate(MepSystemTypeRules rules)
+        {
+            var defs = new List<AecFilterDefinition>();
+            if (rules == null) return defs;
+            foreach (var d in rules.Enabled)
+            {
+                if (string.IsNullOrWhiteSpace(d.Abbreviation) || d.LineColor == null) continue;
+                if (!d.IsDuct && !d.IsPipe) continue;
+                defs.Add(AbbreviationFilter(d));
+            }
+            return defs;
+        }
+
+        /// <summary>Build the abbreviation-keyed filter for a single Phase A def.</summary>
+        public static AecFilterDefinition AbbreviationFilter(MepSystemTypeDef d)
+        {
+            return new AecFilterDefinition
+            {
+                Id   = IdPrefix + d.Id,
+                Name = $"STING - Sys: {d.Name}",
+                Origin = "project",
+                Categories = (d.IsDuct ? DuctCats : PipeCats).ToList(),
+                Rule = new AecFilterRule
+                {
+                    Param = SysNameParam,
+                    Kind  = "shared",
+                    Op    = "beginswith",
+                    Value = d.Abbreviation + "-"
+                },
+                DefaultOverride = OverrideFromColor(d.LineColor, d.LineWeight),
+                Tags = new List<string> { "mep", d.IsDuct ? "duct" : "pipe", "sting-sys" },
+                Standard = "STING",
+                Notes = $"Auto-generated from STING_MEP_SYSTEM_TYPES.json '{d.Id}' " +
+                        $"(classification {d.Classification}, abbreviation {d.Abbreviation})."
+            };
+        }
+
+        /// <summary>
+        /// Synthesise a classification-keyed filter from the Phase A def whose
+        /// classification matches <paramref name="enumClassification"/> (enum name,
+        /// e.g. "SupplyAir"). The rule keys on the DISPLAY value
+        /// (<paramref name="displayClassification"/>, e.g. "Supply Air") since that
+        /// is what RBS_SYSTEM_CLASSIFICATION_PARAM stores. Returns null when no
+        /// Phase A def carries that classification (no colour to use).
+        /// </summary>
+        public static AecFilterDefinition SynthesiseForClassification(
+            MepSystemTypeRules rules, string enumClassification, string displayClassification)
+        {
+            var d = rules?.Enabled.FirstOrDefault(x =>
+                string.Equals(x.Classification, enumClassification, StringComparison.OrdinalIgnoreCase)
+                && x.LineColor != null);
+            if (d == null) return null;
+
+            return new AecFilterDefinition
+            {
+                Id   = IdPrefix + "cls-" + Sanitise(displayClassification),
+                Name = $"STING - Sys (class): {displayClassification}",
+                Origin = "project",
+                Categories = (d.IsDuct ? DuctCats : PipeCats).ToList(),
+                Rule = new AecFilterRule
+                {
+                    Param = "RBS_SYSTEM_CLASSIFICATION_PARAM",
+                    Kind  = "builtin",
+                    Op    = "equals",
+                    Value = displayClassification
+                },
+                DefaultOverride = OverrideFromColor(d.LineColor, d.LineWeight),
+                Tags = new List<string> { "mep", "sting-sys", "auto" },
+                Standard = "STING",
+                Notes = $"Auto-authored for present classification '{displayClassification}' " +
+                        $"using colour from Phase A def '{d.Id}'."
+            };
+        }
+
+        // ── helpers ─────────────────────────────────────────────────────────
+
+        private static FilterDefaultOverride OverrideFromColor(int[] rgb, int weight)
+        {
+            string hex = Hex(rgb);
+            var ov = new FilterDefaultOverride
+            {
+                ProjColor   = hex,
+                CutColor    = hex,
+                SurfFgColor = hex,
+                SurfFgPattern = "Solid fill"
+            };
+            if (weight >= 1 && weight <= 16) { ov.ProjWeight = weight; ov.CutWeight = weight; }
+            return ov;
+        }
+
+        private static string Hex(int[] rgb)
+        {
+            if (rgb == null || rgb.Length < 3) return null;
+            int r = Clamp(rgb[0]), g = Clamp(rgb[1]), b = Clamp(rgb[2]);
+            return $"#{r:X2}{g:X2}{b:X2}";
+        }
+
+        private static int Clamp(int v) => v < 0 ? 0 : (v > 255 ? 255 : v);
+
+        private static string Sanitise(string s)
+            => new string((s ?? "").ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray());
+    }
+}

--- a/StingTools/Core/Mep/MepSystemFilterGenerator.cs
+++ b/StingTools/Core/Mep/MepSystemFilterGenerator.cs
@@ -29,8 +29,9 @@ namespace StingTools.Core.Mep
 {
     public static class MepSystemFilterGenerator
     {
-        public const string IdPrefix    = "sting-sys-";
-        public const string SysNameParam = "ASS_MEP_SYS_NAME_TXT"; // == ParamRegistry.MEP_SYS_NAME
+        public const string IdPrefix = "sting-sys-";
+        // Single source of truth — same shared param Phase B stamps the system name onto.
+        public static readonly string SysNameParam = ParamRegistry.MEP_SYS_NAME;
 
         private static readonly string[] DuctCats =
         {

--- a/StingTools/Core/Mep/MepSystemInstanceBuilder.cs
+++ b/StingTools/Core/Mep/MepSystemInstanceBuilder.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Mechanical;
 using Autodesk.Revit.DB.Plumbing;
@@ -78,8 +79,9 @@ namespace StingTools.Core.Mep
             var mechTypeByClass = BuildTypeIndex<MechanicalSystemType>(doc);
             var pipeTypeByClass = BuildTypeIndex<PipingSystemType>(doc);
 
-            // Per-classification running counter for system names.
-            var nameSeq = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            // Per-abbreviation name counter, primed from existing "<abbr>-NN" systems
+            // so a second run continues the sequence rather than colliding.
+            var nameSeq = SeedNameSeq(doc);
 
             // Seeds: explicit selection, else every duct + pipe in the project.
             var seeds = (seedIds != null && seedIds.Count > 0)
@@ -153,7 +155,7 @@ namespace StingTools.Core.Mep
             {
                 if (!attemptCreateOrphans)
                 {
-                    StampMembers(doc, els, null, row);
+                    StampMembers(doc, els, null, null, row);
                     row.Outcome = MepSystemBuildOutcome.Stamped;
                     row.Note = "orphan network (no system) — members stamped; enable create to build a system";
                     return;
@@ -162,7 +164,7 @@ namespace StingTools.Core.Mep
                 if (system == null)
                 {
                     // Could not create — still stamp members so tags/params land.
-                    StampMembers(doc, els, null, row);
+                    StampMembers(doc, els, null, null, row);
                     row.Outcome = MepSystemBuildOutcome.Skipped;
                     if (string.IsNullOrEmpty(row.Note))
                         row.Note = "no valid source-equipment connector to anchor a system";
@@ -170,40 +172,54 @@ namespace StingTools.Core.Mep
                 }
             }
 
-            // Resolve classification from the system's current type.
+            // Resolve classification + read whether the current type is already a
+            // STING type (so we don't retype a correctly-assigned CHW system to LTHW
+            // just because both are SupplyHydronic).
             MEPSystemClassification cls = MEPSystemClassification.UndefinedSystemClassification;
-            try
-            {
-                var curType = doc.GetElement(system.GetTypeId()) as MEPSystemType;
-                if (curType != null) cls = curType.SystemClassification;
-            }
+            var curTypeEl = doc.GetElement(system.GetTypeId()) as MEPSystemType;
+            bool currentIsSting = (curTypeEl?.Name ?? "").StartsWith("STING", StringComparison.OrdinalIgnoreCase);
+            try { if (curTypeEl != null) cls = curTypeEl.SystemClassification; }
             catch (Exception ex) { result.Warnings.Add($"{row.Network}: classification read: {ex.Message}"); }
             row.Classification = cls.ToString();
 
-            // Assign the STING (Phase A) system type for this classification.
+            // Assign the STING (Phase A) type for this classification — but only when
+            // the current type isn't already a STING type (preserve service identity).
             var typeIndex = hasDuct ? mechTypeByClass : pipeTypeByClass;
-            if (typeIndex.TryGetValue(cls, out var stingTypeId) && stingTypeId != system.GetTypeId())
+            if (!currentIsSting && typeIndex.TryGetValue(cls, out var stingTypeId) && stingTypeId != system.GetTypeId())
             {
-                try { system.ChangeTypeId(stingTypeId); }
+                try { system.ChangeTypeId(stingTypeId); currentIsSting = true; }
                 catch (Exception ex) { result.Warnings.Add($"{row.Network}: ChangeTypeId: {ex.Message}"); }
             }
 
-            // Name it <abbreviation>-<NN> from the matching Phase A definition.
+            // Abbreviation: from the system's (now-STING) type first, else the Phase A
+            // def by classification, else a domain default.
             var def = rules.Enabled.FirstOrDefault(d =>
                 string.Equals(d.Classification, cls.ToString(), StringComparison.OrdinalIgnoreCase) &&
                 (hasDuct ? d.IsDuct : d.IsPipe));
-            string abbr = def?.Abbreviation;
-            if (string.IsNullOrWhiteSpace(abbr))
-                try { abbr = (doc.GetElement(system.GetTypeId()) as MEPSystemType)?.Abbreviation; } catch { }
+            string abbr = null;
+            try { abbr = (doc.GetElement(system.GetTypeId()) as MEPSystemType)?.Abbreviation; } catch { }
+            if (string.IsNullOrWhiteSpace(abbr)) abbr = def?.Abbreviation;
             if (string.IsNullOrWhiteSpace(abbr)) abbr = hasDuct ? "DUCT" : "PIPE";
 
-            int seq = nameSeq.TryGetValue(abbr, out var n) ? n + 1 : 1;
-            nameSeq[abbr] = seq;
-            string sysName = $"{abbr}-{seq:D2}";
+            // Idempotent naming: keep an existing "<abbr>-NN" name; otherwise mint the
+            // next sequence number (the counter was primed from existing systems).
+            string existingName = null; try { existingName = system.Name; } catch { }
+            string sysName;
+            if (!string.IsNullOrEmpty(existingName) &&
+                Regex.IsMatch(existingName, $"^{Regex.Escape(abbr)}-\\d+$", RegexOptions.IgnoreCase))
+            {
+                sysName = existingName; // already STING-named — leave it
+            }
+            else
+            {
+                int seq = (nameSeq.TryGetValue(abbr, out var n) ? n : 0) + 1;
+                nameSeq[abbr] = seq;
+                sysName = $"{abbr}-{seq:D2}";
+                TrySetSystemName(system, sysName, result.Warnings, row.Network);
+            }
             row.SystemName = sysName;
 
-            TrySetSystemName(system, sysName, result.Warnings, row.Network);
-            StampMembers(doc, els, sysName, row);
+            StampMembers(doc, els, sysName, def, row);
 
             row.Outcome = created ? MepSystemBuildOutcome.Created : MepSystemBuildOutcome.Typed;
             if (string.IsNullOrEmpty(row.Note))
@@ -256,20 +272,20 @@ namespace StingTools.Core.Mep
 
             try
             {
+                MEPSystem result;
                 if (isDuct)
                 {
                     var dst = MapDuctSystemType(baseConn);
-                    var ms = doc.Create.NewMechanicalSystem(baseConn, members, dst);
-                    created = ms != null;
-                    return ms;
+                    result = doc.Create.NewMechanicalSystem(baseConn, members, dst);
                 }
                 else
                 {
                     var pst = MapPipeSystemType(baseConn);
-                    var ps = doc.Create.NewPipingSystem(baseConn, members, pst);
-                    created = ps != null;
-                    return ps;
+                    result = doc.Create.NewPipingSystem(baseConn, members, pst);
                 }
+                created = result != null;
+                PlaceSystemOnSourceWorkset(doc, result, baseConn); // workset integration — new object only
+                return result;
             }
             catch (Exception ex)
             {
@@ -279,9 +295,29 @@ namespace StingTools.Core.Mep
             }
         }
 
+        /// <summary>
+        /// Put a newly-created system object on the same workset as its source
+        /// equipment so it lives with its network rather than the active workset.
+        /// Members are never moved — that stays the coordinator's call.
+        /// </summary>
+        private static void PlaceSystemOnSourceWorkset(Document doc, MEPSystem system, Connector baseConn)
+        {
+            try
+            {
+                if (system == null || baseConn?.Owner == null || !doc.IsWorkshared) return;
+                var src = baseConn.Owner.get_Parameter(BuiltInParameter.ELEM_PARTITION_PARAM);
+                var dst = system.get_Parameter(BuiltInParameter.ELEM_PARTITION_PARAM);
+                if (src != null && dst != null && !dst.IsReadOnly &&
+                    src.StorageType == StorageType.Integer && dst.StorageType == StorageType.Integer)
+                    dst.Set(src.AsInteger());
+            }
+            catch { /* non-critical */ }
+        }
+
         // ── helpers ─────────────────────────────────────────────────────────
 
-        private static void StampMembers(Document doc, List<Element> els, string sysName, MepSystemBuildRow row)
+        private static void StampMembers(
+            Document doc, List<Element> els, string sysName, MepSystemTypeDef def, MepSystemBuildRow row)
         {
             if (string.IsNullOrEmpty(sysName))
             {
@@ -295,6 +331,16 @@ namespace StingTools.Core.Mep
             {
                 try { ParameterHelpers.SetString(el, ParamRegistry.MEP_SYS_NAME, sysName, overwrite: true); }
                 catch { }
+                // Feed the ISO 19650 tag grammar: write the SYS / FUNC tokens from the
+                // Phase A definition so AutoTag/BatchTag inherit them instead of falling
+                // back to the generic category code. SetIfEmpty preserves manual edits.
+                if (def != null)
+                {
+                    if (!string.IsNullOrWhiteSpace(def.StingSysCode))
+                        try { ParameterHelpers.SetIfEmpty(el, ParamRegistry.SYS, def.StingSysCode); } catch { }
+                    if (!string.IsNullOrWhiteSpace(def.StingFuncCode))
+                        try { ParameterHelpers.SetIfEmpty(el, ParamRegistry.FUNC, def.StingFuncCode); } catch { }
+                }
             }
         }
 
@@ -314,16 +360,51 @@ namespace StingTools.Core.Mep
         private static Dictionary<MEPSystemClassification, ElementId> BuildTypeIndex<T>(Document doc)
             where T : MEPSystemType
         {
+            // Deterministic: the FIRST STING type per classification (ordered by name)
+            // wins; a non-STING type only fills a classification that has no STING
+            // type. Without the ordering FilteredElementCollector order is arbitrary,
+            // so when several STING types share a classification (CHW/LTHW/CW Flow are
+            // all SupplyHydronic) a re-run could type the same pipes differently.
             var dict = new Dictionary<MEPSystemClassification, ElementId>();
-            foreach (var t in new FilteredElementCollector(doc).OfClass(typeof(T)).Cast<T>())
+            var stingClaimed = new HashSet<MEPSystemClassification>();
+            foreach (var t in new FilteredElementCollector(doc).OfClass(typeof(T)).Cast<T>()
+                         .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase))
             {
                 MEPSystemClassification cls;
                 try { cls = t.SystemClassification; } catch { continue; }
-                // Prefer a STING (Phase A) type when several share a classification.
                 bool isSting = (t.Name ?? "").StartsWith("STING", StringComparison.OrdinalIgnoreCase);
-                if (!dict.ContainsKey(cls) || isSting) dict[cls] = t.Id;
+                if (isSting)
+                {
+                    if (stingClaimed.Add(cls)) dict[cls] = t.Id;
+                }
+                else if (!dict.ContainsKey(cls)) dict[cls] = t.Id;
             }
             return dict;
+        }
+
+        /// <summary>
+        /// Prime the per-abbreviation name counter from existing "&lt;abbr&gt;-NN"
+        /// system names so re-runs continue the sequence instead of colliding.
+        /// </summary>
+        private static Dictionary<string, int> SeedNameSeq(Document doc)
+        {
+            var seq = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var rx = new Regex(@"^([A-Za-z]+)-(\d+)$");
+            void Scan<T>() where T : Element
+            {
+                foreach (var s in new FilteredElementCollector(doc).OfClass(typeof(T)).Cast<T>())
+                {
+                    string name; try { name = s.Name; } catch { continue; }
+                    if (string.IsNullOrEmpty(name)) continue;
+                    var m = rx.Match(name);
+                    if (!m.Success) continue;
+                    string abbr = m.Groups[1].Value;
+                    if (int.TryParse(m.Groups[2].Value, out int n) &&
+                        (!seq.TryGetValue(abbr, out int cur) || n > cur)) seq[abbr] = n;
+                }
+            }
+            try { Scan<MechanicalSystem>(); Scan<PipingSystem>(); } catch { }
+            return seq;
         }
 
         // Map a connector's classification onto the DuctSystemType / PipeSystemType

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -334,6 +334,8 @@ namespace StingTools.Core
                 catch (Exception cEx) { StingLog.Warn($"Climate cache invalidate: {cEx.Message}"); }
                 try { Core.Mep.MepSizingRegistry.Reload(e.Document); }
                 catch (Exception cEx) { StingLog.Warn($"MEP sizing cache invalidate: {cEx.Message}"); }
+                try { Core.Mep.MepSystemTypeRegistry.Reload(e.Document); }
+                catch (Exception cEx) { StingLog.Warn($"MEP system-type cache invalidate: {cEx.Message}"); }
                 try { Core.Hvac.Loads.LoadProfileRegistry.Reload(e.Document); }
                 catch (Exception cEx) { StingLog.Warn($"Load profile cache invalidate: {cEx.Message}"); }
                 try { Commands.Hvac.HvacGenerateCxChecklistCommand.InvalidateTaskCache(); }

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1411,6 +1411,8 @@ namespace StingTools.Core
                 case "MEP_RestyleSystemTypes": return new Commands.Mep.MepRestyleSystemTypesCommand();
                 case "MEP_InspectSystemTypes": return new Commands.Mep.MepInspectSystemTypesCommand();
                 case "MEP_BuildSystems": return new Commands.Mep.MepBuildSystemsCommand();
+                case "MEP_BuildSystemsForce": return new Commands.Mep.MepBuildSystemsForceCommand();
+                case "MEP_GenerateSystemFilters": return new Commands.Mep.MepGenerateSystemFiltersCommand();
                 case "MEP_ApplyMepCoordination": return new Commands.Mep.MepApplyMepCoordinationCommand();
                 case "MEP_InspectMepCoordination": return new Commands.Mep.MepInspectMepCoordinationCommand();
 

--- a/StingTools/Data/STING_MEP_SYSTEM_TYPES.json
+++ b/StingTools/Data/STING_MEP_SYSTEM_TYPES.json
@@ -69,13 +69,13 @@
     {
       "id": "pipe-lthw-flow", "name": "STING LTHW Flow", "discipline": "pipe",
       "classification": "SupplyHydronic", "abbreviation": "LTHWF", "stingSysCode": "HVAC", "stingFuncCode": "HTG",
-      "lineColor": [192, 0, 0], "lineWeight": 4,
+      "lineColor": [255, 120, 0], "lineWeight": 4,
       "uniclass": "Ss_55_30_10", "cibse": "CIBSE-HT01"
     },
     {
       "id": "pipe-lthw-return", "name": "STING LTHW Return", "discipline": "pipe",
       "classification": "ReturnHydronic", "abbreviation": "LTHWR", "stingSysCode": "HVAC", "stingFuncCode": "HTG",
-      "lineColor": [255, 80, 80], "lineWeight": 4, "linePattern": "Dash",
+      "lineColor": [255, 175, 90], "lineWeight": 4, "linePattern": "Dash",
       "uniclass": "Ss_55_30_10", "cibse": "CIBSE-HT01"
     },
     {

--- a/StingTools/UI/StingHvacCommandHandler.cs
+++ b/StingTools/UI/StingHvacCommandHandler.cs
@@ -145,7 +145,11 @@ namespace StingTools.UI
                     // Phase B — MEP System Instance Builder.
                     case "MEP_BuildSystems":
                         Run<StingTools.Commands.Mep.MepBuildSystemsCommand>(app); break;
-                    // Phase C — MEP-aware drawing coordination.
+                    case "MEP_BuildSystemsForce":
+                        Run<StingTools.Commands.Mep.MepBuildSystemsForceCommand>(app); break;
+                    // Phase C/D — MEP-aware drawing coordination + system filters.
+                    case "MEP_GenerateSystemFilters":
+                        Run<StingTools.Commands.Mep.MepGenerateSystemFiltersCommand>(app); break;
                     case "MEP_ApplyMepCoordination":
                         Run<StingTools.Commands.Mep.MepApplyMepCoordinationCommand>(app); break;
                     case "MEP_InspectMepCoordination":

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,37 @@ defaults to type/name/stamp only (zero fragile API calls); the best-effort
 `Commands/Mep/MepSystemInstanceCommands.cs` (opt-in split), `Commands/Mep/MepCoordinationCommands.cs`
 (plan-based display), `StingHvacCommandHandler` + `WorkflowEngine.ResolveCommand` (4 new tags).
 
+**Review hardening (alignment / accuracy / consistency / integration)** — fixes from
+a full code-review pass across Drawing Types / Styles / Tagging / Worksets:
+
+- **[accuracy] Deterministic, service-preserving typing.** `BuildTypeIndex` now picks
+  the first STING type per classification by name-order (was arbitrary collector order —
+  CHW pipes could be typed LTHW since both are `SupplyHydronic`); `ProcessNetwork` no
+  longer retypes a system whose current type is already a STING type.
+- **[accuracy] Idempotent system naming.** The `<abbr>-NN` counter is primed from
+  existing systems and an already-STING-named system keeps its name, so re-runs continue
+  the sequence instead of colliding.
+- **[integration · tagging] SYS / FUNC tag tokens written.** Phase B now stamps
+  `ASS_SYSTEM_TYPE_TXT` (SYS) and `ASS_FUNC_TXT` (FUNC) from the def's `stingSysCode` /
+  `stingFuncCode` via `SetIfEmpty`, so AutoTag/BatchTag inherit the right tokens instead
+  of the generic category fallback.
+- **[integration · worksets] New system objects placed on their source equipment's
+  workset** (workshared only); existing members are never moved.
+- **[integration · drawing types] DrawingType routing fixed.** The coordination command
+  now queries docType `"COORD"` first — the value the corporate routing table actually
+  uses for `mep-coord-A1-1to50` — so the rule resolves deterministically instead of
+  falling through to a purpose scan.
+- **[consistency] `MepSystemFilterGenerator.SysNameParam` now references
+  `ParamRegistry.MEP_SYS_NAME`** (was a duplicated literal); `MepSystemTypeRegistry`
+  added to `OnDocumentClosing` cache invalidation alongside the other registries.
+- **[accuracy] LTHW flow recoloured orange** `[255,120,0]` (was dark red, clashing with
+  the fire-sprinkler red).
+
+Deferred with rationale: auto-appending the generated filters to the `corp-coordination`
+View Style Pack (the project-override merge is replace-by-id, so a partial write risks
+stripping the corporate pack's other settings — the registry persistence already makes
+the filters pack-referenceable, which is the safe enabler).
+
 **Still honest**: runtime behaviour of the force-create path needs live-Revit
 verification; per-discipline view *production* remains the next extension; electrical
 circuits remain a separate mechanism.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,42 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase D: hardening — abbreviation filters + auto-author + opt-in orphans)
+
+Turns the three Phase B/C caveats into capabilities. **Built + verified with
+`dotnet build` against the Revit 2025 API (0 warnings, 0 errors).**
+
+**1. Abbreviation-keyed filters (fixes the flow/return ambiguity).** The Phase A
+abbreviation + Phase B instance name (`ASS_MEP_SYS_NAME_TXT` = `<abbr>-NN`) are the
+disambiguator Revit's classification can't provide. `Core/Mep/MepSystemFilterGenerator.cs`
+generates one AEC filter per Phase A def keyed on `ASS_MEP_SYS_NAME_TXT begins-with
+"<abbr>-"`, coloured from the same Phase A colour — so CHWF / LTHWF / CWF (all
+`SupplyHydronic`) finally read as three different colours. `MEP_GenerateSystemFilters`
+persists them to `<project>/_BIM_COORD/aec_filters.json` (first-class: visible to the
+AEC filter registry, **View Style Packs**, and **Drawing Types**) and creates the
+`ParameterFilterElement`s in the model.
+
+**2. Auto-author missing filters (every present system always colours).**
+`MepCoordinationEngine` now resolves each present system by priority — (1) abbreviation
+filter, (2) corporate classification filter from `STING_AEC_FILTERS.json`, (3) a filter
+**synthesised on the fly from the matching Phase A def's colour**. A `BuildPlan(doc)`
+method shares the exact resolution between `MEP_ApplyMepCoordination` and
+`MEP_InspectMepCoordination`, so the dry run and the real run can't drift.
+
+**3. Opt-in orphan creation (de-risks the default flow).** `MEP_BuildSystems` now
+defaults to type/name/stamp only (zero fragile API calls); the best-effort
+`NewMechanicalSystem`/`NewPipingSystem` path moved behind an explicit
+`MEP_BuildSystemsForce`.
+
+**New files**: `Core/Mep/MepSystemFilterGenerator.cs`, `Commands/Mep/MepSystemFilterCommands.cs`.
+**Changed**: `Core/Mep/MepCoordinationEngine.cs` (priority resolution + `PresentSystems`/`BuildPlan`),
+`Commands/Mep/MepSystemInstanceCommands.cs` (opt-in split), `Commands/Mep/MepCoordinationCommands.cs`
+(plan-based display), `StingHvacCommandHandler` + `WorkflowEngine.ResolveCommand` (4 new tags).
+
+**Still honest**: runtime behaviour of the force-create path needs live-Revit
+verification; per-discipline view *production* remains the next extension; electrical
+circuits remain a separate mechanism.
+
 #### Completed (MEP Systems — Phase C: MEP-aware drawing coordination)
 
 Closes the create-systems → coordinated-drawing loop. Reads the MEP system


### PR DESCRIPTION
## What & why

**Phase D of 4** (stacked on #361). Turns the Phase B/C caveats into capabilities, then a full code-review hardening pass across **Drawing Types / Styles / Tagging / Worksets**.

### Caveats → features
1. **Abbreviation-keyed filters** (`MepSystemFilterGenerator`) keyed on `ASS_MEP_SYS_NAME_TXT begins-with "<abbr>-"`, coloured from the Phase A colour — distinguishes `CHWF` / `LTHWF` / `CWF` that share one `MEPSystemClassification`. `MEP_GenerateSystemFilters` persists them to `_BIM_COORD/aec_filters.json` (first-class for Style Packs + Drawing Types) and creates the filters in-model.
2. **Auto-author** — `MepCoordinationEngine` resolves each present system by priority (abbreviation → corporate classification → **synthesised from the Phase A colour**), so every system always colours. Shared `BuildPlan` keeps `MEP_ApplyMepCoordination` and `MEP_InspectMepCoordination` perfectly consistent.
3. **Opt-in orphans** — `MEP_BuildSystems` defaults to type/name/stamp only; the fragile `NewMechanicalSystem`/`NewPipingSystem` path moved behind `MEP_BuildSystemsForce`.

### Review hardening (a dedicated code-reviewer subagent ran over Phases A–D)
- **[accuracy]** Deterministic, service-preserving typing (`BuildTypeIndex` first-STING-by-name; don't retype an already-STING system) — fixes CHW pipes randomly typed as LTHW.
- **[accuracy]** Idempotent `<abbr>-NN` naming (counter primed from existing systems; keep an existing STING name) — fixes duplicate names on re-run.
- **[integration · tagging]** Phase B now stamps **SYS (`ASS_SYSTEM_TYPE_TXT`) + FUNC (`ASS_FUNC_TXT`)** from `stingSysCode`/`stingFuncCode` via `SetIfEmpty`, so AutoTag/BatchTag inherit the right tokens.
- **[integration · worksets]** New system objects placed on their source equipment's workset (workshared only; members never moved).
- **[integration · drawing types]** Coordination command queries docType `"COORD"` first — the value the corporate routing table actually uses for `mep-coord-A1-1to50` — so the rule resolves deterministically.
- **[consistency]** `SysNameParam` → `ParamRegistry.MEP_SYS_NAME`; `MepSystemTypeRegistry` added to `OnDocumentClosing` invalidation.
- **[accuracy]** LTHW flow recoloured orange (was clashing with fire-sprinkler red).

**Deferred (with rationale)**: auto-appending generated filters to the `corp-coordination` Style Pack — the project-override merge is replace-by-id, so a partial write risks stripping the corporate pack's other settings; the registry persistence already makes the filters pack-referenceable (the safe enabler).

## Verification

`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors** (every revision). JSON validated.

## Stacking

Phase A (#359) → B (#360) → C (#361) → **D** (this). Base is `claude/mep-systems-phase-c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🧪 Live-Revit validation

The full one-pass validation recipe covering **all six phases (A–F)** on a sample model — plus the `WORKFLOW_MEPSystemsValidate.json` preset that runs the whole chain in one go — lives in the tip PR: **#364**. Validate the entire stack there after merging A→F.