### PR TITLE
Export Centre: watermark positioning/scale/opacity/tiling + hub button

### DIFF
--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -2239,7 +2239,8 @@ namespace StingTools.Core
                 ("Scheduling_Dashboard", "Scheduling",    "SD", DrawingColor.MidnightBlue, typeof(HubSchedulingDashboardCommand).FullName),
                 ("Tag3D",                "3D Tag",        "T3", DrawingColor.Crimson,      typeof(HubTag3DCommand).FullName),
                 ("CreateTagFamilies",    "Tag Families",  "TF", DrawingColor.DarkCyan,     typeof(HubCreateTagFamiliesCommand).FullName),
-                ("AutoTag",              "Auto Tag",      "AT", DrawingColor.DarkGreen,    typeof(HubAutoTagCommand).FullName),
+                ("AutoTag",              "Auto Tag",      "AT", DrawingColor.DarkGreen,      typeof(HubAutoTagCommand).FullName),
+                ("ExportCenter",         "Export Center", "EC", DrawingColor.DarkSlateBlue,  typeof(HubExportCenterCommand).FullName),
             };
 
             var buttons = new List<PushButtonData>(12);
@@ -2653,6 +2654,14 @@ namespace StingTools.Core
     {
         public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
             => HubDispatcher.Run(data, "AutoTag", ref message);
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HubExportCenterCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
+            => HubDispatcher.Run(data, "ExportCenter", ref message);
     }
 
     [Transaction(TransactionMode.ReadOnly)]

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -2264,14 +2264,19 @@ namespace StingTools.Core
 
             try
             {
-                // Index-agnostic: stack 3 at a time, then AddItem() any
-                // remainder (1 or 2). Covers ALL buttons regardless of count
-                // — the old hard-coded buttons[0..11] silently dropped the
-                // 13th+ buttons.
+                // Stack 3 at a time. A trailing pair MUST be added as a 2-item
+                // stacked column, NOT as two separate AddItem() large buttons:
+                // Revit renders the first trailing large button but silently
+                // drops a second consecutive one (this dropped the 14th button,
+                // "Export Center", from the hub). A lone trailing single is fine
+                // as a large AddItem.
                 int i = 0;
                 for (; i + 3 <= buttons.Count; i += 3)
                     panel.AddStackedItems(buttons[i], buttons[i + 1], buttons[i + 2]);
-                for (; i < buttons.Count; i++)
+                int rem = buttons.Count - i;
+                if (rem == 2)
+                    panel.AddStackedItems(buttons[i], buttons[i + 1]);
+                else if (rem == 1)
                     panel.AddItem(buttons[i]);
             }
             catch (Exception ex)

--- a/StingTools/Docs/ExportCenterModels.cs
+++ b/StingTools/Docs/ExportCenterModels.cs
@@ -104,6 +104,13 @@ namespace StingTools.Docs
         public int WatermarkFontSize { get; set; } = 96;
         public string WatermarkColourHex { get; set; } = "#999999";
 
+        /// <summary>Repeat the watermark in a grid across the whole page.</summary>
+        public bool WatermarkTile { get; set; }
+        /// <summary>Tile grid columns (used when WatermarkTile is true).</summary>
+        public int WatermarkTileColumns { get; set; } = 3;
+        /// <summary>Tile grid rows (used when WatermarkTile is true).</summary>
+        public int WatermarkTileRows { get; set; } = 4;
+
         /// <summary>User-defined groups (CustomGroups mode). Map of group name → list of sheet ids (as strings).</summary>
         public Dictionary<string, List<string>> CustomGroups { get; set; } = new();
 

--- a/StingTools/Docs/ExportCenterPdfPostProcess.cs
+++ b/StingTools/Docs/ExportCenterPdfPostProcess.cs
@@ -133,25 +133,29 @@ namespace StingTools.Docs
 
                     double w = page.Width.Point;
                     double h = page.Height.Point;
-                    var size = gfx.MeasureString(pdf.WatermarkText, font);
+                    const double margin = 20;
+                    var area = new XRect(margin, margin, w - 2 * margin, h - 2 * margin);
 
                     gfx.Save();
