### PR TITLE
MEP Systems — Phase H: abbreviation-format unification + CSI tag label

### DIFF
--- a/StingTools/Core/TagConfig.Tag7.cs
+++ b/StingTools/Core/TagConfig.Tag7.cs
@@ -1260,6 +1260,21 @@ namespace StingTools.Core
                 classPlain.Append(keynote);
                 classMarked.Append($"\u00ABV\u00BB{keynote}\u00AB/V\u00BB");
             }
+            // Phase H \u2014 CSI MasterFormat section (from CSI_Assign) in the classification narrative.
+            string csiSection = ParameterHelpers.GetString(el, ParamRegistry.CSI_SECTION);
+            string csiTitle   = ParameterHelpers.GetString(el, ParamRegistry.CSI_TITLE);
+            if (!string.IsNullOrEmpty(csiSection))
+            {
+                if (classPlain.Length > 0) { classPlain.Append(", CSI section "); classMarked.Append(", \u00ABL\u00BBCSI section\u00AB/L\u00BB "); }
+                else { classPlain.Append("CSI section "); classMarked.Append("\u00ABL\u00BBCSI section\u00AB/L\u00BB "); }
+                classPlain.Append(csiSection);
+                classMarked.Append($"\u00ABV\u00BB{csiSection}\u00AB/V\u00BB");
+                if (!string.IsNullOrEmpty(csiTitle))
+                {
+                    classPlain.Append($" ({csiTitle})");
+                    classMarked.Append($" ({csiTitle})");
+                }
+            }
             if (!string.IsNullOrEmpty(typeMark))
             {
                 if (classPlain.Length > 0) { classPlain.Append(", identified as type mark "); classMarked.Append(", identified as \u00ABL\u00BBtype mark\u00AB/L\u00BB "); }

--- a/StingTools/Data/LABEL_DEFINITIONS.json
+++ b/StingTools/Data/LABEL_DEFINITIONS.json
@@ -1,13 +1,13 @@
 {
   "version": "5.12",
-  "description": "STING Seed Tag v5.9 — master label specification. Paragraph tiers 1..10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated. (v5.9: backfilled 12 CSV-only families and enriched 39 Revit-category entries with CSV-derived tier_1/2/3 rows. Total 138 categories covering 142 tag families. Naming note: Revit BuiltInCategory display names are plural — CSVs use singular family names — csv_family_alias field links the two.) | v5.10: tier_5 cost rows extended with 14 currency-neutral / payment-cert / variation params (Phase 184 P0.2 + P5) on 19 cost-bound categories; tier_7 fab rows extended with HVAC sizing audit-trail params (Phase 182-183) on 14 MEP categories | v5.11: +76 entries (Phase 187) — 58 healthcare + 9 LPS (6 base + 3 reuse) + 7 ARCH/STR variants (Curtain Panel/Mullion, Railing, Architectural Column, Structural Connection/Slab/Wall) + 2 Tie-In Pipe variants (FP Pipe, Gas Pipe). Aligns category_labels with the 204-family TagFamilyConfig (CategoryTemplateMap + variants + HealthcareVariantFamilies). | v5.12: removed 10 stale entries (Phase 187 dedup) — 4 plural duplicates (Curtain Panels, Curtain Wall Mullions, Railings, Structural Connections — superseded by singular forms) and 6 entries for families the creator never emits (Analytical Duct/Pipe Segments, Area Based Loads, MEP Ancillary, Temporary Structures, Wash).",
+  "description": "STING Seed Tag v5.9 \u00e2\u20ac\u201d master label specification. Paragraph tiers 1..10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated. (v5.9: backfilled 12 CSV-only families and enriched 39 Revit-category entries with CSV-derived tier_1/2/3 rows. Total 138 categories covering 142 tag families. Naming note: Revit BuiltInCategory display names are plural \u00e2\u20ac\u201d CSVs use singular family names \u00e2\u20ac\u201d csv_family_alias field links the two.) | v5.10: tier_5 cost rows extended with 14 currency-neutral / payment-cert / variation params (Phase 184 P0.2 + P5) on 19 cost-bound categories; tier_7 fab rows extended with HVAC sizing audit-trail params (Phase 182-183) on 14 MEP categories | v5.11: +76 entries (Phase 187) \u00e2\u20ac\u201d 58 healthcare + 9 LPS (6 base + 3 reuse) + 7 ARCH/STR variants (Curtain Panel/Mullion, Railing, Architectural Column, Structural Connection/Slab/Wall) + 2 Tie-In Pipe variants (FP Pipe, Gas Pipe). Aligns category_labels with the 204-family TagFamilyConfig (CategoryTemplateMap + variants + HealthcareVariantFamilies). | v5.12: removed 10 stale entries (Phase 187 dedup) \u00e2\u20ac\u201d 4 plural duplicates (Curtain Panels, Curtain Wall Mullions, Railings, Structural Connections \u00e2\u20ac\u201d superseded by singular forms) and 6 entries for families the creator never emits (Analytical Duct/Pipe Segments, Area Based Loads, MEP Ancillary, Temporary Structures, Wash).",
   "presentation_modes": {
     "Compact": {
       "state_1": true,
       "state_2": false,
       "state_3": false,
       "warnings": false,
-      "description": "Basic identification — tag code + type name only",
+      "description": "Basic identification \u00e2\u20ac\u201d tag code + type name only",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -21,7 +21,7 @@
       "state_2": true,
       "state_3": false,
       "warnings": true,
-      "description": "Engineering documentation — key properties + threshold warnings",
+      "description": "Engineering documentation \u00e2\u20ac\u201d key properties + threshold warnings",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -35,7 +35,7 @@
       "state_2": true,
       "state_3": true,
       "warnings": true,
-      "description": "Complete specification — all tiers + paragraph + warnings",
+      "description": "Complete specification \u00e2\u20ac\u201d all tiers + paragraph + warnings",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -49,7 +49,7 @@
       "state_2": true,
       "state_3": false,
       "warnings": false,
-      "description": "Client presentation — clean tags without warning text",
+      "description": "Client presentation \u00e2\u20ac\u201d clean tags without warning text",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -63,7 +63,7 @@
       "state_2": true,
       "state_3": false,
       "warnings": false,
-      "description": "Bill of Quantities — identity + quantities for cost schedules",
+      "description": "Bill of Quantities \u00e2\u20ac\u201d identity + quantities for cost schedules",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -84,7 +84,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": false,
-      "description": "FM handover — identity + commissioning + maintenance (T1-T4)"
+      "description": "FM handover \u00e2\u20ac\u201d identity + commissioning + maintenance (T1-T4)"
     },
     "Procurement": {
       "state_1": true,
@@ -98,7 +98,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": false,
-      "description": "Procurement / cost manager — identity + cost roll-up (T1-T5)"
+      "description": "Procurement / cost manager \u00e2\u20ac\u201d identity + cost roll-up (T1-T5)"
     },
     "Carbon": {
       "state_1": true,
@@ -112,7 +112,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": true,
-      "description": "Sustainability audit — identity + carbon stages A1-C4 (T1-T3+T6)"
+      "description": "Sustainability audit \u00e2\u20ac\u201d identity + carbon stages A1-C4 (T1-T3+T6)"
     },
     "Fabrication": {
       "state_1": true,
@@ -126,7 +126,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": true,
-      "description": "Shop drawings / fab package — identity + fab+QC (T1-T3+T7)"
+      "description": "Shop drawings / fab package \u00e2\u20ac\u201d identity + fab+QC (T1-T3+T7)"
     },
     "Coordination": {
       "state_1": true,
@@ -140,7 +140,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": true,
-      "description": "Clash / coordination review — identity + clash triage (T1-T3+T8)"
+      "description": "Clash / coordination review \u00e2\u20ac\u201d identity + clash triage (T1-T3+T8)"
     },
     "AsBuilt": {
       "state_1": true,
@@ -154,7 +154,7 @@
       "state_9": true,
       "state_10": false,
       "warnings": false,
-      "description": "As-built model — identity + commissioning + asbuilt/health (T1-T4+T9)"
+      "description": "As-built model \u00e2\u20ac\u201d identity + commissioning + asbuilt/health (T1-T4+T9)"
     },
     "Audit": {
       "state_1": true,
@@ -168,60 +168,60 @@
       "state_9": true,
       "state_10": true,
       "warnings": true,
-      "description": "Full audit trail — every tier + warnings (T1-T10)"
+      "description": "Full audit trail \u00e2\u20ac\u201d every tier + warnings (T1-T10)"
     }
   },
   "calculated_value_templates": {
     "cv_show_tier2": {
       "name": "Show Tier 2",
       "formula": "if(TAG_PARA_STATE_2_BOOL, <param>, \"\")",
-      "description": "Gates tier 2 parameters — visible at Standard or above"
+      "description": "Gates tier 2 parameters \u00e2\u20ac\u201d visible at Standard or above"
     },
     "cv_show_tier3": {
       "name": "Show Tier 3",
       "formula": "if(TAG_PARA_STATE_3_BOOL, <param>, \"\")",
-      "description": "Gates tier 3 parameters — visible at Comprehensive"
+      "description": "Gates tier 3 parameters \u00e2\u20ac\u201d visible at Comprehensive"
     },
     "cv_show_warning": {
       "name": "Show Warning",
       "formula": "if(TAG_WARN_VISIBLE_BOOL, <param>, \"\")",
-      "description": "Gates warning text — visible when warnings enabled. Respects TAG_WARN_SEVERITY_FILTER_TXT"
+      "description": "Gates warning text \u00e2\u20ac\u201d visible when warnings enabled. Respects TAG_WARN_SEVERITY_FILTER_TXT"
     },
-    "_comment": "Calculated Value templates that tag family labels plug in to. CONDITION-FORM CONTRACT: every BOOL gate referenced by one of these templates is stored as YESNO in MR_PARAMETERS v5.4+ — YESNO is Revit's native type for an if()/and()/or() condition, so the gate is written BARE: `if(gate, <param>, \"\")`. Do NOT compare a YESNO gate to \"Yes\" — Revit rejects `gate` on a YESNO parameter with 'Inconsistent Units'. The VALUE parameter in the <param> position must stay TEXT (a Revit label can only emit a TEXT result). The emitter (TagConfig.GateToken via FamilyLabelAuthor) picks the form per storage type — it emits bare for YESNO and stays the safety net for any legacy family still holding a gate as TEXT. The file-declared gate type (MR_PARAMETERS.txt) must equal the type bound in the project and in the tag family.",
+    "_comment": "Calculated Value templates that tag family labels plug in to. CONDITION-FORM CONTRACT: every BOOL gate referenced by one of these templates is stored as YESNO in MR_PARAMETERS v5.4+ \u00e2\u20ac\u201d YESNO is Revit's native type for an if()/and()/or() condition, so the gate is written BARE: `if(gate, <param>, \"\")`. Do NOT compare a YESNO gate to \"Yes\" \u00e2\u20ac\u201d Revit rejects `gate` on a YESNO parameter with 'Inconsistent Units'. The VALUE parameter in the <param> position must stay TEXT (a Revit label can only emit a TEXT result). The emitter (TagConfig.GateToken via FamilyLabelAuthor) picks the form per storage type \u00e2\u20ac\u201d it emits bare for YESNO and stays the safety net for any legacy family still holding a gate as TEXT. The file-declared gate type (MR_PARAMETERS.txt) must equal the type bound in the project and in the tag family.",
     "cv_show_tier4": {
       "name": "Show Tier 4",
       "formula": "if(TAG_PARA_STATE_4_BOOL, <param>, \"\")",
-      "description": "Gates tier 4 — Commissioning & handover data"
+      "description": "Gates tier 4 \u00e2\u20ac\u201d Commissioning & handover data"
     },
     "cv_show_tier5": {
       "name": "Show Tier 5",
       "formula": "if(TAG_PARA_STATE_5_BOOL, <param>, \"\")",
-      "description": "Gates tier 5 — Cost & procurement roll-up"
+      "description": "Gates tier 5 \u00e2\u20ac\u201d Cost & procurement roll-up"
     },
     "cv_show_tier6": {
       "name": "Show Tier 6",
       "formula": "if(TAG_PARA_STATE_6_BOOL, <param>, \"\")",
-      "description": "Gates tier 6 — Carbon & sustainability (A1-A3 / A4 / A5 / B6 / C1-C4)"
+      "description": "Gates tier 6 \u00e2\u20ac\u201d Carbon & sustainability (A1-A3 / A4 / A5 / B6 / C1-C4)"
     },
     "cv_show_tier7": {
       "name": "Show Tier 7",
       "formula": "if(TAG_PARA_STATE_7_BOOL, <param>, \"\")",
-      "description": "Gates tier 7 — Fabrication & QC (spool, weld/bolt/flange counts, QC inspector)"
+      "description": "Gates tier 7 \u00e2\u20ac\u201d Fabrication & QC (spool, weld/bolt/flange counts, QC inspector)"
     },
     "cv_show_tier8": {
       "name": "Show Tier 8",
       "formula": "if(TAG_PARA_STATE_8_BOOL, <param>, \"\")",
-      "description": "Gates tier 8 — Clash & coordination (triage score, severity, resolution action)"
+      "description": "Gates tier 8 \u00e2\u20ac\u201d Clash & coordination (triage score, severity, resolution action)"
     },
     "cv_show_tier9": {
       "name": "Show Tier 9",
       "formula": "if(TAG_PARA_STATE_9_BOOL, <param>, \"\")",
-      "description": "Gates tier 9 — As-built & model health metrics"
+      "description": "Gates tier 9 \u00e2\u20ac\u201d As-built & model health metrics"
     },
     "cv_show_tier10": {
       "name": "Show Tier 10",
       "formula": "if(TAG_PARA_STATE_10_BOOL, <param>, \"\")",
-      "description": "Gates tier 10 — Compliance / audit trail (RGL_*, IFC_PSET_OVERRIDE_TXT)"
+      "description": "Gates tier 10 \u00e2\u20ac\u201d Compliance / audit trail (RGL_*, IFC_PSET_OVERRIDE_TXT)"
     },
     "cv_show_section_a": {
       "name": "Show TAG7 Section A",
@@ -265,7 +265,7 @@
       "prefix": "",
       "suffix": "",
       "label": "Scheme Tag (project grammar)",
-      "note": "Project-grammar rendering of the canonical tokens (TagSchemeEngine) — e.g. ISO 19650 KUT-ZZZ-XX-XX-M3-A-0001. Add this as a label row on an annotation tag family to display the scheme identifier on drawings. Derived, never hand-edited."
+      "note": "Project-grammar rendering of the canonical tokens (TagSchemeEngine) \u00e2\u20ac\u201d e.g. ISO 19650 KUT-ZZZ-XX-XX-M3-A-0001. Add this as a label row on an annotation tag family to display the scheme identifier on drawings. Derived, never hand-edited."
     },
     "ASS_TAG_2_TXT": {
       "prefix": "",
@@ -275,7 +275,7 @@
         "tier_2": "underline",
         "tier_3": "bold underline"
       },
-      "note": "Heading line in TAG7 — underlined in State 2, bold+underlined in State 3. Style controlled via batch command."
+      "note": "Heading line in TAG7 \u00e2\u20ac\u201d underlined in State 2, bold+underlined in State 3. Style controlled via batch command."
     },
     "ASS_TAG_4_TXT": {
       "prefix": "",
@@ -354,7 +354,7 @@
     },
     "BLE_ROOF_SLOPE_DEG": {
       "prefix": "Slope: ",
-      "suffix": "°",
+      "suffix": "\u00c2\u00b0",
       "label": "Roof Slope"
     },
     "BLE_ROOF_COVERING_MAT_TXT": {
@@ -394,7 +394,7 @@
     },
     "BLE_WINDOW_U_VALUE_W_M_2K_NR": {
       "prefix": "U=",
-      "suffix": " W/m²K",
+      "suffix": " W/m\u00c2\u00b2K",
       "label": "Window U-Value"
     },
     "BLE_WINDOW_FRAME_MAT_TXT": {
@@ -464,12 +464,12 @@
     },
     "PER_THERM_U_VALUE_W_M2K": {
       "prefix": "U=",
-      "suffix": " W/m²K",
+      "suffix": " W/m\u00c2\u00b2K",
       "label": "Thermal U-Value"
     },
     "PER_THERM_R_VALUE_M2K_W": {
       "prefix": "R=",
-      "suffix": " m²K/W",
+      "suffix": " m\u00c2\u00b2K/W",
       "label": "Thermal R-Value"
     },
     "PER_THERM_CONDENSATION_RISK_TXT": {
@@ -609,7 +609,7 @@
     },
     "FLS_SFTY_COVERAGE_AREA_SQ_M": {
       "prefix": "Coverage: ",
-      "suffix": " m²",
+      "suffix": " m\u00c2\u00b2",
       "label": "Sprinkler Coverage"
     },
     "FLS_SFTY_K_FACTOR_NR": {
@@ -664,10 +664,10 @@
     },
     "PER_SUST_EMBODIED_CARBON_KG": {
       "prefix": "",
-      "suffix": " kgCO₂e",
+      "suffix": " kgCO\u00e2\u201a\u201ae",
       "label": "Embodied Carbon"
     },
-    "_paragraph_comment": "TAG7 paragraph containers — tier_3 natural-language specification paragraphs. No prefix/suffix needed as content is a pre-assembled descriptive statement from the formula engine.",
+    "_paragraph_comment": "TAG7 paragraph containers \u00e2\u20ac\u201d tier_3 natural-language specification paragraphs. No prefix/suffix needed as content is a pre-assembled descriptive statement from the formula engine.",
     "ARCH_TAG_7_PARA_WALL_TXT": {
       "prefix": "",
       "suffix": "",
@@ -890,7 +890,7 @@
     },
     "ELC_CBL_FEEDER_SZ_MM2": {
       "prefix": "Feeder: ",
-      "suffix": " mm²",
+      "suffix": " mm\u00c2\u00b2",
       "label": "Feeder Cable Size"
     },
     "ELC_PNL_SHORT_CIRCUIT_RATING_KA": {
@@ -955,7 +955,7 @@
     },
     "ASS_ROOM_AREA_SQ_M": {
       "prefix": "",
-      "suffix": " m²",
+      "suffix": " m\u00c2\u00b2",
       "label": "Room Area"
     },
     "MEP_TIE_POINT_ID_TXT": {
@@ -964,20 +964,20 @@
       "label": "MEP Tie-Point Identifier"
     },
     "WARN_BLE_RAMP_SLOPE_PCT_RAMPS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Ramp Slope"
     },
     "WARN_ELC_LPS_NO_CLASS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: LPS Class Missing",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-1:2011 §8",
+      "standard": "BS EN 62305-1:2011 \u00c2\u00a78",
       "severity": "CRITICAL"
     },
     "WARN_ELC_LPS_DOWN_COND_INSUFFICIENT": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Insufficient Down Conductors",
       "data_type": "TEXT",
