### PR TITLE
MEP Systems — Phase F: per-level fan-out + sheets + circuit auto-grouping

### DIFF
--- a/StingTools/Commands/Mep/MepPhaseFCommands.cs
+++ b/StingTools/Commands/Mep/MepPhaseFCommands.cs
@@ -1,0 +1,126 @@
+// StingTools — Phase F commands: per-level view fan-out + auto sheet-placement,
+// and opt-in electrical circuit auto-grouping.
+//
+//   MEP_ProduceMepViewsByLevel — one coordinated plan per (level × present
+//     discipline), each placed on its own sheet (title block + number/name from
+//     the DrawingType patterns).
+//   MEP_AutoGroupCircuits      — FIRST-PASS: group uncircuited electrical devices
+//     by nearest panel into power circuits (engineer reviews / rebalances after).
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Mep;
+using StingTools.UI;
+
+namespace StingTools.Commands.Mep
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepProduceMepViewsByLevelCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                MepLevelViewResult res;
+                using (var t = new Transaction(doc, "STING Produce MEP Views by Level"))
+                {
+                    t.Start();
+                    res = MepLevelViewProducer.Produce(doc, placeOnSheets: true);
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create("MEP — Per-Level Views + Sheets");
+                panel.SetSubtitle($"{res.Views} view(s) · {res.Sheets} sheet(s) across levels × disciplines");
+
+                panel.AddSection("VIEWS / SHEETS");
+                foreach (var r in res.Rows.Take(120))
+                    panel.Text($"{(r.ViewCreated ? "✚" : "·")} {r.Level,-14} {r.Discipline,-12} " +
+                               $"{r.ViewName,-38} {(r.SheetCreated ? "sheet " + r.SheetNumber : "(no sheet)"),-18} {r.Note}");
+                if (res.Rows.Count == 0)
+                    panel.Text("No level hosts MEP of any discipline — model ducts/pipes/devices first.");
+
+                if (res.Warnings.Count > 0)
+                {
+                    panel.AddSection($"WARNINGS ({res.Warnings.Count})");
+                    foreach (var w in res.Warnings.Take(40)) panel.Text(w);
+                }
+                panel.Show();
+
+                StingLog.Info($"MEP per-level views: views={res.Views} sheets={res.Sheets}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepProduceMepViewsByLevelCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MepAutoGroupCircuitsCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                var doc = ctx?.Doc;
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                const int maxPerCircuit = 8;     // sensible default; engineer rebalances after
+                const double maxDistM = 30.0;
+
+                CircuitGroupResult res;
+                using (var t = new Transaction(doc, "STING Auto-Group Circuits"))
+                {
+                    t.Start();
+                    res = MepCircuitBuilder.AutoGroup(doc, maxPerCircuit, maxDistM);
+                    t.Commit();
+                }
+
+                var panel = StingResultPanel.Create("MEP — Auto-Group Circuits (first pass)");
+                panel.SetSubtitle($"{res.Created} circuit(s) created across {res.Groups} panel(s) · " +
+                                  $"{res.Unreachable} device(s) out of range");
+
+                panel.AddSection("⚠ REVIEW REQUIRED")
+                     .Text($"First pass only: ≤{maxPerCircuit} devices per circuit, nearest panel within {maxDistM:F0} m, " +
+                           "same level preferred. No load balancing or phase allocation — review and rebalance " +
+                           "in the panel schedules before issue.");
+
+                panel.AddSection("CIRCUITS CREATED");
+                foreach (var r in res.Rows.Take(80)) panel.Text(r);
+                if (res.Created == 0)
+                    panel.Text("Nothing created — all electrical devices are already circuited, or no panels/devices found.");
+
+                if (res.Warnings.Count > 0)
+                {
+                    panel.AddSection($"WARNINGS ({res.Warnings.Count})");
+                    foreach (var w in res.Warnings.Take(40)) panel.Text(w);
+                }
+                panel.Show();
+
+                StingLog.Info($"MEP auto-group circuits: created={res.Created} groups={res.Groups} unreachable={res.Unreachable}");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("MepAutoGroupCircuitsCommand", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+}

--- a/StingTools/Core/Mep/MepCircuitBuilder.cs
+++ b/StingTools/Core/Mep/MepCircuitBuilder.cs
@@ -30,6 +30,15 @@ namespace StingTools.Core.Mep
         public List<string> Warnings { get; } = new List<string>();
     }
 
+    public sealed class CircuitGroupResult
+    {
+        public int Groups { get; set; }       // panels that received circuits
+        public int Created { get; set; }       // circuits created
+        public int Unreachable { get; set; }   // devices with no panel in range
+        public List<string> Rows { get; } = new List<string>();
+        public List<string> Warnings { get; } = new List<string>();
+    }
+
     public static class MepCircuitBuilder
     {
         /// <summary>Name + stamp every existing electrical circuit. Requires an open transaction.</summary>
@@ -121,7 +130,107 @@ namespace StingTools.Core.Mep
             }
         }
 