-                    switch (pdf.WatermarkPosition)
+                    string pos = string.IsNullOrWhiteSpace(pdf.WatermarkPosition)
+                        ? "DiagonalCentre" : pdf.WatermarkPosition.Trim();
+
+                    if (pos == "DiagonalCentre")
                     {
-                        case "TopLeft":
-                            gfx.DrawString(pdf.WatermarkText, font, brush,
-                                new XPoint(20, 20 + size.Height));
-                            break;
-                        case "BottomRight":
-                            gfx.DrawString(pdf.WatermarkText, font, brush,
-                                new XPoint(w - size.Width - 20, h - 20));
-                            break;
-                        default: // DiagonalCentre
-                            gfx.TranslateTransform(w / 2, h / 2);
-                            gfx.RotateTransform(-30);
-                            gfx.DrawString(pdf.WatermarkText, font, brush,
-                                new XPoint(-size.Width / 2, size.Height / 2));
-                            break;
+                        // True page centre, rotated -30°. Translate to the centre and let
+                        // XStringFormats.Center place the string about the origin so it is
+                        // genuinely centred regardless of font metrics / baseline.
+                        gfx.TranslateTransform(w / 2.0, h / 2.0);
+                        gfx.RotateTransform(-30);
+                        gfx.DrawString(pdf.WatermarkText, font, brush,
+                            new XPoint(0, 0), XStringFormats.Center);
+                    }
+                    else
+                    {
+                        // Grid placement: anchor the string in the requested cell of the
+                        // page area using the matching alignment format.
+                        gfx.DrawString(pdf.WatermarkText, font, brush, area,
+                            ResolveStringFormat(pos));
                     }
                     gfx.Restore();
                 }
@@ -165,6 +169,28 @@ namespace StingTools.Docs
         }
 
         // ── Helpers ─────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Maps a watermark grid position id to the matching XStringFormat