@@ -985,15 +985,15 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_EARTH_RESISTANCE_HIGH": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
-      "label": "Warning: Earth Resistance > 10 Ω",
+      "label": "Warning: Earth Resistance > 10 \u00ce\u00a9",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 §5.4.1",
+      "standard": "BS EN 62305-3:2011 \u00c2\u00a75.4.1",
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_NO_RISK_ASSESSMENT": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: No Risk Assessment",
       "data_type": "TEXT",
@@ -1001,23 +1001,23 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_SEPARATION_FAIL": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Separation Distance Fail",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 §6.3",
+      "standard": "BS EN 62305-3:2011 \u00c2\u00a76.3",
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_INSPECTION_OVERDUE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Inspection Overdue",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 §E.7",
+      "standard": "BS EN 62305-3:2011 \u00c2\u00a7E.7",
       "severity": "MEDIUM"
     },
     "WARN_ELC_LPS_CONDUCTOR_CROSS_SECT_LOW": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Cross-Section Below Min",
       "data_type": "TEXT",
@@ -1025,15 +1025,15 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_NO_BONDING": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: No Bonding Type",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 §6.2",
+      "standard": "BS EN 62305-3:2011 \u00c2\u00a76.2",
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_MESH_SIZE_EXCEEDED": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Mesh Exceeds Class",
       "data_type": "TEXT",
