### PR TITLE
Placement Center: categories & rules hardening (17 fixes, build-verified)

### DIFF
--- a/StingTools/Core/Placement/CoverageGridGenerator.cs
+++ b/StingTools/Core/Placement/CoverageGridGenerator.cs
@@ -5,6 +5,16 @@ using StingTools.Core;
 // Produces an evenly-spaced grid that fills the room polygon so every
 // floor point lies within CoverageRadiusMm of a placed device, honouring
 // MaxSpacingMm, MinSpacingMm, WallClearanceMm and ObstructionClearanceMm.
+//
+// ── DEFERRED (Phase 188 review fix #3a) ──────────────────────────────
+// This class is NOT YET wired into FixturePlacementEngine. The engine's
+// ComputeCap does not route GuaranteeCoverage rules through Generate(),
+// so the documented "fill until ≥99 % coverage" guarantee is not active;
+// GuaranteeCoverage currently only relaxes PlacementScorer's score
+// threshold. PlacementRuleLoader.ValidateRuleSet warns when a rule sets
+// GuaranteeCoverage=true. To activate, call Generate() from
+// ProcessRoomRule and feed its points into the candidate list. Until
+// then, treat this as a staged implementation, not live behaviour.
 
 using System;
 using System.Collections.Generic;

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -641,7 +641,15 @@ namespace StingTools.Core.Placement
             int cap = ComputeCap(effRule, room, candidates.Count, alreadyInRoom);
             if (cap == 0) return;
 
-            var chosen = candidates.Take(cap).ToList();
+            // Phase 188 (review pass-2 #3) — enforce intra-rule MinSpacingMm at
+            // selection. The scorer scores every candidate against an EMPTY
+            // already-placed list (placedPoints is filled only after placement),
+            // so SpacingScore is always 1.0 and a plain Take(cap) could pick
+            // adjacent candidates closer than MinSpacingMm (e.g. CEILING_TILE_CORNER
+            // emits points every 600 mm but the rule asks for 1000 mm). Greedily
+            // accept ranked candidates that clear MinSpacingMm from the ones
+            // already accepted. MinSpacingMm <= 0 ⇒ legacy Take(cap).
+            var chosen = SelectWithSpacing(candidates, cap, effRule.MinSpacingMm);
 
             if (dryRun)
             {
@@ -764,6 +772,15 @@ namespace StingTools.Core.Placement
                     }
 
                     WriteAnchorParameters(fi, effRule);
+                    // Phase 188 (review pass-2 #1) — orient the freshly-placed
+                    // instance. OrientPlacedInstance applies RotationDeg, flips
+                    // the family to face INTO the room, and snaps it off the wall
+                    // centerline onto the wall face. It was wired only into the
+                    // CoPlaceWith path (ProcessRoomRuleAtPoint), so the MAIN path —
+                    // where most fixtures are placed — left switches/sockets facing
+                    // world-X and sitting inside the wall. Run it here too.
+                    try { OrientPlacedInstance(doc, fi, effRule, room); }
+                    catch (Exception oex) { result.Warnings.Add($"Orient {rule.CategoryFilter} in {SafeRoomName(room)}: {oex.Message}"); }
                     // Pack 123 / Gap E — stamp provenance so BOQ / cleanup /
                     // audit can identify auto-created fixtures. Centre's
                     // "Stamp provenance" checkbox flips PlaceFixturesOptions.
@@ -886,6 +903,38 @@ namespace StingTools.Core.Placement
             if (rule.MaxPerRoom > 0)
                 cap = Math.Min(cap, Math.Max(0, rule.MaxPerRoom - alreadyInRoom));
             return Math.Min(cap, candidateCount);
+        }
+
+        /// <summary>
+        /// Phase 188 (review pass-2 #3) — greedy spacing-aware selection. Walks
+        /// the ranked candidates and accepts up to <paramref name="cap"/> whose
+        /// position clears <paramref name="minSpacingMm"/> centre-to-centre from
+        /// every already-accepted candidate. minSpacingMm &lt;= 0 ⇒ plain Take(cap).
+        /// </summary>
+        private static List<PlacementCandidate> SelectWithSpacing(
+            List<PlacementCandidate> ranked, int cap, double minSpacingMm)
+        {
+            if (ranked == null || cap <= 0) return new List<PlacementCandidate>();
+            if (minSpacingMm <= 0) return ranked.Take(cap).ToList();
+
+            double minFt = minSpacingMm * MmToFt;
+            double minSq = minFt * minFt;
+            var accepted = new List<PlacementCandidate>(Math.Min(cap, ranked.Count));
+            foreach (var c in ranked)
+            {
+                if (accepted.Count >= cap) break;
+                if (c?.Position == null) continue;
+                bool tooClose = false;
+                foreach (var a in accepted)
+                {
+                    double dx = a.Position.X - c.Position.X;
+                    double dy = a.Position.Y - c.Position.Y;
+                    double dz = a.Position.Z - c.Position.Z;
+                    if (dx * dx + dy * dy + dz * dz < minSq) { tooClose = true; break; }
+                }
+                if (!tooClose) accepted.Add(c);
+            }
+            return accepted;
         }
 
         /// <summary>
@@ -1391,10 +1440,16 @@ namespace StingTools.Core.Placement
         private static bool IsRegexLike(string s)
         {
             if (string.IsNullOrEmpty(s)) return false;
+            // Phase 188 (review pass-2 #5) — tightened so literal variant/type
+            // names aren't misclassified as regex. A lone '$' or an unbalanced
+            // '[' (e.g. a literal type "A[1") no longer trips regex mode; we now
+            // require a real anchor / escape / quantifier / balanced char-class.
             return s.StartsWith("^", StringComparison.Ordinal)
-                || s.Contains("$")
-                || s.Contains("\\d")
-                || s.Contains("[");
+                || s.EndsWith("$", StringComparison.Ordinal)
+                || s.Contains("\\")                                   // escape (\d, \w, \., …)
+                || s.Contains(".*") || s.Contains(".+") || s.Contains(".?")
+                || (s.Contains("[") && s.Contains("]"))               // balanced char-class
+                || (s.Contains("(") && s.Contains(")"));              // group
         }
 
         private static void WriteAnchorParameters(FamilyInstance fi, PlacementRule rule)
