### PR TITLE
MEP Systems — Phase E: per-discipline view production + electrical circuits

### DIFF
--- a/StingTools/Commands/Mep/MepPhaseECommands.cs
+++ b/StingTools/Commands/Mep/MepPhaseECommands.cs
@@ -1,0 +1,130 @@
+// StingTools — Phase E commands: per-discipline view production + electrical circuits.
+//
+//   MEP_ProduceMepViews — duplicate the active plan once per present MEP discipline
+//     (M/E/P), set the view discipline, apply the resolved MEP DrawingType, and
+//     overlay the system colours. The last link of create-systems → coordinated drawing.
+//   MEP_BuildCircuits   — name + stamp every existing electrical circuit (and create
+//     a power circuit from the current selection, assigning a selected panel).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Mep;
+using StingTools.UI;
+
+namespace StingTools.Commands.Mep
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepProduceMepViewsCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+                var source = doc.ActiveView;
+
+                MepViewResult res;
+                using (var t = new Transaction(doc, "STING Produce MEP Views"))
+                {
+                    t.Start();
+                    res = MepViewProducer.Produce(doc, source);
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create("MEP — Produce Per-Discipline Views");
+                panel.SetSubtitle($"{res.Created} view(s) created from '{source?.Name}'");
+
+                panel.AddSection("VIEWS");
+                foreach (var r in res.Rows)
+                    panel.Text($"{(r.Created ? "✚" : "·")} {r.Discipline,-12} {r.ViewName,-40} {r.Note}");
+                if (res.Rows.Count == 0)
+                    panel.Text("No MEP disciplines present, or the active view is not a duplicatable plan.");
+
+                if (res.Warnings.Count > 0)
+                {
+                    panel.AddSection($"WARNINGS ({res.Warnings.Count})");
+                    foreach (var w in res.Warnings.Take(40)) panel.Text(w);
+                }
+                panel.AddSection("NEXT");
+                panel.Text("Place the new views on sheets (Docs → Sheet Manager / Place Unplaced). " +
+                           "Electrical colour comes from the elec DrawingType's style pack; duct/pipe from the system filters.");
+                panel.Show();
+
+                StingLog.Info($"MEP produce views: created={res.Created}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepProduceMepViewsCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepBuildCircuitsCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                ICollection<ElementId> sel = null;
+                try { sel = ctx.UIDoc?.Selection?.GetElementIds(); } catch { }
+
+                MepCircuitResult res;
+                using (var t = new Transaction(doc, "STING Build Circuits"))
+                {
+                    t.Start();
+                    res = MepCircuitBuilder.BuildExisting(doc);
+                    if (sel != null && sel.Count > 0)
+                        MepCircuitBuilder.CreateFromSelection(doc, sel, res);
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create("MEP — Build Electrical Circuits");
+                panel.SetSubtitle($"{res.Named} named · {res.Stamped} stamped · {res.Created} created from selection");
+
+                panel.AddSection("SUMMARY")
+                     .Metric("Circuits named",   res.Named.ToString())
+                     .Metric("Circuits stamped", res.Stamped.ToString())
+                     .Metric("Created (selection)", res.Created.ToString());
+
+                panel.AddSection("CIRCUITS");
+                foreach (var r in res.Rows.Take(80)) panel.Text(r);
+
+                if (res.Warnings.Count > 0)
+                {
+                    panel.AddSection($"WARNINGS ({res.Warnings.Count})");
+                    foreach (var w in res.Warnings.Take(40)) panel.Text(w);
+                }
+                panel.AddSection("NEXT");
+                panel.Text("Circuits now carry ASS_MEP_SYS_NAME_TXT + DISC/SYS/FUNC tokens — they tag + schedule " +
+                           "like duct/pipe systems. To create a circuit: select the devices (+ a panel) and re-run.");
+                panel.Show();
+
+                StingLog.Info($"MEP build circuits: named={res.Named} stamped={res.Stamped} created={res.Created}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepBuildCircuitsCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/Core/Mep/MepCircuitBuilder.cs
+++ b/StingTools/Core/Mep/MepCircuitBuilder.cs
@@ -1,0 +1,166 @@
+// StingTools — MEP Circuit Builder (Phase E, electrical).
+//
+// Electrical circuits use a different mechanism than duct/pipe systems
+// (ElectricalSystem, not a user-creatable system type). This mirrors Phase B's
+// reliable path for electrical:
+//
+//   BuildExisting — name every ElectricalSystem "<Panel>-<Circuit>", stamp
+//     ASS_MEP_SYS_NAME_TXT + the DISC/SYS/FUNC tag tokens on the circuit and its
+//     members, so circuits flow into schedules / tags like duct/pipe systems.
+//   CreateFromSelection — best-effort, user-driven: create a power circuit from
+//     the currently-selected electrical devices and (if a panel is selected) assign it.
+//
+// CALLER OWNS THE ACTIVE TRANSACTION.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Electrical;
+using StingTools.Core;
+
+namespace StingTools.Core.Mep
+{
+    public sealed class MepCircuitResult
+    {
+        public int Named { get; set; }
+        public int Stamped { get; set; }
+        public int Created { get; set; }
+        public List<string> Rows { get; } = new List<string>();
+        public List<string> Warnings { get; } = new List<string>();
+    }
+
+    public static class MepCircuitBuilder
+    {
+        /// <summary>Name + stamp every existing electrical circuit. Requires an open transaction.</summary>
+        public static MepCircuitResult BuildExisting(Document doc)
+        {
+            var r = new MepCircuitResult();
+            if (doc == null) { r.Warnings.Add("No document."); return r; }
+
+            var circuits = new FilteredElementCollector(doc).OfClass(typeof(ElectricalSystem))
+                .Cast<ElectricalSystem>().ToList();
+            if (circuits.Count == 0) { r.Warnings.Add("No electrical circuits in the model."); return r; }
+
+            foreach (var sys in circuits)
+            {
+                try
+                {
+                    string panel = ""; try { panel = sys.PanelName ?? ""; } catch { }
+                    string num   = ""; try { num = sys.CircuitNumber ?? ""; } catch { }
+                    string name = (!string.IsNullOrWhiteSpace(panel) && !string.IsNullOrWhiteSpace(num))
+                        ? $"{panel}-{num}"
+                        : SafeName(sys);
+                    if (string.IsNullOrWhiteSpace(name)) continue;
+
+                    string func = FuncFor(sys);
+
+                    // Stamp the circuit element itself.
+                    StampTokens(sys, name, func);
+                    r.Named++;
+
+                    // Stamp its members so tags / schedules pick the circuit up.
+                    try
+                    {
+                        foreach (Element el in sys.Elements.Cast<Element>())
+                            StampTokens(el, name, func);
+                    }
+                    catch (Exception ex) { r.Warnings.Add($"{name}: members: {ex.Message}"); }
+
+                    r.Stamped++;
+                    if (r.Rows.Count < 80) r.Rows.Add($"◉ {name}  ({func})");
+                }
+                catch (Exception ex) { r.Warnings.Add($"Circuit {sys.Id}: {ex.Message}"); }
+            }
+            return r;
+        }
+
+        /// <summary>
+        /// Best-effort: create a power circuit from selected electrical devices and
+        /// assign the selected panel (if any). Requires an open transaction.
+        /// </summary>
+        public static ElectricalSystem CreateFromSelection(
+            Document doc, ICollection<ElementId> selection, MepCircuitResult r)
+        {
+            if (doc == null || selection == null || selection.Count == 0) return null;
+
+            FamilyInstance panel = null;
+            var deviceIds = new List<ElementId>();
+            foreach (var id in selection)
+            {
+                var fi = doc.GetElement(id) as FamilyInstance;
+                if (fi?.MEPModel == null) continue;
+                var bic = (BuiltInCategory)(fi.Category?.Id.Value ?? 0);
+                if (bic == BuiltInCategory.OST_ElectricalEquipment && panel == null) { panel = fi; continue; }
+                // any electrical device with electrical connectors becomes a member
+                if (HasElectricalConnector(fi)) deviceIds.Add(id);
+            }
+
+            if (deviceIds.Count == 0)
+            {
+                r?.Warnings.Add("Selection create: no electrical devices selected.");
+                return null;
+            }
+
+            try
+            {
+                var circuit = ElectricalSystem.Create(doc, deviceIds, ElectricalSystemType.PowerCircuit);
+                if (circuit == null) { r?.Warnings.Add("Selection create: ElectricalSystem.Create returned null."); return null; }
+                if (panel != null)
+                {
+                    try { circuit.SelectPanel(panel); }
+                    catch (Exception ex) { r?.Warnings.Add($"Selection create: SelectPanel: {ex.Message}"); }
+                }
+                if (r != null) r.Created++;
+                return circuit;
+            }
+            catch (Exception ex)
+            {
+                r?.Warnings.Add($"Selection create failed: {ex.Message}");
+                return null;
+            }
+        }
+
+        // ── helpers ─────────────────────────────────────────────────────────
+
+        private static void StampTokens(Element el, string name, string func)
+        {
+            try { ParameterHelpers.SetString(el, ParamRegistry.MEP_SYS_NAME, name, overwrite: true); } catch { }
+            try { ParameterHelpers.SetIfEmpty(el, ParamRegistry.DISC, "E"); } catch { }
+            try { ParameterHelpers.SetIfEmpty(el, ParamRegistry.SYS, "LV"); } catch { }
+            if (!string.IsNullOrWhiteSpace(func))
+                try { ParameterHelpers.SetIfEmpty(el, ParamRegistry.FUNC, func); } catch { }
+        }
+
+        private static string FuncFor(ElectricalSystem sys)
+        {
+            try
+            {
+                // Lighting circuits → LTG, everything else power → PWR.
+                bool lighting = sys.Elements.Cast<Element>().Any(e =>
+                    (BuiltInCategory)(e.Category?.Id.Value ?? 0) is BuiltInCategory.OST_LightingFixtures
+                                                                  or BuiltInCategory.OST_LightingDevices);
+                return lighting ? "LTG" : "PWR";
+            }
+            catch { return "PWR"; }
+        }
+
+        private static string SafeName(ElectricalSystem sys)
+        {
+            try { return sys.Name; } catch { return ""; }
+        }
+
+        private static bool HasElectricalConnector(FamilyInstance fi)
+        {
+            try
+            {
+                var cs = fi.MEPModel?.ConnectorManager?.Connectors;
+                if (cs == null) return false;
+                foreach (Connector c in cs)
+                    try { if (c.Domain == Domain.DomainElectrical) return true; } catch { }
+            }
+            catch { }
+            return false;
+        }
+    }
+}

--- a/StingTools/Core/Mep/MepCoordinationEngine.cs
+++ b/StingTools/Core/Mep/MepCoordinationEngine.cs
@@ -26,6 +26,9 @@ using StingTools.Core.Drawing;
 
 namespace StingTools.Core.Mep
 {
+    /// <summary>Restrict coordination colouring to one MEP domain (for per-discipline views).</summary>
+    public enum MepDomain { All, Duct, Pipe }
+
     /// <summary>A distinct MEP system present in the model.</summary>
     public sealed class PresentSystem
     {
@@ -145,7 +148,7 @@ namespace StingTools.Core.Mep
         // ── apply ────────────────────────────────────────────────────────────
 
         /// <summary>Apply the resolved colour filters to <paramref name="view"/>. Requires an open transaction.</summary>
-        public static MepCoordResult ApplyToView(Document doc, View view)
+        public static MepCoordResult ApplyToView(Document doc, View view, MepDomain domain = MepDomain.All)
         {
             var result = new MepCoordResult();
             if (doc == null || view == null) { result.Warnings.Add("No document / view."); return result; }
@@ -156,6 +159,8 @@ namespace StingTools.Core.Mep
             }
 
             var systems = PresentSystems(doc);
+            if (domain == MepDomain.Duct) systems = systems.Where(s => s.IsDuct).ToList();
+            else if (domain == MepDomain.Pipe) systems = systems.Where(s => !s.IsDuct).ToList();
             if (systems.Count == 0)
             {
                 result.Warnings.Add("No duct/pipe members carry a system yet — run MEP_BuildSystems (Phase B) first.");

--- a/StingTools/Core/Mep/MepViewProducer.cs
+++ b/StingTools/Core/Mep/MepViewProducer.cs
@@ -1,0 +1,167 @@
+// StingTools — MEP View Producer (Phase E).
+//
+// Per-discipline view production: the final link of the create-systems →
+// coordinated-drawing loop. For each MEP discipline present in the model
+// (M = ducts, P = pipes, E = electrical circuits) it duplicates a source plan,
+// sets the view discipline, applies the resolved MEP DrawingType (template +
+// style pack via DrawingDispatcher), and overlays the system-classification
+// colours for that domain (M/P; E inherits its colours from the elec pack).
+//
+// CALLER OWNS THE ACTIVE TRANSACTION.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Electrical;
+using Autodesk.Revit.DB.Mechanical;
+using Autodesk.Revit.DB.Plumbing;
+using StingTools.Core.Drawing;
+
+namespace StingTools.Core.Mep
+{
+    public sealed class MepViewRow
+    {
+        public string Discipline { get; set; } = "";
+        public string ViewName { get; set; } = "";
+        public string DrawingType { get; set; } = "";
+        public int FiltersApplied { get; set; }
+        public bool Created { get; set; }
+        public string Note { get; set; } = "";
+    }
+
+    public sealed class MepViewResult
+    {
+        public List<MepViewRow> Rows { get; } = new List<MepViewRow>();
+        public List<string> Warnings { get; } = new List<string>();
+        public int Created => Rows.Count(r => r.Created);
+    }
+
+    public static class MepViewProducer
+    {
+        private sealed class Disc
+        {
+            public string Code;                 // M / E / P
+            public string Label;                // Mechanical / Electrical / Plumbing
+            public string DocType;              // COORD / POWER / DRAINAGE
+            public ViewDiscipline ViewDisc;
+            public MepDomain Domain;            // Duct / Pipe / All(E)
+            public Func<Document, bool> Present;
+        }
+
+        private static readonly List<Disc> Disciplines = new List<Disc>
+        {
+            new Disc { Code="M", Label="Mechanical", DocType="COORD",    ViewDisc=ViewDiscipline.Mechanical, Domain=MepDomain.Duct,
+                       Present = d => Any<Duct>(d) },
+            new Disc { Code="P", Label="Plumbing",   DocType="DRAINAGE", ViewDisc=ViewDiscipline.Plumbing,   Domain=MepDomain.Pipe,
+                       Present = d => Any<Pipe>(d) },
+            new Disc { Code="E", Label="Electrical", DocType="POWER",    ViewDisc=ViewDiscipline.Electrical, Domain=MepDomain.All,
+                       Present = d => Any<ElectricalSystem>(d) },
+        };
+
+        /// <summary>
+        /// Produce one coordinated plan per present MEP discipline by duplicating
+        /// <paramref name="source"/> (which must be a duplicatable plan view).
+        /// </summary>
+        public static MepViewResult Produce(Document doc, View source)
+        {
+            var result = new MepViewResult();
+            if (doc == null) { result.Warnings.Add("No document."); return result; }
+
+            if (source == null || !(source is ViewPlan) || source.IsTemplate ||
+                !source.CanViewBeDuplicated(ViewDuplicateOption.WithDetailing))
+            {
+                result.Warnings.Add("Active view is not a duplicatable plan. Open a floor/ceiling plan and re-run.");
+                return result;
+            }
+
+            var existingNames = new HashSet<string>(
+                new FilteredElementCollector(doc).OfClass(typeof(View)).Cast<View>().Select(v => v.Name),
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var disc in Disciplines)
+            {
+                if (!disc.Present(doc)) continue;
+                var row = new MepViewRow { Discipline = disc.Label };
+                result.Rows.Add(row);
+
+                try
+                {
+                    var dupId = source.Duplicate(ViewDuplicateOption.WithDetailing);
+                    var v = doc.GetElement(dupId) as View;
+                    if (v == null) { row.Note = "duplicate returned null"; continue; }
+
+                    try { v.Discipline = disc.ViewDisc; } catch (Exception ex) { result.Warnings.Add($"{disc.Code}: set discipline: {ex.Message}"); }
+
+                    string name = UniqueName(existingNames, $"{source.Name} - {disc.Label} Coordination");
+                    try { v.Name = name; } catch (Exception ex) { result.Warnings.Add($"{disc.Code}: rename: {ex.Message}"); }
+                    existingNames.Add(v.Name);
+                    row.ViewName = v.Name;
+                    row.Created = true;
+
+                    var dt = ResolveDrawingType(doc, disc.Code, disc.DocType);
+                    if (dt != null)
+                    {
+                        row.DrawingType = dt.Id;
+                        try { DrawingTypePresentation.Apply(doc, v, dt, runAnnotation: false); }
+                        catch (Exception ex) { result.Warnings.Add($"{disc.Code}: presentation: {ex.Message}"); }
+                    }
+
+                    // Duct/pipe systems get the classification colours; electrical
+                    // inherits its colouring from the elec DrawingType's style pack.
+                    if (disc.Domain != MepDomain.All)
+                    {
+                        var coord = MepCoordinationEngine.ApplyToView(doc, v, disc.Domain);
+                        row.FiltersApplied = coord.Applied;
+                        result.Warnings.AddRange(coord.Warnings.Select(w => $"{disc.Code}: {w}"));
+                    }
+
+                    row.Note = dt != null ? $"created · {dt.Id} · {row.FiltersApplied} filter(s)" : "created · no DrawingType matched";
+                }
+                catch (Exception ex)
+                {
+                    row.Note = ex.Message;
+                    result.Warnings.Add($"{disc.Code}: {ex.Message}");
+                }
+            }
+
+            if (result.Rows.Count == 0)
+                result.Warnings.Add("No MEP disciplines present (no ducts / pipes / circuits).");
+            return result;
+        }
+
+        private static DrawingType ResolveDrawingType(Document doc, string disc, string docType)
+        {
+            try
+            {
+                return DrawingDispatcher.Resolve(doc, disc, "*", docType)
+                    ?? DrawingDispatcher.Resolve(doc, disc, "*", "MEP")
+                    ?? DrawingDispatcher.CandidatesForDiscipline(doc, disc)
+                        .FirstOrDefault(d => d.Purpose == DrawingPurpose.Coordination
+                                          || d.Purpose == DrawingPurpose.Plan);
+            }
+            catch (Exception ex) { StingLog.Warn($"MEP view producer: DrawingType resolve {disc}/{docType}: {ex.Message}"); return null; }
+        }
+
+        private static string UniqueName(HashSet<string> taken, string baseName)
+        {
+            if (!taken.Contains(baseName)) return baseName;
+            for (int i = 2; i < 1000; i++)
+            {
+                string n = $"{baseName} ({i})";
+                if (!taken.Contains(n)) return n;
+            }
+            return $"{baseName} ({Guid.NewGuid():N})".Substring(0, Math.Min(baseName.Length + 6, 200));
+        }
+
+        private static bool Any<T>(Document doc) where T : Element
+        {
+            try
+            {
+                return new FilteredElementCollector(doc).OfClass(typeof(T))
+                    .WhereElementIsNotElementType().Any();
+            }
+            catch { return false; }
+        }
+    }
+}

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1415,6 +1415,8 @@ namespace StingTools.Core
                 case "MEP_GenerateSystemFilters": return new Commands.Mep.MepGenerateSystemFiltersCommand();
                 case "MEP_ApplyMepCoordination": return new Commands.Mep.MepApplyMepCoordinationCommand();
                 case "MEP_InspectMepCoordination": return new Commands.Mep.MepInspectMepCoordinationCommand();
+                case "MEP_ProduceMepViews": return new Commands.Mep.MepProduceMepViewsCommand();
+                case "MEP_BuildCircuits": return new Commands.Mep.MepBuildCircuitsCommand();
 
                 // Schedules
                 case "FullAutoPopulate": return new Temp.FullAutoPopulateCommand();

--- a/StingTools/UI/StingHvacCommandHandler.cs
+++ b/StingTools/UI/StingHvacCommandHandler.cs
@@ -154,6 +154,11 @@ namespace StingTools.UI
                         Run<StingTools.Commands.Mep.MepApplyMepCoordinationCommand>(app); break;
                     case "MEP_InspectMepCoordination":
                         Run<StingTools.Commands.Mep.MepInspectMepCoordinationCommand>(app); break;
+                    // Phase E — per-discipline view production + electrical circuits.
+                    case "MEP_ProduceMepViews":
+                        Run<StingTools.Commands.Mep.MepProduceMepViewsCommand>(app); break;
+                    case "MEP_BuildCircuits":
+                        Run<StingTools.Commands.Mep.MepBuildCircuitsCommand>(app); break;
                     case "Hvac_AutoFireDamper":
                     case "Routing_AutoFireDamper":
                         Run<StingTools.Commands.RoutingExt.AutoFireDamperCommand>(app); break;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,41 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase E: per-discipline view production + electrical circuits)
+
+The two remaining extensions. **Built + verified with `dotnet build` against the
+Revit 2025 API (0 warnings, 0 errors)** — including the live `ElectricalSystem.Create`
+/ `SelectPanel` / `ViewDiscipline` / `View.Duplicate` calls.
+
+**1. Per-discipline view production** (`Core/Mep/MepViewProducer.cs` + `MEP_ProduceMepViews`).
+Duplicates the active plan once per MEP discipline *present* in the model — M (ducts),
+P (pipes), E (circuits) — sets `View.Discipline`, resolves the MEP DrawingType via
+`DrawingDispatcher` (docTypes `COORD` / `DRAINAGE` / `POWER` — the corporate routing
+keys), applies its template + style pack, and overlays the system-classification colours
+**filtered to that domain** (new `MepDomain` arg on `MepCoordinationEngine.ApplyToView` —
+the M view colours only ducts, the P view only pipes; E inherits colour from the elec
+pack). This is the final link of create-systems → coordinated drawing: one command turns
+a blank plan into M/E/P coordinated sheets-ready views.
+
+**2. Electrical circuits** (`Core/Mep/MepCircuitBuilder.cs` + `MEP_BuildCircuits`).
+Electrical uses `ElectricalSystem`, not a user-creatable system type, so this mirrors
+Phase B's *reliable* path rather than forcing creation: `BuildExisting` names every
+circuit `<Panel>-<Circuit>` and stamps `ASS_MEP_SYS_NAME_TXT` + the DISC/SYS/FUNC tag
+tokens (`E` / `LV` / `PWR`|`LTG`) on the circuit and its members, so circuits tag +
+schedule like duct/pipe systems. `CreateFromSelection` is the safe, user-driven creation
+path: select electrical devices (+ optionally a panel) and it builds a `PowerCircuit` via
+`ElectricalSystem.Create` and assigns the panel via `SelectPanel`.
+
+**Wiring**: `StingHvacCommandHandler` (SYS tab) + `WorkflowEngine.ResolveCommand`
+(`MEP_ProduceMepViews`, `MEP_BuildCircuits`).
+
+**Still honest**: view production duplicates the active plan (a sensible single-source
+default); multi-level fan-out (one view per level per discipline) and automatic sheet
+placement are the next conveniences. Circuit *auto-grouping* (deciding which loose devices
+share a circuit) stays user-driven by design — that's a load-balancing/design decision,
+not a mechanical one. Runtime behaviour of the new-circuit + force-create paths still
+wants live-Revit verification.
+
 #### Completed (MEP Systems — Phase D: hardening — abbreviation filters + auto-author + opt-in orphans)
 
 Turns the three Phase B/C caveats into capabilities. **Built + verified with


### PR DESCRIPTION
## What & why

**Phase E of 5** (stacked on #362) — the two extensions called out in Phase D.

### 1. Per-discipline view production
`Core/Mep/MepViewProducer.cs` + `MEP_ProduceMepViews`. Duplicates the active plan once per MEP discipline **present** in the model (M=ducts, P=pipes, E=circuits), sets `View.Discipline`, resolves the MEP DrawingType via `DrawingDispatcher` (docTypes `COORD`/`DRAINAGE`/`POWER` — the corporate routing keys), applies its template + style pack, and overlays the system-classification colours **filtered to that domain** (new `MepDomain` arg on `MepCoordinationEngine.ApplyToView` — the M view colours only ducts, P only pipes; E inherits colour from the elec pack). One command turns a blank plan into M/E/P coordinated, sheets-ready views — the final link of create-systems → coordinated drawing.

### 2. Electrical circuits
`Core/Mep/MepCircuitBuilder.cs` + `MEP_BuildCircuits`. Electrical uses `ElectricalSystem` (not a user-creatable system type), so this mirrors Phase B's **reliable** path:
- `BuildExisting` — names every circuit `<Panel>-<Circuit>` and stamps `ASS_MEP_SYS_NAME_TXT` + DISC/SYS/FUNC tokens (`E`/`LV`/`PWR`|`LTG`) on the circuit + members, so circuits tag + schedule like duct/pipe systems.
- `CreateFromSelection` — the safe, **user-driven** creation path: select devices (+ optionally a panel) → `ElectricalSystem.Create(PowerCircuit)` + `SelectPanel`.

## Verification

`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors** (incl. `ElectricalSystem.Create`/`SelectPanel`, `ViewDiscipline`, `View.Duplicate`/`CanViewBeDuplicated`).

## Honest scope

View production duplicates the active plan (sensible single-source default); per-level fan-out + auto sheet-placement are the next conveniences. Circuit **auto-grouping** (which loose devices share a circuit) stays user-driven by design — that's a load-balancing decision, not a mechanical one. The new-circuit + force-create paths still want live-Revit verification.

## Stacking

A (#359) → B (#360) → C (#361) → D (#362) → **E** (this). Base `claude/mep-systems-phase-d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🧪 Live-Revit validation

The full one-pass validation recipe covering **all six phases (A–F)** on a sample model — plus the `WORKFLOW_MEPSystemsValidate.json` preset that runs the whole chain in one go — lives in the tip PR: **#364**. Validate the entire stack there after merging A→F.