### PR TITLE
MEP Systems — Phase I: cross-check hardening fixes

### DIFF
--- a/StingTools/Commands/Mep/MepSystemFilterCommands.cs
+++ b/StingTools/Commands/Mep/MepSystemFilterCommands.cs
@@ -128,7 +128,11 @@ namespace StingTools.Commands.Mep
             foreach (var d in defs) byId[d.Id] = d;
             lib.Filters = byId.Values.ToList();
 
-            File.WriteAllText(path, JsonConvert.SerializeObject(lib, Formatting.Indented));
+            // Atomic write — a crash mid-write must not corrupt the project filter override.
+            string tmp = path + ".tmp";
+            File.WriteAllText(tmp, JsonConvert.SerializeObject(lib, Formatting.Indented));
+            if (File.Exists(path)) File.Delete(path);
+            File.Move(tmp, path);
             return defs.Count;
         }
     }

--- a/StingTools/Core/Classification/ClassificationStandard.cs
+++ b/StingTools/Core/Classification/ClassificationStandard.cs
@@ -29,16 +29,16 @@ namespace StingTools.Core.Classification
 
         /// <summary>Active standard for the document (cached). Defaults to Uniclass.</summary>
         public static ClassStandard Active(Document doc)
-        {
-            string key = doc?.PathName ?? "<no-doc>";
-            return _cache.GetOrAdd(key, _ => Load(doc));
-        }
+            => _cache.GetOrAdd(DocKey(doc), _ => Load(doc));
 
         public static void Reload() => _cache.Clear();
         public static void Reload(Document doc)
         {
-            if (doc != null) _cache.TryRemove(doc.PathName ?? "<no-doc>", out _);
+            if (doc != null) _cache.TryRemove(DocKey(doc), out _);
         }
+
+        private static string DocKey(Document doc)
+            => !string.IsNullOrEmpty(doc?.PathName) ? doc.PathName : $"<unsaved:{doc?.GetHashCode() ?? 0}>";
 
         /// <summary>Persist the choice to the project config file. Returns the path written.</summary>
         public static string Set(Document doc, ClassStandard std)
@@ -49,7 +49,11 @@ namespace StingTools.Core.Classification
             Directory.CreateDirectory(dir);
             string path = Path.Combine(dir, "sting_classification.json");
             var j = new JObject { ["standard"] = std.ToString(), ["_note"] = "STING classification standard (Phase G). Values: Uniclass | CSI | OmniClass | Native." };
-            File.WriteAllText(path, j.ToString());
+            // Atomic write — a crash mid-write must not leave a corrupt config.
+            string tmp = path + ".tmp";
+            File.WriteAllText(tmp, j.ToString());
+            if (File.Exists(path)) File.Delete(path);
+            File.Move(tmp, path);
             _cache[doc.PathName] = std;
             return path;
         }

--- a/StingTools/Core/Mep/MepCircuitBuilder.cs
+++ b/StingTools/Core/Mep/MepCircuitBuilder.cs
@@ -142,7 +142,7 @@ namespace StingTools.Core.Mep
             var r = new CircuitGroupResult();
             if (doc == null) { r.Warnings.Add("No document."); return r; }
             if (maxPerCircuit < 1) maxPerCircuit = 8;
-            double maxFt = (maxDistM <= 0 ? 30.0 : maxDistM) / 0.3048;
+            double maxFt = (maxDistM <= 0 ? 30.0 : maxDistM) / 0.3048; // metres → Revit internal feet (1 ft = 0.3048 m)
 
             var panels = new FilteredElementCollector(doc)
                 .OfCategory(BuiltInCategory.OST_ElectricalEquipment)

--- a/StingTools/Core/Mep/MepCoordinationEngine.cs
+++ b/StingTools/Core/Mep/MepCoordinationEngine.cs
@@ -80,6 +80,17 @@ namespace StingTools.Core.Mep
             var byKey = new Dictionary<string, PresentSystem>(StringComparer.OrdinalIgnoreCase);
             if (doc == null) return new List<PresentSystem>();
 