+        /// <summary>
+        /// Best-effort FIRST PASS: group every UN-circuited electrical device by its
+        /// nearest panel (same level preferred) into power circuits of at most
+        /// <paramref name="maxPerCircuit"/> devices, create them, and assign the panel.
+        /// A starting point for an engineer to rebalance — it does NOT do load
+        /// balancing or phase allocation. Requires an open transaction.
+        /// </summary>
+        public static CircuitGroupResult AutoGroup(Document doc, int maxPerCircuit, double maxDistM)
+        {
+            var r = new CircuitGroupResult();
+            if (doc == null) { r.Warnings.Add("No document."); return r; }
+            if (maxPerCircuit < 1) maxPerCircuit = 8;
+            double maxFt = (maxDistM <= 0 ? 30.0 : maxDistM) / 0.3048;
+
+            var panels = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_ElectricalEquipment)
+                .OfClass(typeof(FamilyInstance)).Cast<FamilyInstance>()
+                .Where(p => HasElectricalConnector(p) && Pt(p) != null).ToList();
+            if (panels.Count == 0) { r.Warnings.Add("No electrical panels (OST_ElectricalEquipment) to circuit to."); return r; }
+
+            var byPanel = new Dictionary<ElementId, List<ElementId>>();
+            var panelById = panels.ToDictionary(p => p.Id, p => p);
+            var deviceCats = new ElementMulticategoryFilter(new[]
+            {
+                BuiltInCategory.OST_ElectricalFixtures, BuiltInCategory.OST_LightingFixtures,
+                BuiltInCategory.OST_LightingDevices
+            });
+            foreach (var fi in new FilteredElementCollector(doc).WhereElementIsNotElementType()
+                         .WherePasses(deviceCats).OfClass(typeof(FamilyInstance)).Cast<FamilyInstance>())
+            {
+                try
+                {
+                    if (!HasElectricalConnector(fi)) continue;
+                    var existing = fi.MEPModel?.GetElectricalSystems();
+                    if (existing != null && existing.Count > 0) continue; // already on a circuit
+                    var pt = Pt(fi); if (pt == null) continue;
+
+                    var nearest = panels
+                        .Select(p => new { p, d = Pt(p).DistanceTo(pt), sameLvl = SameLevel(fi, p) })
+                        .Where(x => x.d <= maxFt)
+                        .OrderByDescending(x => x.sameLvl).ThenBy(x => x.d)
+                        .FirstOrDefault();
+                    if (nearest == null) { r.Unreachable++; continue; }
+
+                    if (!byPanel.TryGetValue(nearest.p.Id, out var list))
+                        byPanel[nearest.p.Id] = list = new List<ElementId>();
+                    list.Add(fi.Id);
+                }
+                catch (Exception ex) { r.Warnings.Add($"Device {fi.Id}: {ex.Message}"); }
+            }
+
+            foreach (var kv in byPanel)
+            {
+                var panel = panelById[kv.Key];
+                string panelName = SafeInstName(panel);
+                int circuitOnPanel = 0;
+                foreach (var chunk in Chunk(kv.Value, maxPerCircuit))
+                {
+                    circuitOnPanel++;
+                    try
+                    {
+                        var circuit = ElectricalSystem.Create(doc, chunk, ElectricalSystemType.PowerCircuit);
+                        if (circuit == null) { r.Warnings.Add($"{panelName}: Create returned null"); continue; }
+                        try { circuit.SelectPanel(panel); } catch (Exception ex) { r.Warnings.Add($"{panelName}: SelectPanel: {ex.Message}"); }
+                        string name = $"{panelName}-AG{circuitOnPanel:D2}";
+                        StampTokens(circuit, name, "PWR");
+                        foreach (var id in chunk)
+                            try { StampTokens(doc.GetElement(id), name, "PWR"); } catch { }
+                        r.Created++;
+                        if (r.Rows.Count < 80) r.Rows.Add($"✚ {name}  ({chunk.Count} device(s))");
+                    }
+                    catch (Exception ex) { r.Warnings.Add($"{panelName}: circuit create: {ex.Message}"); }
+                }
+            }
+            r.Groups = byPanel.Count;
+            return r;
+        }
+
         // ── helpers ─────────────────────────────────────────────────────────