@@ -1405,6 +1460,15 @@ namespace StingTools.Core.Placement
 
             // MNT_HGT_MM may be absent on some families; swallow failure.
             TrySetDoubleMm(fi, "MNT_HGT_MM", rule.MountingHeightMm);
+
+            // Phase 188 (review pass-2 #6) — persist the rest of the placement
+            // intent so audit / round-trip captures the full transform, not just
+            // X-offset. These shared params may not be bound (no registry
+            // constant); TrySet* no-ops gracefully when the param is absent, and
+            // activates automatically once a project binds them.
+            TrySetDoubleMm(fi, "ASS_PLACE_OFFSET_Y_MM", rule.OffsetYMm);
+            TrySetDoubleMm(fi, "ASS_PLACE_OFFSET_Z_MM", rule.OffsetZMm);
+            TrySetDoubleMm(fi, "ASS_PLACE_ROTATION_DEG", rule.RotationDeg);
         }
 
         /// <summary>

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -780,32 +780,40 @@ namespace StingTools.Core.Placement
             {
                 case PlacementRuleKind.Density:
                 {
-                    int byArea = 0, byOcc = 0;
+                    // Phase 188 (review fix #2) — derive the count from EVERY
+                    // declared density rate, not just PerAreaM2 / PerOccupant.
+                    // PerBed / PerWorkstation / PerPupil / PerToiletCubicle are
+                    // first-class fields validated by the loader and surfaced in
+                    // the Centre + Excel export, but the engine never read them —
+                    // so healthcare / education / office density rules silently
+                    // collapsed to one fixture per room. cap = max across all
+                    // populated rates (a rule may set several; the binding one
+                    // wins).
+                    int byArea = 0;
                     if (rule.PerAreaM2 > 0)
                     {
                         double areaM2 = 0;
                         try { areaM2 = room.Area * 0.3048 * 0.3048; } catch { }
                         if (areaM2 > 0) byArea = Math.Max(1, (int)Math.Ceiling(areaM2 / rule.PerAreaM2));
                     }
-                    if (rule.PerOccupant > 0)
-                    {
-                        int occ = 0;
-                        try
-                        {
-                            string occParam = string.IsNullOrEmpty(rule.OccupancyParamName)
-                                ? "STING_OCC_COUNT_INT" : rule.OccupancyParamName;
-                            var p = room.LookupParameter(occParam);
-                            if (p != null && p.HasValue && p.StorageType == StorageType.Integer) occ = p.AsInteger();
-                        }
-                        catch { }
-                        if (occ > 0) byOcc = Math.Max(1, (int)Math.Ceiling((double)occ / rule.PerOccupant));
-                    }
-                    cap = Math.Max(byArea, byOcc);
-                    // Phase 139.4 — Density rule with neither PerAreaM2 nor PerOccupant
-                    // (or with both = 0) used to fall through with cap=1, then later
-                    // collapse to candidateCount once MaxPerRoom = 0. Treat the rule
-                    // as misconfigured: place at most one and warn upstream via the
-                    // rule-loader validation pass (#39 below).
+
+                    string occParam = string.IsNullOrEmpty(rule.OccupancyParamName)
+                        ? "STING_OCC_COUNT_INT" : rule.OccupancyParamName;
+                    int byOcc    = CountFromRoomRate(room, occParam,                     rule.PerOccupant);
+                    int byBed    = CountFromRoomRate(room, "STING_BED_COUNT_INT",            rule.PerBed);
+                    int byWs     = CountFromRoomRate(room, "STING_WS_COUNT_INT",             rule.PerWorkstation);
+                    int byPupil  = CountFromRoomRate(room, "STING_PUPIL_COUNT_INT",          rule.PerPupil);
+                    int byCubicle= CountFromRoomRate(room, "STING_TOILET_CUBICLE_COUNT_INT", rule.PerToiletCubicle);
+
+                    cap = Math.Max(byArea,
+                          Math.Max(byOcc,
+                          Math.Max(byBed,
+                          Math.Max(byWs,
+                          Math.Max(byPupil, byCubicle)))));
+
+                    // Phase 139.4 — Density rule with no derivable rate falls
+                    // through with cap=1; the rule-loader validation pass warns
+                    // the user the rule is misconfigured.
                     if (cap == 0) cap = 1;
                     break;
                 }
@@ -838,6 +846,25 @@ namespace StingTools.Core.Placement
             if (rule.MaxPerRoom > 0)
                 cap = Math.Min(cap, Math.Max(0, rule.MaxPerRoom - alreadyInRoom));
             return Math.Min(cap, candidateCount);
+        }
+
+        /// <summary>
+        /// Phase 188 (review fix #2) — read an integer room parameter and
+        /// derive a density count = ceil(count / rate). Returns 0 when the
+        /// rate is unset (≤ 0), the parameter is missing/empty, or the value
+        /// is ≤ 0 — so it contributes nothing to the Math.Max chain.
+        /// </summary>
+        private static int CountFromRoomRate(Room room, string paramName, double ratePerUnit)
+        {
+            if (ratePerUnit <= 0 || room == null || string.IsNullOrEmpty(paramName)) return 0;
+            int count = 0;
+            try
+            {
+                var p = room.LookupParameter(paramName);
+                if (p != null && p.HasValue && p.StorageType == StorageType.Integer) count = p.AsInteger();
+            }
+            catch (Exception ex) { StingLog.Warn($"ComputeCap: read room param '{paramName}': {ex.Message}"); }
+            return count > 0 ? Math.Max(1, (int)Math.Ceiling(count / ratePerUnit)) : 0;
         }
 
         /// <summary>
@@ -1632,7 +1659,10 @@ namespace StingTools.Core.Placement
             = new Dictionary<string, Dictionary<string, BuiltInCategory>>(StringComparer.Ordinal);
         private static readonly object _bicByNameLock = new object();
 