+            // Pre-build a system-type-id → classification map once (PERF — avoids a
+            // doc.GetElement(typeId) per duct/pipe on large models). MEPSystemType is
+            // abstract, so collect the two concrete subclasses.
+            var clsByType = new Dictionary<ElementId, string>();
+            foreach (var t in new FilteredElementCollector(doc).OfClass(typeof(Autodesk.Revit.DB.Mechanical.MechanicalSystemType))
+                         .Cast<MEPSystemType>())
+                try { clsByType[t.Id] = t.SystemClassification.ToString(); } catch { }
+            foreach (var t in new FilteredElementCollector(doc).OfClass(typeof(Autodesk.Revit.DB.Plumbing.PipingSystemType))
+                         .Cast<MEPSystemType>())
+                try { clsByType[t.Id] = t.SystemClassification.ToString(); } catch { }
+
             var collector = new FilteredElementCollector(doc)
                 .WherePasses(new ElementMulticategoryFilter(new[]
                 {
@@ -94,7 +105,7 @@ namespace StingTools.Core.Mep
                 {
                     string display = el.get_Parameter(BuiltInParameter.RBS_SYSTEM_CLASSIFICATION_PARAM)?.AsValueString()?.Trim() ?? "";
                     string abbr = AbbrevFromSysName(el.LookupParameter(MepSystemFilterGenerator.SysNameParam)?.AsString());
-                    string enumCls = EnumClassification(doc, el);
+                    string enumCls = EnumClassification(el, clsByType);
                     if (string.IsNullOrEmpty(display) && string.IsNullOrEmpty(abbr)) continue;
 
                     var ps = new PresentSystem
@@ -244,14 +255,13 @@ namespace StingTools.Core.Mep
             return dash > 0 ? sysName.Substring(0, dash).Trim() : "";
         }
 
-        private static string EnumClassification(Document doc, Element el)
+        private static string EnumClassification(Element el, Dictionary<ElementId, string> clsByType)
         {
             try
             {
                 var sys = (el as MEPCurve)?.MEPSystem;
                 if (sys == null) return "";
-                var t = doc.GetElement(sys.GetTypeId()) as MEPSystemType;
-                return t?.SystemClassification.ToString() ?? "";
+                return clsByType.TryGetValue(sys.GetTypeId(), out var cls) ? cls : "";
             }
             catch { return ""; }
         }

--- a/StingTools/Core/Mep/MepLevelViewProducer.cs
+++ b/StingTools/Core/Mep/MepLevelViewProducer.cs
@@ -88,13 +88,23 @@ namespace StingTools.Core.Mep
                     var row = new MepLevelViewRow { Level = lvl.Name, Discipline = disc.Label };
                     result.Rows.Add(row);
 
+                    // Idempotent: if this level×discipline coordination view already
+                    // exists (prior run), skip it — don't proliferate "(2)" views + sheets.
+                    string canonicalName = $"{lvl.Name} - {disc.Label} Coordination";
+                    if (existingViewNames.Contains(canonicalName))
+                    {
+                        row.ViewName = canonicalName;
+                        row.Note = "exists — skipped (re-run safe)";
+                        continue;
+                    }
+
                     try
                     {
                         var v = ViewPlan.Create(doc, vft.Id, lvl.Id);
                         if (v == null) { row.Note = "ViewPlan.Create returned null"; continue; }
                         try { v.Discipline = disc.ViewDisc; } catch { }
 
-                        v.Name = Unique(existingViewNames, $"{lvl.Name} - {disc.Label} Coordination");
+                        v.Name = Unique(existingViewNames, canonicalName);
                         existingViewNames.Add(v.Name);
                         row.ViewName = v.Name;
                         row.ViewCreated = true;
@@ -273,7 +283,11 @@ namespace StingTools.Core.Mep
             var up = n.ToUpperInvariant();
             if (up.Contains("GROUND")) return "GF";
             if (up.Contains("ROOF")) return "RF";
-            if (up.Contains("BASEMENT")) return "B1";
+            if (up.Contains("BASEMENT"))
+            {
+                var bd = new string(n.Where(char.IsDigit).ToArray());
+                return string.IsNullOrEmpty(bd) ? "B1" : "B" + bd; // Sub-Basement 2 -> B2, not B1
+            }
             var digits = new string(n.Where(char.IsDigit).ToArray());
             if (!string.IsNullOrEmpty(digits)) return "L" + digits;
             return n.Length <= 4 ? n.Replace(" ", "") : n.Substring(0, 4);

--- a/StingTools/Core/Mep/MepSystemInstanceBuilder.cs
+++ b/StingTools/Core/Mep/MepSystemInstanceBuilder.cs
@@ -144,9 +144,16 @@ namespace StingTools.Core.Mep
             result.Rows.Add(row);
 
             // Existing MEPSystem? Any member MEPCurve that already belongs to one.
-            MEPSystem existing = els.OfType<MEPCurve>()
+            // A fragmented network can carry more than one — retype/rename the first
+            // (canonical) and warn so the user can merge the rest in the System Browser.
+            var memberSystems = els.OfType<MEPCurve>()
                 .Select(c => { try { return c.MEPSystem; } catch { return null; } })
-                .FirstOrDefault(s => s != null);
+                .Where(s => s != null)
+                .GroupBy(s => s.Id).Select(g => g.First()).ToList();
+            MEPSystem existing = memberSystems.FirstOrDefault();
+            if (memberSystems.Count > 1)
+                result.Warnings.Add($"{row.Network}: network spans {memberSystems.Count} MEP systems — " +
+                                    "only the first was typed/named; merge the rest in the System Browser.");
 
             MEPSystem system = existing;
             bool created = false;
@@ -389,7 +396,7 @@ namespace StingTools.Core.Mep
         private static Dictionary<string, int> SeedNameSeq(Document doc)
         {
             var seq = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            var rx = new Regex(@"^([A-Za-z]+)-(\d+)$");
+            var rx = new Regex(@"^([A-Za-z0-9]+)-(\d+)$"); // allow digit-bearing abbreviations (DCW2, CO2, R410A)
             void Scan<T>() where T : Element
             {
                 foreach (var s in new FilteredElementCollector(doc).OfClass(typeof(T)).Cast<T>())

--- a/StingTools/Core/Mep/MepSystemTypeMaterializer.cs
+++ b/StingTools/Core/Mep/MepSystemTypeMaterializer.cs
@@ -120,7 +120,11 @@ namespace StingTools.Core.Mep
                     bool stampGraphics = created || overwriteGraphics;
                     int applied = ApplyGraphics(doc, st, def, stampGraphics, result.Warnings);
 
-                    row.Action = created ? MepTypeAction.Created : MepTypeAction.Updated;
+                    // Untouched existing types report as Skipped (not Updated) so the
+                    // counter reflects reality — "updated" only when graphics were re-applied.
+                    row.Action = created ? MepTypeAction.Created
+                               : stampGraphics ? MepTypeAction.Updated
+                               : MepTypeAction.Skipped;
                     row.Note = created
                         ? $"created ({applied} graphic prop(s) set)"
                         : (stampGraphics ? $"updated ({applied} graphic prop(s) re-applied)"

--- a/StingTools/Core/Mep/MepSystemTypeRegistry.cs
+++ b/StingTools/Core/Mep/MepSystemTypeRegistry.cs
@@ -85,7 +85,7 @@ namespace StingTools.Core.Mep
         /// <summary>Resolve the active definitions for a Revit document (cached by project file path).</summary>
         public static MepSystemTypeRules Get(Document doc)
         {
-            string key = doc?.PathName ?? "<no-doc>";
+            string key = !string.IsNullOrEmpty(doc?.PathName) ? doc.PathName : $"<unsaved:{doc?.GetHashCode() ?? 0}>";
             return _cache.GetOrAdd(key, _ => Load(doc));
         }
 
@@ -95,7 +95,7 @@ namespace StingTools.Core.Mep
         /// <summary>Force a reload for a single document (e.g. after Save As).</summary>
         public static void Reload(Document doc)
         {
-            string key = doc?.PathName ?? "<no-doc>";
+            string key = !string.IsNullOrEmpty(doc?.PathName) ? doc.PathName : $"<unsaved:{doc?.GetHashCode() ?? 0}>";
             _cache.TryRemove(key, out _);
         }
 
@@ -146,6 +146,9 @@ namespace StingTools.Core.Mep
                 def.Discipline    = (string)t["discipline"]     ?? def.Discipline;
                 def.Classification= (string)t["classification"] ?? def.Classification;
                 def.Abbreviation  = (string)t["abbreviation"]   ?? def.Abbreviation;
+                if (def.Abbreviation != null && def.Abbreviation.Contains('-'))
+                    StingLog.Warn($"MepSystemTypeRegistry: '{id}' abbreviation '{def.Abbreviation}' contains a dash — " +
+                                  "Phase D name parsing splits on '-', so use alphanumeric abbreviations only.");
                 def.StingSysCode  = (string)t["stingSysCode"]   ?? def.StingSysCode;
                 def.StingFuncCode = (string)t["stingFuncCode"]  ?? def.StingFuncCode;
                 def.LinePattern   = (string)t["linePattern"]    ?? def.LinePattern;

--- a/StingTools/Core/Mep/MepViewProducer.cs
+++ b/StingTools/Core/Mep/MepViewProducer.cs
@@ -85,6 +85,15 @@ namespace StingTools.Core.Mep
                 var row = new MepViewRow { Discipline = disc.Label };
                 result.Rows.Add(row);
 
+                // Idempotent: skip if this discipline's coordination view already exists.
+                string canonicalName = $"{source.Name} - {disc.Label} Coordination";
+                if (existingNames.Contains(canonicalName))
+                {
+                    row.ViewName = canonicalName;
+                    row.Note = "exists — skipped (re-run safe)";
+                    continue;
+                }
+
                 try
                 {
                     var dupId = source.Duplicate(ViewDuplicateOption.WithDetailing);
@@ -93,7 +102,7 @@ namespace StingTools.Core.Mep
 
                     try { v.Discipline = disc.ViewDisc; } catch (Exception ex) { result.Warnings.Add($"{disc.Code}: set discipline: {ex.Message}"); }
 
-                    string name = UniqueName(existingNames, $"{source.Name} - {disc.Label} Coordination");
+                    string name = UniqueName(existingNames, canonicalName);
                     try { v.Name = name; } catch (Exception ex) { result.Warnings.Add($"{disc.Code}: rename: {ex.Message}"); }
                     existingNames.Add(v.Name);
                     row.ViewName = v.Name;

--- a/StingTools/Data/STING_AEC_FILTERS.json
+++ b/StingTools/Data/STING_AEC_FILTERS.json
@@ -2301,7 +2301,7 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "MTHW-F"
+        "value": "MTHWF"
       },
       "override": {
         "projColor": "#C80000",
@@ -2326,7 +2326,7 @@
       "rule": {
         "param": "RBS_DUCT_PIPE_SYSTEM_ABBREVIATION_PARAM",
         "op": "equals",
-        "value": "MTHW-R"
+        "value": "MTHWR"
       },
       "override": {
         "projColor": "#780000",

--- a/StingTools/Data/STING_MEP_SYSTEM_TYPES.json
+++ b/StingTools/Data/STING_MEP_SYSTEM_TYPES.json
@@ -1,6 +1,6 @@
 {
   "_notes": [
-    "STING MEP System Types — corporate baseline (Phase A: System Type Materializer).",
+    "STING MEP System Types \u00e2\u20ac\u201d corporate baseline (Phase A: System Type Materializer).",
     "Single source of truth for the Revit MEP *system types* STING creates/maintains in a project:",
     "  duct systems  -> MechanicalSystemType.Create(doc, classification, name)",
     "  pipe systems  -> PipingSystemType.Create(doc, classification, name)",
@@ -9,7 +9,7 @@
     "Each entry carries the Revit system CLASSIFICATION (the enum the 19 MEP AEC filters in",
     "STING_AEC_FILTERS.json key off via RBS_SYSTEM_CLASSIFICATION_PARAM) PLUS the STING tag",
     "tokens (stingSysCode / stingFuncCode). Materializing these is what makes the existing",
-    "system-colour filters and the System Browser light up — the integration hook for the",
+    "system-colour filters and the System Browser light up \u00e2\u20ac\u201d the integration hook for the",
     "Drawing Types / View Style Packs / AEC Filters pipeline.",
     "",
     "Layered like every other STING registry:",
@@ -21,7 +21,7 @@
     "  name           the Revit system-type NAME to create/maintain (the System Browser label)",
     "  discipline     'duct' (MechanicalSystemType) | 'pipe' (PipingSystemType)",
     "  classification MEPSystemClassification enum name; unknown values are warned + skipped",
-    "  abbreviation   MEPSystemType.Abbreviation — the prefix Revit uses to auto-name systems",
+    "  abbreviation   MEPSystemType.Abbreviation \u00e2\u20ac\u201d the prefix Revit uses to auto-name systems",
     "  stingSysCode   STING SYS token (ties the type back to the ISO 19650 tag grammar)",
     "  stingFuncCode  STING FUNC token",
     "  lineColor      [r,g,b] -> MEPSystemType.LineColor graphic override (0..255)",
@@ -31,134 +31,405 @@
     "  uniclass/cibse reference only (documentation / BOQ calibration)",
     "  enabled        false to keep a definition on file without materializing it (default true)",
     "",
-    "Project teams extend / recolour by dropping a mep_system_types.json override — no recompile."
+    "Project teams extend / recolour by dropping a mep_system_types.json override \u00e2\u20ac\u201d no recompile."
   ],
-
   "systemTypes": [
     {
-      "id": "duct-supply-air", "name": "STING Supply Air", "discipline": "duct",
-      "classification": "SupplyAir", "abbreviation": "SA", "stingSysCode": "HVAC", "stingFuncCode": "SUP",
-      "lineColor": [0, 112, 192], "lineWeight": 5,
-      "uniclass": "Ss_55_30_36", "cibse": "CIBSE-HV01"
+      "id": "duct-supply-air",
+      "name": "STING Supply Air",
+      "discipline": "duct",
+      "classification": "SupplyAir",
+      "abbreviation": "SA",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "SUP",
+      "lineColor": [
+        0,
+        112,
+        192
+      ],
+      "lineWeight": 5,
+      "uniclass": "Ss_55_30_36",
+      "cibse": "CIBSE-HV01"
     },
     {
-      "id": "duct-return-air", "name": "STING Return Air", "discipline": "duct",
-      "classification": "ReturnAir", "abbreviation": "RA", "stingSysCode": "HVAC", "stingFuncCode": "RET",
-      "lineColor": [0, 176, 80], "lineWeight": 4,
-      "uniclass": "Ss_55_30_27", "cibse": "CIBSE-HV02"
+      "id": "duct-return-air",
+      "name": "STING Return Air",
+      "discipline": "duct",
+      "classification": "ReturnAir",
+      "abbreviation": "RA",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "RET",
+      "lineColor": [
+        0,
+        176,
+        80
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_27",
+      "cibse": "CIBSE-HV02"
     },
     {
-      "id": "duct-extract-air", "name": "STING Extract Air", "discipline": "duct",
-      "classification": "ExhaustAir", "abbreviation": "EA", "stingSysCode": "HVAC", "stingFuncCode": "EXT",
-      "lineColor": [255, 128, 0], "lineWeight": 4,
-      "uniclass": "Ss_55_30_27", "cibse": "CIBSE-HV02"
+      "id": "duct-extract-air",
+      "name": "STING Extract Air",
+      "discipline": "duct",
+      "classification": "ExhaustAir",
+      "abbreviation": "EA",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "EXT",
+      "lineColor": [
+        255,
+        128,
+        0
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_27",
+      "cibse": "CIBSE-HV02"
     },
     {
-      "id": "duct-fresh-air", "name": "STING Fresh Air", "discipline": "duct",
-      "classification": "SupplyAir", "abbreviation": "FA", "stingSysCode": "HVAC", "stingFuncCode": "SUP",
-      "lineColor": [0, 176, 240], "lineWeight": 4,
-      "uniclass": "Ss_55_30_36", "cibse": "CIBSE-HV03"
+      "id": "duct-fresh-air",
+      "name": "STING Fresh Air",
+      "discipline": "duct",
+      "classification": "SupplyAir",
+      "abbreviation": "FA",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "SUP",
+      "lineColor": [
+        0,
+        176,
+        240
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_36",
+      "cibse": "CIBSE-HV03"
     },
     {
-      "id": "duct-smoke-extract", "name": "STING Smoke Extract", "discipline": "duct",
-      "classification": "ExhaustAir", "abbreviation": "SMK", "stingSysCode": "HVAC", "stingFuncCode": "EXT",
-      "lineColor": [127, 0, 0], "lineWeight": 5,
-      "uniclass": "Ss_55_30_70", "cibse": "CIBSE-HV04"
-    },
-
-    {
-      "id": "pipe-lthw-flow", "name": "STING LTHW Flow", "discipline": "pipe",
-      "classification": "SupplyHydronic", "abbreviation": "LTHWF", "stingSysCode": "HVAC", "stingFuncCode": "HTG",
-      "lineColor": [255, 120, 0], "lineWeight": 4,
-      "uniclass": "Ss_55_30_10", "cibse": "CIBSE-HT01"
-    },
-    {
-      "id": "pipe-lthw-return", "name": "STING LTHW Return", "discipline": "pipe",
-      "classification": "ReturnHydronic", "abbreviation": "LTHWR", "stingSysCode": "HVAC", "stingFuncCode": "HTG",
-      "lineColor": [255, 175, 90], "lineWeight": 4, "linePattern": "Dash",
-      "uniclass": "Ss_55_30_10", "cibse": "CIBSE-HT01"
+      "id": "duct-smoke-extract",
+      "name": "STING Smoke Extract",
+      "discipline": "duct",
+      "classification": "ExhaustAir",
+      "abbreviation": "SMK",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "EXT",
+      "lineColor": [
+        127,
+        0,
+        0
+      ],
+      "lineWeight": 5,
+      "uniclass": "Ss_55_30_70",
+      "cibse": "CIBSE-HV04"
     },
     {
-      "id": "pipe-chw-flow", "name": "STING CHW Flow", "discipline": "pipe",
-      "classification": "SupplyHydronic", "abbreviation": "CHWF", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
-      "lineColor": [0, 32, 96], "lineWeight": 4,
-      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL01"
+      "id": "pipe-lthw-flow",
+      "name": "STING LTHW Flow",
+      "discipline": "pipe",
+      "classification": "SupplyHydronic",
+      "abbreviation": "LTHWF",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "HTG",
+      "lineColor": [
+        255,
+        120,
+        0
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_10",
+      "cibse": "CIBSE-HT01"
     },
     {
-      "id": "pipe-chw-return", "name": "STING CHW Return", "discipline": "pipe",
-      "classification": "ReturnHydronic", "abbreviation": "CHWR", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
-      "lineColor": [0, 112, 192], "lineWeight": 4, "linePattern": "Dash",
-      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL01"
+      "id": "pipe-lthw-return",
+      "name": "STING LTHW Return",
+      "discipline": "pipe",
+      "classification": "ReturnHydronic",
+      "abbreviation": "LTHWR",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "HTG",
+      "lineColor": [
+        255,
+        175,
+        90
+      ],
+      "lineWeight": 4,
+      "linePattern": "Dash",
+      "uniclass": "Ss_55_30_10",
+      "cibse": "CIBSE-HT01"
     },
     {
-      "id": "pipe-condenser-flow", "name": "STING Condenser Water Flow", "discipline": "pipe",
-      "classification": "SupplyHydronic", "abbreviation": "CWF", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
-      "lineColor": [0, 128, 128], "lineWeight": 4,
-      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL02"
+      "id": "pipe-chw-flow",
+      "name": "STING CHW Flow",
+      "discipline": "pipe",
+      "classification": "SupplyHydronic",
+      "abbreviation": "CHWF",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "CLG",
+      "lineColor": [
+        0,
+        32,
+        96
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_15",
+      "cibse": "CIBSE-CL01"
     },
     {
-      "id": "pipe-condenser-return", "name": "STING Condenser Water Return", "discipline": "pipe",
-      "classification": "ReturnHydronic", "abbreviation": "CWR", "stingSysCode": "HVAC", "stingFuncCode": "CLG",
-      "lineColor": [64, 160, 160], "lineWeight": 4, "linePattern": "Dash",
-      "uniclass": "Ss_55_30_15", "cibse": "CIBSE-CL02"
-    },
-
-    {
-      "id": "pipe-dcw", "name": "STING Domestic Cold Water", "discipline": "pipe",
-      "classification": "DomesticColdWater", "abbreviation": "DCW", "stingSysCode": "DCW", "stingFuncCode": "DCW",
-      "lineColor": [0, 176, 240], "lineWeight": 4,
-      "uniclass": "Ss_55_70_21", "cibse": "CIBSE-PH01"
-    },
-    {
-      "id": "pipe-dhw", "name": "STING Domestic Hot Water", "discipline": "pipe",
-      "classification": "DomesticHotWater", "abbreviation": "DHW", "stingSysCode": "DHW", "stingFuncCode": "DHW",
-      "lineColor": [255, 0, 0], "lineWeight": 4,
-      "uniclass": "Ss_55_40_25", "cibse": "CIBSE-PH02"
-    },
-    {
-      "id": "pipe-dhwr", "name": "STING DHW Circulation", "discipline": "pipe",
-      "classification": "DomesticHotWater", "abbreviation": "DHWR", "stingSysCode": "DHW", "stingFuncCode": "DHW",
-      "lineColor": [255, 128, 128], "lineWeight": 3, "linePattern": "Dash",
-      "uniclass": "Ss_55_40_25", "cibse": "CIBSE-PH02"
-    },
-
-    {
-      "id": "pipe-soil", "name": "STING Soil and Waste", "discipline": "pipe",
-      "classification": "Sanitary", "abbreviation": "SAN", "stingSysCode": "SAN", "stingFuncCode": "SAN",
-      "lineColor": [102, 51, 0], "lineWeight": 5,
-      "uniclass": "Ss_50_30_70", "cibse": "CIBSE-PH03"
+      "id": "pipe-chw-return",
+      "name": "STING CHW Return",
+      "discipline": "pipe",
+      "classification": "ReturnHydronic",
+      "abbreviation": "CHWR",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "CLG",
+      "lineColor": [
+        0,
+        112,
+        192
+      ],
+      "lineWeight": 4,
+      "linePattern": "Dash",
+      "uniclass": "Ss_55_30_15",
+      "cibse": "CIBSE-CL01"
     },
     {
-      "id": "pipe-vent", "name": "STING Soil Vent", "discipline": "pipe",
-      "classification": "Vent", "abbreviation": "SVP", "stingSysCode": "SAN", "stingFuncCode": "SAN",
-      "lineColor": [153, 153, 0], "lineWeight": 3,
-      "uniclass": "Ss_50_30_70", "cibse": "CIBSE-PH03"
+      "id": "pipe-condenser-flow",
+      "name": "STING Condenser Water Flow",
+      "discipline": "pipe",
+      "classification": "SupplyHydronic",
+      "abbreviation": "CWF",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "CLG",
+      "lineColor": [
+        0,
+        128,
+        128
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_15",
+      "cibse": "CIBSE-CL02"
     },
     {
-      "id": "pipe-rainwater", "name": "STING Rainwater", "discipline": "pipe",
-      "classification": "OtherPipe", "abbreviation": "RWD", "stingSysCode": "RWD", "stingFuncCode": "RWD",
-      "lineColor": [0, 153, 153], "lineWeight": 4,
-      "uniclass": "Ss_50_30_67", "cibse": "CIBSE-PH04"
+      "id": "pipe-condenser-return",
+      "name": "STING Condenser Water Return",
+      "discipline": "pipe",
+      "classification": "ReturnHydronic",
+      "abbreviation": "CWR",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "CLG",
+      "lineColor": [
+        64,
+        160,
+        160
+      ],
+      "lineWeight": 4,
+      "linePattern": "Dash",
+      "uniclass": "Ss_55_30_15",
+      "cibse": "CIBSE-CL02"
     },
-
     {
-      "id": "pipe-fire-wet", "name": "STING Sprinkler (Wet)", "discipline": "pipe",
-      "classification": "FireProtectWet", "abbreviation": "SPR", "stingSysCode": "FP", "stingFuncCode": "FP",
-      "lineColor": [192, 0, 0], "lineWeight": 5,
-      "uniclass": "Ss_55_70_30", "cibse": "CIBSE-FP01"
+      "id": "pipe-dcw",
+      "name": "STING Domestic Cold Water",
+      "discipline": "pipe",
+      "classification": "DomesticColdWater",
+      "abbreviation": "DCW",
+      "stingSysCode": "DCW",
+      "stingFuncCode": "DCW",
+      "lineColor": [
+        0,
+        176,
+        240
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_70_21",
+      "cibse": "CIBSE-PH01"
     },
     {
-      "id": "pipe-fire-dry", "name": "STING Sprinkler (Dry)", "discipline": "pipe",
-      "classification": "FireProtectDry", "abbreviation": "SPRD", "stingSysCode": "FP", "stingFuncCode": "FP",
-      "lineColor": [192, 80, 0], "lineWeight": 5, "linePattern": "Dash",
-      "uniclass": "Ss_55_70_30", "cibse": "CIBSE-FP01"
+      "id": "pipe-dhw",
+      "name": "STING Domestic Hot Water",
+      "discipline": "pipe",
+      "classification": "DomesticHotWater",
+      "abbreviation": "DHW",
+      "stingSysCode": "DHW",
+      "stingFuncCode": "DHW",
+      "lineColor": [
+        255,
+        0,
+        0
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_40_25",
+      "cibse": "CIBSE-PH02"
     },
-
     {
-      "id": "pipe-natural-gas", "name": "STING Natural Gas", "discipline": "pipe",
-      "classification": "OtherPipe", "abbreviation": "GAS", "stingSysCode": "GAS", "stingFuncCode": "GAS",
-      "lineColor": [255, 192, 0], "lineWeight": 4,
-      "uniclass": "Ss_55_70_38", "cibse": "CIBSE-GS01"
+      "id": "pipe-dhwr",
+      "name": "STING DHW Circulation",
+      "discipline": "pipe",
+      "classification": "DomesticHotWater",
+      "abbreviation": "DHWR",
+      "stingSysCode": "DHW",
+      "stingFuncCode": "DHW",
+      "lineColor": [
+        255,
+        128,
+        128
+      ],
+      "lineWeight": 3,
+      "linePattern": "Dash",
+      "uniclass": "Ss_55_40_25",
+      "cibse": "CIBSE-PH02"
+    },
+    {
+      "id": "pipe-soil",
+      "name": "STING Soil and Waste",
+      "discipline": "pipe",
+      "classification": "Sanitary",
+      "abbreviation": "SAN",
+      "stingSysCode": "SAN",
+      "stingFuncCode": "SAN",
+      "lineColor": [
+        102,
+        51,
+        0
+      ],
+      "lineWeight": 5,
+      "uniclass": "Ss_50_30_70",
+      "cibse": "CIBSE-PH03"
+    },
+    {
+      "id": "pipe-vent",
+      "name": "STING Soil Vent",
+      "discipline": "pipe",
+      "classification": "Vent",
+      "abbreviation": "SVP",
+      "stingSysCode": "SAN",
+      "stingFuncCode": "SAN",
+      "lineColor": [
+        153,
+        153,
+        0
+      ],
+      "lineWeight": 3,
+      "uniclass": "Ss_50_30_70",
+      "cibse": "CIBSE-PH03"
+    },
+    {
+      "id": "pipe-rainwater",
+      "name": "STING Rainwater",
+      "discipline": "pipe",
+      "classification": "OtherPipe",
+      "abbreviation": "RWD",
+      "stingSysCode": "RWD",
+      "stingFuncCode": "RWD",
+      "lineColor": [
+        0,
+        153,
+        153
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_50_30_67",
+      "cibse": "CIBSE-PH04"
+    },
+    {
+      "id": "pipe-fire-wet",
+      "name": "STING Sprinkler (Wet)",
+      "discipline": "pipe",
+      "classification": "FireProtectWet",
+      "abbreviation": "SPR",
+      "stingSysCode": "FP",
+      "stingFuncCode": "FP",
+      "lineColor": [
+        192,
+        0,
+        0
+      ],
+      "lineWeight": 5,
+      "uniclass": "Ss_55_70_30",
+      "cibse": "CIBSE-FP01"
+    },
+    {
+      "id": "pipe-fire-dry",
+      "name": "STING Sprinkler (Dry)",
+      "discipline": "pipe",
+      "classification": "FireProtectDry",
+      "abbreviation": "SPRD",
+      "stingSysCode": "FP",
+      "stingFuncCode": "FP",
+      "lineColor": [
+        192,
+        80,
+        0
+      ],
+      "lineWeight": 5,
+      "linePattern": "Dash",
+      "uniclass": "Ss_55_70_30",
+      "cibse": "CIBSE-FP01"
+    },
+    {
+      "id": "pipe-natural-gas",
+      "name": "STING Natural Gas",
+      "discipline": "pipe",
+      "classification": "OtherPipe",
+      "abbreviation": "GAS",
+      "stingSysCode": "GAS",
+      "stingFuncCode": "GAS",
+      "lineColor": [
+        255,
+        192,
+        0
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_70_38",
+      "cibse": "CIBSE-GS01"
+    },
+    {
+      "id": "pipe-mthw-flow",
+      "name": "STING MTHW Flow",
+      "discipline": "pipe",
+      "classification": "SupplyHydronic",
+      "abbreviation": "MTHWF",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "HTG",
+      "lineColor": [
+        200,
+        0,
+        0
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_10",
+      "cibse": "CIBSE-HT02"
+    },
+    {
+      "id": "pipe-mthw-return",
+      "name": "STING MTHW Return",
+      "discipline": "pipe",
+      "classification": "ReturnHydronic",
+      "abbreviation": "MTHWR",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "HTG",
+      "lineColor": [
+        120,
+        0,
+        0
+      ],
+      "lineWeight": 4,
+      "linePattern": "Dash",
+      "uniclass": "Ss_55_30_10",
+      "cibse": "CIBSE-HT02"
+    },
+    {
+      "id": "pipe-refrigerant",
+      "name": "STING Refrigerant",
+      "discipline": "pipe",
+      "classification": "OtherPipe",
+      "abbreviation": "REF",
+      "stingSysCode": "HVAC",
+      "stingFuncCode": "CLG",
+      "lineColor": [
+        150,
+        0,
+        200
+      ],
+      "lineWeight": 4,
+      "uniclass": "Ss_55_30_93",
+      "cibse": "CIBSE-HV05"
     }
   ]
 }

--- a/StingTools/Data/STING_VIEW_STYLE_PACKS.json
+++ b/StingTools/Data/STING_VIEW_STYLE_PACKS.json
@@ -652,6 +652,30 @@
           "projWeight": 4,
           "surfFgColor": "#40A0A0",
           "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: MTHW Flow",
+          "visible": true,
+          "projColor": "#C80000",
+          "projWeight": 4,
+          "surfFgColor": "#C80000",
+          "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: MTHW Return",
+          "visible": true,
+          "projColor": "#780000",
+          "projWeight": 4,
+          "surfFgColor": "#780000",
+          "transparency": 15
+        },
+        {
+          "name": "STING - HVAC: Refrigerant",
+          "visible": true,
+          "projColor": "#9600C8",
+          "projWeight": 4,
+          "surfFgColor": "#9600C8",
+          "transparency": 15
         }
       ]
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,49 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (MEP Systems — Phase I: cross-check hardening fixes)
+
+A two-stream adversarial review (engine logic + data/integration) over the whole A–H
+feature surfaced 17 + 9 findings; the real ones are fixed here. **Built + verified with
+`dotnet build` against the Revit 2025 API (0 warnings, 0 errors)**; JSON validated.
+
+**Bugs**
+- **View/sheet re-run duplication** (`MepViewProducer`, `MepLevelViewProducer`) — re-running
+  the producers created `… (2)` / `… (3)` views *and a fresh sheet each time*. Now idempotent:
+  if the canonical `<level/source> - <discipline> Coordination` view exists, it's skipped.
+- **`SeedNameSeq` regex** (`MepSystemInstanceBuilder`) — `^([A-Za-z]+)-` dropped digit-bearing
+  abbreviations (`DCW2`, `CO2`, `R410A`), so re-runs collided their names. Now `[A-Za-z0-9]+`.
+- **Misleading "Updated" count** (`MepSystemTypeMaterializer`) — untouched existing types reported
+  as Updated; now Skipped, so the counter reflects what actually changed.
+- **Basement level-code** (`MepLevelViewProducer.LevelCode`) — every basement returned `B1`;
+  Sub-Basement 2 now returns `B2`.
+
+**Edge / consistency**
+- Unsaved-document cache key (`MepSystemTypeRegistry`, `ClassificationStandard`) — two unsaved
+  projects shared one `<no-doc>` slot; now keyed per document.
+- Abbreviation-with-dash warning in `MepSystemTypeRegistry` (Phase D name parsing splits on `-`).
+- Fragmented-network warning (`MepSystemInstanceBuilder`) — a network spanning >1 MEPSystem now
+  warns to merge the rest, instead of silently typing only the first.
+
+**Performance**
+- `MepCoordinationEngine.PresentSystems` — replaced the per-element `doc.GetElement(typeId)` with
+  a one-pass system-type-id → classification map (collected from the two concrete `MEPSystemType`
+  subclasses, since the base is abstract).
+
+**Robustness**
+- Atomic JSON writes (`MepGenerateSystemFiltersCommand`, `ClassificationStandard.Set`) — temp-file
+  + move so a crash mid-write can't corrupt the project override.
+
+**Data**
+- Resolved the two orphaned filters the audit found: `hvac-mthw-flow/return` rule values unified to
+  the no-dash format (`MTHW-F → MTHWF`), and three missing system types added — **MTHW Flow/Return +
+  Refrigerant** (colours matched to the existing filters) — so they're no longer orphaned. Added all
+  three to `corp-coordination` (now **15 MEP filters**, 23 system types).
+
+**Deferred (with reason)**: classification filters keyed on the localised display string (matches the
+entire corporate filter library; English is the deployment target) · abbreviation+classification filter
+co-existence precedence (rare mixed-state, low impact) · minor multi-collector perf in the level producer.
+
 #### Completed (MEP Systems — Phase H: abbreviation-format unification + CSI tag label)
 
 The two Phase G follow-ups. **Built + verified with `dotnet build` against the Revit


### PR DESCRIPTION
## What & why

**Phase I of 9** (stacked on #366). A two-stream adversarial review (engine logic + data/integration) over the whole A–H feature; the real findings are fixed here.

### Bugs
- **View/sheet re-run duplication** — `MepViewProducer` / `MepLevelViewProducer` created `… (2)`/`… (3)` views **and a fresh sheet each run**. Now idempotent: existing canonical `<level/source> - <discipline> Coordination` views are skipped.
- **`SeedNameSeq` regex** dropped digit-bearing abbreviations (`DCW2`, `CO2`, `R410A`) → name collisions on re-run. Now `[A-Za-z0-9]+`.
- **Misleading "Updated" count** — untouched existing system types reported as Updated; now Skipped.
- **Basement level-code** — every basement returned `B1`; Sub-Basement 2 now → `B2`.

### Edge / consistency
- Per-document cache key for unsaved projects (`MepSystemTypeRegistry`, `ClassificationStandard`) — two unsaved docs no longer share one slot.
- Warn on dash-in-abbreviation (Phase D name parsing splits on `-`) + on fragmented networks spanning >1 MEPSystem.

### Performance
- `PresentSystems` — replaced per-element `doc.GetElement(typeId)` with a one-pass type→classification map (collected from the two concrete `MEPSystemType` subclasses; the base is abstract so `OfClass` on it returns empty).

### Robustness
- Atomic JSON writes (`MepGenerateSystemFiltersCommand`, `ClassificationStandard.Set`) — temp + move so a crash can't corrupt the project override.

### Data
- Resolved the two orphaned filters the audit found: `hvac-mthw-flow/return` unified to no-dash (`MTHW-F → MTHWF`), and **MTHW Flow/Return + Refrigerant** system types added (colours matched) — no longer orphaned. `corp-coordination` now **15 filters**, **23 system types**.

### Deferred (with reason)
Classification filters keyed on the localised display string (matches the entire corporate filter library; English is the target) · abbreviation+classification co-existence precedence (rare, low impact) · minor multi-collector perf.

## Verification
`dotnet build` against the **Revit 2025 API → 0 warnings, 0 errors**; all 3 edited JSON files validated.

## Stacking
A (#359) → … → H (#366) → **I** (this). Base `claude/mep-systems-phase-h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)