+
+        private static IEnumerable<List<ElementId>> Chunk(List<ElementId> ids, int size)
+        {
+            for (int i = 0; i < ids.Count; i += size)
+                yield return ids.GetRange(i, Math.Min(size, ids.Count - i));
+        }
+
+        private static XYZ Pt(Element el)
+        {
+            try { return (el.Location as LocationPoint)?.Point; } catch { return null; }
+        }
+
+        private static bool SameLevel(Element a, Element b)
+        {
+            try { return a.LevelId != ElementId.InvalidElementId && a.LevelId == b.LevelId; }
+            catch { return false; }
+        }
+
+        private static string SafeInstName(Element el)
+        {
+            try { return el.Name; } catch { return "PANEL"; }
+        }
 
         private static void StampTokens(Element el, string name, string func)
         {

--- a/StingTools/Core/Mep/MepLevelViewProducer.cs
+++ b/StingTools/Core/Mep/MepLevelViewProducer.cs
@@ -1,0 +1,293 @@
+// StingTools — MEP Level View Producer (Phase F).
+//
+// Per-level fan-out + auto sheet-placement. Where Phase E duplicates the active
+// plan once per discipline, this creates a fresh floor plan for EVERY level that
+// hosts MEP of a discipline (M = ducts, P = pipes, E = electrical devices),
+// applies the resolved MEP DrawingType + per-domain system colours, and — when
+// asked — drops each view onto its own sheet (title block + number/name from the
+// DrawingType patterns).
+//
+// CALLER OWNS THE ACTIVE TRANSACTION.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Mechanical;
+using Autodesk.Revit.DB.Plumbing;
+using StingTools.Core.Drawing;
+
+namespace StingTools.Core.Mep
+{
+    public sealed class MepLevelViewRow
+    {
+        public string Level { get; set; } = "";
+        public string Discipline { get; set; } = "";
+        public string ViewName { get; set; } = "";
+        public string SheetNumber { get; set; } = "";
+        public bool ViewCreated { get; set; }
+        public bool SheetCreated { get; set; }
+        public string Note { get; set; } = "";
+    }
+
+    public sealed class MepLevelViewResult
+    {
+        public List<MepLevelViewRow> Rows { get; } = new List<MepLevelViewRow>();
+        public List<string> Warnings { get; } = new List<string>();
+        public int Views  => Rows.Count(r => r.ViewCreated);
+        public int Sheets => Rows.Count(r => r.SheetCreated);
+    }
+
+    public static class MepLevelViewProducer
+    {
+        private sealed class Disc
+        {
+            public string Code, Label, DocType;
+            public ViewDiscipline ViewDisc;
+            public MepDomain Domain;
+            public HashSet<ElementId> Levels; // levels that host this discipline
+        }
+
+        public static MepLevelViewResult Produce(Document doc, bool placeOnSheets)
+        {
+            var result = new MepLevelViewResult();
+            if (doc == null) { result.Warnings.Add("No document."); return result; }
+
+            var vft = new FilteredElementCollector(doc).OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>().FirstOrDefault(t => t.ViewFamily == ViewFamily.FloorPlan);
+            if (vft == null) { result.Warnings.Add("No FloorPlan ViewFamilyType in the project."); return result; }
+
+            var disciplines = new List<Disc>
+            {
+                new Disc { Code="M", Label="Mechanical", DocType="COORD",    ViewDisc=ViewDiscipline.Mechanical, Domain=MepDomain.Duct,
+                           Levels = LevelsWith<Duct>(doc) },
+                new Disc { Code="P", Label="Plumbing",   DocType="DRAINAGE", ViewDisc=ViewDiscipline.Plumbing,   Domain=MepDomain.Pipe,
+                           Levels = LevelsWith<Pipe>(doc) },
+                new Disc { Code="E", Label="Electrical", DocType="POWER",    ViewDisc=ViewDiscipline.Electrical, Domain=MepDomain.All,
+                           Levels = LevelsWithElectrical(doc) },
+            };
+
+            var levels = new FilteredElementCollector(doc).OfClass(typeof(Level)).Cast<Level>()
+                .OrderBy(l => l.Elevation).ToList();
+            var levelById = levels.ToDictionary(l => l.Id, l => l);
+
+            var existingViewNames = new HashSet<string>(
+                new FilteredElementCollector(doc).OfClass(typeof(View)).Cast<View>().Select(v => v.Name),
+                StringComparer.OrdinalIgnoreCase);
+            var existingSheetNos = new HashSet<string>(
+                new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)).Cast<ViewSheet>().Select(s => s.SheetNumber),
+                StringComparer.OrdinalIgnoreCase);
+            var seqByDisc = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var lvl in levels)
+            {
+                string levelCode = LevelCode(lvl);
+                foreach (var disc in disciplines)
+                {
+                    if (!disc.Levels.Contains(lvl.Id)) continue;
+                    var row = new MepLevelViewRow { Level = lvl.Name, Discipline = disc.Label };
+                    result.Rows.Add(row);
+
+                    try
+                    {
+                        var v = ViewPlan.Create(doc, vft.Id, lvl.Id);
+                        if (v == null) { row.Note = "ViewPlan.Create returned null"; continue; }
+                        try { v.Discipline = disc.ViewDisc; } catch { }
+
+                        v.Name = Unique(existingViewNames, $"{lvl.Name} - {disc.Label} Coordination");
+                        existingViewNames.Add(v.Name);
+                        row.ViewName = v.Name;
+                        row.ViewCreated = true;
+
+                        var dt = ResolveDrawingType(doc, disc.Code, disc.DocType);
+                        if (dt != null)
+                            try { DrawingTypePresentation.Apply(doc, v, dt, runAnnotation: false); } catch (Exception ex) { result.Warnings.Add($"{row.ViewName}: presentation: {ex.Message}"); }
+
+                        if (disc.Domain != MepDomain.All)
+                        {
+                            var coord = MepCoordinationEngine.ApplyToView(doc, v, disc.Domain);
+                            result.Warnings.AddRange(coord.Warnings.Select(w => $"{row.ViewName}: {w}"));
+                        }
+
+                        if (placeOnSheets)
+                            PlaceOnSheet(doc, v, dt, disc, levelCode, seqByDisc, existingSheetNos, row, result.Warnings);
+
+                        row.Note = (dt != null ? dt.Id : "no DrawingType") + (row.SheetCreated ? $" · sheet {row.SheetNumber}" : "");
+                    }
+                    catch (Exception ex)
+                    {
+                        row.Note = ex.Message;
+                        result.Warnings.Add($"{lvl.Name}/{disc.Code}: {ex.Message}");
+                    }
+                }
+            }
+
+            if (result.Rows.Count == 0)
+                result.Warnings.Add("No level hosts MEP of any discipline (no ducts / pipes / electrical devices).");
+            return result;
+        }
+
+        // ── sheet placement ──────────────────────────────────────────────────
+
+        private static void PlaceOnSheet(
+            Document doc, View v, DrawingType dt, Disc disc, string levelCode,
+            Dictionary<string, int> seqByDisc, HashSet<string> takenNos,
+            MepLevelViewRow row, List<string> warnings)
+        {
+            var tbId = ResolveTitleBlock(doc, dt);
+            if (tbId == null || tbId == ElementId.InvalidElementId)
+            { warnings.Add($"{row.ViewName}: no title block available — view left unplaced."); return; }
+
+            ViewSheet sheet;
+            try { sheet = ViewSheet.Create(doc, tbId); }
+            catch (Exception ex) { warnings.Add($"{row.ViewName}: ViewSheet.Create: {ex.Message}"); return; }
+
+            int seq = (seqByDisc.TryGetValue(disc.Code, out var n) ? n : 0) + 1;
+            seqByDisc[disc.Code] = seq;
+
+            string numPat = dt?.SheetNumberPattern ?? "{disc}-{seq:D3}";
+            string namPat = dt?.SheetNamePattern   ?? "{discipline} {purpose} - {lvl}";
+            string number = Unique(takenNos, Substitute(numPat, disc, levelCode, seq));
+            takenNos.Add(number);
+            try { sheet.SheetNumber = number; } catch (Exception ex) { warnings.Add($"{row.ViewName}: sheet number: {ex.Message}"); }
+            try { sheet.Name = Substitute(namPat, disc, levelCode, seq); } catch { }
+            row.SheetNumber = sheet.SheetNumber;
+
+            try
+            {
+                if (Viewport.CanAddViewToSheet(doc, sheet.Id, v.Id))
+                {
+                    Viewport.Create(doc, sheet.Id, v.Id, SheetCentre(doc, sheet));
+                    row.SheetCreated = true;
+                }
+                else warnings.Add($"{row.ViewName}: view cannot be added to a sheet (already placed?).");
+            }
+            catch (Exception ex) { warnings.Add($"{row.ViewName}: Viewport.Create: {ex.Message}"); }
+        }
+
+        private static XYZ SheetCentre(Document doc, ViewSheet sheet)
+        {
+            try
+            {
+                var tb = new FilteredElementCollector(doc, sheet.Id)
+                    .OfCategory(BuiltInCategory.OST_TitleBlocks).FirstElement();
+                var bb = tb?.get_BoundingBox(sheet);
+                if (bb != null) return new XYZ((bb.Min.X + bb.Max.X) / 2.0, (bb.Min.Y + bb.Max.Y) / 2.0, 0);
+            }
+            catch { }
+            return XYZ.Zero;
+        }
+
+        private static ElementId ResolveTitleBlock(Document doc, DrawingType dt)
+        {
+            var symbols = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_TitleBlocks)
+                .OfClass(typeof(FamilySymbol)).Cast<FamilySymbol>().ToList();
+            if (symbols.Count == 0) return ElementId.InvalidElementId;
+
+            FamilySymbol pick = null;
+            if (!string.IsNullOrWhiteSpace(dt?.TitleBlockFamily))
+                pick = symbols.FirstOrDefault(s =>
+                    string.Equals(s.FamilyName, dt.TitleBlockFamily, StringComparison.OrdinalIgnoreCase));
+            pick ??= symbols[0];
+            try { if (!pick.IsActive) pick.Activate(); } catch { }
+            return pick.Id;
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────────
+
+        private static string Substitute(string pattern, Disc disc, string levelCode, int seq)
+        {
+            if (string.IsNullOrEmpty(pattern)) return $"{disc.Code}-{seq:D3}";
+            string s = pattern
+                .Replace("{disc}", disc.Code)
+                .Replace("{discipline}", disc.Label)
+                .Replace("{lvl}", levelCode)
+                .Replace("{purpose}", "Coordination")
+                .Replace("{seq:D2}", seq.ToString("D2"))
+                .Replace("{seq:D3}", seq.ToString("D3"))
+                .Replace("{seq:D4}", seq.ToString("D4"))
+                .Replace("{seq}", seq.ToString("D4"));
+            return s;
+        }
+
+        private static DrawingType ResolveDrawingType(Document doc, string disc, string docType)
+        {
+            try
+            {
+                return DrawingDispatcher.Resolve(doc, disc, "*", docType)
+                    ?? DrawingDispatcher.Resolve(doc, disc, "*", "MEP")
+                    ?? DrawingDispatcher.CandidatesForDiscipline(doc, disc)
+                        .FirstOrDefault(d => d.Purpose == DrawingPurpose.Coordination || d.Purpose == DrawingPurpose.Plan);
+            }
+            catch { return null; }
+        }
+
+        private static HashSet<ElementId> LevelsWith<T>(Document doc) where T : Element
+        {
+            var set = new HashSet<ElementId>();
+            foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(T)).WhereElementIsNotElementType())
+            {
+                var lid = LevelOf(el);
+                if (lid != ElementId.InvalidElementId) set.Add(lid);
+            }
+            return set;
+        }
+
+        private static HashSet<ElementId> LevelsWithElectrical(Document doc)
+        {
+            var set = new HashSet<ElementId>();
+            var cats = new ElementMulticategoryFilter(new[]
+            {
+                BuiltInCategory.OST_ElectricalFixtures, BuiltInCategory.OST_ElectricalEquipment,
+                BuiltInCategory.OST_LightingFixtures, BuiltInCategory.OST_LightingDevices,
+                BuiltInCategory.OST_DataDevices, BuiltInCategory.OST_FireAlarmDevices
+            });
+            foreach (var el in new FilteredElementCollector(doc).WhereElementIsNotElementType().WherePasses(cats))
+            {
+                var lid = LevelOf(el);
+                if (lid != ElementId.InvalidElementId) set.Add(lid);
+            }
+            return set;
+        }
+
+        private static ElementId LevelOf(Element el)
+        {
+            try
+            {
+                if (el.LevelId != null && el.LevelId != ElementId.InvalidElementId) return el.LevelId;
+                var p = el.get_Parameter(BuiltInParameter.RBS_START_LEVEL_PARAM);
+                if (p != null && p.StorageType == StorageType.ElementId) return p.AsElementId();
+                var p2 = el.get_Parameter(BuiltInParameter.FAMILY_LEVEL_PARAM);
+                if (p2 != null && p2.StorageType == StorageType.ElementId) return p2.AsElementId();
+            }
+            catch { }
+            return ElementId.InvalidElementId;
+        }
+
+        private static string LevelCode(Level lvl)
+        {
+            string n = (lvl?.Name ?? "").Trim();
+            if (string.IsNullOrEmpty(n)) return "XX";
+            // Compact: "Level 1" → "L1", "Ground Floor" → "GF", else first token.
+            var up = n.ToUpperInvariant();
+            if (up.Contains("GROUND")) return "GF";
+            if (up.Contains("ROOF")) return "RF";
+            if (up.Contains("BASEMENT")) return "B1";
+            var digits = new string(n.Where(char.IsDigit).ToArray());
+            if (!string.IsNullOrEmpty(digits)) return "L" + digits;
+            return n.Length <= 4 ? n.Replace(" ", "") : n.Substring(0, 4);
+        }
+
+        private static string Unique(HashSet<string> taken, string baseName)
+        {
+            if (!taken.Contains(baseName)) return baseName;
+            for (int i = 2; i < 1000; i++)
+            {
+                string c = $"{baseName} ({i})";
+                if (!taken.Contains(c)) return c;
+            }
+            return baseName + " " + Guid.NewGuid().ToString("N").Substring(0, 4);
+        }
+    }
+}

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1417,6 +1417,8 @@ namespace StingTools.Core
                 case "MEP_InspectMepCoordination": return new Commands.Mep.MepInspectMepCoordinationCommand();
                 case "MEP_ProduceMepViews": return new Commands.Mep.MepProduceMepViewsCommand();
                 case "MEP_BuildCircuits": return new Commands.Mep.MepBuildCircuitsCommand();