-        private static BuiltInCategory ResolveBuiltInCategoryByName(Document doc, string categoryName)
+        // Phase 188 (review fix #1b) — promoted from private to internal so
+        // PlacementScorer can reuse the cached category-name → BuiltInCategory
+        // resolution for its sample-instance prefilter.
+        internal static BuiltInCategory ResolveBuiltInCategoryByName(Document doc, string categoryName)
         {
             if (doc == null || string.IsNullOrEmpty(categoryName)) return BuiltInCategory.INVALID;
             string path = "", title = "";

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -225,6 +225,17 @@ namespace StingTools.Core.Placement
                      (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0));
                 if (profileActive)
                 {
+                    // Phase 188 (review fix #5a) — the standards gate keys off the
+                    // structured ApplicableStandards field, but shipped rules cite
+                    // standards via free-text StandardRef instead. Warn when the
+                    // profile declares active standards yet no rule populates
+                    // ApplicableStandards — the standards filter is then inert.
+                    if (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0
+                        && !rules.Any(r => r != null && !string.IsNullOrEmpty(r.ApplicableStandards)))
+                    {
+                        result.Warnings.Add("Building profile declares ActiveStandards but no rule populates the structured ApplicableStandards field (rules cite standards via free-text StandardRef) — the standards filter is inert. Populate ApplicableStandards on rules to enable standards-based filtering.");
+                    }
+
                     int before = rules.Count;
                     rules = PlacementRuleLoader.FilterByProfile(new List<PlacementRule>(rules), profile);
                     int removed = before - rules.Count;
@@ -974,9 +985,10 @@ namespace StingTools.Core.Placement
             // by symbol name.
             string hint  = rule?.VariantHint ?? "";
             string ftrx  = rule?.FamilyTypeRegex ?? "";
-            string cacheKey = string.IsNullOrEmpty(hint) && string.IsNullOrEmpty(ftrx)
+            string bicHint = rule?.CategoryBic ?? "";
+            string cacheKey = string.IsNullOrEmpty(hint) && string.IsNullOrEmpty(ftrx) && string.IsNullOrEmpty(bicHint)
                 ? categoryName
-                : $"{categoryName}|{hint}|{ftrx}";
+                : $"{categoryName}|{hint}|{ftrx}|{bicHint}";
             if (cache.TryGetValue(cacheKey, out var cached)) return cached;
 
             // Build matcher and ordered fallback chain.
@@ -1004,8 +1016,22 @@ namespace StingTools.Core.Placement
                 // Phase 139.4 — apply OfCategory before OfClass so the
                 // collector pre-filters by category index (Revit's native
                 // index lookup) instead of walking every FamilySymbol.
+                // Phase 188 (review fix #5b) — when the rule sets CategoryBic,
+                // resolve the BuiltInCategory directly and match on the category
+                // id (locale-robust) instead of the localized Category.Name.
                 BuiltInCategory bic = BuiltInCategory.INVALID;
-                try { bic = ResolveBuiltInCategoryByName(doc, categoryName); } catch { }
+                bool useBic = false;
+                if (!string.IsNullOrEmpty(bicHint)
+                    && Enum.TryParse<BuiltInCategory>(bicHint, true, out var parsedBic)
+                    && parsedBic != BuiltInCategory.INVALID)
+                {
+                    bic = parsedBic;
+                    useBic = true;
+                }
+                else
+                {
+                    try { bic = ResolveBuiltInCategoryByName(doc, categoryName); } catch { }
+                }
                 FilteredElementCollector collector = (bic != BuiltInCategory.INVALID)
                     ? new FilteredElementCollector(doc).OfCategory(bic).OfClass(typeof(FamilySymbol))
                     : new FilteredElementCollector(doc).OfClass(typeof(FamilySymbol));
@@ -1013,7 +1039,11 @@ namespace StingTools.Core.Placement
                 {
                     if (!(el is FamilySymbol fs)) continue;
                     if (fs.Category == null) continue;
-                    if (!string.Equals(fs.Category.Name, categoryName, StringComparison.OrdinalIgnoreCase))
+                    if (useBic)
+                    {
+                        if ((BuiltInCategory)fs.Category.Id.Value != bic) continue;
+                    }
+                    else if (!string.Equals(fs.Category.Name, categoryName, StringComparison.OrdinalIgnoreCase))
                         continue;
 
                     // FamilyTypeRegex is an additional gate, applied to symbol name.

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -211,6 +211,35 @@ namespace StingTools.Core.Placement
                 return result;
             }
 
+            // Phase 188 (review fix #3b) — apply the project building profile so
+            // a run matches what the Placement Centre displays. FilterByProfile
+            // existed and the UI mirrored it, but the engine ran every rule
+            // regardless of building type. No-op when no
+            // _BIM_COORD/placement_profile.json is configured (empty BuildingType
+            // + ActiveStandards → FilterByProfile returns the set unchanged).
+            try
+            {
+                var profile = ProjectBuildingProfileIO.Load(doc.PathName);
+                bool profileActive = profile != null &&
+                    (!string.IsNullOrEmpty(profile.BuildingType) ||
+                     (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0));
+                if (profileActive)
+                {
+                    int before = rules.Count;
+                    rules = PlacementRuleLoader.FilterByProfile(new List<PlacementRule>(rules), profile);
+                    int removed = before - rules.Count;
+                    StingLog.Info($"FixturePlacementEngine: building-profile filter kept {rules.Count} of {before} rules (BuildingType='{profile.BuildingType}').");
+                    if (removed > 0)
+                        result.Warnings.Add($"Building profile '{profile.BuildingType}' filtered out {removed} of {before} rule(s) not matching the active building type / standards.");
+                    if (rules.Count == 0)
+                    {
+                        result.Warnings.Add($"Building profile '{profile.BuildingType}' filtered out ALL rules — nothing to place. Check the profile's BuildingType / ActiveStandards against your rule set.");
+                        return result;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"FixturePlacementEngine: building-profile filter: {ex.Message}"); }
+
             // Phase 139.27 (C-03) — surface a one-shot warning at start
             // of run when the user enabled "Tag every placement" but
             // the reflection target is missing. RunFor() warns once per

--- a/StingTools/Core/Placement/PlacementHostPreflight.cs
+++ b/StingTools/Core/Placement/PlacementHostPreflight.cs
@@ -51,19 +51,29 @@ namespace StingTools.Core.Placement
         // don't run a FilteredElementCollector for every PlaceOnCeilingSoffit
         // call. Cleared whenever the active document changes.
         private static View3D _cachedView3D;
-        private static int _cachedView3DDocHash;
+        // Phase 188 (review pass-2 #4) — key the cache by PathName|Title instead
+        // of doc.GetHashCode(). GetHashCode can collide across documents (the
+        // engine's ResolveBuiltInCategoryByName already moved off it for this
+        // exact reason), which could hand back a View3D belonging to a different
+        // open document. The IsValidObject + Document identity checks below are
+        // the belt-and-braces guard.
+        private static string _cachedView3DDocKey;
 
         private static View3D ResolveView3D(Document doc)
         {
             if (doc == null) return null;
-            int docHash = doc.GetHashCode();
-            if (_cachedView3D != null && _cachedView3DDocHash == docHash && _cachedView3D.IsValidObject)
+            string docKey;
+            try { docKey = (doc.PathName ?? "") + "|" + (doc.Title ?? ""); }
+            catch { docKey = ""; }
+            if (_cachedView3D != null && _cachedView3DDocKey == docKey
+                && _cachedView3D.IsValidObject
+                && ReferenceEquals(_cachedView3D.Document, doc))
                 return _cachedView3D;
             try
             {
                 _cachedView3D = new FilteredElementCollector(doc).OfClass(typeof(View3D))
                     .Cast<View3D>().FirstOrDefault(v => v != null && !v.IsTemplate);
-                _cachedView3DDocHash = docHash;
+                _cachedView3DDocKey = docKey;
             }
             catch { _cachedView3D = null; }
             return _cachedView3D;
@@ -446,9 +456,20 @@ namespace StingTools.Core.Placement
             double bestSq = maxDistFt * maxDistFt;
             try
             {
+                // Phase 188 (review pass-2 #2) — bound the search with a
+                // BoundingBoxIntersectsFilter around the point ± maxDistFt so the
+                // collector only touches hosts near the placement, not every wall
+                // / ceiling / floor in the model (this runs once per placement).
                 var col = new FilteredElementCollector(doc)
                     .OfClass(typeof(T))
                     .WhereElementIsNotElementType();
+                if (point != null)
+                {
+                    var outline = new Outline(
+                        new XYZ(point.X - maxDistFt, point.Y - maxDistFt, point.Z - maxDistFt),
+                        new XYZ(point.X + maxDistFt, point.Y + maxDistFt, point.Z + maxDistFt));
+                    col = col.WherePasses(new BoundingBoxIntersectsFilter(outline));
+                }
                 foreach (var el in col)
                 {
                     if (el is not T candidate) continue;

--- a/StingTools/Core/Placement/PlacementRule.cs
+++ b/StingTools/Core/Placement/PlacementRule.cs
@@ -53,6 +53,15 @@ namespace StingTools.Core.Placement
         public string CategoryFilter { get; set; } = "";
 
         /// <summary>
+        /// Phase 188 (review fix #5b) — optional BuiltInCategory name
+        /// (e.g. "OST_LightingFixtures"). When set, symbol resolution matches
+        /// on the category id rather than the localized Category.Name, so rules
+        /// resolve correctly on non-English Revit. Empty (default) ⇒ legacy
+        /// behaviour: match by CategoryFilter against Element.Category.Name.
+        /// </summary>
+        public string CategoryBic { get; set; } = "";
+
+        /// <summary>
         /// PC-08 — comma-separated fallback chain (FLUSH,SURFACE,RECESSED)
         /// or a single regex (^IP6[5-7]$). Engine tries each in order
         /// and falls back to the first symbol when nothing matches.
@@ -554,6 +563,7 @@ namespace StingTools.Core.Placement
                 RuleId               = this.RuleId,
                 RuleKind             = this.RuleKind,
                 CategoryFilter       = this.CategoryFilter,
+                CategoryBic          = this.CategoryBic,
                 VariantHint          = this.VariantHint,
                 FamilyTypeRegex      = this.FamilyTypeRegex,
                 RoomFilter           = this.RoomFilter,

--- a/StingTools/Core/Placement/PlacementRule.cs
+++ b/StingTools/Core/Placement/PlacementRule.cs
@@ -164,7 +164,7 @@ namespace StingTools.Core.Placement
         /// <summary>PC-12 — Density rule: 1 fixture per N pupils (education; read from room's STING_PUPIL_COUNT_INT).</summary>
         public double PerPupil { get; set; } = 0.0;
 
-        /// <summary>PC-12 — Density rule: 1 fixture per N toilet cubicles (BS 6465 accessory rules).</summary>
+        /// <summary>PC-12 — Density rule: 1 fixture per N toilet cubicles (BS 6465 accessory rules; read from room's STING_TOILET_CUBICLE_COUNT_INT).</summary>
         public double PerToiletCubicle { get; set; } = 0.0;
 
         /// <summary>PC-12 — Name of a room integer parameter to read occupancy from when PerOccupant is set. Defaults to STING_OCC_COUNT_INT.</summary>

--- a/StingTools/Core/Placement/PlacementRuleLoader.cs
+++ b/StingTools/Core/Placement/PlacementRuleLoader.cs
@@ -277,6 +277,20 @@ namespace StingTools.Core.Placement
                     StingLog.Info($"PlacementRuleLoader: rule '{r.MergeKey}' is Density with MaxPerRoom=0 — placement count is bounded only by PerAreaM2/PerOccupant.");
                 }
 
+                // Phase 188 (review fix #3a, Option B) — GuaranteeCoverage is only
+                // half-wired: PlacementScorer relaxes its score-threshold gate for
+                // such rules, but the count is NOT expanded to actually guarantee
+                // coverage. CoverageGridGenerator implements the ≥99 % fill but is
+                // not invoked by the engine (deferred — see the DEFERRED note on
+                // that class). Warn so the rule's behaviour isn't mistaken for the
+                // documented coverage guarantee.
+                if (r.GuaranteeCoverage)
+                {
+                    string msg = $"PlacementRuleLoader: rule '{r.MergeKey}' sets GuaranteeCoverage=true, but coverage-guarantee count expansion is not active — only score-threshold relaxation applies. Achieve coverage via a grid anchor (LIGHTING_GRID) + CoverageRadiusMm/MaxSpacingMm instead.";
+                    sink?.Add(msg);
+                    StingLog.Warn(msg);
+                }
+
                 // Phase 139.27 (M-05) — flag truncated RuleIds so users
                 // know their rule may collide with another rule whose
                 // long form starts the same. The MergeKey is whatever

--- a/StingTools/Core/Placement/PlacementScorer.AnchorTypes.cs
+++ b/StingTools/Core/Placement/PlacementScorer.AnchorTypes.cs
@@ -22,6 +22,12 @@ namespace StingTools.Core.Placement
 {
     public partial class PlacementScorer
     {
+        // Phase 188 (review fix #5d) — upper bound on candidate points emitted
+        // by the grid-style anchors (CEILING_TILE_CORNER / RAISED_FLOOR_TILE_EDGE)
+        // so a large room can't generate thousands of candidates that each get
+        // scored. 2000 covers a ~17 m × 17 m room at 600 mm tile corners.
+        private const int MaxGridAnchorPoints = 2000;
+
         /// <summary>
         /// Append candidate XYZs for one of the 22 Phase 139 anchor types.
         /// Returns true when the anchor was recognised (caller should not
@@ -661,9 +667,23 @@ namespace StingTools.Core.Placement
             var bb = room.get_BoundingBox(null);
             if (bb == null) return;
             double tileFt = 600.0 / 304.8;
+            // Phase 188 (review fix #5d) — bound the emitted candidate count.
+            // A large hall could otherwise emit thousands of grid points, each
+            // then scored (and sampled). Cap + log once when truncating.
+            int emitted = 0;
             for (double x = bb.Min.X + tileFt; x < bb.Max.X; x += tileFt)
-            for (double y = bb.Min.Y + tileFt; y < bb.Max.Y; y += tileFt)
-                points.Add(new XYZ(x + offsetXFt, y + offsetYFt, anchorZ));
+            {
+                for (double y = bb.Min.Y + tileFt; y < bb.Max.Y; y += tileFt)
+                {
+                    if (emitted >= MaxGridAnchorPoints)
+                    {
+                        StingLog.Info($"EmitCeilingTileCorner room {room.Id}: capped candidate grid at {MaxGridAnchorPoints} points.");
+                        return;
+                    }
+                    points.Add(new XYZ(x + offsetXFt, y + offsetYFt, anchorZ));
+                    emitted++;
+                }
+            }
         }
 
         private void EmitCurtainPanelCentre(Room room, PlacementRule rule,
@@ -749,8 +769,14 @@ namespace StingTools.Core.Placement
             var bb = room.get_BoundingBox(null);
             if (bb == null) return;
             double stepFt = 600.0 / 304.8;
+            // Phase 188 (review fix #5d) — bound the emitted candidate count.
             for (double x = bb.Min.X; x <= bb.Max.X; x += stepFt)
             {
+                if (points.Count >= MaxGridAnchorPoints)
+                {
+                    StingLog.Info($"EmitRaisedFloorTileEdge room {room.Id}: capped candidate grid at {MaxGridAnchorPoints} points.");
+                    return;
+                }
                 points.Add(new XYZ(x + offsetXFt, bb.Min.Y + offsetYFt, anchorZ));
                 points.Add(new XYZ(x + offsetXFt, bb.Max.Y + offsetYFt, anchorZ));
             }

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -203,7 +203,14 @@ namespace StingTools.Core.Placement
             double offsetZFt = rule.OffsetZMm * MmToFt;
 
             // PC-06 — mounting reference picks which datum MountingHeight is measured from.
-            double anchorZ = ResolveMountingDatumZ(room, rule, roomPt) + (rule.MountingHeightMm * MmToFt) + offsetZFt;
+            // Phase 188 (review fix #6) — MountingHeightMm sign depends on the datum:
+            // FFL / SLAB measure UP from the floor; CEILING / SOFFIT measure DOWN from
+            // the ceiling/soffit face. The original code always added the height, so a
+            // ceiling-referenced fixture with a positive MountingHeightMm landed ABOVE
+            // the ceiling. OffsetZMm stays a signed trim either way.
+            double anchorZ = ResolveMountingDatumZ(room, rule, roomPt)
+                           + MountingHeightSign(rule) * (rule.MountingHeightMm * MmToFt)
+                           + offsetZFt;
 
             string anchor = (rule.AnchorType ?? "ROOM_CENTRE").ToUpperInvariant();
             switch (anchor)
@@ -308,6 +315,17 @@ namespace StingTools.Core.Placement
             }
             catch (Exception ex) { StingLog.Warn($"ResolveMountingDatumZ {room.Id}: {ex.Message}"); }
             return roomPt.Z;
+        }
+
+        /// <summary>
+        /// Phase 188 (review fix #6) — direction MountingHeightMm is applied from
+        /// the resolved datum. FFL / SLAB → +1 (measure up from floor);
+        /// CEILING / SOFFIT → −1 (measure down from the overhead face).
+        /// </summary>
+        private static double MountingHeightSign(PlacementRule rule)
+        {
+            string r = (rule?.MountingReference ?? "FFL").ToUpperInvariant();
+            return (r == "CEILING" || r == "SOFFIT") ? -1.0 : 1.0;
         }
 
         // PC-10 — emit lighting-grid points snapped to the ceiling tile grid.

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -82,7 +82,23 @@ namespace StingTools.Core.Placement
 
         public PlacementScorer(Document doc)
         {
+            // Phase 188 (review fix #1) — bind the document. The original
+            // constructor discarded its argument, leaving the readonly _doc
+            // field null for the scorer's whole life. Every _doc use is
+            // try/catch-wrapped, so collision scoring, RejectInsideWall,
+            // door/window/grid/column/MEP anchors and manufacturer scoring
+            // all silently no-op'd. Binding it here re-enables them.
+            _doc = doc;
+            if (_doc == null)
+                StingLog.Warn("PlacementScorer constructed with null document — Revit-querying anchors and collision scoring disabled.");
         }
+
+        // Phase 188 (review fix #1b) — doc-wide sample-instance cache keyed
+        // by category name (negative-cached). Replaces a full-model
+        // FilteredElementCollector that previously ran once per candidate
+        // inside ApplyPlacementHints.
+        private readonly Dictionary<string, Element> _sampleInstanceByCategory
+            = new Dictionary<string, Element>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Lazy-initialised BS EN 12464-1 lux calculator. Shared across
@@ -498,21 +514,44 @@ namespace StingTools.Core.Placement
         /// </summary>
         private Element ResolveSampleInstanceForRule(Room room, PlacementRule rule)
         {
-            if (rule == null || room == null) return null;
+            if (rule == null || _doc == null || string.IsNullOrEmpty(rule.CategoryFilter)) return null;
+
+            // Phase 188 (review fix #1b) — doc-wide cache + category prefilter.
+            // The sample is the first instance of the rule's category anywhere
+            // in the model (used only to read family-level placement hints), so
+            // it is the same regardless of room. Caching by category — and
+            // pre-filtering the collector with OfCategory — replaces the
+            // previous whole-model walk that ran once per candidate.
+            if (_sampleInstanceByCategory.TryGetValue(rule.CategoryFilter, out var cached))
+                return cached;
+
+            Element found = null;
             try
             {
-                var col = new FilteredElementCollector(_doc)
-                    .WhereElementIsNotElementType();
+                BuiltInCategory bic = BuiltInCategory.INVALID;
+                try { bic = FixturePlacementEngine.ResolveBuiltInCategoryByName(_doc, rule.CategoryFilter); }
+                catch (Exception ex) { StingLog.Warn($"PlacementScorer.ResolveSampleInstanceForRule BIC resolve '{rule.CategoryFilter}': {ex.Message}"); }
+
+                var col = (bic != BuiltInCategory.INVALID)
+                    ? new FilteredElementCollector(_doc).OfCategory(bic).WhereElementIsNotElementType()
+                    : new FilteredElementCollector(_doc).WhereElementIsNotElementType();
+
                 foreach (var el in col)
                 {
                     if (el.Category == null) continue;
                     if (!string.Equals(el.Category.Name, rule.CategoryFilter, StringComparison.OrdinalIgnoreCase))
                         continue;
-                    return el;
+                    found = el;
+                    break;
                 }
             }
-            catch { }
-            return null;
+            catch (Exception ex)
+            {
+                StingLog.Warn($"PlacementScorer.ResolveSampleInstanceForRule '{rule.CategoryFilter}': {ex.Message}");
+            }
+
+            _sampleInstanceByCategory[rule.CategoryFilter] = found; // negative-cache null too
+            return found;
         }
 
         /// <summary>

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -42,6 +42,10 @@ namespace StingTools.Core.Placement
 
         // Phase 139.2 P — re-weighted scoring; coverage-contribution and
         // manufacturer-resolution scores added.  Sum = 1.00.
+        // NOTE (Phase 188 review #5e): ScoreThreshold (above) and these weights
+        // are process-global run configuration, not true constants — the weights
+        // are const today but ScoreThreshold is a mutable static set from the
+        // Centre's Run & Routing tab. Safe single-threaded; treat as shared config.
         private const double AnchorWeight       = 0.35;
         private const double SideWeight         = 0.22;
         private const double SpacingWeight      = 0.18;
@@ -609,7 +613,13 @@ namespace StingTools.Core.Placement
         private Dictionary<string, string> _loadedFamilyCategoryByName;
         private double ScoreManufacturerResolution(PlacementRule rule)
         {
-            if (rule == null || string.IsNullOrEmpty(rule.CatalogueRef)) return 0.0;
+            // Phase 188 (review fix #5e) — neutral 0.5 (was 0.0) when no
+            // catalogue is specified, matching ScoreCoverageContribution's
+            // neutral default. A constant 0.0 docked every catalogue-less rule
+            // ManufacturerWeight (0.03) of absolute score, which could tip
+            // borderline candidates below ScoreThreshold for no good reason.
+            if (rule == null) return 0.5;
+            if (string.IsNullOrEmpty(rule.CatalogueRef)) return 0.5;
             try
             {
                 var entry = ManufacturerCatalogueRegistry.GetForRule(rule);
@@ -1493,17 +1503,38 @@ namespace StingTools.Core.Placement
             return true;
         }
 
+        // Phase 188 (review fix #5c) — compiled-regex cache for the room-scope
+        // filters (dept / level / phase / workset / room). RoomMatchesScope ran
+        // Regex.IsMatch uncompiled on every call; the engine already pre-compiles
+        // RoomFilter / ExcludeRoomFilter, so this brings the remaining scope
+        // filters up to the same standard.
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, Regex> _scopeRxCache
+            = new System.Collections.Concurrent.ConcurrentDictionary<string, Regex>();
+
+        private static Regex GetScopeRegex(string pattern)
+        {
+            return _scopeRxCache.GetOrAdd(pattern, p =>
+            {
+                try { return new Regex(p, RegexOptions.IgnoreCase | RegexOptions.Compiled); }
+                catch (Exception ex) { StingLog.Warn($"PlacementScorer scope regex '{p}': {ex.Message}"); return null; }
+            });
+        }
+
         private static bool RegexAllow(string pattern, string text)
         {
             if (string.IsNullOrEmpty(pattern)) return true;
-            try { return Regex.IsMatch(text ?? "", pattern, RegexOptions.IgnoreCase); }
+            var rx = GetScopeRegex(pattern);
+            if (rx == null) return false; // malformed pattern — fail closed (as before)
+            try { return rx.IsMatch(text ?? ""); }
             catch (Exception ex) { StingLog.Warn($"PlacementScorer regex '{pattern}': {ex.Message}"); return false; }
         }
 
         private static bool RegexBlock(string pattern, string text)
         {
             if (string.IsNullOrEmpty(pattern)) return false;
-            try { return Regex.IsMatch(text ?? "", pattern, RegexOptions.IgnoreCase); }
+            var rx = GetScopeRegex(pattern);
+            if (rx == null) return false; // malformed pattern — don't block (as before)
+            try { return rx.IsMatch(text ?? ""); }
             catch (Exception ex) { StingLog.Warn($"PlacementScorer block regex '{pattern}': {ex.Message}"); return false; }
         }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7165,3 +7165,29 @@ Remaining review items (GuaranteeCoverage/CoverageGridGenerator wiring,
 FilterByProfile at run time, ceiling/soffit mounting-reference sign, and
 the flexibility/minor batch) are deferred to follow-up branches per the
 review's recommended order.
+
+#### Completed (Phase 188 — Placement Center hardening, batch 2)
+
+Branch `claude/placement-rules-hardening`. **Verified with `dotnet build`
+against the Revit 2025 API — 0 warnings, 0 errors.**
+
+4. **`GuaranteeCoverage` deprecate + warn (review fix #3a, Option B).**
+   `CoverageGridGenerator` implements the ≥99 % coverage fill but is not
+   wired into the engine; `GuaranteeCoverage` only relaxes the scorer's
+   threshold. Added a `DEFERRED` header note on the class and a
+   `PlacementRuleLoader.ValidateRuleSet` warning when a rule sets
+   `GuaranteeCoverage=true`. (`CoverageGridGenerator.cs`, `PlacementRuleLoader.cs`)
+
+5. **`FilterByProfile` now applied at run time (review fix #3b).** The
+   building-profile gate existed and the Centre mirrored it for display,
+   but the engine ran every rule regardless of building type. The engine
+   now loads `_BIM_COORD/placement_profile.json` and applies
+   `FilterByProfile` before ordering, warning with the removed count and
+   hard-stopping if the profile removes every rule. No-op when no profile
+   is configured. (`FixturePlacementEngine.cs`)
+
+6. **Ceiling/soffit mounting-reference sign (review fix #6).**
+   `MountingHeightMm` was always added to the datum, so a `CEILING`/`SOFFIT`
+   reference with a positive height landed the fixture *above* the ceiling.
+   New `MountingHeightSign` helper: FFL/SLAB → +1, CEILING/SOFFIT → −1.
+   `OffsetZMm` stays a signed trim. (`PlacementScorer.cs`)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7191,3 +7191,38 @@ against the Revit 2025 API — 0 warnings, 0 errors.**
    reference with a positive height landed the fixture *above* the ceiling.
    New `MountingHeightSign` helper: FFL/SLAB → +1, CEILING/SOFFIT → −1.
    `OffsetZMm` stays a signed trim. (`PlacementScorer.cs`)
+
+#### Completed (Phase 188 — Placement Center hardening, batch 3: flexibility + minors)
+
+Branch `claude/placement-rules-hardening`. **Verified with `dotnet build`
+against the Revit 2025 API — 0 warnings, 0 errors.**
+
+7. **`CategoryBic` locale-robust matching (review fix #5b).** New optional
+   `PlacementRule.CategoryBic` (e.g. `"OST_LightingFixtures"`). When set,
+   `ResolveSymbol` matches family symbols by `Category.Id` instead of the
+   localized `Category.Name`, so rules resolve on non-English Revit. Empty ⇒
+   legacy name match. Additive; needs in-Revit verification on a localized
+   install. (`PlacementRule.cs`, `FixturePlacementEngine.cs`)
+
+8. **Standards-gate inert warning (review fix #5a).** Shipped rules cite
+   standards via free-text `StandardRef`, not the structured
+   `ApplicableStandards` the profile gate keys off. The engine now warns when
+   a profile declares `ActiveStandards` but no rule populates
+   `ApplicableStandards` (the filter is then inert). (`FixturePlacementEngine.cs`)
+
+9. **Scope-filter regex caching (review fix #5c).** `RoomMatchesScope` ran
+   `Regex.IsMatch` uncompiled per call for dept/level/phase/workset/room
+   filters; now compiled + cached, matching the engine's RoomFilter handling.
+   (`PlacementScorer.cs`)
+
+10. **Bounded grid anchors (review fix #5d).** `CEILING_TILE_CORNER` /
+    `RAISED_FLOOR_TILE_EDGE` emitted an unbounded candidate grid in large
+    rooms; now capped at `MaxGridAnchorPoints` (2000) with a log on truncation.
+    (`PlacementScorer.AnchorTypes.cs`)
+
+11. **Minors (review fix #5e).** `ScoreManufacturerResolution` returns a
+    neutral 0.5 (was 0.0) for catalogue-less rules so they aren't docked
+    against `ScoreThreshold`; a note documents that `ScoreThreshold` + weights
+    are process-global run config. The MergeKey-collision case is already
+    surfaced by the existing `MergeRules` duplicate-key warning.
+    (`PlacementScorer.cs`)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7125,3 +7125,43 @@ section + connection + foundation set.
    the JSON files are read directly from `StingTools/Data/Symbols/`).
    Adding a project overlay layer matching the Drawing-Type project
    override mechanism would be the natural follow-up.
+
+#### Completed (Phase 188 — Placement Center categories/rules hardening, batch 1)
+
+Branch `claude/placement-rules-hardening`. First two fixes from the
+Placement Center categories-and-rules review. **Verified with
+`dotnet build` against the Revit 2025 API — 0 warnings, 0 errors.**
+
+1. **`PlacementScorer._doc` was never assigned (CRITICAL).** The
+   constructor `public PlacementScorer(Document doc) {}` discarded its
+   argument, leaving the `readonly` `_doc` field null for the scorer's
+   whole life. Because every `_doc` use is `try/catch → StingLog.Warn`,
+   obstruction collision scoring, `RejectInsideWall`, the door / window /
+   grid / column / MEP / curtain-panel anchors and manufacturer-resolution
+   scoring all silently no-op'd. Fixed by binding `_doc = doc;` plus a
+   null-doc warning. (`Core/Placement/PlacementScorer.cs`)
+
+2. **Per-candidate full-model scan (`ResolveSampleInstanceForRule`).**
+   `ApplyPlacementHints` runs once per candidate and the helper walked the
+   whole model with no category prefilter — harmless while `_doc` was null,
+   O(model × candidates) once fix #1 landed. Now category-prefiltered via
+   `FixturePlacementEngine.ResolveBuiltInCategoryByName` (promoted
+   `private`→`internal`) and doc-wide cached per category (negative-cached).
+   (`Core/Placement/PlacementScorer.cs`, `FixturePlacementEngine.cs`)
+
+3. **Density count ignored `PerBed` / `PerWorkstation` / `PerPupil` /
+   `PerToiletCubicle`.** `ComputeCap` only derived counts from `PerAreaM2`
+   and `PerOccupant`, so healthcare / education / office density rules
+   collapsed to one fixture per room despite the loader validating those
+   rates and the Centre + Excel exposing them. `ComputeCap` now takes the
+   max across every populated rate via a new `CountFromRoomRate` helper
+   reading `STING_BED_COUNT_INT` / `STING_WS_COUNT_INT` /
+   `STING_PUPIL_COUNT_INT` / `STING_TOILET_CUBICLE_COUNT_INT` (consistent
+   with the existing `STING_OCC_COUNT_INT` project-bound room-param
+   pattern; none are registered in `MR_PARAMETERS`).
+   (`Core/Placement/FixturePlacementEngine.cs`, `PlacementRule.cs`)
+
+Remaining review items (GuaranteeCoverage/CoverageGridGenerator wiring,
+FilterByProfile at run time, ceiling/soffit mounting-reference sign, and
+the flexibility/minor batch) are deferred to follow-up branches per the
+review's recommended order.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7226,3 +7226,41 @@ against the Revit 2025 API — 0 warnings, 0 errors.**
     are process-global run config. The MergeKey-collision case is already
     surfaced by the existing `MergeRules` duplicate-key warning.
     (`PlacementScorer.cs`)
+
+#### Completed (Phase 188 — Placement Center hardening, batch 4: deep-review pass-2)
+
+Branch `claude/placement-center-fixes` (worktree-isolated). **Verified with
+`dotnet build` against the Revit 2025 API — 0 warnings, 0 errors.**
+
+12. **Primary placements now oriented (pass-2 #1).** `OrientPlacedInstance`
+    (applies `RotationDeg`, flips the family to face into the room, snaps it
+    off the wall centerline) was wired only into the `CoPlaceWith` path; the
+    main `ProcessRoomRule` loop never called it, so most placed fixtures
+    ignored rotation and sat on the wall centerline facing world-X. Now
+    invoked after `WriteAnchorParameters` on the main path too.
+    (`FixturePlacementEngine.cs`)
+
+13. **`NearestOf<T>` bounded by bbox (pass-2 #2).** The host search ran an
+    unbounded full-category `FilteredElementCollector` per placement; now
+    pre-filtered with a `BoundingBoxIntersectsFilter` around the point ±
+    search radius. (`PlacementHostPreflight.cs`)
+
+14. **Intra-rule `MinSpacingMm` enforced at selection (pass-2 #3).** Candidate
+    selection passed an empty placed-list to the scorer (SpacingScore always
+    1.0) and `Take(cap)` could pick points closer than `MinSpacingMm`. New
+    `SelectWithSpacing` greedily accepts ranked candidates clearing the
+    spacing from already-accepted ones. (`FixturePlacementEngine.cs`)
+
+15. **`ResolveView3D` cross-document hazard (pass-2 #4).** Cache keyed on
+    `doc.GetHashCode()` in a single static slot; now keyed by `PathName|Title`
+    with an `IsValidObject` + `Document` identity guard. (`PlacementHostPreflight.cs`)
+
+16. **`IsRegexLike` tightened (pass-2 #5).** A lone `$` or unbalanced `[` no
+    longer misclassifies a literal variant/type name as a regex; now requires
+    a real anchor / escape / quantifier / balanced class or group.
+    (`FixturePlacementEngine.cs`)
+
+17. **`WriteAnchorParameters` persists full transform (pass-2 #6).** Now also
+    writes `ASS_PLACE_OFFSET_Y_MM` / `_Z_MM` / `ASS_PLACE_ROTATION_DEG`
+    (best-effort; no-op when unbound) so placement intent round-trips.
+    (`FixturePlacementEngine.cs`)


### PR DESCRIPTION
## Summary

Hardening pass over the **Placement Center** (categories & rules) from a two-round review. 17 fixes across correctness, accuracy, flexibility, efficiency, and performance. Every commit is **verified with `dotnet build` against the Revit 2025 API (0 warnings, 0 errors)** — not the usual unbuilt caveat.

Scope: `StingTools/Core/Placement/` (engine, scorer, rule model, loader, host preflight, coverage generator).

## Commits

| Commit | Batch |
|---|---|
| `f4a30c8b4` | 1 — scorer doc bind, sample cache, density rates |
| `e3427953b` | 2 — profile filter at run time, ceiling sign, coverage-guarantee warn |
| `2a600eb93` | 3 — CategoryBic, regex cache, grid bounds, scoring minors |
| `b3c6d05f1` | 4 — deep-review pass-2 (orient, host search, spacing, view cache, regex, anchor params) |

## Fixes

**Critical correctness**
1. `PlacementScorer._doc` was never assigned — the constructor discarded its argument, leaving the readonly field null, so collision scoring, `RejectInsideWall`, door/window/grid/column/MEP anchors and manufacturer scoring all silently no-op'd. Now bound.
2. `OrientPlacedInstance` (rotation + face-into-room + wall-snap) was wired only into the `CoPlaceWith` path; the main placement loop never called it, so most fixtures ignored `RotationDeg` and sat on the wall centerline. Now invoked on the main path.

**Accuracy / automation logic**
3. Density counts now honour `PerBed` / `PerWorkstation` / `PerPupil` / `PerToiletCubicle` (were validated + UI-exposed but never read → collapsed to 1/room).
4. `FilterByProfile` is now applied at run time so a run matches what the Centre displays (was display-only).
5. Intra-rule `MinSpacingMm` enforced at candidate selection via `SelectWithSpacing` (selection scored against an empty placed-list, so `Take(cap)` could cluster).
6. `CEILING`/`SOFFIT` mounting-reference sign fixed (height was added above the ceiling instead of dropped below).
7. `GuaranteeCoverage` / `CoverageGridGenerator` deprecate-and-warn (documented behaviour was never wired into the engine).

**Flexibility**
8. New optional `CategoryBic` for locale-robust symbol matching (match by category id vs localized `Category.Name`).
9. Standards-gate inert warning when a profile declares `ActiveStandards` but no rule populates the structured `ApplicableStandards`.
10. `IsRegexLike` tightened so literal variant/type names aren't misread as regex.

**Performance / efficiency**
11. `ResolveSampleInstanceForRule` category-prefiltered + cached (was a whole-model scan per candidate).
12. `NearestOf<T>` host search bounded with a `BoundingBoxIntersectsFilter` (was a full-category scan per placement).
13. Grid anchors (`CEILING_TILE_CORNER` / `RAISED_FLOOR_TILE_EDGE`) bounded at 2000 points.
14. Scope-filter regex compiled + cached in `RoomMatchesScope`.

**Robustness / minor**
15. `ResolveView3D` cache keyed by `PathName|Title` + `Document` identity (was `GetHashCode()` cross-document hazard).
16. `ScoreManufacturerResolution` returns neutral 0.5 for catalogue-less rules (was 0.0, docking them against `ScoreThreshold`).
17. `WriteAnchorParameters` persists Y/Z offset + rotation (best-effort; was X-only).

## Verification

- ✅ `dotnet build` against Revit 2025 API: 0 warnings, 0 errors (all four commits).
- ⚠️ **In-Revit sanity check recommended before merge** for the fixes that change model output — especially #2 (orientation) and #3/#5 (placement counts/spacing). The build proves it compiles; it does not exercise the Revit runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)