@@ -1041,11 +1041,11 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_NO_ZONE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: LPZ Not Assigned",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-4:2011 §4.1",
+      "standard": "BS EN 62305-4:2011 \u00c2\u00a74.1",
       "severity": "MEDIUM"
     },
     "ELC_LPS_CLASS_TXT": {
@@ -1069,8 +1069,8 @@
       "label": "Air Termination Mesh Size"
     },
     "ELC_LPS_PROTECTION_ANGLE_DEG": {
-      "prefix": "α:",
-      "suffix": "°",
+      "prefix": "\u00ce\u00b1:",
+      "suffix": "\u00c2\u00b0",
       "label": "Protection Angle"
     },
     "ELC_LPS_AIR_TERMINAL_COUNT_NR": {
@@ -1090,7 +1090,7 @@
     },
     "ELC_LPS_EARTH_RESISTANCE_OHM": {
       "prefix": "R:",
-      "suffix": " Ω",
+      "suffix": " \u00ce\u00a9",
       "label": "Earth Resistance"
     },
     "ELC_LPS_EARTH_TYPE_TXT": {
@@ -1115,7 +1115,7 @@
     },
     "ELC_LPS_CONDUCTOR_CROSS_SECT_MM2": {
       "prefix": "A:",
-      "suffix": " mm²",
+      "suffix": " mm\u00c2\u00b2",
       "label": "Conductor Cross-Section"
     },
     "ELC_LPS_CONDUCTOR_MATERIAL_TXT": {
@@ -1150,7 +1150,7 @@
     },
     "ELC_LPS_PROJECT_NG_OVERRIDE_NR": {
       "prefix": "Ng:",
-      "suffix": " /km²/yr",
+      "suffix": " /km\u00c2\u00b2/yr",
       "label": "Ground Flash Density"
     },
     "ELC_LPS_AIRTERM_TAG_TXT": {
@@ -1209,274 +1209,279 @@
       "label": "Circuit Label Override (SLD)"
     },
     "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Voltage Drop"
     },
     "WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Sprinkler Coverage"
     },
     "WARN_HVC_DCT_SOUNDLVL_DB": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Sound Level"
     },
     "WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Efficiency Ratio"
     },
     "WARN_HVC_VEL_MPS_FLEX_DUCTS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Flex Duct Velocity"
     },
     "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Carbon Footprint"
     },
     "WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Floor U-Value"
     },
     "WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Roof U-Value"
     },
     "WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Wall U-Value"
     },
     "WARN_PLM_PPE_FLW_LPS_PIPES__HOT_WATE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Pipe Flow Rate"
     },
     "WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Access Clear Width"
     },
     "WARN_ASS_ROOM_AREA_MIN": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Room Area Minimum"
     },
     "WARN_ASS_ROOM_VENTILATION": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Room Ventilation"
     },
     "WARN_BLE_CW_PANEL_SHGC": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Curtain Panel SHGC"
     },
     "WARN_BLE_CW_PANEL_U_VALUE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Curtain Panel U-Value"
     },
     "WARN_BLE_DOOR_ACOUSTIC": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Door Acoustic Rating"
     },
     "WARN_BLE_FLR_LD_CAP_KPA": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Floor Load Capacity"
     },
     "WARN_BLE_RAIL_HEIGHT_MM": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Railing Height"
     },
     "WARN_BLE_RAIL_LOAD_KN_M": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Railing Load"
     },
     "WARN_BLE_ROOF_SLOPE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Roof Slope"
     },
     "WARN_BLE_STAIR_GOING": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Stair Going"
     },
     "WARN_BLE_STAIR_RISE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Stair Rise"
     },
     "WARN_BLE_STRUCT_FDN_BEARING": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Foundation Bearing"
     },
     "WARN_BLE_STRUCT_LD_CAP": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Structural Load Capacity"
     },
     "WARN_BLE_VERT_CIRC_LOAD": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Vertical Circulation Load"
     },
     "WARN_BLE_WINDOW_SHGC": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Window SHGC"
     },
     "WARN_BLE_WINDOW_U_VALUE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Window U-Value"
     },
     "WARN_DOOR_FRR": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Door Fire Rating"
     },
     "WARN_ELC_CDT_FILL_RATIO": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Conduit Fill Ratio"
     },
     "WARN_ELC_CTR_FILL_RATIO": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Cable Tray Fill Ratio"
     },
     "WARN_ELC_PNL_SHORT_CIRCUIT": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Short Circuit Rating"
     },
     "WARN_ELC_PNL_SPARE_WAYS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Panel Spare Ways"
     },
     "WARN_FAB_HANGER_LOAD_KN": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Hanger Load"
     },
     "WARN_FLS_PROT_COVERAGE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Fire Protection Coverage"
     },
     "WARN_FLS_SFTY_SPACING": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Sprinkler Spacing"
     },
     "WARN_HVC_VEL_MPS_DUCTS": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Duct Velocity"
     },
     "WARN_INS_THICKNESS_MM": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Insulation Thickness"
     },
     "WARN_LTG_ILLUMINANCE": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Illuminance Level"
     },
     "WARN_MEP_SPC_LIGHTING": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Space Lighting"
     },
     "WARN_PLM_EQP_PRESSURE_KPA": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Equipment Pressure"
     },
     "WARN_PLM_FIXTURE_FLOW": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Fixture Flow Rate"
     },
     "WARN_PLM_PIPE_GRADIENT": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Pipe Gradient"
     },
     "WARN_PLM_VEL_MPS_PIPES": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Pipe Velocity"
     },
     "WARN_ROAD_GRADIENT_PCT": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Road Gradient"
     },
     "WARN_SITE_BEARING_CAP_KPA": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Site Bearing Capacity"
     },
     "WARN_STR_BLT_PROOF_LOAD_KN": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Bolt Proof Load"
     },
     "WARN_STR_CONN_CAPACITY_KN": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Connection Capacity"
     },
     "WARN_STR_FABRIC_SPEC": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Fabric Specification"
     },
     "WARN_STR_RBR_COVER_MM": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Rebar Cover"
     },
     "WARN_STR_RBR_LAP_LENGTH_MM": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Rebar Lap Length"
     },
     "WARN_STR_TRUSS_SPAN": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Truss Span"
     },
     "WARN_STR_WIR_TENSILE_MPA": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Wire Tensile Strength"
     },
     "WARN_STR_WLD_STRENGTH_MPA": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Weld Strength"
     },
     "WARN_STR_WLD_THROAT_MM": {
-      "prefix": "⚠ ",
+      "prefix": "\u00e2\u0161\u00a0 ",
       "suffix": "",
       "label": "Warning: Weld Throat"
+    },
+    "CSI_SECTION_TXT": {
+      "prefix": "CSI ",
+      "suffix": "",
+      "note": "CSI MasterFormat section (Phase H \u2014 from CSI_Assign)"
     }
   },
   "tier_style_defaults": {
@@ -1587,7 +1592,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -1664,7 +1669,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area: ",
-          "suffix_override": " m²",
+          "suffix_override": " m\u00c2\u00b2",
           "note": "Casework area"
         },
         {
@@ -1709,13 +1714,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_CASEWORK_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive, no technical codes"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -1728,7 +1733,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -1948,7 +1953,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -2214,7 +2219,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2225,7 +2230,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2236,7 +2241,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2312,7 +2317,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -2398,7 +2403,7 @@
     "Ceilings": {
       "family_name": "STING - Ceiling Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_CEIL_TXT",
-      "paragraph_template": "This ceiling is finished with {material} at a height of {height} mm above finished floor level, covering an area of {area} m². Fire resistance: {FRR} minutes. Acoustic absorption coefficient: {NRC}. The ceiling system is {suspension_type} with {access} access. Located in {room} ({room_number}) on level {level} in the {zone} zone, serving the {department} department. Assembly code: {assembly_code}. Manufacturer: {manufacturer}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
+      "paragraph_template": "This ceiling is finished with {material} at a height of {height} mm above finished floor level, covering an area of {area} m\u00c2\u00b2. Fire resistance: {FRR} minutes. Acoustic absorption coefficient: {NRC}. The ceiling system is {suspension_type} with {access} access. Located in {room} ({room_number}) on level {level} in the {zone} zone, serving the {department} department. Assembly code: {assembly_code}. Manufacturer: {manufacturer}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -2521,7 +2526,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCO₂/m²",
+          "suffix_override": "kgCO\u00e2\u201a\u201a/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -2615,7 +2620,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2626,7 +2631,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2637,7 +2642,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2713,7 +2718,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -2806,7 +2811,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "µg/m³",
+          "unit": "\u00c2\u00b5g/m\u00c2\u00b3",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -2859,7 +2864,7 @@
           "param": "BLE_DOOR_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "× H:",
+          "prefix_override": "\u00c3\u2014 H:",
           "suffix_override": "mm",
           "style": "NOM",
           "color": "BLACK",
@@ -3063,7 +3068,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3074,7 +3079,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3085,7 +3090,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3161,7 +3166,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -3265,7 +3270,7 @@
     "Floors": {
       "family_name": "STING - Floor Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_FLOOR_TXT",
-      "paragraph_template": "This {function} floor is {thickness} mm thick covering an area of {area} m², constructed with {material} using {method} construction. The floor achieves a thermal transmittance of {U-value} W/m²K and provides {FRR} minutes of fire resistance with an impact insulation class of {IIC} dB. The imposed load capacity is {load} kPa. Located on level {level} in {room}, {zone} zone. Embodied carbon: {carbon} kgCO₂e, recyclability: {recycle}%. Structural type: {struct_type}. Assembly code: {assembly_code}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
+      "paragraph_template": "This {function} floor is {thickness} mm thick covering an area of {area} m\u00c2\u00b2, constructed with {material} using {method} construction. The floor achieves a thermal transmittance of {U-value} W/m\u00c2\u00b2K and provides {FRR} minutes of fire resistance with an impact insulation class of {IIC} dB. The imposed load capacity is {load} kPa. Located on level {level} in {room}, {zone} zone. Embodied carbon: {carbon} kgCO\u00e2\u201a\u201ae, recyclability: {recycle}%. Structural type: {struct_type}. Assembly code: {assembly_code}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -3315,7 +3320,7 @@
           "param": "BLE_FLR_AREA_SQ_M",
           "spaces": 0,
           "break": true,
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3324,7 +3329,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/m²K",
+          "suffix_override": "W/m\u00c2\u00b2K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3388,7 +3393,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Load:",
-          "suffix_override": "kN/m²",
+          "suffix_override": "kN/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3424,7 +3429,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCO₂/m²",
+          "suffix_override": "kgCO\u00e2\u201a\u201a/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3518,7 +3523,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3529,7 +3534,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3540,7 +3545,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3616,7 +3621,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -3682,7 +3687,7 @@
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/m²K",
+          "unit": "W/m\u00c2\u00b2K",
           "description": "Floor U-value thermal transmittance limit",
           "standard": "Building Regs Part L / Uganda ES / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS, \"\")"
@@ -3691,7 +3696,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -3736,7 +3741,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "µg/m³",
+          "unit": "\u00c2\u00b5g/m\u00c2\u00b3",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -3760,7 +3765,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -3837,7 +3842,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area: ",
-          "suffix_override": " m²",
+          "suffix_override": " m\u00c2\u00b2",
           "note": "Footprint area"
         },
         {
@@ -3882,13 +3887,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_FURNITURE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive, no technical codes"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -3901,7 +3906,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -4121,7 +4126,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -4387,7 +4392,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -4398,7 +4403,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -4409,7 +4414,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -4485,7 +4490,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -4569,7 +4574,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "µg/m³",
+          "unit": "\u00c2\u00b5g/m\u00c2\u00b3",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -4594,7 +4599,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -4670,7 +4675,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area: ",
-          "suffix_override": " m²",
+          "suffix_override": " m\u00c2\u00b2",
           "note": "System area"
         },
         {
@@ -4715,13 +4720,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_FURN_SYS_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -4734,7 +4739,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -4954,7 +4959,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -5079,7 +5084,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5090,7 +5095,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5101,7 +5106,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5177,7 +5182,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -5276,7 +5281,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -5389,13 +5394,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PARKING_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -5408,7 +5413,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -5628,7 +5633,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -5753,7 +5758,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5764,7 +5769,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5775,7 +5780,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5851,7 +5856,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -6120,7 +6125,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6131,7 +6136,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6142,7 +6147,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6218,7 +6223,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -6286,7 +6291,7 @@
           "threshold": "8.33",
           "unit": "%",
           "description": "Ramp gradient accessibility limit (1:12 max)",
-          "standard": "BS 8300:2018 §7.2 / ADA §405.2",
+          "standard": "BS 8300:2018 \u00c2\u00a77.2 / ADA \u00c2\u00a7405.2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAMP_SLOPE_PCT_RAMPS, \"\")"
         },
         {
@@ -6304,7 +6309,7 @@
     "Roofs": {
       "family_name": "STING - Roof Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_ROOF_TXT",
-      "paragraph_template": "This {function} roof has a total thickness of {thickness} mm with a slope of {slope}°, covering an area of {area} m². The primary material is {material} with {insulation} insulation achieving a U-value of {U-value} W/m²K. Fire resistance: {FRR} minutes. Drainage is via {drainage}. Located on level {level} in the {zone} zone. Embodied carbon: {carbon} kgCO₂e, recyclability: {recycle}%. Structural load capacity: {load} kPa. Assembly code: {assembly_code}. Phase: {phase}. Expected life: {life} years. Compliant with {standard}.",
+      "paragraph_template": "This {function} roof has a total thickness of {thickness} mm with a slope of {slope}\u00c2\u00b0, covering an area of {area} m\u00c2\u00b2. The primary material is {material} with {insulation} insulation achieving a U-value of {U-value} W/m\u00c2\u00b2K. Fire resistance: {FRR} minutes. Drainage is via {drainage}. Located on level {level} in the {zone} zone. Embodied carbon: {carbon} kgCO\u00e2\u201a\u201ae, recyclability: {recycle}%. Structural load capacity: {load} kPa. Assembly code: {assembly_code}. Phase: {phase}. Expected life: {life} years. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -6354,7 +6359,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/m²K",
+          "suffix_override": "W/m\u00c2\u00b2K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6373,7 +6378,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Slope:",
-          "suffix_override": "°",
+          "suffix_override": "\u00c2\u00b0",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6382,7 +6387,7 @@
           "param": "BLE_ROOF_AREA_SQ_M",
           "spaces": 0,
           "break": true,
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6436,7 +6441,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCO₂/m²",
+          "suffix_override": "kgCO\u00e2\u201a\u201a/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6539,7 +6544,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6550,7 +6555,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6561,7 +6566,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6637,7 +6642,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -6703,7 +6708,7 @@
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/m²K",
+          "unit": "W/m\u00c2\u00b2K",
           "description": "Roof U-value thermal transmittance limit",
           "standard": "Building Regs Part L / Uganda ES / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS, \"\")"
@@ -6712,7 +6717,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -6773,7 +6778,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area:",
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6970,7 +6975,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6981,7 +6986,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6992,7 +6997,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7068,7 +7073,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -7134,7 +7139,7 @@
           "param": "WARN_ASS_ROOM_AREA_MIN",
           "severity": "HIGH",
           "threshold": "7.0",
-          "unit": "m²",
+          "unit": "m\u00c2\u00b2",
           "description": "Room minimum area compliance",
           "standard": "Building Regs / Space Standards",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_ROOM_AREA_MIN, \"\")"
@@ -7194,7 +7199,7 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESSIBLE_WC, \"\")"
         }
       ],
-      "paragraph_template": "This is {room_name} (Room {room_number}) with a floor area of {area} m² and volume of {volume} m³, located on level {level} in the {zone} zone within the {department} department. The room has a ceiling height of {height} mm with {finishes} finishes. Design lighting level: {lux} lux. Ventilation rate: {ventilation} L/s per person. Acoustic requirement: {noise} dB background noise maximum. Fire escape travel distance: {travel} m. Occupancy load: {occupancy} persons. Grid reference: {grid}. Phase: {phase}. Workset: {workset}. Compliant with {standard}.",
+      "paragraph_template": "This is {room_name} (Room {room_number}) with a floor area of {area} m\u00c2\u00b2 and volume of {volume} m\u00c2\u00b3, located on level {level} in the {zone} zone within the {department} department. The room has a ceiling height of {height} mm with {finishes} finishes. Design lighting level: {lux} lux. Ventilation rate: {ventilation} L/s per person. Acoustic requirement: {noise} dB background noise maximum. Fire escape travel distance: {travel} m. Occupancy load: {occupancy} persons. Grid reference: {grid}. Phase: {phase}. Workset: {workset}. Compliant with {standard}.",
       "csv_family_alias": "Room"
     },
     "Site": {
@@ -7214,7 +7219,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -7328,19 +7333,19 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_SITE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive"
         },
         {
           "param": "WARN_SITE_BEARING_CAP_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_SITE_BEARING_CAP_KPA, \"\")"
         },
         {
@@ -7354,7 +7359,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -7574,7 +7579,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -7699,7 +7704,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7710,7 +7715,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7721,7 +7726,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7797,7 +7802,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -8085,7 +8090,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8096,7 +8101,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8107,7 +8112,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8183,7 +8188,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -8305,7 +8310,7 @@
     "Walls": {
       "family_name": "STING - Wall Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_WALL_TXT",
-      "paragraph_template": "This {function} wall is {thickness} mm thick and {height} mm high with a total length of {length} mm, constructed using {method} with {material} as the primary material. The wall is classified as {type} under the {assembly_code} Uniformat classification, and achieves a thermal transmittance of {U-value} W/m²K with a thermal resistance of {R-value} m²K/W, assessed as {condensation} condensation risk. It provides {FRR} minutes of fire resistance with an acoustic rating of {STC} dB STC. The assembly incorporates {recycled}% recycled content with an embodied carbon of {carbon} kgCO₂e per unit and an expected service life of {life} years. It is situated in {room} on level {level} within the {zone} zone. The wall was created during the {phase} phase under {workset} workset. Manufacturer: {manufacturer}, Model: {model}. Maintenance frequency: {maint_freq}. Compliant with {standard}.",
+      "paragraph_template": "This {function} wall is {thickness} mm thick and {height} mm high with a total length of {length} mm, constructed using {method} with {material} as the primary material. The wall is classified as {type} under the {assembly_code} Uniformat classification, and achieves a thermal transmittance of {U-value} W/m\u00c2\u00b2K with a thermal resistance of {R-value} m\u00c2\u00b2K/W, assessed as {condensation} condensation risk. It provides {FRR} minutes of fire resistance with an acoustic rating of {STC} dB STC. The assembly incorporates {recycled}% recycled content with an embodied carbon of {carbon} kgCO\u00e2\u201a\u201ae per unit and an expected service life of {life} years. It is situated in {room} on level {level} within the {zone} zone. The wall was created during the {phase} phase under {workset} workset. Manufacturer: {manufacturer}, Model: {model}. Maintenance frequency: {maint_freq}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -8355,7 +8360,7 @@
           "param": "BLE_ELE_AREA_SQ_M",
           "spaces": 0,
           "break": true,
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -8364,7 +8369,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/m²K",
+          "suffix_override": "W/m\u00c2\u00b2K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -8463,7 +8468,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCO₂/m²",
+          "suffix_override": "kgCO\u00e2\u201a\u201a/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -8585,7 +8590,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8596,7 +8601,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8607,7 +8612,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8683,7 +8688,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -8749,7 +8754,7 @@
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/m²K",
+          "unit": "W/m\u00c2\u00b2K",
           "description": "Wall U-value thermal transmittance limit",
           "standard": "Building Regs Part L / Uganda ES / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS, \"\")"
@@ -8758,7 +8763,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -8812,7 +8817,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "µg/m³",
+          "unit": "\u00c2\u00b5g/m\u00c2\u00b3",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -8823,7 +8828,7 @@
     "Windows": {
       "family_name": "STING - Window Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_WIN_TXT",
-      "paragraph_template": "This is a {width} by {height} millimetre {type} window with a sill height of {sill_height} mm above finished floor level, constructed from {frame_material} framing with {glazing_type} glazing. The window achieves a U-value of {U-value} W/m²K with a solar heat gain coefficient (SHGC) of {SHGC} and visible light transmittance of {VLT}%. Located in {room} on level {level} in the {zone} zone. Assembly code: {assembly_code}. Manufacturer: {manufacturer}, Model: {model}. Expected life: {life} years. Compliant with {standard}.",
+      "paragraph_template": "This is a {width} by {height} millimetre {type} window with a sill height of {sill_height} mm above finished floor level, constructed from {frame_material} framing with {glazing_type} glazing. The window achieves a U-value of {U-value} W/m\u00c2\u00b2K with a solar heat gain coefficient (SHGC) of {SHGC} and visible light transmittance of {VLT}%. Located in {room} on level {level} in the {zone} zone. Assembly code: {assembly_code}. Manufacturer: {manufacturer}, Model: {model}. Expected life: {life} years. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -8865,7 +8870,7 @@
           "param": "BLE_WINDOW_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "× H:",
+          "prefix_override": "\u00c3\u2014 H:",
           "suffix_override": "mm",
           "style": "NOM",
           "color": "BLACK",
@@ -8893,7 +8898,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/m²K",
+          "suffix_override": "W/m\u00c2\u00b2K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -8949,7 +8954,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Vent:",
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -9052,7 +9057,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9063,7 +9068,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9074,7 +9079,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9150,7 +9155,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -9216,7 +9221,7 @@
           "param": "WARN_BLE_WINDOW_U_VALUE",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/m²K",
+          "unit": "W/m\u00c2\u00b2K",
           "description": "U-value thermal transmittance check",
           "standard": "Building Regs Part L / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_WINDOW_U_VALUE, \"\")"
@@ -9249,7 +9254,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -9355,7 +9360,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_REBAR_TXT",
@@ -9367,14 +9372,14 @@
           "param": "WARN_STR_RBR_COVER_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
           "param": "WARN_STR_RBR_LAP_LENGTH_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_LAP_LENGTH_MM, \"\")"
         },
         {
@@ -9388,7 +9393,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -9608,7 +9613,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -9733,7 +9738,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9744,7 +9749,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9755,7 +9760,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9831,7 +9836,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -9899,7 +9904,7 @@
           "threshold": "25",
           "unit": "mm",
           "description": "Rebar concrete cover minimum",
-          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 \u00c2\u00a74.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
@@ -9908,7 +9913,7 @@
           "threshold": "500",
           "unit": "mm",
           "description": "Rebar lap length minimum",
-          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 \u00c2\u00a74.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_LAP_LENGTH_MM, \"\")"
         },
         {
@@ -9938,7 +9943,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -10044,7 +10049,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_AREAS_TXT",
@@ -10063,7 +10068,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -10283,7 +10288,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -10408,7 +10413,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -10419,7 +10424,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -10430,7 +10435,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -10506,7 +10511,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -10572,7 +10577,7 @@
           "param": "WARN_ASS_ROOM_AREA_MIN",
           "severity": "HIGH",
           "threshold": "7.0",
-          "unit": "m²",
+          "unit": "m\u00c2\u00b2",
           "description": "Room minimum area compliance",
           "standard": "Building Regs / Space Standards",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_ROOM_AREA_MIN, \"\")"
@@ -10595,7 +10600,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -10701,7 +10706,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_SPACES_TXT",
@@ -10713,7 +10718,7 @@
           "param": "WARN_MEP_SPC_LIGHTING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_MEP_SPC_LIGHTING, \"\")"
         },
         {
@@ -10727,7 +10732,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -10947,7 +10952,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -11072,7 +11077,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11083,7 +11088,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11094,7 +11099,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11170,7 +11175,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -11236,7 +11241,7 @@
           "param": "WARN_MEP_SPC_LIGHTING",
           "severity": "MEDIUM",
           "threshold": "10",
-          "unit": "W/m²",
+          "unit": "W/m\u00c2\u00b2",
           "description": "Space lighting power density limit",
           "standard": "CIBSE SLL LG7 / BS EN 15193",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_MEP_SPC_LIGHTING, \"\")"
@@ -11259,7 +11264,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -11372,7 +11377,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_COLUMNS_TXT",
@@ -11391,7 +11396,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -11611,7 +11616,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -11736,7 +11741,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11747,7 +11752,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11758,7 +11763,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11834,7 +11839,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -11902,7 +11907,7 @@
           "threshold": "30",
           "unit": "ratio",
           "description": "Column slenderness ratio limit",
-          "standard": "BS EN 1992-1-1 §5.8 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 \u00c2\u00a75.8 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_COLUMN_SLENDERNESS, \"\")"
         }
       ]
@@ -11923,7 +11928,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -12029,7 +12034,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ASSEMBLIES_TXT",
@@ -12048,7 +12053,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -12268,7 +12273,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -12393,7 +12398,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -12404,7 +12409,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -12415,7 +12420,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -12491,7 +12496,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -12557,7 +12562,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -12580,7 +12585,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -12686,7 +12691,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_DETAIL_ITEMS_TXT",
@@ -12705,7 +12710,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -12925,7 +12930,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -13050,7 +13055,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13061,7 +13066,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13072,7 +13077,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13148,7 +13153,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -13237,7 +13242,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -13343,7 +13348,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ENTOURAGE_TXT",
@@ -13362,7 +13367,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -13582,7 +13587,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -13707,7 +13712,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13718,7 +13723,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13729,7 +13734,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13805,7 +13810,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -13894,7 +13899,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -14000,7 +14005,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_FOOD_EQUIP_TXT",
@@ -14019,7 +14024,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -14239,7 +14244,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -14364,7 +14369,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -14375,7 +14380,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -14386,7 +14391,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -14462,7 +14467,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -14560,7 +14565,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -14666,7 +14671,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_HARDSCAPE_TXT",
@@ -14678,7 +14683,7 @@
           "param": "WARN_BLE_RAMP_SLOPE_PCT_RAMPS",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAMP_SLOPE_PCT_RAMPS, \"\")"
         },
         {
@@ -14692,7 +14697,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -14912,7 +14917,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -15037,7 +15042,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15048,7 +15053,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15059,7 +15064,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15135,7 +15140,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -15224,7 +15229,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -15330,7 +15335,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_MASS_TXT",
@@ -15349,7 +15354,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -15569,7 +15574,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -15694,7 +15699,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15705,7 +15710,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15716,7 +15721,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15792,7 +15797,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -15858,7 +15863,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -15881,7 +15886,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -15987,7 +15992,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_MODEL_GROUPS_TXT",
@@ -16006,7 +16011,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -16226,7 +16231,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -16351,7 +16356,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -16362,7 +16367,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -16373,7 +16378,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -16449,7 +16454,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -16515,7 +16520,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -16538,7 +16543,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -16644,7 +16649,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PADS_TXT",
@@ -16656,7 +16661,7 @@
           "param": "WARN_SITE_BEARING_CAP_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_SITE_BEARING_CAP_KPA, \"\")"
         },
         {
@@ -16670,7 +16675,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -16890,7 +16895,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -17015,7 +17020,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17026,7 +17031,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17037,7 +17042,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17113,7 +17118,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -17202,7 +17207,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -17308,7 +17313,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PARTS_TXT",
@@ -17327,7 +17332,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -17547,7 +17552,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -17672,7 +17677,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17683,7 +17688,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17694,7 +17699,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17770,7 +17775,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -17836,7 +17841,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -17859,7 +17864,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -17965,7 +17970,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PLANTING_TXT",
@@ -17984,7 +17989,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -18204,7 +18209,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -18329,7 +18334,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -18340,7 +18345,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -18351,7 +18356,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -18427,7 +18432,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -18516,7 +18521,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -18622,7 +18627,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PROFILES_TXT",
@@ -18641,7 +18646,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -18861,7 +18866,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -18986,7 +18991,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -18997,7 +19002,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19008,7 +19013,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19084,7 +19089,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -19173,7 +19178,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -19279,7 +19284,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PROPERTY_LINES_TXT",
@@ -19298,7 +19303,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -19518,7 +19523,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -19643,7 +19648,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19654,7 +19659,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19665,7 +19670,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19741,7 +19746,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -19830,7 +19835,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -19936,7 +19941,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ROADS_TXT",
@@ -19948,7 +19953,7 @@
           "param": "WARN_ROAD_GRADIENT_PCT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ROAD_GRADIENT_PCT, \"\")"
         },
         {
@@ -19962,7 +19967,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -20182,7 +20187,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -20307,7 +20312,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20318,7 +20323,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20329,7 +20334,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20405,7 +20410,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -20494,7 +20499,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -20600,7 +20605,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_SIGNAGE_TXT",
@@ -20619,7 +20624,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -20839,7 +20844,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -20964,7 +20969,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20975,7 +20980,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20986,7 +20991,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21062,7 +21067,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -21160,7 +21165,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -21266,7 +21271,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_TOPOSOLID_TXT",
@@ -21278,7 +21283,7 @@
           "param": "WARN_SITE_BEARING_CAP_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_SITE_BEARING_CAP_KPA, \"\")"
         },
         {
@@ -21292,7 +21297,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -21512,7 +21517,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -21637,7 +21642,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21648,7 +21653,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21659,7 +21664,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21735,7 +21740,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -21824,7 +21829,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -21930,7 +21935,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_VERT_CIRC_TXT",
@@ -21942,7 +21947,7 @@
           "param": "WARN_BLE_VERT_CIRC_LOAD",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_VERT_CIRC_LOAD, \"\")"
         },
         {
@@ -21956,7 +21961,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -22176,7 +22181,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -22301,7 +22306,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22312,7 +22317,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22323,7 +22328,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22399,7 +22404,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -22465,7 +22470,7 @@
           "param": "WARN_BLE_VERT_CIRC_LOAD",
           "severity": "HIGH",
           "threshold": "5.0",
-          "unit": "kN/m²",
+          "unit": "kN/m\u00c2\u00b2",
           "description": "Vertical circulation structural load check",
           "standard": "Building Regs Part K / BS EN 81-20",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_VERT_CIRC_LOAD, \"\")"
@@ -22497,7 +22502,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -22603,7 +22608,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ZONES_TXT",
@@ -22622,7 +22627,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -22842,7 +22847,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -22967,7 +22972,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22978,7 +22983,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22989,7 +22994,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23065,7 +23070,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -23154,7 +23159,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -23260,7 +23265,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_RVT_LINKS_TXT",
@@ -23279,7 +23284,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -23499,7 +23504,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -23624,7 +23629,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23635,7 +23640,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23646,7 +23651,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23722,7 +23727,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -23788,7 +23793,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -23811,7 +23816,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -23917,7 +23922,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_FASCIA_TXT",
@@ -23936,7 +23941,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -24156,7 +24161,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -24281,7 +24286,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24292,7 +24297,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24303,7 +24308,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24379,7 +24384,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -24445,7 +24450,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -24468,7 +24473,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -24574,7 +24579,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_GUTTER_TXT",
@@ -24593,7 +24598,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -24813,7 +24818,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -24938,7 +24943,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24949,7 +24954,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24960,7 +24965,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25036,7 +25041,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -25125,7 +25130,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -25231,7 +25236,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_HANDRAILS_TXT",
@@ -25243,14 +25248,14 @@
           "param": "WARN_BLE_RAIL_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_HEIGHT_MM, \"\")"
         },
         {
           "param": "WARN_BLE_RAIL_LOAD_KN_M",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_LOAD_KN_M, \"\")"
         },
         {
@@ -25264,7 +25269,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -25484,7 +25489,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -25609,7 +25614,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25620,7 +25625,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25631,7 +25636,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25707,7 +25712,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -25805,7 +25810,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -25911,7 +25916,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_ROOF_SOFFITS_TXT",
@@ -25930,7 +25935,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -26150,7 +26155,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -26275,7 +26280,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26286,7 +26291,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26297,7 +26302,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26373,7 +26378,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -26448,7 +26453,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -26471,7 +26476,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -26577,7 +26582,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_SLAB_EDGES_TXT",
@@ -26596,7 +26601,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -26816,7 +26821,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -26941,7 +26946,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26952,7 +26957,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26963,7 +26968,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27039,7 +27044,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -27105,7 +27110,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -27128,7 +27133,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -27234,7 +27239,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_STAIR_LANDINGS_TXT",
@@ -27253,7 +27258,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -27473,7 +27478,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -27598,7 +27603,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27609,7 +27614,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27620,7 +27625,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27696,7 +27701,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -27785,7 +27790,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -27891,7 +27896,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_STAIR_RUNS_TXT",
@@ -27903,14 +27908,14 @@
           "param": "WARN_BLE_STAIR_RISE",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_RISE, \"\")"
         },
         {
           "param": "WARN_BLE_STAIR_GOING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_GOING, \"\")"
         },
         {
@@ -27924,7 +27929,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -28144,7 +28149,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -28269,7 +28274,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28280,7 +28285,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28291,7 +28296,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28367,7 +28372,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -28483,7 +28488,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -28589,7 +28594,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_STAIR_SUPPORTS_TXT",
@@ -28601,7 +28606,7 @@
           "param": "WARN_BLE_STRUCT_LD_CAP",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STRUCT_LD_CAP, \"\")"
         },
         {
@@ -28615,7 +28620,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -28835,7 +28840,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -28960,7 +28965,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28971,7 +28976,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28982,7 +28987,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29058,7 +29063,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -29147,7 +29152,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -29253,7 +29258,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_TOP_RAILS_TXT",
@@ -29265,14 +29270,14 @@
           "param": "WARN_BLE_RAIL_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_HEIGHT_MM, \"\")"
         },
         {
           "param": "WARN_BLE_RAIL_LOAD_KN_M",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_LOAD_KN_M, \"\")"
         },
         {
@@ -29286,7 +29291,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -29506,7 +29511,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -29631,7 +29636,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29642,7 +29647,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29653,7 +29658,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29729,7 +29734,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -29827,7 +29832,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -29933,7 +29938,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_WALL_SWEEPS_TXT",
@@ -29952,7 +29957,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -30172,7 +30177,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -30297,7 +30302,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30308,7 +30313,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30319,7 +30324,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30395,7 +30400,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -30461,7 +30466,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -30642,7 +30647,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCO₂/m²",
+          "suffix_override": "kgCO\u00e2\u201a\u201a/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -30764,7 +30769,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30775,7 +30780,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30786,7 +30791,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30862,7 +30867,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -30939,7 +30944,7 @@
           "threshold": "30",
           "unit": "ratio",
           "description": "Column slenderness ratio limit",
-          "standard": "BS EN 1992-1-1 §5.8 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 \u00c2\u00a75.8 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_COLUMN_SLENDERNESS, \"\")"
         },
         {
@@ -30948,7 +30953,7 @@
           "threshold": "15",
           "unit": "mm",
           "description": "Column eccentricity limit",
-          "standard": "BS EN 1992-1-1 §5.8 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 \u00c2\u00a75.8 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_COL_ECCENTRICITY, \"\")"
         }
       ],