+                case "MEP_ProduceMepViewsByLevel": return new Commands.Mep.MepProduceMepViewsByLevelCommand();
+                case "MEP_AutoGroupCircuits": return new Commands.Mep.MepAutoGroupCircuitsCommand();
 
                 // Schedules
                 case "FullAutoPopulate": return new Temp.FullAutoPopulateCommand();

--- a/StingTools/Data/WORKFLOW_MEPSystemsValidate.json
+++ b/StingTools/Data/WORKFLOW_MEPSystemsValidate.json
@@ -1,0 +1,22 @@
+{
+  "name": "MEP Systems Validate",
+  "description": "One-pass live-Revit validation of the whole MEP Systems chain (Phases A-F). Open a floor plan that shows ducts/pipes/electrical first, then run. Every step is optional so the chain runs to completion even if one path has nothing to act on; each command shows its own result panel. Choose 'Keep' at the end to inspect, or 'Roll back' to leave the model untouched.",
+  "rollback_on_failure": false,
+  "rollback_on_optional_failure": false,
+  "steps": [
+    { "commandTag": "MEP_BuildSystemTypes",      "label": "A — materialize duct/pipe system types",          "optional": true },
+    { "commandTag": "MEP_BuildSystems",          "label": "B — type / name / stamp existing systems",        "optional": true },
+    { "commandTag": "MEP_GenerateSystemFilters", "label": "D — generate abbreviation-keyed filters",         "optional": true },
+    { "commandTag": "MEP_ApplyMepCoordination",  "label": "C — colour the ACTIVE view by system",            "optional": true },
+    { "commandTag": "MEP_AutoGroupCircuits",     "label": "F — auto-group loose electrical devices (review)", "optional": true },
+    { "commandTag": "MEP_BuildCircuits",         "label": "E — name / stamp every electrical circuit",       "optional": true },
+    { "commandTag": "MEP_ProduceMepViewsByLevel","label": "F — per-level M/E/P views + sheets",               "optional": true },
+    { "commandTag": "MEP_InspectMepCoordination","label": "Audit — final dry-run of the resolution plan",     "optional": true }
+  ],
+  "_notes": [
+    "Discovered automatically by WorkflowEngine.AppendUserPresets (any data/WORKFLOW_*.json).",
+    "Run via the STING Run-Workflow picker → 'MEP Systems Validate'.",
+    "Force-create orphan systems (MEP_BuildSystemsForce) and create-from-selection circuits are",
+    "deliberately NOT in the chain — run those manually after pre-selecting elements (see the PR recipe)."
+  ]
+}