+        /// (alignment within the page area). "DiagonalCentre" is handled
+        /// separately by the caller (rotated). Unknown values centre the text.
+        /// </summary>
+        private static XStringFormat ResolveStringFormat(string position)
+        {
+            switch (position)
+            {
+                case "TopLeft":      return XStringFormats.TopLeft;
+                case "TopCentre":    return XStringFormats.TopCenter;
+                case "TopRight":     return XStringFormats.TopRight;
+                case "MiddleLeft":   return XStringFormats.CenterLeft;
+                case "Centre":       return XStringFormats.Center;
+                case "MiddleRight":  return XStringFormats.CenterRight;
+                case "BottomLeft":   return XStringFormats.BottomLeft;
+                case "BottomCentre": return XStringFormats.BottomCenter;
+                case "BottomRight":  return XStringFormats.BottomRight;
+                default:             return XStringFormats.Center;
+            }
+        }
 
         private static string ResolveLevelLabel(View v)
         {

--- a/StingTools/Docs/ExportCenterPdfPostProcess.cs
+++ b/StingTools/Docs/ExportCenterPdfPostProcess.cs
@@ -127,25 +127,75 @@ namespace StingTools.Docs
                 int fontSize = Math.Max(24, pdf.WatermarkFontSize);
                 var font = new XFont("Arial", fontSize, XFontStyleEx.Bold);
 
+                bool geomLogged = false;
                 foreach (PdfPage page in doc.Pages)
                 {
                     using var gfx = XGraphics.FromPdfPage(page, XGraphicsPdfPageOptions.Append);
 
-                    double w = page.Width.Point;
-                    double h = page.Height.Point;
+                    if (!geomLogged)
+                    {
+                        var mb = page.MediaBox; var cb = page.CropBox;
+                        StingLog.Info(
+                            $"InjectWatermark geom {Path.GetFileName(pdfPath)}: Rotate={page.Rotate} " +
+                            $"Media=[{mb.X1:0},{mb.Y1:0},{mb.X2:0},{mb.Y2:0}] " +
+                            $"Crop=[{cb.X1:0},{cb.Y1:0},{cb.X2:0},{cb.Y2:0}] " +
+                            $"Width={page.Width.Point:0} Height={page.Height.Point:0} pos={pdf.WatermarkPosition}");
+                        geomLogged = true;
+                    }
+
+                    // Derive placement from the page's ACTUAL MediaBox. PdfSharp's
+                    // XGraphics assumes a 0-based MediaBox origin, but Revit can export
+                    // sheets whose MediaBox is centred on (0,0) — e.g. A1 as
+                    // [-1684,-1191,1684,1191]. In that case (w/2, h/2) maps to the
+                    // top-right corner, not the centre. Map the true page centre +
+                    // extents into PdfSharp's drawing space: drawing-x = user-x, and
+                    // drawing-y = pageHeight - user-y (PdfSharp's Y flip).
+                    var mbox = page.MediaBox;
+                    double mx1 = Math.Min(mbox.X1, mbox.X2), mx2 = Math.Max(mbox.X1, mbox.X2);
+                    double my1 = Math.Min(mbox.Y1, mbox.Y2), my2 = Math.Max(mbox.Y1, mbox.Y2);
+                    double pageW = mx2 - mx1;
+                    double pageH = my2 - my1;
+                    double centreX = (mx1 + mx2) / 2.0;          // drawing-x = user-x
+                    double centreY = pageH - (my1 + my2) / 2.0;  // drawing-y = H - user-y
                     const double margin = 20;
-                    var area = new XRect(margin, margin, w - 2 * margin, h - 2 * margin);
+                    var area = new XRect(mx1 + margin, (pageH - my2) + margin,
+                                         pageW - 2 * margin, pageH - 2 * margin);
 
                     gfx.Save();
                     string pos = string.IsNullOrWhiteSpace(pdf.WatermarkPosition)
                         ? "DiagonalCentre" : pdf.WatermarkPosition.Trim();
 
-                    if (pos == "DiagonalCentre")
+                    if (pdf.WatermarkTile)
+                    {
+                        // Tiled: repeat the watermark rotated -30° in a cols×rows grid
+                        // across the page. Each tile is centred in its own cell.
+                        int cols = Math.Max(1, pdf.WatermarkTileColumns);
+                        int rows = Math.Max(1, pdf.WatermarkTileRows);
+                        double cellW = pageW / cols;
+                        double cellH = pageH / rows;
+                        for (int c = 0; c < cols; c++)
+                        {
+                            for (int r = 0; r < rows; r++)
+                            {
+                                // Cell centre in drawing space (drawing-y origin is the
+                                // top of the MediaBox: pageH - my2).
+                                double tx = mx1 + (c + 0.5) * cellW;
+                                double ty = (pageH - my2) + (r + 0.5) * cellH;
+                                gfx.Save();
+                                gfx.TranslateTransform(tx, ty);
+                                gfx.RotateTransform(-30);
+                                gfx.DrawString(pdf.WatermarkText, font, brush,
+                                    new XPoint(0, 0), XStringFormats.Center);
+                                gfx.Restore();
+                            }
+                        }
+                    }
+                    else if (pos == "DiagonalCentre")
                     {
                         // True page centre, rotated -30°. Translate to the centre and let
                         // XStringFormats.Center place the string about the origin so it is
                         // genuinely centred regardless of font metrics / baseline.
-                        gfx.TranslateTransform(w / 2.0, h / 2.0);
+                        gfx.TranslateTransform(centreX, centreY);
                         gfx.RotateTransform(-30);
                         gfx.DrawString(pdf.WatermarkText, font, brush,
                             new XPoint(0, 0), XStringFormats.Center);

--- a/StingTools/UI/StingExportCenterDialog.cs
+++ b/StingTools/UI/StingExportCenterDialog.cs
@@ -601,6 +601,31 @@ namespace StingTools.UI
             };
             sp.Children.Add(LabelFor("Watermark position", wmPos));
 
+            // Watermark scale (font size in points)
+            var wmSize = new ComboBox { IsEditable = true };
+            foreach (int s in new[] { 48, 72, 96, 144, 200, 300 }) wmSize.Items.Add(s);
+            wmSize.Text = _profile.Pdf.WatermarkFontSize.ToString();
+            wmSize.SelectionChanged += (_, __) => { if (int.TryParse(wmSize.SelectedItem?.ToString(), out int n) && n > 0) _profile.Pdf.WatermarkFontSize = n; };
+            wmSize.LostFocus      += (_, __) => { if (int.TryParse(wmSize.Text, out int n) && n > 0) _profile.Pdf.WatermarkFontSize = n; };
+            sp.Children.Add(LabelFor("Watermark scale (pt)", wmSize));
+
+            // Watermark opacity (transparency) — 0 = invisible, 100 = solid
+            var wmOpacity = new ComboBox { IsEditable = true };
+            foreach (int o in new[] { 10, 20, 30, 40, 50, 60, 75, 100 }) wmOpacity.Items.Add(o);
+            wmOpacity.Text = _profile.Pdf.WatermarkOpacityPct.ToString();
+            wmOpacity.SelectionChanged += (_, __) => { if (int.TryParse(wmOpacity.SelectedItem?.ToString(), out int n)) _profile.Pdf.WatermarkOpacityPct = Math.Clamp(n, 0, 100); };
+            wmOpacity.LostFocus      += (_, __) => { if (int.TryParse(wmOpacity.Text, out int n)) _profile.Pdf.WatermarkOpacityPct = Math.Clamp(n, 0, 100); };
+            sp.Children.Add(LabelFor("Watermark opacity %", wmOpacity));
+
+            // Tiling — repeat the watermark in a grid across the page
+            sp.Children.Add(BindCheck("Tile across page", () => _profile.Pdf.WatermarkTile, v => _profile.Pdf.WatermarkTile = v));
+            var wmCols = new TextBox { Text = _profile.Pdf.WatermarkTileColumns.ToString() };
+            wmCols.TextChanged += (_, __) => { if (int.TryParse(wmCols.Text, out int n) && n > 0) _profile.Pdf.WatermarkTileColumns = n; };
+            sp.Children.Add(LabelFor("Tile columns", wmCols));
+            var wmRows = new TextBox { Text = _profile.Pdf.WatermarkTileRows.ToString() };
+            wmRows.TextChanged += (_, __) => { if (int.TryParse(wmRows.Text, out int n) && n > 0) _profile.Pdf.WatermarkTileRows = n; };
+            sp.Children.Add(LabelFor("Tile rows", wmRows));
+
             return card;
         }
 

--- a/StingTools/UI/StingExportCenterDialog.cs
+++ b/StingTools/UI/StingExportCenterDialog.cs
@@ -575,6 +575,32 @@ namespace StingTools.UI
             wmText.TextChanged += (_, __) => _profile.Pdf.WatermarkText = wmText.Text;
             sp.Children.Add(LabelFor("Watermark text", wmText));
 
+            // Watermark position — friendly label → engine position id
+            var wmPositions = new (string Label, string Value)[]
+            {
+                ("Diagonal (centre)", "DiagonalCentre"),
+                ("Centre",            "Centre"),
+                ("Top left",          "TopLeft"),
+                ("Top centre",        "TopCentre"),
+                ("Top right",         "TopRight"),
+                ("Middle left",       "MiddleLeft"),
+                ("Middle right",      "MiddleRight"),
+                ("Bottom left",       "BottomLeft"),
+                ("Bottom centre",     "BottomCentre"),
+                ("Bottom right",      "BottomRight"),
+            };
+            var wmPos = new ComboBox();
+            foreach (var (label, value) in wmPositions)
+                wmPos.Items.Add(new ComboBoxItem { Content = label, Tag = value });
+            wmPos.SelectedIndex = Math.Max(0, Array.FindIndex(wmPositions,
+                p => string.Equals(p.Value, _profile.Pdf.WatermarkPosition, StringComparison.OrdinalIgnoreCase)));
+            wmPos.SelectionChanged += (_, __) =>
+            {
+                if (wmPos.SelectedItem is ComboBoxItem item && item.Tag is string v)
+                    _profile.Pdf.WatermarkPosition = v;
+            };
+            sp.Children.Add(LabelFor("Watermark position", wmPos));
+
             return card;
         }
 


### PR DESCRIPTION
## Summary

Export Centre enhancements from the shared branch (not on `main`): 9-cell + diagonal watermark positioning, watermark **scale / opacity / tiling**, placement fixes, and restoring the **Export Center hub button** on the STING ribbon.

## What's included
- Watermark engine: 9-cell + diagonal positioning, scale/opacity/tiling, placement fix (`ExportCenterPdfPostProcess`, `ExportCenterModels`, `StingExportCenterDialog`)
- Restore Export Center hub button (`StingToolsApp`)

## Verification
- **Compile-verified: `dotnet build` → 0 errors / 0 warnings** against current `main`.
- 4 files, +172/−24. Cherry-picked clean onto current `main` (no conflicts).
- **Author review pending** — extracted mechanically off the shared `claude/mep-from-dwg` branch to land the newer Export Centre work that wasn't on `main`.

## Note
MEP Systems was **not** extracted — its author already landed Phases A/B/D/I on `main` directly (newer than the shared-branch copies), so those were redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