@@ -31036,7 +31041,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Bearing:",
-          "suffix_override": "kN/m²",
+          "suffix_override": "kN/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -31129,7 +31134,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCO₂/m²",
+          "suffix_override": "kgCO\u00e2\u201a\u201a/m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -31251,7 +31256,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -31262,7 +31267,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -31273,7 +31278,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -31349,7 +31354,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -31458,7 +31463,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "BLE_STRUCT_BEAM_SZ_TXT",
@@ -31610,54 +31615,54 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_BEAM_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive, no technical codes"
         },
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STRUCT_LD_CAP, \"\")"
         },
         {
           "param": "WARN_STR_BEAM_WEB_OPENING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BEAM_WEB_OPENING, \"\")"
         },
         {
           "param": "WARN_STR_BEAM_NOTCH",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BEAM_NOTCH, \"\")"
         },
         {
           "param": "WARN_STR_BEAM_PENETRATION_REVIEW",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BEAM_PENETRATION_REVIEW, \"\")"
         },
         {
           "param": "WARN_STR_TRANSFER_BEAM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_TRANSFER_BEAM, \"\")"
         },
         {
           "param": "WARN_STR_COMPOSITE_SHEAR_STUD",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_COMPOSITE_SHEAR_STUD, \"\")"
         },
         {
@@ -31671,7 +31676,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -31891,7 +31896,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -32016,7 +32021,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32027,7 +32032,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32038,7 +32043,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32114,7 +32119,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -32221,7 +32226,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -32327,7 +32332,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_FABRIC_REINF_TXT",
@@ -32339,7 +32344,7 @@
           "param": "WARN_STR_FABRIC_SPEC",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_FABRIC_SPEC, \"\")"
         },
         {
@@ -32353,7 +32358,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -32573,7 +32578,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -32698,7 +32703,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32709,7 +32714,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32720,7 +32725,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32796,7 +32801,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -32885,7 +32890,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -32991,7 +32996,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_LINKS_TXT",
@@ -33010,7 +33015,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -33230,7 +33235,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -33355,7 +33360,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -33366,7 +33371,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -33377,7 +33382,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -33453,7 +33458,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -33542,7 +33547,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -33648,7 +33653,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_MEMBERS_TXT",
@@ -33667,7 +33672,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -33887,7 +33892,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -34012,7 +34017,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34023,7 +34028,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34034,7 +34039,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34110,7 +34115,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -34199,7 +34204,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -34305,7 +34310,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_NODES_TXT",
@@ -34324,7 +34329,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -34544,7 +34549,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -34669,7 +34674,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34680,7 +34685,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34691,7 +34696,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34767,7 +34772,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -34856,7 +34861,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -34962,7 +34967,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_OPENINGS_TXT",
@@ -34981,7 +34986,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -35201,7 +35206,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -35326,7 +35331,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -35337,7 +35342,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -35348,7 +35353,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -35424,7 +35429,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -35513,7 +35518,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -35619,7 +35624,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_PANELS_TXT",
@@ -35638,7 +35643,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -35858,7 +35863,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -35983,7 +35988,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -35994,7 +35999,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36005,7 +36010,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36081,7 +36086,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -36170,7 +36175,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -36276,7 +36281,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_AREA_LOADS_TXT",
@@ -36295,7 +36300,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -36515,7 +36520,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -36640,7 +36645,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36651,7 +36656,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36662,7 +36667,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36738,7 +36743,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -36827,7 +36832,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -36933,7 +36938,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_LINE_LOADS_TXT",
@@ -36952,7 +36957,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -37172,7 +37177,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -37297,7 +37302,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37308,7 +37313,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37319,7 +37324,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37395,7 +37400,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -37484,7 +37489,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -37590,7 +37595,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_POINT_LOADS_TXT",
@@ -37609,7 +37614,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -37829,7 +37834,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -37954,7 +37959,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37965,7 +37970,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37976,7 +37981,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38052,7 +38057,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -38141,7 +38146,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -38247,7 +38252,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_INT_AREA_LOADS_TXT",
@@ -38266,7 +38271,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -38486,7 +38491,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -38611,7 +38616,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38622,7 +38627,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38633,7 +38638,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38709,7 +38714,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -38798,7 +38803,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -38904,7 +38909,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_INT_LINE_LOADS_TXT",
@@ -38923,7 +38928,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -39143,7 +39148,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -39268,7 +39273,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39279,7 +39284,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39290,7 +39295,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39366,7 +39371,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -39455,7 +39460,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -39561,7 +39566,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_INT_POINT_LOADS_TXT",
@@ -39580,7 +39585,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -39800,7 +39805,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -39925,7 +39930,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39936,7 +39941,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39947,7 +39952,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40023,7 +40028,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -40179,7 +40184,7 @@
           "param": "WARN_STR_BLT_PROOF_LOAD_KN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BLT_PROOF_LOAD_KN, \"\")"
         },
         {
@@ -40193,7 +40198,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -40413,7 +40418,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -40538,7 +40543,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40549,7 +40554,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40560,7 +40565,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40636,7 +40641,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -40792,14 +40797,14 @@
           "param": "WARN_STR_WLD_STRENGTH_MPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_STRENGTH_MPA, \"\")"
         },
         {
           "param": "WARN_STR_WLD_THROAT_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_THROAT_MM, \"\")"
         },
         {
@@ -40813,7 +40818,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -41033,7 +41038,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -41158,7 +41163,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41169,7 +41174,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41180,7 +41185,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41256,7 +41261,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -41324,7 +41329,7 @@
           "threshold": "6",
           "unit": "mm",
           "description": "Weld throat thickness minimum",
-          "standard": "BS EN 1993-1-8 §4.5 / AWS D1.1",
+          "standard": "BS EN 1993-1-8 \u00c2\u00a74.5 / AWS D1.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_THROAT_MM, \"\")"
         },
         {
@@ -41333,7 +41338,7 @@
           "threshold": "250",
           "unit": "MPa",
           "description": "Weld strength minimum",
-          "standard": "BS EN 1993-1-8 §4.5 / AWS D1.1",
+          "standard": "BS EN 1993-1-8 \u00c2\u00a74.5 / AWS D1.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_STRENGTH_MPA, \"\")"
         }
       ]