--- a/StingTools/UI/StingHvacCommandHandler.cs
+++ b/StingTools/UI/StingHvacCommandHandler.cs
@@ -159,6 +159,11 @@ namespace StingTools.UI
                         Run<StingTools.Commands.Mep.MepProduceMepViewsCommand>(app); break;
                     case "MEP_BuildCircuits":
                         Run<StingTools.Commands.Mep.MepBuildCircuitsCommand>(app); break;
+                    // Phase F — per-level fan-out + sheets, circuit auto-grouping.
+                    case "MEP_ProduceMepViewsByLevel":
+                        Run<StingTools.Commands.Mep.MepProduceMepViewsByLevelCommand>(app); break;
+                    case "MEP_AutoGroupCircuits":
+                        Run<StingTools.Commands.Mep.MepAutoGroupCircuitsCommand>(app); break;
                     case "Hvac_AutoFireDamper":
                     case "Routing_AutoFireDamper":
                         Run<StingTools.Commands.RoutingExt.AutoFireDamperCommand>(app); break;

--- a/StingTools/UI/StingHvacPanel.xaml
+++ b/StingTools/UI/StingHvacPanel.xaml
@@ -443,6 +443,67 @@
                             <Button Style="{StaticResource HvacWarnBtn}" Content="Audit topology"
                                     Tag="Mep_SystemAnalyse" Click="Cmd_Click" ToolTip="Run system-level connectivity analysis"/>
                         </WrapPanel>