@@ -41421,7 +41426,7 @@
           "param": "WARN_STR_WIR_TENSILE_MPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WIR_TENSILE_MPA, \"\")"
         },
         {
@@ -41435,7 +41440,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -41655,7 +41660,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -41780,7 +41785,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41791,7 +41796,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41802,7 +41807,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41878,7 +41883,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -41967,7 +41972,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -42073,7 +42078,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_AREA_REINF_TXT",
@@ -42085,7 +42090,7 @@
           "param": "WARN_STR_RBR_COVER_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
@@ -42099,7 +42104,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -42319,7 +42324,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -42444,7 +42449,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -42455,7 +42460,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -42466,7 +42471,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -42542,7 +42547,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -42610,7 +42615,7 @@
           "threshold": "25",
           "unit": "mm",
           "description": "Rebar concrete cover minimum",
-          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 \u00c2\u00a74.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         }
       ]
@@ -42631,7 +42636,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -42737,7 +42742,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_PATH_REINF_TXT",
@@ -42749,7 +42754,7 @@
           "param": "WARN_STR_RBR_COVER_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
@@ -42763,7 +42768,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -42983,7 +42988,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -43108,7 +43113,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43119,7 +43124,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43130,7 +43135,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43206,7 +43211,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -43274,7 +43279,7 @@
           "threshold": "25",
           "unit": "mm",
           "description": "Rebar concrete cover minimum",
-          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 \u00c2\u00a74.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         }
       ]