+
+                        <!-- ===== STING MEP Systems pipeline (Phases A–F) ===== -->
+                        <Separator Margin="0,10,0,4"/>
+                        <TextBlock Text="STING MEP SYSTEMS" Style="{StaticResource HvacSectionHeader}"/>
+                        <TextBlock Text="Types → instances → coordination → views, from one data source."
+                                   Style="{StaticResource HvacLabel}" Opacity="0.75" Margin="0,0,0,2" TextWrapping="Wrap"/>
+
+                        <TextBlock Text="System types (A)" Style="{StaticResource HvacLabel}" Margin="0,2,0,0"/>
+                        <WrapPanel Margin="0,0,0,2">
+                            <Button Style="{StaticResource HvacPrimaryBtn}" Content="Build types"
+                                    Tag="MEP_BuildSystemTypes" Click="Cmd_Click"
+                                    ToolTip="Phase A — create / update the duct &amp; pipe system TYPES from STING_MEP_SYSTEM_TYPES.json (idempotent, no duplicates)"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Restyle"
+                                    Tag="MEP_RestyleSystemTypes" Click="Cmd_Click"
+                                    ToolTip="Phase A — re-apply the baseline graphic colours to existing STING system types"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Inspect"
+                                    Tag="MEP_InspectSystemTypes" Click="Cmd_Click"
+                                    ToolTip="Phase A — read-only: which type definitions are present vs still to build"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Reload"
+                                    Tag="MEP_ReloadSystemTypes" Click="Cmd_Click"
+                                    ToolTip="Phase A — drop the registry cache so an edit to the JSON / project override is picked up"/>
+                        </WrapPanel>
+
+                        <TextBlock Text="Instances (B)" Style="{StaticResource HvacLabel}" Margin="0,2,0,0"/>
+                        <WrapPanel Margin="0,0,0,2">
+                            <Button Style="{StaticResource HvacPrimaryBtn}" Content="Build systems"
+                                    Tag="MEP_BuildSystems" Click="Cmd_Click"
+                                    ToolTip="Phase B — type / name / stamp the systems Revit already formed (selection if any, else whole project)"/>
+                            <Button Style="{StaticResource HvacWarnBtn}" Content="Force build"
+                                    Tag="MEP_BuildSystemsForce" Click="Cmd_Click"
+                                    ToolTip="Phase B — also best-effort CREATE MechanicalSystem / PipingSystem for orphan networks with a valid source (review after)"/>
+                        </WrapPanel>
+
+                        <TextBlock Text="Coordination (C / D)" Style="{StaticResource HvacLabel}" Margin="0,2,0,0"/>
+                        <WrapPanel Margin="0,0,0,2">
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Gen filters"
+                                    Tag="MEP_GenerateSystemFilters" Click="Cmd_Click"
+                                    ToolTip="Phase D — generate abbreviation-keyed AEC filters from the system types and persist them to the project (so packs / drawing types can use them)"/>
+                            <Button Style="{StaticResource HvacPrimaryBtn}" Content="Colour view"
+                                    Tag="MEP_ApplyMepCoordination" Click="Cmd_Click"
+                                    ToolTip="Phase C — colour the ACTIVE view by system + apply the resolved MEP coordination DrawingType"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Inspect"
+                                    Tag="MEP_InspectMepCoordination" Click="Cmd_Click"
+                                    ToolTip="Phase C / D — read-only dry run of the system → filter → DrawingType resolution"/>
+                        </WrapPanel>
+
+                        <TextBlock Text="Views &amp; circuits (E / F)" Style="{StaticResource HvacLabel}" Margin="0,2,0,0"/>
+                        <WrapPanel Margin="0,0,0,2">
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Build circuits"
+                                    Tag="MEP_BuildCircuits" Click="Cmd_Click"
+                                    ToolTip="Phase E — name + stamp every electrical circuit; create one from the current selection (devices + a panel)"/>
+                            <Button Style="{StaticResource HvacWarnBtn}" Content="Auto-group circuits"
+                                    Tag="MEP_AutoGroupCircuits" Click="Cmd_Click"
+                                    ToolTip="Phase F — FIRST PASS: group uncircuited devices by nearest panel into power circuits (no load balancing — review in the panel schedules)"/>
+                            <Button Style="{StaticResource HvacActionBtn}" Content="Produce views"
+                                    Tag="MEP_ProduceMepViews" Click="Cmd_Click"
+                                    ToolTip="Phase E — duplicate the ACTIVE plan once per present discipline (M / E / P), coloured + typed"/>
+                            <Button Style="{StaticResource HvacPrimaryBtn}" Content="Per-level + sheets"
+                                    Tag="MEP_ProduceMepViewsByLevel" Click="Cmd_Click"
+                                    ToolTip="Phase F — one coordinated plan per level × discipline, each placed on its own sheet"/>
+                        </WrapPanel>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,42 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase F: per-level fan-out + sheets + circuit auto-grouping)
+
+The two deferred conveniences from Phase E. **Built + verified with `dotnet build`
+against the Revit 2025 API (0 warnings, 0 errors)** — including the live
+`ViewPlan.Create` / `ViewSheet.Create` / `Viewport.Create` / `FamilySymbol.Activate`
+/ `MEPModel.GetElectricalSystems` / `ElectricalSystem.Create` calls.
+
+**1. Per-level fan-out + auto sheet-placement** (`Core/Mep/MepLevelViewProducer.cs`
++ `MEP_ProduceMepViewsByLevel`). For every Level that hosts MEP of a discipline
+(M = ducts, P = pipes, E = electrical devices) it creates a fresh floor plan via
+`ViewPlan.Create`, sets `View.Discipline`, applies the resolved MEP DrawingType +
+per-domain system colours, then drops the view onto its own sheet: resolves the
+title block from `DrawingType.TitleBlockFamily` (else first available, activated),
+numbers + names the sheet from `SheetNumberPattern` / `SheetNamePattern`
+(`{disc}`/`{discipline}`/`{lvl}`/`{purpose}`/`{seq:Dn}` substituted, uniqued against
+existing), and places a centred `Viewport` (guarded by `CanAddViewToSheet`). One
+command turns a model into a per-level M/E/P coordinated sheet set.
+
+**2. Electrical circuit auto-grouping** (`Core/Mep/MepCircuitBuilder.AutoGroup` +
+`MEP_AutoGroupCircuits`). Reconsidered the "user-driven only" stance into an
+**opt-in, reviewable first pass**: groups every *un-circuited* device (those whose
+`MEPModel.GetElectricalSystems()` is empty) by nearest panel — same level preferred,
+within 30 m — into power circuits of ≤8 devices, creates each via
+`ElectricalSystem.Create(PowerCircuit)` + `SelectPanel`, and stamps the STING name +
+tokens. The result panel leads with a **⚠ REVIEW REQUIRED** banner: it does no load
+balancing or phase allocation — it's a starting point an engineer rebalances in the
+panel schedules, not silent authority. The final design call stays with the engineer.
+
+**Wiring**: `StingHvacCommandHandler` (SYS tab) + `WorkflowEngine.ResolveCommand`
+(`MEP_ProduceMepViewsByLevel`, `MEP_AutoGroupCircuits`).
+
+**Still honest**: sheet layout is one-view-per-sheet (multi-view packing is the
+Sheet Manager's job — these views are ready for it); auto-grouping defaults
+(8/30 m) are corporate sensible, not yet project-overridable; runtime behaviour of
+the view/sheet/circuit-creation paths still wants live-Revit verification.
+
 #### Completed (MEP Systems — Phase E: per-discipline view production + electrical circuits)
 
 The two remaining extensions. **Built + verified with `dotnet build` against the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,13 @@ panel schedules, not silent authority. The final design call stays with the engi
 **Wiring**: `StingHvacCommandHandler` (SYS tab) + `WorkflowEngine.ResolveCommand`
 (`MEP_ProduceMepViewsByLevel`, `MEP_AutoGroupCircuits`).
 
+**UI surfacing**: all 13 MEP-systems commands (Phases A–F) now have buttons in a new
+**"STING MEP SYSTEMS"** section at the foot of the HVAC panel's **SYS** tab, grouped
+by phase (System types / Instances / Coordination / Views &amp; circuits), reusing the
+existing `HvacPrimaryBtn` / `HvacActionBtn` / `HvacWarnBtn` styles and the `Cmd_Click`
+→ `StingHvacCommandHandler.SetCommand` dispatch. The validation workflow preset stays
+the one-click "run the whole chain" path.
+
 **Still honest**: sheet layout is one-view-per-sheet (multi-view packing is the
 Sheet Manager's job — these views are ready for it); auto-grouping defaults
 (8/30 m) are corporate sensible, not yet project-overridable; runtime behaviour of


### PR DESCRIPTION
## What & why

**Phase F of 6** (stacked on #363) — the two deferred conveniences from Phase E.

### 1. Per-level fan-out + auto sheet-placement
`Core/Mep/MepLevelViewProducer.cs` + `MEP_ProduceMepViewsByLevel`. For every Level that hosts MEP of a discipline (M=ducts, P=pipes, E=devices) it creates a fresh floor plan via `ViewPlan.Create`, sets `View.Discipline`, applies the resolved MEP DrawingType + per-domain colours, then places the view on its own sheet — title block from `DrawingType.TitleBlockFamily` (else first available, activated), sheet number/name from `SheetNumberPattern`/`SheetNamePattern` (`{disc}`/`{discipline}`/`{lvl}`/`{purpose}`/`{seq:Dn}`, uniqued), centred `Viewport` (guarded by `CanAddViewToSheet`). One command → a per-level M/E/P coordinated sheet set.

### 2. Electrical circuit auto-grouping (reconsidered → opt-in first pass)
`Core/Mep/MepCircuitBuilder.AutoGroup` + `MEP_AutoGroupCircuits`. I'd deferred this as "user-driven by design"; this delivers it as an **opt-in, reviewable first pass**: groups every *un-circuited* device (`MEPModel.GetElectricalSystems()` empty) by nearest panel — same level preferred, ≤30 m — into power circuits of ≤8 devices, creates each via `ElectricalSystem.Create(PowerCircuit)` + `SelectPanel`, stamps the STING name + tokens. The result panel **leads with ⚠ REVIEW REQUIRED**: no load balancing or phase allocation — a starting point an engineer rebalances, not silent authority. The design call stays with the engineer.

## Verification

`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors** (incl. `ViewPlan.Create`, `ViewSheet.Create`, `Viewport.Create`/`CanAddViewToSheet`, `FamilySymbol.Activate`, `MEPModel.GetElectricalSystems`, `ElectricalSystem.Create`).

## Honest scope

One-view-per-sheet (multi-view packing is the Sheet Manager's job — these views are ready for it); auto-group defaults (8 / 30 m) are corporate-sensible, not yet project-overridable; the view/sheet/circuit-creation paths still want live-Revit verification.

## Stacking

A (#359) → B (#360) → C (#361) → D (#362) → E (#363) → **F** (this). Base `claude/mep-systems-phase-e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 🧪 Live-Revit validation recipe — all six phases, one pass

> These MEP-systems commands currently surface through the **Run-Workflow runner** (every tag is wired into `WorkflowEngine.ResolveCommand`; now also on the HVAC panel SYS tab → "STING MEP SYSTEMS"). This branch ships `Data/WORKFLOW_MEPSystemsValidate.json` so the whole chain runs in one go.

### 0. Prereqs (≈5 min if building a sample)
- Revit 2025/2026/2027 with this StingTools build loaded.
- A model with some MEP. Minimal sample that exercises every path:
  - **2 levels**.
  - **Mechanical**: 1 AHU (Mechanical Equipment) → supply ducts → 2 air terminals; a CHW **flow** + **return** pipe loop from a pump (so a flow/return pair shares a classification — the Phase D test).
  - **Electrical**: 1 distribution panel + ~4 sockets and ~2 lights, **left un-circuited** (for the Phase F auto-group test).
- Run **STING → Setup → Load Params** once (binds `ASS_MEP_SYS_NAME_TXT`, `ASS_SYSTEM_TYPE_TXT`, `ASS_FUNC_TXT`, `ASS_DISCIPLINE_COD_TXT`).
- **Open a Level 1 floor plan** that shows the MEP (the coordination + view steps act on the active view).

### 1. One-pass run
**STING → Run Workflow → “MEP Systems Validate.”** It runs A → final audit; each command shows its own result panel — close each to advance. At the end choose **Keep** to inspect (below) or **Roll back** to leave the model untouched.

### 2. Per-phase expected result + deep check

| Phase | Command | Expect in the panel | Deep check (Keep, then inspect) |
|---|---|---|---|
| **A** | `MEP_BuildSystemTypes` | `21 created` first run; `…updated/exists` on re-run | Manage → MEP Settings (or System Browser): **STING Supply Air / CHW Flow / …** exist with abbreviations **SA / CHWF / LTHWF** and the JSON colours. Re-run ⇒ **no duplicates** (idempotent). |
| **B** | `MEP_BuildSystems` | `N networks · M typed · … stamped` | Select a duct → Properties: **System Type** is a `STING …` type, **System Name** = `SA-01`; `ASS_MEP_SYS_NAME_TXT` = `SA-01`; **SYS** (`ASS_SYSTEM_TYPE_TXT`) = `HVAC`, **FUNC** (`ASS_FUNC_TXT`) set. Re-run ⇒ names **don't duplicate** (counter primed). |
| **D** | `MEP_GenerateSystemFilters` | `21 filters · created · N written to project override` | View → Visibility/Graphics → Filters tab: **STING - Sys: …** filters present. File `…/_BIM_COORD/aec_filters.json` written. |
| **C** | `MEP_ApplyMepCoordination` | `K system filter(s) applied · DrawingType 'mep-coord-A1-1to50'` | Active plan: supply air **blue**, return **green**, CHW **navy**, LTHW **orange** — **CHWF and LTHWF are different colours** (the flow/return-ambiguity fix). View carries the MEP coordination template. |
| **F** | `MEP_AutoGroupCircuits` | panel **leads with ⚠ REVIEW REQUIRED**; `X circuit(s) across Y panel(s)` | The loose sockets/lights are now on `…-AG01` circuits assigned to the nearest panel. (No load balancing — that's the engineer's call.) |
| **E** | `MEP_BuildCircuits` | `named · stamped` | Select a circuit → `ASS_MEP_SYS_NAME_TXT` = `<Panel>-<Circuit>`, **DISC**=`E`, **SYS**=`LV`, **FUNC**=`PWR`/`LTG`. |
| **F** | `MEP_ProduceMepViewsByLevel` | `V view(s) · S sheet(s)` | New floor plans `Level 1 - Mechanical Coordination`, `… - Electrical …`, `… - Plumbing …` per level; each on **its own sheet** (numbered from the DrawingType pattern, viewport placed, view discipline set). |
| audit | `MEP_InspectMepCoordination` | per-system **source** column: `abbreviation` / `classification` / `synthesised` | Confirms every present system resolves to a filter — `none` only if a system has no Phase-A colour. |

### 3. Manual paths not in the auto-chain (selection / opt-in)
- **Force-create orphan systems** — make a duct network with an AHU but **no system**, run `MEP_BuildSystemsForce`: expect a new `MechanicalSystem` created + named, placed on its source equipment's workset (workshared models).
- **Create circuit from selection** — select 2 sockets **+ a panel**, run `MEP_BuildCircuits`: expect one `PowerCircuit` created on that panel.
- **Restyle** — `MEP_RestyleSystemTypes` re-applies the baseline colours to existing types (after a project hand-tuned them).

### 4. Pass criteria
✅ A re-run creates **zero** duplicate types / system names · ✅ CHWF and LTHWF render as **distinct** colours · ✅ every duct/pipe carries SYS+FUNC tag tokens · ✅ per-level views land on sheets · ✅ uncircuited devices end up on review-flagged circuits · ✅ no unhandled exception (each panel reports cleanly; warnings are expected where a path has nothing to act on).

### 5. Cleanup
Roll back the workflow at the prompt, or `Ctrl+Z` repeatedly, or close without saving.

> **Still unverified by this recipe:** behaviour on edge-case topologies (orphan networks that fail Revit's source/flow/tree rule are *reported*, not forced) and multi-title-block projects. Those are the known live-only risks called out in the phase notes.