@@ -43295,7 +43300,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -43401,7 +43406,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_REBAR_COUPLERS_TXT",
@@ -43413,7 +43418,7 @@
           "param": "WARN_STR_CONN_CAPACITY_KN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_CONN_CAPACITY_KN, \"\")"
         },
         {
@@ -43427,7 +43432,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -43647,7 +43652,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -43772,7 +43777,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43783,7 +43788,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43794,7 +43799,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43870,7 +43875,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -43959,7 +43964,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -44065,7 +44070,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_BEAM_SYSTEMS_TXT",
@@ -44084,7 +44089,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -44304,7 +44309,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -44429,7 +44434,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -44440,7 +44445,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -44451,7 +44456,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -44527,7 +44532,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -44616,7 +44621,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -44722,7 +44727,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_STIFFENERS_TXT",
@@ -44741,7 +44746,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -44961,7 +44966,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -45086,7 +45091,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45097,7 +45102,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45108,7 +45113,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45184,7 +45189,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -45273,7 +45278,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -45379,7 +45384,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_TRUSSES_TXT",
@@ -45391,7 +45396,7 @@
           "param": "WARN_STR_TRUSS_SPAN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_TRUSS_SPAN, \"\")"
         },
         {
@@ -45405,7 +45410,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -45625,7 +45630,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -45750,7 +45755,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45761,7 +45766,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45772,7 +45777,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45848,7 +45853,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -46249,6 +46254,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -46257,7 +46272,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46268,7 +46283,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46279,7 +46294,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46415,7 +46430,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -46629,7 +46644,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46640,7 +46655,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46651,7 +46666,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46787,7 +46802,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -46993,6 +47008,16 @@
           "style": "NOM",
           "color": "PURPLE",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -47001,7 +47026,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47012,7 +47037,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47023,7 +47048,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47159,7 +47184,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -47363,7 +47388,7 @@
           "param": "HVC_DUCT_AREA_SQ_M",
           "spaces": 1,
           "break": true,
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -47372,7 +47397,7 @@
           "param": "HVC_DUCT_FLOWRATE_M3H",
           "spaces": 1,
           "break": true,
-          "suffix_override": "m³/h",
+          "suffix_override": "m\u00c2\u00b3/h",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -47471,7 +47496,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| Area:",
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -47558,6 +47583,16 @@
           "style": "NOM",
           "color": "PURPLE",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -47566,7 +47601,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47577,7 +47612,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47588,7 +47623,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47724,7 +47759,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -47882,7 +47917,7 @@
           "param": "HVC_DUCT_FLOWRATE_M3H",
           "spaces": 1,
           "break": true,
-          "suffix_override": "m³/h",
+          "suffix_override": "m\u00c2\u00b3/h",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -47960,6 +47995,16 @@
           "style": "NOM",
           "color": "PURPLE",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -47968,7 +48013,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47979,7 +48024,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47990,7 +48035,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -48126,7 +48171,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -48227,7 +48272,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -48403,19 +48448,19 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_SPEC_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive, no technical codes"
         },
         {
           "param": "WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI, \"\")"
         },
         {
@@ -48429,7 +48474,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -48649,7 +48694,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -48907,6 +48952,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -48915,7 +48970,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -48926,7 +48981,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -48937,7 +48992,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49085,7 +49140,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -49318,6 +49373,16 @@
           "style": "NOM",
           "color": "PURPLE",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -49326,7 +49391,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49337,7 +49402,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49348,7 +49413,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49474,7 +49539,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -49690,7 +49755,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49701,7 +49766,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49712,7 +49777,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49838,7 +49903,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -50055,6 +50120,16 @@
           "style": "NOM",
           "color": "PURPLE",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -50063,7 +50138,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50074,7 +50149,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50085,7 +50160,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50211,7 +50286,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -50598,6 +50673,16 @@
           "style": "NOM",
           "color": "PURPLE",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -50606,7 +50691,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50617,7 +50702,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50628,7 +50713,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50754,7 +50839,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -51254,6 +51339,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -51262,7 +51357,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51273,7 +51368,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51284,7 +51379,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51410,7 +51505,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -51514,7 +51609,7 @@
     "Fire Alarm Devices": {
       "family_name": "STING - Fire Alarm Device Tag",
       "paragraph_container": "FLS_TAG_7_PARA_FA_TXT",
-      "paragraph_template": "This {device_type} fire alarm device provides detection coverage of {coverage} m² with a maximum spacing of {spacing} m. Sensitivity: {sensitivity}. Power supply: {power}. Loop address: {address}. Circuit: {circuit}. Located in {room} on level {level} in the {zone} zone. Maximum detector spacing for this room type: {max_spacing} m. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Commissioning status: {commissioning}. Compliant with {standard}.",
+      "paragraph_template": "This {device_type} fire alarm device provides detection coverage of {coverage} m\u00c2\u00b2 with a maximum spacing of {spacing} m. Sensitivity: {sensitivity}. Power supply: {power}. Loop address: {address}. Circuit: {circuit}. Located in {room} on level {level} in the {zone} zone. Maximum detector spacing for this room type: {max_spacing} m. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Commissioning status: {commissioning}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -51747,7 +51842,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51758,7 +51853,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51769,7 +51864,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51845,7 +51940,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -51911,7 +52006,7 @@
           "param": "WARN_FLS_PROT_COVERAGE",
           "severity": "CRITICAL",
           "threshold": "12.0",
-          "unit": "m²",
+          "unit": "m\u00c2\u00b2",
           "description": "Fire safety device coverage limit",
           "standard": "Building Regs Part B / BS 9999",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_PROT_COVERAGE, \"\")"
@@ -51931,7 +52026,7 @@
     "Sprinklers": {
       "family_name": "STING - Sprinkler Tag",
       "paragraph_container": "FLS_TAG_7_PARA_SPR_TXT",
-      "paragraph_template": "This {type} sprinkler head has a K-factor of {k_factor} with a temperature rating of {temp_rating}°C ({response} response). Coverage area: {coverage} m². Spacing: {spacing} m. Operating pressure: {pressure} kPa. Orientation: {orientation}. Connected to {system} system. Located in {room} on level {level} in the {zone} zone. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Compliant with {standard}.",
+      "paragraph_template": "This {type} sprinkler head has a K-factor of {k_factor} with a temperature rating of {temp_rating}\u00c2\u00b0C ({response} response). Coverage area: {coverage} m\u00c2\u00b2. Spacing: {spacing} m. Operating pressure: {pressure} kPa. Orientation: {orientation}. Connected to {system} system. Located in {room} on level {level} in the {zone} zone. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -51956,7 +52051,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "Coverage:",
-          "suffix_override": "m²",
+          "suffix_override": "m\u00c2\u00b2",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -52012,7 +52107,7 @@
           "param": "FLS_SFTY_TEMP_RATING_C",
           "spaces": 0,
           "break": true,
-          "suffix_override": "°C",
+          "suffix_override": "\u00c2\u00b0C",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -52315,6 +52410,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -52323,7 +52428,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52334,7 +52439,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52345,7 +52450,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52421,7 +52526,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -52487,7 +52592,7 @@
           "param": "WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR",
           "severity": "CRITICAL",
           "threshold": "12.0",
-          "unit": "m²",
+          "unit": "m\u00c2\u00b2",
           "description": "Sprinkler coverage area limit",
           "standard": "BS 9251:2021 / BS EN 12845",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR, \"\")"
@@ -52643,7 +52748,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52654,7 +52759,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52665,7 +52770,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52741,7 +52846,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -52809,7 +52914,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 §522 / BS EN 61386",
+          "standard": "BS 7671 \u00c2\u00a7522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ],
@@ -53172,6 +53277,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -53180,7 +53295,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53191,7 +53306,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53202,7 +53317,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53278,7 +53393,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -53346,7 +53461,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 §522 / BS EN 61386",
+          "standard": "BS 7671 \u00c2\u00a7522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ],
@@ -53494,7 +53609,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53505,7 +53620,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53516,7 +53631,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53592,7 +53707,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -53660,7 +53775,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 §522 / BS EN 61386",
+          "standard": "BS 7671 \u00c2\u00a7522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_FILL_RATIO, \"\")"
         }
       ],
@@ -53731,7 +53846,7 @@
           "param": "ELC_CBL_DEST_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "→",
+          "prefix_override": "\u00e2\u2020\u2019",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -54075,6 +54190,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -54083,7 +54208,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -54094,7 +54219,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -54105,7 +54230,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -54181,7 +54306,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -54249,7 +54374,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 §522 / BS EN 61386",
+          "standard": "BS 7671 \u00c2\u00a7522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_FILL_RATIO, \"\")"
         }
       ],
@@ -54280,7 +54405,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ELC_PNL_DESIGNATION_NAME_TXT",
@@ -54363,7 +54488,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "Feeder: ",
-          "suffix_override": " mm²",
+          "suffix_override": " mm\u00c2\u00b2",
           "note": "Feeder cable"
         },
         {
@@ -54499,54 +54624,54 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ELC_TAG_7_PARA_PANEL_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive, no technical codes"
         },
         {
           "param": "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_SHORT_CIRCUIT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_SHORT_CIRCUIT, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_SPARE_WAYS",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_SPARE_WAYS, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_SCHEDULE_MISSING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_SCHEDULE_MISSING, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_LOAD_BALANCE",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_LOAD_BALANCE, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_FEEDER_UNDERSIZED",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_FEEDER_UNDERSIZED, \"\")"
         },
         {
@@ -54560,7 +54685,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -54780,7 +54905,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -55038,6 +55163,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -55046,7 +55181,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55057,7 +55192,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55068,7 +55203,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55144,7 +55279,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -55239,7 +55374,7 @@
           "threshold": "TN-S",
           "unit": "type",
           "description": "Earthing system type compliance",
-          "standard": "BS 7671 §411 / IEC 60364",
+          "standard": "BS 7671 \u00c2\u00a7411 / IEC 60364",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_EARTHING_TYPE, \"\")"
         },
         {
@@ -55576,6 +55711,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -55584,7 +55729,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55595,7 +55740,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55606,7 +55751,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55682,7 +55827,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -55759,7 +55904,7 @@
           "threshold": "1200",
           "unit": "mm",
           "description": "Fixture mounting height standard",
-          "standard": "BS 7671 §559 / Building Regs Part M",
+          "standard": "BS 7671 \u00c2\u00a7559 / Building Regs Part M",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_FIXTURE_MOUNTING_HEIGHT, \"\")"
         },
         {
@@ -55933,7 +56078,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55944,7 +56089,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55955,7 +56100,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56031,7 +56176,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -56521,6 +56666,16 @@
           "style": "NOM",
           "color": "GREEN",
           "size": "2.0"
+        },
+        {
+          "param": "CSI_SECTION_TXT",
+          "spaces": 0,
+          "break": true,
+          "prefix_override": "CSI ",
+          "note": "T5 CSI MasterFormat section (Phase H)",
+          "style": "NOM",
+          "color": "PURPLE",
+          "size": "2.0"
         }
       ],
       "tier_6": [
@@ -56529,7 +56684,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56540,7 +56695,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56551,7 +56706,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56627,7 +56782,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -57058,7 +57213,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57069,7 +57224,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57080,7 +57235,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57156,7 +57311,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -57520,7 +57675,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57531,7 +57686,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57542,7 +57697,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57618,7 +57773,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -57975,7 +58130,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57986,7 +58141,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57997,7 +58152,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58073,7 +58228,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -58439,7 +58594,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58450,7 +58605,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58461,7 +58616,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58537,7 +58692,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -58628,7 +58783,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -58750,13 +58905,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ICT_TAG_7_PARA_TEL_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -58769,7 +58924,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -58989,7 +59144,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -59255,7 +59410,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59266,7 +59421,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59277,7 +59432,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59353,7 +59508,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -59803,7 +59958,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59814,7 +59969,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59825,7 +59980,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59901,7 +60056,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -59992,7 +60147,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -60130,13 +60285,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ASS_TAG_7_PARA_EQUIPMENT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph — purely descriptive, no technical codes"
+          "note": "Natural language paragraph \u00e2\u20ac\u201d purely descriptive, no technical codes"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -60149,7 +60304,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -60369,7 +60524,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -60635,7 +60790,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60646,7 +60801,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60657,7 +60812,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60733,7 +60888,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -60809,7 +60964,7 @@
     "Specialty Equipment Asset": {
       "family_name": "STING - Specialty Equipment Tag Asset",
       "paragraph_container": "ASS_TAG_7_PARA_EQUIPMENT_TXT",
-      "paragraph_template": "Asset {asset_id} ({description}) — serial {serial}. Installed: {install_date}. Expected life: {life} yr. Maintenance frequency: {maint} months. Warranty: {warranty}. Criticality: {criticality}/5. Status: {status}.",
+      "paragraph_template": "Asset {asset_id} ({description}) \u00e2\u20ac\u201d serial {serial}. Installed: {install_date}. Expected life: {life} yr. Maintenance frequency: {maint} months. Warranty: {warranty}. Criticality: {criticality}/5. Status: {status}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -61136,7 +61291,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61147,7 +61302,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61158,7 +61313,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61234,7 +61389,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -61302,7 +61457,7 @@
           "data_type": "TEXT",
           "threshold": "Criticality rating > 3 without commissioning plan",
           "standard": "ISO 55000 / PAS 1192-3",
-          "description": "Asset criticality rating exceeds threshold — commissioning plan required",
+          "description": "Asset criticality rating exceeds threshold \u00e2\u20ac\u201d commissioning plan required",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_CRITICALITY_SPECIALTY_EQUIP, \"\")"
         },
         {
@@ -61320,7 +61475,7 @@
     "Specialty Equipment General": {
       "family_name": "STING - Specialty Equipment Tag General",
       "paragraph_container": "ASS_TAG_7_PARA_EQUIPMENT_TXT",
-      "paragraph_template": "{description} — function {func}, system {system}. Manufacturer: {mfr}, model {model}. Standard: {standard}. Status: {status}.",
+      "paragraph_template": "{description} \u00e2\u20ac\u201d function {func}, system {system}. Manufacturer: {mfr}, model {model}. Standard: {standard}. Status: {status}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -61624,7 +61779,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61635,7 +61790,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61646,7 +61801,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61722,7 +61877,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -61790,7 +61945,7 @@
           "data_type": "TEXT",
           "threshold": "ASS_SYSTEM_TYPE_TXT empty",
           "standard": "ISO 19650-2 / CIBSE",
-          "description": "System type not assigned — required for equipment register",
+          "description": "System type not assigned \u00e2\u20ac\u201d required for equipment register",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_GEN_SPEC_EQUIP_NO_SYS, \"\")"
         },
         {
@@ -61821,7 +61976,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -61933,7 +62088,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_DUCT_INSULATION_TXT",
@@ -61945,7 +62100,7 @@
           "param": "WARN_INS_THICKNESS_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_MM, \"\")"
         },
         {
@@ -61959,7 +62114,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -62179,7 +62334,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -62304,7 +62459,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62315,7 +62470,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62326,7 +62481,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62402,7 +62557,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -62491,7 +62646,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -62597,7 +62752,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_DUCT_LINING_TXT",
@@ -62609,7 +62764,7 @@
           "param": "WARN_INS_THICKNESS_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_MM, \"\")"
         },
         {
@@ -62623,7 +62778,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -62843,7 +62998,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -62968,7 +63123,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62979,7 +63134,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62990,7 +63145,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63066,7 +63221,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -63155,7 +63310,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -63267,7 +63422,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "PLM_TAG_7_PARA_PIPE_INSULATION_TXT",
@@ -63279,7 +63434,7 @@
           "param": "WARN_INS_THICKNESS_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_MM, \"\")"
         },
         {
@@ -63293,7 +63448,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -63513,7 +63668,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -63638,7 +63793,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63649,7 +63804,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63660,7 +63815,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63736,7 +63891,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -63825,7 +63980,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -63931,7 +64086,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "PLM_TAG_7_PARA_PLM_EQUIP_TXT",
@@ -63943,7 +64098,7 @@
           "param": "WARN_PLM_EQP_PRESSURE_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_EQP_PRESSURE_KPA, \"\")"
         },
         {
@@ -63957,7 +64112,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -64177,7 +64332,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -64443,7 +64598,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -64454,7 +64609,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -64465,7 +64620,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -64591,7 +64746,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -64707,7 +64862,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -64813,7 +64968,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT",
@@ -64832,7 +64987,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -65052,7 +65207,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -65177,7 +65332,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65188,7 +65343,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65199,7 +65354,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65275,7 +65430,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -65364,7 +65519,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -65470,7 +65625,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_MECH_EQUIP_SETS_TXT",
@@ -65489,7 +65644,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -65709,7 +65864,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -65834,7 +65989,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65845,7 +66000,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65856,7 +66011,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65932,7 +66087,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -66021,7 +66176,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -66127,7 +66282,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ELC_TAG_7_PARA_ELC_CONNECTORS_TXT",
@@ -66146,7 +66301,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -66366,7 +66521,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -66491,7 +66646,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66502,7 +66657,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66513,7 +66668,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66589,7 +66744,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -66678,7 +66833,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -66784,7 +66939,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "FLS_TAG_7_PARA_FIRE_PROT_TXT",
@@ -66796,7 +66951,7 @@
           "param": "WARN_FLS_PROT_COVERAGE",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_PROT_COVERAGE, \"\")"
         },
         {
@@ -66810,7 +66965,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -67030,7 +67185,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -67155,7 +67310,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67166,7 +67321,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67177,7 +67332,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67253,7 +67408,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -67319,7 +67474,7 @@
           "param": "WARN_FLS_PROT_COVERAGE",
           "severity": "CRITICAL",
           "threshold": "12.0",
-          "unit": "m²",
+          "unit": "m\u00c2\u00b2",
           "description": "Fire safety device coverage limit",
           "standard": "Building Regs Part B / BS 9999",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_PROT_COVERAGE, \"\")"
@@ -67342,7 +67497,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -67448,7 +67603,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ELC_TAG_7_PARA_FAB_CONTAINMENT_TXT",
@@ -67467,7 +67622,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -67687,7 +67842,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -67812,7 +67967,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67823,7 +67978,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67834,7 +67989,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67910,7 +68065,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -67978,7 +68133,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 §522 / BS EN 61386",
+          "standard": "BS 7671 \u00c2\u00a7522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ]
@@ -67999,7 +68154,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -68105,7 +68260,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_FAB_DUCTWORK_TXT",
@@ -68124,7 +68279,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -68344,7 +68499,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -68469,7 +68624,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68480,7 +68635,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68491,7 +68646,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68567,7 +68722,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -68656,7 +68811,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -68762,7 +68917,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_FAB_DCT_STIFFENERS_TXT",
@@ -68781,7 +68936,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -69001,7 +69156,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -69126,7 +69281,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69137,7 +69292,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69148,7 +69303,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69224,7 +69379,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -69313,7 +69468,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -69432,7 +69587,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "MEP_TAG_7_PARA_FAB_HANGERS_TXT",
@@ -69444,7 +69599,7 @@
           "param": "WARN_FAB_HANGER_LOAD_KN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning \u00e2\u20ac\u201d visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FAB_HANGER_LOAD_KN, \"\")"
         },
         {
@@ -69458,7 +69613,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -69678,7 +69833,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -69803,7 +69958,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69814,7 +69969,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69825,7 +69980,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69901,7 +70056,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -69990,7 +70145,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -70096,7 +70251,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "PLM_TAG_7_PARA_FAB_PIPEWORK_TXT",
@@ -70115,7 +70270,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -70335,7 +70490,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -70460,7 +70615,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70471,7 +70626,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70482,7 +70637,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70558,7 +70713,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -70647,7 +70802,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -70753,7 +70908,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "PROP_TAG_7_PARA_MATERIALS_TXT",
@@ -70772,7 +70927,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -70992,7 +71147,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -71117,7 +71272,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71128,7 +71283,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71139,7 +71294,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71215,7 +71370,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -71281,7 +71436,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCO₂e/m²",
+          "unit": "kgCO\u00e2\u201a\u201ae/m\u00c2\u00b2",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -71304,7 +71459,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -71410,7 +71565,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ICT_TAG_7_PARA_AV_DEV_TXT",
@@ -71429,7 +71584,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -71649,7 +71804,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -71774,7 +71929,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71785,7 +71940,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71796,7 +71951,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71872,7 +72027,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -71961,7 +72116,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -72067,7 +72222,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "MED_TAG_7_PARA_MED_EQUIP_TXT",
@@ -72086,7 +72241,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -72306,7 +72461,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -72431,7 +72586,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72442,7 +72597,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72453,7 +72608,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72529,7 +72684,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -72627,7 +72782,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -72733,7 +72888,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PROPERTY_LINE_SEGMENTS_TXT",
@@ -72752,7 +72907,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -72972,7 +73127,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -73097,7 +73252,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73108,7 +73263,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73119,7 +73274,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73195,7 +73350,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -73284,7 +73439,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) \u00e2\u20ac\u201d underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -73390,7 +73545,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading — bold underlined in family"
+          "note": "Short tag heading \u00e2\u20ac\u201d bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_TOPOSOLID_LINKS_TXT",
@@ -73409,7 +73564,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Uniformat description"
         },
         {
@@ -73629,7 +73784,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " — ",
+          "prefix_override": " \u00e2\u20ac\u201d ",
           "note": "Assembly description"
         },
         {
@@ -73754,7 +73909,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73765,7 +73920,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCO₂e",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73776,7 +73931,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCO₂e/yr",
+          "suffix_override": " kgCO\u00e2\u201a\u201ae/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73852,7 +74007,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -74060,7 +74215,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74070,7 +74225,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74080,7 +74235,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74149,7 +74304,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -74206,8 +74361,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_ARCH.csv"
     },
-    "Tie-In Point Tag (Pipe — Plumbing & Hydraulic)": {
-      "family_name": "STING - Tie-In Point Tag (Pipe — Plumbing & Hydraulic)",
+    "Tie-In Point Tag (Pipe \u00e2\u20ac\u201d Plumbing & Hydraulic)": {
+      "family_name": "STING - Tie-In Point Tag (Pipe \u00e2\u20ac\u201d Plumbing & Hydraulic)",
       "paragraph_container": "PLM_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -74425,7 +74580,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74435,7 +74590,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74445,7 +74600,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74514,7 +74669,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -74571,8 +74726,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Duct — HVAC)": {
-      "family_name": "STING - Tie-In Point Tag (Duct — HVAC)",
+    "Tie-In Point Tag (Duct \u00e2\u20ac\u201d HVAC)": {
+      "family_name": "STING - Tie-In Point Tag (Duct \u00e2\u20ac\u201d HVAC)",
       "paragraph_container": "HVC_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -74789,7 +74944,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74799,7 +74954,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74809,7 +74964,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74878,7 +75033,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -74935,8 +75090,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Conduit — Electrical LV/ELV)": {
-      "family_name": "STING - Tie-In Point Tag (Conduit — Electrical LV/ELV)",
+    "Tie-In Point Tag (Conduit \u00e2\u20ac\u201d Electrical LV/ELV)": {
+      "family_name": "STING - Tie-In Point Tag (Conduit \u00e2\u20ac\u201d Electrical LV/ELV)",
       "paragraph_container": "ELC_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -74951,7 +75106,7 @@
           "param": "ELC_CDT_SZ_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "∅",
+          "prefix_override": "\u00e2\u02c6\u2026",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.5"
@@ -75126,7 +75281,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75136,7 +75291,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75146,7 +75301,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75215,7 +75370,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -75272,8 +75427,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Cable Tray — Electrical)": {
-      "family_name": "STING - Tie-In Point Tag (Cable Tray — Electrical)",
+    "Tie-In Point Tag (Cable Tray \u00e2\u20ac\u201d Electrical)": {
+      "family_name": "STING - Tie-In Point Tag (Cable Tray \u00e2\u20ac\u201d Electrical)",
       "paragraph_container": "ELC_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -75462,7 +75617,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75472,7 +75627,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75482,7 +75637,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75551,7 +75706,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -75608,8 +75763,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)": {
-      "family_name": "STING - Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)",
+    "Tie-In Point Tag (Fire Protection \u00e2\u20ac\u201d Sprinkler / Suppression)": {
+      "family_name": "STING - Tie-In Point Tag (Fire Protection \u00e2\u20ac\u201d Sprinkler / Suppression)",
       "paragraph_container": "FLS_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -75809,7 +75964,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75819,7 +75974,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75829,7 +75984,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75898,7 +76053,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -75955,8 +76110,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)": {
-      "family_name": "STING - Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)",
+    "Tie-In Point Tag (Gas \u00e2\u20ac\u201d Medical / Industrial / Natural Gas)": {
+      "family_name": "STING - Tie-In Point Tag (Gas \u00e2\u20ac\u201d Medical / Industrial / Natural Gas)",
       "paragraph_container": "PLM_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -76164,7 +76319,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76174,7 +76329,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76184,7 +76339,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76253,7 +76408,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -76445,7 +76600,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76455,7 +76610,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76465,7 +76620,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76534,7 +76689,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -76616,7 +76771,7 @@
           "param": "SLV_SZ_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Ø",
+          "prefix_override": "\u00c3\u02dc",
           "suffix_override": "mm",
           "style": "NOM",
           "color": "BLACK",
@@ -76769,7 +76924,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76779,7 +76934,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76789,7 +76944,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76858,7 +77013,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -76991,7 +77146,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection air terminal — LPS class {class}, zone {zone}. Compliant with BS EN 62305-3 §5.2."
+      "paragraph_template": "Lightning protection air terminal \u00e2\u20ac\u201d LPS class {class}, zone {zone}. Compliant with BS EN 62305-3 \u00c2\u00a75.2."
     },
     "LPS Down Conductor": {
       "family_name": "STING - LPS Down Conductor Tag",
@@ -77060,7 +77215,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection down conductor — LPS class {class}. Compliant with BS EN 62305-3 §5.3."
+      "paragraph_template": "Lightning protection down conductor \u00e2\u20ac\u201d LPS class {class}. Compliant with BS EN 62305-3 \u00c2\u00a75.3."
     },
     "LPS Earth Electrode": {
       "family_name": "STING - LPS Earth Electrode Tag",
@@ -77129,7 +77284,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection earth electrode — LPS class {class}. Compliant with BS EN 62305-3 §5.4."
+      "paragraph_template": "Lightning protection earth electrode \u00e2\u20ac\u201d LPS class {class}. Compliant with BS EN 62305-3 \u00c2\u00a75.4."
     },
     "LPS Bond": {
       "family_name": "STING - LPS Bond Tag",
@@ -77405,7 +77560,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection earth — structural foundation reuse. Compliant with BS EN 62305-3."
+      "paragraph_template": "Lightning protection earth \u00e2\u20ac\u201d structural foundation reuse. Compliant with BS EN 62305-3."
     },
     "LPS Natural Air Termination (Architectural Reuse)": {
       "family_name": "STING - LPS Natural Air Termination (Architectural Reuse) Tag",
@@ -77474,7 +77629,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection air termination — architectural element reuse (roof / parapet / fascia). Compliant with BS EN 62305-3 §5.2."
+      "paragraph_template": "Lightning protection air termination \u00e2\u20ac\u201d architectural element reuse (roof / parapet / fascia). Compliant with BS EN 62305-3 \u00c2\u00a75.2."
     },
     "LPS Generic Component": {
       "family_name": "STING - LPS Generic Component Tag",
@@ -77751,7 +77906,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -77761,7 +77916,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -77771,7 +77926,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -77840,7 +77995,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -78032,7 +78187,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78042,7 +78197,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78052,7 +78207,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78121,7 +78276,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -78331,7 +78486,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78341,7 +78496,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCO₂e",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78351,7 +78506,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCO₂e/yr",
+          "suffix_override": "kgCO\u00e2\u201a\u201ae/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78420,7 +78575,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Δ:",
+          "prefix_override": "\u00ce\u201d:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -78523,7 +78678,7 @@
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0",
-          "prefix_override": "ΔP:"
+          "prefix_override": "\u00ce\u201dP:"
         },
         {
           "param": "RGL_STD_TXT",
@@ -78679,7 +78834,7 @@
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0",
-          "prefix_override": "ΔP:"
+          "prefix_override": "\u00ce\u201dP:"
         },
         {
           "param": "RGL_STD_TXT",
@@ -79343,7 +79498,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "X-ray shielded door — lead equivalent {Pb} mm (NCRP 147). Compliant with {standard}."
+      "paragraph_template": "X-ray shielded door \u00e2\u20ac\u201d lead equivalent {Pb} mm (NCRP 147). Compliant with {standard}."
     },
     "X-ray Window": {
       "family_name": "STING - X-ray Window Tag",
@@ -79413,7 +79568,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "X-ray shielded viewing window — lead equivalent {Pb} mm (NCRP 147)."
+      "paragraph_template": "X-ray shielded viewing window \u00e2\u20ac\u201d lead equivalent {Pb} mm (NCRP 147)."
     },
     "X-ray Barrier": {
       "family_name": "STING - X-ray Barrier Tag",
@@ -79492,7 +79647,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "X-ray protective barrier wall — {Pb} mm lead equivalent, type {type}. Compliant with NCRP 147."
+      "paragraph_template": "X-ray protective barrier wall \u00e2\u20ac\u201d {Pb} mm lead equivalent, type {type}. Compliant with NCRP 147."
     },
     "MRI Faraday Cage": {
       "family_name": "STING - MRI Faraday Cage Tag",
@@ -79561,7 +79716,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "MRI Faraday cage wall — RF shield for zone {zone}. Compliant with MHRA DB2007(03)."
+      "paragraph_template": "MRI Faraday cage wall \u00e2\u20ac\u201d RF shield for zone {zone}. Compliant with MHRA DB2007(03)."
     },
     "Linac Maze": {
       "family_name": "STING - Linac Maze Tag",
@@ -79640,7 +79795,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Linear accelerator maze wall — {type} construction, {Pb} mm lead equivalent. Compliant with NCRP 151."
+      "paragraph_template": "Linear accelerator maze wall \u00e2\u20ac\u201d {type} construction, {Pb} mm lead equivalent. Compliant with NCRP 151."
     },
     "Anti-Ligature (Lighting Fixture)": {
       "family_name": "STING - Anti-Ligature (Lighting Fixture) Tag",
@@ -82214,7 +82369,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Hyperbaric oxygen chamber. Compliant with NFPA 99 §14."
+      "paragraph_template": "Hyperbaric oxygen chamber. Compliant with NFPA 99 \u00c2\u00a714."
     },
     "IVF Workstation": {
       "family_name": "STING - IVF Workstation Tag",
@@ -82607,7 +82762,7 @@
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0",
-          "suffix_override": "W/m²K"
+          "suffix_override": "W/m\u00c2\u00b2K"
         },
         {
           "param": "RGL_STD_TXT",
@@ -82637,7 +82792,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Curtain wall panel — {thickness} mm, U-value {U-value} W/m²K. Compliant with {standard}."
+      "paragraph_template": "Curtain wall panel \u00e2\u20ac\u201d {thickness} mm, U-value {U-value} W/m\u00c2\u00b2K. Compliant with {standard}."
     },
     "Curtain Wall Mullion": {
       "family_name": "STING - Curtain Wall Mullion Tag",
@@ -83076,7 +83231,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Fire protection pipe tie-in point — DN{DN}."
+      "paragraph_template": "Fire protection pipe tie-in point \u00e2\u20ac\u201d DN{DN}."
     },
     "Tie-In Gas Pipe": {
       "family_name": "STING - Tie-In Gas Pipe Tag",
@@ -83154,7 +83309,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Gas pipe tie-in point — {gas}, DN{DN}."
+      "paragraph_template": "Gas pipe tie-in point \u00e2\u20ac\u201d {gas}, DN{DN}."
     }
   },
   "tag7_heading_style": {
@@ -83164,14 +83319,14 @@
       "bold": false,
       "italic": false,
       "underline": true,
-      "note": "Underlined in State 2 (Technical) — functional emphasis without visual dominance"
+      "note": "Underlined in State 2 (Technical) \u00e2\u20ac\u201d functional emphasis without visual dominance"
     },
     "tier_3_heading": {
       "param": "ASS_TAG_2_TXT",
       "bold": true,
       "italic": false,
       "underline": true,
-      "note": "Bold + Underlined in State 3 (Full Specification) — primary heading treatment"
+      "note": "Bold + Underlined in State 3 (Full Specification) \u00e2\u20ac\u201d primary heading treatment"
     },
     "batch_control": {
       "description": "Use the Set TAG7 Heading Style command to batch-update the heading format across all tag families. Supported styles: bold, italic, underline, bold+underline, bold+italic, all.",
@@ -83207,7 +83362,7 @@
       "TAG_WARN_SEVERITY_FILTER_TXT"
     ],
     "text_style_matrix": {
-      "_comment": "128 combinations — 4 sizes x 4 styles x 8 colors. Exactly one BOOL set to Yes per element type.",
+      "_comment": "128 combinations \u00e2\u20ac\u201d 4 sizes x 4 styles x 8 colors. Exactly one BOOL set to Yes per element type.",
       "sizes": [
         "2",
         "2.5",

--- a/StingTools/Data/STING_AEC_FILTERS.json
+++ b/StingTools/Data/STING_AEC_FILTERS.json
@@ -2244,12 +2244,14 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "LTHW-F"
+        "value": "LTHWF"
       },
       "override": {
-        "projColor": "#FF3232",
-        "cutColor": "#FF3232",
-        "cutWeight": 4
+        "projColor": "#FF7800",
+        "cutColor": "#FF7800",
+        "cutWeight": 4,
+        "surfFgColor": "#FF7800",
+        "surfFgPattern": "Solid fill"
       },
       "tags": [
         "mech",
@@ -2271,12 +2273,14 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "LTHW-R"
+        "value": "LTHWR"
       },
       "override": {
-        "projColor": "#A01E1E",
-        "cutColor": "#A01E1E",
-        "cutWeight": 4
+        "projColor": "#FFAF5A",
+        "cutColor": "#FFAF5A",
+        "cutWeight": 4,
+        "surfFgColor": "#FFAF5A",
+        "surfFgPattern": "Solid fill"
       },
       "tags": [
         "mech",
@@ -2348,12 +2352,14 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "CHW-F"
+        "value": "CHWF"
       },
       "override": {
-        "projColor": "#0000FF",
-        "cutColor": "#0000FF",
-        "cutWeight": 4
+        "projColor": "#002060",
+        "cutColor": "#002060",
+        "cutWeight": 4,
+        "surfFgColor": "#002060",
+        "surfFgPattern": "Solid fill"
       },
       "tags": [
         "mech",
@@ -2375,12 +2381,14 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "CHW-R"
+        "value": "CHWR"
       },
       "override": {
-        "projColor": "#000096",
-        "cutColor": "#000096",
-        "cutWeight": 4
+        "projColor": "#0070C0",
+        "cutColor": "#0070C0",
+        "cutWeight": 4,
+        "surfFgColor": "#0070C0",
+        "surfFgPattern": "Solid fill"
       },
       "tags": [
         "mech",
@@ -2401,12 +2409,14 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "CW-F"
+        "value": "CWF"
       },
       "override": {
-        "projColor": "#0064C8",
-        "cutColor": "#0064C8",
-        "cutWeight": 4
+        "projColor": "#008080",
+        "cutColor": "#008080",
+        "cutWeight": 4,
+        "surfFgColor": "#008080",
+        "surfFgPattern": "Solid fill"
       },
       "tags": [
         "mech",
@@ -2426,12 +2436,14 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "CW-R"
+        "value": "CWR"
       },
       "override": {
-        "projColor": "#003C82",
-        "cutColor": "#003C82",
-        "cutWeight": 4
+        "projColor": "#40A0A0",
+        "cutColor": "#40A0A0",
+        "cutWeight": 4,
+        "surfFgColor": "#40A0A0",
+        "surfFgPattern": "Solid fill"
       },
       "tags": [
         "mech",

--- a/StingTools/Data/STING_VIEW_STYLE_PACKS.json
+++ b/StingTools/Data/STING_VIEW_STYLE_PACKS.json
@@ -604,6 +604,54 @@
           "projWeight": 4,
           "surfFgColor": "#999900",
           "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: Chilled Water Flow",
+          "visible": true,
+          "projColor": "#002060",
+          "projWeight": 4,
+          "surfFgColor": "#002060",
+          "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: Chilled Water Return",
+          "visible": true,
+          "projColor": "#0070C0",
+          "projWeight": 4,
+          "surfFgColor": "#0070C0",
+          "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: LTHW Flow",
+          "visible": true,
+          "projColor": "#FF7800",
+          "projWeight": 4,
+          "surfFgColor": "#FF7800",
+          "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: LTHW Return",
+          "visible": true,
+          "projColor": "#FFAF5A",
+          "projWeight": 4,
+          "surfFgColor": "#FFAF5A",
+          "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: Condenser Water Flow",
+          "visible": true,
+          "projColor": "#008080",
+          "projWeight": 4,
+          "surfFgColor": "#008080",
+          "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: Condenser Water Return",
+          "visible": true,
+          "projColor": "#40A0A0",
+          "projWeight": 4,
+          "surfFgColor": "#40A0A0",
+          "transparency": 15
         }
       ]
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,35 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase H: abbreviation-format unification + CSI tag label)
+
+The two Phase G follow-ups. **Built + verified with `dotnet build` against the Revit
+2025 API (0 warnings, 0 errors)**; JSON validated.
+
+**1. Abbreviation-format unification.** The corporate per-service hydronic filters keyed
+on `RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM = "CHW-F"` (dashed), but the STING system types
+stamp Revit's System Abbreviation as `"CHWF"` (no dash — the format Phase B's `<abbr>-NN`
+naming requires, since the name parser splits on `-`). So the corporate filters never matched
+STING-built hydronic systems. Fix: changed the six per-service filter rule values to the
+no-dash form (`CHW-F → CHWF`, `LTHW-F → LTHWF`, `CW-F → CWF`, + returns) and reconciled their
+colours to the system-type colours (CHW navy, LTHW orange, CW teal). One canonical abbreviation
+now flows everywhere: system-type `Abbreviation` = the value Revit stamps = the filter rule =
+the `MEP_SYS_NAME` prefix. Added the six to `corp-coordination` (now **12 MEP filters** — air
++ water by classification, hydronic by service), so the drawing-type pipeline colours CHW vs
+LTHW vs CW distinctly without the extra Apply step.
+
+**2. CSI on tags.** `TagConfig.Tag7.cs` Section F (the classification narrative) now includes
+the CSI MasterFormat section + title (`CSI section 23 31 00 (HVAC Ducts and Casings)`) alongside
+Uniformat / OmniClass / keynote — so CSI surfaces on the rich TAG7 tag. `LABEL_DEFINITIONS.json`
+gains a `CSI_SECTION_TXT` render entry (`parameter_text`) + a `tier_5` (spec/procurement) CSI
+label row on the 15 representative MEP categories (Pipes, Ducts, fittings, equipment, fixtures,
+trays, conduits, sprinklers), so the dedicated tag families show CSI too. Completes the
+classification → keynote → tag chain from Phase G.
+
+**Still honest**: the `tier_5` CSI label is on the 15 core MEP categories, not all 138 — the
+full rollout + tag-family regeneration is a bulk data follow-up; the TAG7 narrative path covers
+every category already.
+
 #### Completed (MEP Systems — Phase G: VG/colour reconciliation + classification selectability + CSI↔keynote)
 
 Closes the three gaps from the alignment review. **Built + verified with `dotnet build`


### PR DESCRIPTION
## What & why

**Phase H of 8** (stacked on #365) — the two follow-ups flagged in Phase G.

### 1. Abbreviation-format unification
The corporate per-service hydronic filters keyed on `RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM = "CHW-F"` (dashed), but the STING system types stamp Revit's System Abbreviation as `"CHWF"` (no dash — required because Phase B's `<abbr>-NN` naming splits on `-`). So the corporate filters **never matched** STING-built hydronic systems. Fix: changed the six per-service rule values to the no-dash form (`CHW-F → CHWF`, `LTHW-F → LTHWF`, `CW-F → CWF`, + returns), reconciled their colours to the system-type colours, and added them to `corp-coordination` (**now 12 MEP filters** — air+water by classification, hydronic by service). One canonical abbreviation now flows everywhere: system-type `Abbreviation` = the value Revit stamps = the filter rule = the `MEP_SYS_NAME` prefix. CHW vs LTHW vs CW now colour distinctly in the drawing-type pipeline (no extra Apply step).

### 2. CSI on tags
`TagConfig.Tag7` Section F (the classification narrative) now includes the CSI MasterFormat section + title (`CSI section 23 31 00 (HVAC Ducts and Casings)`) alongside Uniformat/OmniClass/keynote — so CSI surfaces on the rich TAG7 tag for **every** category. `LABEL_DEFINITIONS.json` adds a `CSI_SECTION_TXT` render entry + a `tier_5` CSI label on the **15 core MEP categories** so the dedicated tag families show it too. Completes the classification → keynote → tag chain.

## Verification
`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors**; both edited JSON files validated.

## Honest scope
The `tier_5` CSI label is on the 15 core MEP categories, not all 138 — the full rollout + tag-family regeneration is a bulk data follow-up. The TAG7 narrative path already covers every category.

## Stacking
A (#359) → … → G (#365) → **H** (this). Base `claude/mep-systems-phase-g`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)