### PR TITLE
Placement Centre — review, gap-closure & hardening

### DIFF
--- a/Planscape.Server/src/Planscape.Core/Entities/ElementGlobalIdRegistry.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ElementGlobalIdRegistry.cs
@@ -6,6 +6,19 @@ namespace Planscape.Core.Entities;
 /// maps each tool's element identity to a single canonical IfcGlobalId so
 /// clash detection, issue linking, and BCF topic references all refer to
 /// the same physical element regardless of which tool created it.
+///
+/// INT-0 — SUPERSEDED (consolidation target): this "wide" registry (one row
+/// per element, per-tool columns ArchiCadGuid/RevitUniqueId/TeklaGuid) and the
+/// "tall" <see cref="ExternalElementMapping"/> (one row per
+/// (IfcGlobalId, Host, HostDocumentGuid)) answer the SAME question —
+/// "IFC GlobalId ↔ host element id". <see cref="ExternalElementMapping"/> is
+/// the declared authority (written by every IFC ingest) and is the canonical
+/// spine going forward. New cross-host identity work MUST target
+/// ExternalElementMapping, not this table. Folding the per-tool columns here
+/// into ExternalElementMapping rows (Host="archicad"/"tekla") + retiring this
+/// entity is a follow-up requiring an EF migration + a sweep of every reader
+/// (IdentityResolverService, CrossHostMappingReconciliation), so it is staged
+/// separately rather than done blind. Do not extend this table.
 /// </summary>
 public class ElementGlobalIdRegistry : ITenantScoped
 {

--- a/StingTools.Boq.Tests/IfcGuidEncoderTests.cs
+++ b/StingTools.Boq.Tests/IfcGuidEncoderTests.cs
@@ -71,5 +71,30 @@ namespace StingTools.Boq.Tests
             Assert.Equal("", IfcGuidEncoder.FromRevitUniqueId(""));
             Assert.Equal("", IfcGuidEncoder.FromRevitUniqueId(null!));
         }
+
+        // Stub exposing only a UniqueId string — stands in for a Revit Element
+        // (which cannot be constructed in the no-Revit test sandbox).
+        private sealed class FakeElement { public string UniqueId { get; set; } = ""; }
+
+        [Fact]
+        public void FromElementGoldStandard_falls_back_to_string_encoder_when_ifc_absent()
+        {
+            // RevitAPIIFC is not loaded in the test process, so the reflection
+            // path is unavailable and the helper must return exactly the
+            // canonical string-encoder value for the element's UniqueId.
+            string uid = RefGuid + "-0000007b";
+            var fake = new FakeElement { UniqueId = uid };
+            Assert.Equal(IfcGuidEncoder.FromRevitUniqueId(uid),
+                         IfcGuidEncoder.FromElementGoldStandard(fake));
+            // And that value is the canonical folded GlobalId pinned above.
+            Assert.Equal("3t3TDZl_D9NOIWB0BSjzIf",
+                         IfcGuidEncoder.FromElementGoldStandard(fake));
+        }
+
+        [Fact]
+        public void FromElementGoldStandard_null_returns_empty()
+        {
+            Assert.Equal("", IfcGuidEncoder.FromElementGoldStandard(null!));
+        }
     }
 }

--- a/StingTools.Boq.Tests/IfcGuidEncoderTests.cs
+++ b/StingTools.Boq.Tests/IfcGuidEncoderTests.cs
@@ -1,0 +1,75 @@
+using System;
+using Xunit;
+using StingTools.IfcResults;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// INT-0 — pins the IFC GlobalId encoder to the canonical buildingSMART /
+    /// RevitIFC algorithm. The reference vector is from the IfcOpenShell docs
+    /// (the same compression Revit's exporter uses):
+    ///   GUID  f70dd363-bfe3-495d-84a0-2c02dcb7d4d2
+    ///   IfcId 3t3TDZl_D9NOIWB0BSjzJI
+    /// Without this pin the encoder can silently regress (the Linux sandbox
+    /// has no Revit API to verify against).
+    /// </summary>
+    public class IfcGuidEncoderTests
+    {
+        private const string RefGuid   = "f70dd363-bfe3-495d-84a0-2c02dcb7d4d2";
+        private const string RefIfcGuid = "3t3TDZl_D9NOIWB0BSjzJI";
+        private const string Alphabet =
+            "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$";
+
+        [Fact]
+        public void FromGuid_matches_canonical_reference_vector()
+        {
+            Assert.Equal(RefIfcGuid, IfcGuidEncoder.FromGuid(new Guid(RefGuid)));
+        }
+
+        [Fact]
+        public void FromGuid_output_is_22_chars_and_alphabet_valid()
+        {
+            string s = IfcGuidEncoder.FromGuid(new Guid(RefGuid));
+            Assert.Equal(22, s.Length);
+            foreach (char c in s)
+                Assert.Contains(c, Alphabet);
+        }
+
+        [Fact]
+        public void FromRevitUniqueId_zero_elementid_equals_FromGuid()
+        {
+            // XOR-folding element id 0 is the identity, so a UniqueId with a
+            // 00000000 suffix must equal the raw episode-GUID encoding.
+            string fromUid = IfcGuidEncoder.FromRevitUniqueId(RefGuid + "-00000000");
+            Assert.Equal(RefIfcGuid, fromUid);
+        }
+
+        [Fact]
+        public void FromRevitUniqueId_folds_elementid_into_low_bytes()
+        {
+            // Element id 0x7b XORs the last GUID byte 0xd2 -> 0xa9, changing only
+            // the final base64 group "jzJI" -> "jzIf" (hand-derived from the
+            // canonical algorithm and cross-checked against the reference vector).
+            string folded = IfcGuidEncoder.FromRevitUniqueId(RefGuid + "-0000007b");
+            Assert.Equal("3t3TDZl_D9NOIWB0BSjzIf", folded);
+        }
+
+        [Fact]
+        public void FromRevitUniqueId_is_elementid_sensitive()
+        {
+            // Same episode GUID, different element-id suffix -> different GlobalId.
+            string a = IfcGuidEncoder.FromRevitUniqueId(RefGuid + "-00000001");
+            string b = IfcGuidEncoder.FromRevitUniqueId(RefGuid + "-00000002");
+            Assert.NotEqual(a, b);
+            Assert.NotEqual(IfcGuidEncoder.FromRevitUniqueId(RefGuid + "-00000000"), a);
+            Assert.Equal(22, a.Length);
+        }
+
+        [Fact]
+        public void FromRevitUniqueId_empty_returns_empty()
+        {
+            Assert.Equal("", IfcGuidEncoder.FromRevitUniqueId(""));
+            Assert.Equal("", IfcGuidEncoder.FromRevitUniqueId(null!));
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\StingTools\IfcResults\IfcGuidEncoder.cs" Link="IfcResults\IfcGuidEncoder.cs" />
     <Compile Include="..\StingTools\BOQ\WasteFactor.cs" Link="WasteFactor.cs" />
     <Compile Include="..\StingTools\BOQ\MeasuredAddition.cs" Link="MeasuredAddition.cs" />
     <Compile Include="..\StingTools\UI\MaterialLookupParser.cs" Link="UI\MaterialLookupParser.cs" />

--- a/StingTools/BIMManager/BIMManagerCommands.cs
+++ b/StingTools/BIMManager/BIMManagerCommands.cs
@@ -2726,8 +2726,12 @@ namespace StingTools.BIMManager
                     ["Name"] = friendlyName, ["CreatedBy"] = createdBy, ["CreatedOn"] = createdOn,
                     ["TypeName"] = typeName, ["Space"] = roomName,
                     ["Description"] = !string.IsNullOrEmpty(tag7) ? tag7 : desc,
+                    // INT-0 — COBie ExternalIdentifier (NBIMS-US ExtIdentifier)
+                    // must be the stable 22-char IFC GlobalId, not the 45-char
+                    // Revit UniqueId. It is the cross-tool join key into the IFC,
+                    // Speckle applicationId and the server identity map.
                     ["ExternalSystem"] = "Revit", ["ExternalObject"] = cat,
-                    ["ExternalIdentifier"] = el.UniqueId,
+                    ["ExternalIdentifier"] = StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(el.UniqueId),
                     ["SerialNumber"] = serialNumber,
                     ["InstallationDate"] = installDate,
                     ["WarrantyStartDate"] = warrantyStart,

--- a/StingTools/BIMManager/BIMManagerCommands.cs
+++ b/StingTools/BIMManager/BIMManagerCommands.cs
@@ -2731,7 +2731,7 @@ namespace StingTools.BIMManager
                     // Revit UniqueId. It is the cross-tool join key into the IFC,
                     // Speckle applicationId and the server identity map.
                     ["ExternalSystem"] = "Revit", ["ExternalObject"] = cat,
-                    ["ExternalIdentifier"] = StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(el.UniqueId),
+                    ["ExternalIdentifier"] = StingTools.IfcResults.IfcGuidEncoder.FromElementGoldStandard(el),
                     ["SerialNumber"] = serialNumber,
                     ["InstallationDate"] = installDate,
                     ["WarrantyStartDate"] = warrantyStart,

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -322,7 +322,10 @@ namespace StingTools.BOQ
             return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string NormaliseUnit(string u)
+        // internal so IfcQuantitySetWriter (same assembly) can canonicalise
+        // units against the same table — avoids the m²/m2 glyph mismatch that
+        // silently zeroed every exported Qto (P0-1).
+        internal static string NormaliseUnit(string u)
         {
             if (string.IsNullOrEmpty(u)) return "";
             string s = u.Trim().ToLowerInvariant();

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -60,13 +60,68 @@ namespace StingTools.BOQ
         /// defaults. Merges manual/PS rows from project_boq_manual.json so
         /// a QS can author extra line items without modelling them.
         /// </summary>
-        /// <summary>
-        /// When true, BuildBOQDocument also quantifies elements in loaded Revit
-        /// links. Process-wide so every consumer (panel, QTO export, snapshots)
-        /// stays consistent; toggled from the Cost Manager header checkbox.
-        /// Linked rows are read-only for cost write-back (see STEP 6c).
-        /// </summary>
-        internal static bool IncludeLinkedModels = false;
+        // ── Linked-model inclusion (per-link, persisted) ─────────────────────
+        // The set holds the Titles of loaded links whose quantities are folded
+        // into the takeoff. Persisted to <project>/_BIM_COORD/boq_links.json so
+        // the choice survives reopen (sustainable) and is per-link (flexible).
+        // Empty ⇒ host model only. Every consumer (panel, QTO export, snapshots)
+        // reads the same persisted set, so the takeoff is consistent everywhere.
+        private static readonly Dictionary<string, HashSet<string>> _linkInclusionCache
+            = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        private static string LinkSelectionPath(Document doc)
+        {
+            string parent = System.IO.Path.GetDirectoryName(doc?.PathName ?? "");
+            if (string.IsNullOrEmpty(parent)) return null;   // unsaved doc — memory only
+            return System.IO.Path.Combine(parent, "_BIM_COORD", "boq_links.json");
+        }
+
+        /// <summary>Titles of loaded links included in the takeoff for this doc
+        /// (loaded from boq_links.json on first ask, cached per doc path).</summary>
+        internal static HashSet<string> GetIncludedLinkTitles(Document doc)
+        {
+            string key = doc?.PathName ?? "";
+            lock (_linkInclusionCache)
+            {
+                if (_linkInclusionCache.TryGetValue(key, out var cached)) return cached;
+                var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                try
+                {
+                    string path = LinkSelectionPath(doc);
+                    if (path != null && System.IO.File.Exists(path))
+                    {
+                        var titles = Newtonsoft.Json.JsonConvert.DeserializeObject<List<string>>(
+                            System.IO.File.ReadAllText(path));
+                        if (titles != null) foreach (var t in titles)
+                            if (!string.IsNullOrWhiteSpace(t)) set.Add(t.Trim());
+                    }
+                }
+                catch (Exception ex) { StingLog.Warn($"GetIncludedLinkTitles: {ex.Message}"); }
+                _linkInclusionCache[key] = set;
+                return set;
+            }
+        }
+
+        /// <summary>Persist the per-link inclusion set + refresh the cache.</summary>
+        internal static void SetIncludedLinkTitles(Document doc, IEnumerable<string> titles)
+        {
+            string key = doc?.PathName ?? "";
+            var set = new HashSet<string>(
+                (titles ?? Enumerable.Empty<string>()).Where(t => !string.IsNullOrWhiteSpace(t)).Select(t => t.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+            lock (_linkInclusionCache) { _linkInclusionCache[key] = set; }
+            try
+            {
+                string path = LinkSelectionPath(doc);
+                if (path != null)
+                {
+                    System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path));
+                    System.IO.File.WriteAllText(path,
+                        Newtonsoft.Json.JsonConvert.SerializeObject(set.ToList(), Newtonsoft.Json.Formatting.Indented));
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"SetIncludedLinkTitles: {ex.Message}"); }
+        }
 
         internal static BOQDocument BuildBOQDocument(Document doc, IEnumerable<BOQLineItem> extraManualRows = null,
             BoqGroupingMode grouping = BoqGroupingMode.WorkSection)
@@ -133,11 +188,12 @@ namespace StingTools.BOQ
             // forced to -1 and IfcQuantitySetWriter / CostStamp / select-in-Revit
             // all skip them — they contribute quantity + cost + carbon only,
             // tagged "[Linked: <model>]".
-            if (IncludeLinkedModels)
+            var includedLinks = GetIncludedLinkTitles(doc);
+            if (includedLinks.Count > 0)
             {
                 try
                 {
-                    var linkItems = CollectLinkedItems(doc, knownCats, csvRates, cobieCostCodes, grouping);
+                    var linkItems = CollectLinkedItems(doc, knownCats, csvRates, cobieCostCodes, grouping, includedLinks);
                     if (linkItems.Count > 0) items.AddRange(linkItems);
                 }
                 catch (Exception ex) { StingLog.Warn($"BOQ linked-model takeoff: {ex.Message}"); }
@@ -1866,9 +1922,11 @@ namespace StingTools.BOQ
             Document doc, HashSet<string> knownCategories,
             Dictionary<string, (double rate, string unit)> csvRates,
             Dictionary<string, string> cobieCostCodes,
-            BoqGroupingMode grouping)
+            BoqGroupingMode grouping,
+            HashSet<string> includedTitles)
         {
             var result = new List<BOQLineItem>();
+            var seenTitles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var links = new FilteredElementCollector(doc)
                 .OfClass(typeof(RevitLinkInstance))
                 .Cast<RevitLinkInstance>();
@@ -1881,6 +1939,11 @@ namespace StingTools.BOQ
 
                 string linkName;
                 try { linkName = ld.Title; } catch { linkName = "link"; }
+
+                // Per-link gate. Only links the user ticked are quantified; a
+                // shared link placed multiple times is taken off exactly once.
+                if (includedTitles != null && includedTitles.Count > 0 && !includedTitles.Contains(linkName)) continue;
+                if (!seenTitles.Add(linkName)) continue;
 
                 var linkEls = CollectCandidateElements(ld, knownCategories);
                 var linkItems = new List<BOQLineItem>(linkEls.Count);

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -1959,6 +1959,7 @@ namespace StingTools.BOQ
                     li.RevitElementId = -1;                       // never resolve against the host doc
                     li.UniqueId = "";                             // avoid cross-doc id reuse
                     li.ConstituentElementIds = new List<long>();  // link-doc ids — not host-resolvable
+                    li.SourceModel = linkName;                    // drives "Group by Source model"
                     li.Note = string.IsNullOrEmpty(li.Note)
                         ? $"[Linked: {linkName}]"
                         : $"{li.Note} [Linked: {linkName}]";
@@ -2181,6 +2182,8 @@ namespace StingTools.BOQ
                     return GroupBySpatial(items, i => Blank(i.Zone, "(no zone)"));
                 case BoqGroupingMode.Location:
                     return GroupBySpatial(items, i => Blank(i.Location, "(no location)"));
+                case BoqGroupingMode.SourceModel:
+                    return GroupBySpatial(items, i => Blank(i.SourceModel, "Host model"));
                 case BoqGroupingMode.LevelThenWorkSection:
                     return GroupByLevelThenSection(items);
                 case BoqGroupingMode.WorkSection:

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -69,6 +69,30 @@ namespace StingTools.BOQ
         private static readonly Dictionary<string, HashSet<string>> _linkInclusionCache
             = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
+        // ── P1.2 — per-link takeoff cache ────────────────────────────────────
+        // RefreshAsync runs BuildBOQDocument synchronously, and STEP 6c walks every
+        // linked document on every rebuild (filter toggle / rate edit / grouping
+        // change). On a federated model that re-traverse freezes Revit. We cache the
+        // RAW per-link line items (post-BuildLineItemFromElement, PRE-aggregate /
+        // PRE-neutralise) keyed on the linked file's PathName, so a host-side
+        // refresh reuses them without re-reading the link's Revit DB. Grouping is
+        // applied AFTER the cache (cheap CPU on the cached rows) so it stays correct
+        // across grouping changes without invalidating. Cleared on document close.
+        private sealed class LinkTakeoffCacheEntry { public List<BOQLineItem> RawItems; }
+
+        private static readonly Dictionary<string, LinkTakeoffCacheEntry> _linkTakeoffCache
+            = new Dictionary<string, LinkTakeoffCacheEntry>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Drop cached per-link takeoffs. Call when a link may have changed
+        /// (document close, manual rebuild). Selection changes do NOT need this — the
+        /// cache is keyed per-link, so toggling which links are included just changes
+        /// which keys get looked up; a reload of the same selection still hits the
+        /// cache.</summary>
+        internal static void InvalidateLinkCache()
+        {
+            lock (_linkTakeoffCache) { _linkTakeoffCache.Clear(); }
+        }
+
         private static string LinkSelectionPath(Document doc)
         {
             string parent = System.IO.Path.GetDirectoryName(doc?.PathName ?? "");
@@ -1945,15 +1969,49 @@ namespace StingTools.BOQ
                 if (includedTitles != null && includedTitles.Count > 0 && !includedTitles.Contains(linkName)) continue;
                 if (!seenTitles.Add(linkName)) continue;
 
-                var linkEls = CollectCandidateElements(ld, knownCategories);
-                var linkItems = new List<BOQLineItem>(linkEls.Count);
-                foreach (var el in linkEls)
+                // P1.2 — reuse the raw per-link takeoff when it's already cached so a
+                // host-side refresh doesn't re-walk this link's Revit DB.
+                string cacheKey;
+                try { cacheKey = string.IsNullOrEmpty(ld.PathName) ? linkName : ld.PathName; }
+                catch { cacheKey = linkName; }
+
+                List<BOQLineItem> rawItems = null;
+                bool cacheHit;
+                lock (_linkTakeoffCache)
                 {
-                    var line = BuildLineItemFromElement(ld, el, csvRates, cobieCostCodes);
-                    if (line != null) linkItems.Add(line);
+                    cacheHit = _linkTakeoffCache.TryGetValue(cacheKey, out var entry)
+                        && entry?.RawItems != null;
+                    if (cacheHit) rawItems = entry.RawItems.Select(x => x.Clone()).ToList();
                 }
 
-                linkItems = AggregateLineItems(linkItems, grouping);
+                if (!cacheHit)
+                {
+                    var linkEls = CollectCandidateElements(ld, knownCategories);
+                    rawItems = new List<BOQLineItem>(linkEls.Count);
+                    foreach (var el in linkEls)
+                    {
+                        var line = BuildLineItemFromElement(ld, el, csvRates, cobieCostCodes);
+                        if (line != null) rawItems.Add(line);
+                    }
+                    // Store an isolated clone so a later caller mutating the returned
+                    // rows can never corrupt the cache.
+                    lock (_linkTakeoffCache)
+                    {
+                        _linkTakeoffCache[cacheKey] = new LinkTakeoffCacheEntry
+                        { RawItems = rawItems.Select(x => x.Clone()).ToList() };
+                    }
+                    StingLog.Info($"BOQ linked-model takeoff (cache MISS — walked link): "
+                        + $"{rawItems.Count} raw row(s) from '{linkName}'.");
+                }
+                else
+                {
+                    StingLog.Info($"BOQ linked-model takeoff (cache hit — link not re-walked): "
+                        + $"{rawItems.Count} raw row(s) from '{linkName}'.");
+                }
+
+                // Aggregate + neutralise on the (cloned) raw rows every time so
+                // grouping changes stay correct without invalidating the cache.
+                var linkItems = AggregateLineItems(rawItems, grouping);
                 foreach (var li in linkItems)
                 {
                     li.RevitElementId = -1;                       // never resolve against the host doc
@@ -1965,7 +2023,6 @@ namespace StingTools.BOQ
                         : $"{li.Note} [Linked: {linkName}]";
                 }
                 result.AddRange(linkItems);
-                StingLog.Info($"BOQ linked-model takeoff: {linkItems.Count} row(s) from '{linkName}'.");
             }
             return result;
         }

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -60,6 +60,14 @@ namespace StingTools.BOQ
         /// defaults. Merges manual/PS rows from project_boq_manual.json so
         /// a QS can author extra line items without modelling them.
         /// </summary>
+        /// <summary>
+        /// When true, BuildBOQDocument also quantifies elements in loaded Revit
+        /// links. Process-wide so every consumer (panel, QTO export, snapshots)
+        /// stays consistent; toggled from the Cost Manager header checkbox.
+        /// Linked rows are read-only for cost write-back (see STEP 6c).
+        /// </summary>
+        internal static bool IncludeLinkedModels = false;
+
         internal static BOQDocument BuildBOQDocument(Document doc, IEnumerable<BOQLineItem> extraManualRows = null,
             BoqGroupingMode grouping = BoqGroupingMode.WorkSection)
         {
@@ -117,6 +125,23 @@ namespace StingTools.BOQ
             // The grouping mode feeds the aggregation key (P2.2) so similar
             // items collapse within the active spatial dimension.
             items = AggregateLineItems(items, grouping);
+
+            // ── STEP 6c: Linked-model takeoff (opt-in) ───────────────────
+            // Quantify elements in loaded Revit links when enabled. Linked rows
+            // are READ-ONLY for cost write-back: a link element's id can collide
+            // with a host id and stamp the wrong element, so RevitElementId is
+            // forced to -1 and IfcQuantitySetWriter / CostStamp / select-in-Revit
+            // all skip them — they contribute quantity + cost + carbon only,
+            // tagged "[Linked: <model>]".
+            if (IncludeLinkedModels)
+            {
+                try
+                {
+                    var linkItems = CollectLinkedItems(doc, knownCats, csvRates, cobieCostCodes, grouping);
+                    if (linkItems.Count > 0) items.AddRange(linkItems);
+                }
+                catch (Exception ex) { StingLog.Warn($"BOQ linked-model takeoff: {ex.Message}"); }
+            }
 
             // ── STEP 7: Group into sections ──────────────────────────────
             boq.Sections = GroupIntoSections(items, grouping);
@@ -1827,6 +1852,58 @@ namespace StingTools.BOQ
             }
             catch (Exception ex) { StingLog.Warn($"BuildExcludedCategoryNames: {ex.Message}"); }
             return set;
+        }
+
+        /// <summary>
+        /// STEP 6c — quantify elements in every loaded Revit link. Each link is
+        /// aggregated on its own, then its rows are neutralised for host
+        /// write-back (RevitElementId = -1, UniqueId cleared, constituents
+        /// dropped) and tagged "[Linked: &lt;model&gt;]". Unloaded links are
+        /// skipped. Quantities are parameter-derived, so the link transform does
+        /// not affect them.
+        /// </summary>
+        private static List<BOQLineItem> CollectLinkedItems(
+            Document doc, HashSet<string> knownCategories,
+            Dictionary<string, (double rate, string unit)> csvRates,
+            Dictionary<string, string> cobieCostCodes,
+            BoqGroupingMode grouping)
+        {
+            var result = new List<BOQLineItem>();
+            var links = new FilteredElementCollector(doc)
+                .OfClass(typeof(RevitLinkInstance))
+                .Cast<RevitLinkInstance>();
+
+            foreach (var rli in links)
+            {
+                Document ld = null;
+                try { ld = rli.GetLinkDocument(); } catch { }
+                if (ld == null) continue;   // link not loaded / not found
+
+                string linkName;
+                try { linkName = ld.Title; } catch { linkName = "link"; }
+
+                var linkEls = CollectCandidateElements(ld, knownCategories);
+                var linkItems = new List<BOQLineItem>(linkEls.Count);
+                foreach (var el in linkEls)
+                {
+                    var line = BuildLineItemFromElement(ld, el, csvRates, cobieCostCodes);
+                    if (line != null) linkItems.Add(line);
+                }
+
+                linkItems = AggregateLineItems(linkItems, grouping);
+                foreach (var li in linkItems)
+                {
+                    li.RevitElementId = -1;                       // never resolve against the host doc
+                    li.UniqueId = "";                             // avoid cross-doc id reuse
+                    li.ConstituentElementIds = new List<long>();  // link-doc ids — not host-resolvable
+                    li.Note = string.IsNullOrEmpty(li.Note)
+                        ? $"[Linked: {linkName}]"
+                        : $"{li.Note} [Linked: {linkName}]";
+                }
+                result.AddRange(linkItems);
+                StingLog.Info($"BOQ linked-model takeoff: {linkItems.Count} row(s) from '{linkName}'.");
+            }
+            return result;
         }
 
         private static List<Element> CollectCandidateElements(Document doc, HashSet<string> knownCategories)

--- a/StingTools/BOQ/BOQExportCommand.cs
+++ b/StingTools/BOQ/BOQExportCommand.cs
@@ -167,8 +167,13 @@ namespace StingTools.BOQ
 
             // Row 6 — column headers
             int hr = 6;
+            // INT-2 — "Ifc GlobalId" (col 14) is the stable round-trip join key.
+            // An external estimator fills "Rate UGX"; re-import (BOQImportCommand)
+            // joins each priced row back to its element on this GlobalId
+            // (fallback Line ref), so the join survives BOQLineRef churn.
             string[] cols = { "NRM2 §", "Line ref", "Description (NRM2 narrative)", "Unit", "Quantity",
-                "Rate UGX", "Total UGX", "Rate USD", "Total USD", "Source", "Discipline", "Level / Location", "Note" };
+                "Rate UGX", "Total UGX", "Rate USD", "Total USD", "Source", "Discipline", "Level / Location", "Note",
+                "Ifc GlobalId" };
             for (int i = 0; i < cols.Length; i++)
             {
                 ws.Cell(hr, i + 1).Value = cols[i];
@@ -206,7 +211,8 @@ namespace StingTools.BOQ
                     ws.Cell(row, 11).Value = item.Discipline ?? "";
                     ws.Cell(row, 12).Value = JoinLevelLocation(item);
                     ws.Cell(row, 13).Value = item.Note ?? "";
-                    if (item.Source != BOQRowSource.Model) ws.Range(row, 1, row, 13).Style.Fill.SetBackgroundColor(SourceFill(item.Source));
+                    ws.Cell(row, 14).Value = item.IfcGlobalId ?? "";   // INT-2 round-trip join key
+                    if (item.Source != BOQRowSource.Model) ws.Range(row, 1, row, 14).Style.Fill.SetBackgroundColor(SourceFill(item.Source));
                     row++;
                 }
             }

--- a/StingTools/BOQ/BOQExportCommand.cs
+++ b/StingTools/BOQ/BOQExportCommand.cs
@@ -173,17 +173,17 @@ namespace StingTools.BOQ
             // (fallback Line ref), so the join survives BOQLineRef churn.
             string[] cols = { "NRM2 §", "Line ref", "Description (NRM2 narrative)", "Unit", "Quantity",
                 "Rate UGX", "Total UGX", "Rate USD", "Total USD", "Source", "Discipline", "Level / Location", "Note",
-                "Ifc GlobalId" };
+                "Source Model", "Ifc GlobalId" };
             for (int i = 0; i < cols.Length; i++)
             {
                 ws.Cell(hr, i + 1).Value = cols[i];
             }
-            ws.Range(hr, 1, hr, 13).Style.Font.SetBold().Font.SetFontColor(XLColor.White)
+            ws.Range(hr, 1, hr, cols.Length).Style.Font.SetBold().Font.SetFontColor(XLColor.White)
                 .Fill.SetBackgroundColor(HeaderFill);
             ws.SheetView.FreezeRows(hr);
 
             // Column widths
-            double[] widths = { 8, 10, 58, 6, 9, 14, 14, 12, 12, 9, 9, 18, 22 };
+            double[] widths = { 8, 10, 58, 6, 9, 14, 14, 12, 12, 9, 9, 18, 22, 16 };
             for (int i = 0; i < widths.Length; i++) ws.Column(i + 1).Width = widths[i];
 
             // Data rows — section headers + items
@@ -211,7 +211,8 @@ namespace StingTools.BOQ
                     ws.Cell(row, 11).Value = item.Discipline ?? "";
                     ws.Cell(row, 12).Value = JoinLevelLocation(item);
                     ws.Cell(row, 13).Value = item.Note ?? "";
-                    ws.Cell(row, 14).Value = item.IfcGlobalId ?? "";   // INT-2 round-trip join key
+                    ws.Cell(row, 14).Value = string.IsNullOrWhiteSpace(item.SourceModel) ? "Host" : item.SourceModel; // P1.1 provenance
+                    ws.Cell(row, 15).Value = item.IfcGlobalId ?? "";   // INT-2 round-trip join key
                     if (item.Source != BOQRowSource.Model) ws.Range(row, 1, row, 14).Style.Fill.SetBackgroundColor(SourceFill(item.Source));
                     row++;
                 }
@@ -248,7 +249,7 @@ namespace StingTools.BOQ
         {
             BannerRow(ws, $"{boq.ProjectName} — Item Schedule (edit in place and re-import via BOQ → Import)");
             string[] cols = { "Line ref", "NRM2 §", "Category", "Discipline", "Item", "Family", "Unit", "Quantity",
-                "Rate UGX", "Total UGX", "Rate USD", "Total USD", "Source", "Note", "Revit ElementId",
+                "Rate UGX", "Total UGX", "Rate USD", "Total USD", "Source", "Note", "Source Model", "Revit ElementId",
                 "UniqueId", "Level", "Location", "Embodied kgCO2e", "Lifecycle UGX", "Rate confidence" };
             WriteHeader(ws, 3, cols);
 
@@ -269,13 +270,14 @@ namespace StingTools.BOQ
                 ws.Cell(row, 12).Value = it.TotalUSD;
                 ws.Cell(row, 13).Value = SourceLabel(it.Source);
                 ws.Cell(row, 14).Value = it.Note ?? "";
-                ws.Cell(row, 15).Value = it.RevitElementId;
-                ws.Cell(row, 16).Value = it.UniqueId ?? "";
-                ws.Cell(row, 17).Value = it.Level ?? "";
-                ws.Cell(row, 18).Value = it.Location ?? "";
-                ws.Cell(row, 19).Value = it.EmbodiedCarbonKg;
-                ws.Cell(row, 20).Value = it.LifecycleCostUGX;
-                ws.Cell(row, 21).Value = it.RateConfidence;
+                ws.Cell(row, 15).Value = string.IsNullOrWhiteSpace(it.SourceModel) ? "Host" : it.SourceModel; // P1.1 provenance
+                ws.Cell(row, 16).Value = it.RevitElementId;
+                ws.Cell(row, 17).Value = it.UniqueId ?? "";
+                ws.Cell(row, 18).Value = it.Level ?? "";
+                ws.Cell(row, 19).Value = it.Location ?? "";
+                ws.Cell(row, 20).Value = it.EmbodiedCarbonKg;
+                ws.Cell(row, 21).Value = it.LifecycleCostUGX;
+                ws.Cell(row, 22).Value = it.RateConfidence;
                 row++;
             }
             ws.Range(3, 1, 3, cols.Length).SetAutoFilter();

--- a/StingTools/BOQ/BOQExportIfcQtoCommand.cs
+++ b/StingTools/BOQ/BOQExportIfcQtoCommand.cs
@@ -1,0 +1,150 @@
+// BOQExportIfcQtoCommand.cs — INT-1: QTO-conformant IFC export for estimators.
+//
+// Produces an IFC4 file carrying base quantities + the BOQ cost/classification
+// property sets, so an external estimator (RIB iTWO / CostX / Candy) can ingest
+// measured quantities directly. This is the BOQ-facing IFC path — distinct from
+// the generic IFC2x3 export (ExLink/AutomationEngine) and the Tekla-facing
+// IFC4 Reference View (Commands/Mep/ExportPfvIfcCommand); it does NOT change
+// either of those.
+//
+// HONEST SCOPE (read before trusting for external interop):
+//  • There is NO literal "Quantity Takeoff MVD" in Revit's IFCVersion enum.
+//    The buildingSMART QTO MVD is delivered in practice as IFC4 (or IFC2x3 CV2)
+//    WITH ExportBaseQuantities=true — Revit computes and emits the standard
+//    Qto_*BaseQuantities, which is exactly what CostX/iTWO read. That is the
+//    "QTO-conformant" claim here.
+//  • NRM2 (and CSI/ICMS where present) travels as Pset_StingCost.NRM2Section,
+//    stamped by IfcQuantitySetWriter and carried via the cost pset. A proper
+//    IfcClassificationReference entity requires a Revit classification-mapping
+//    file (Export → Modify Setup → Classification), which can't be set through
+//    the headless IFCExportOptions API — TODO-VERIFY-API / future.
+//  • TODO-VERIFY-API: confirm in Revit which Qto/pset options actually emit the
+//    stamped Pset_StingCost (ExportUserDefinedPsets may need a Pset definition
+//    file). The base quantities (the core QTO payload) come from
+//    ExportBaseQuantities=true and do NOT depend on that.
+//
+// Output: <project>/_BIM_COORD/ifc/sting_boq_qto_<ts>.ifc
+//
+// Reference:
+//   https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcElementQuantity.htm
+//   https://standards.buildingsmart.org/MVD/RELEASE/IFC4/ADD2_TC1/RV1_2/HTML/schema/templates/quantity-sets.htm
+//   https://www.revitapidocs.com/2025/  → IFCExportOptions
+
+using System;
+using System.IO;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.UI;
+
+namespace StingTools.BOQ
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class BOQExportIfcQtoCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            var ctx = ParameterHelpers.GetContext(commandData);
+            if (ctx == null) { message = "No active document."; return Result.Failed; }
+            var doc = ctx.Doc;
+
+            string outDir, path;
+            try
+            {
+                var projDir = Path.GetDirectoryName(doc.PathName ?? "") ?? Path.GetTempPath();
+                outDir = Path.Combine(projDir, "_BIM_COORD", "ifc");
+                Directory.CreateDirectory(outDir);
+                string stamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
+                path = Path.Combine(outDir, $"sting_boq_qto_{stamp}.ifc");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("BOQExportIfcQtoCommand: path resolve", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+
+            // 1) Build the BOQ and stamp Qto_*.* + Pset_StingCost.* (incl.
+            //    NRM2Section + unit rate) onto every priced element, so the IFC
+            //    carries quantities + cost + classification proxy. This is a real
+            //    param write and MUST commit so the export below sees it.
+            int stamped;
+            try
+            {
+                var boq = BOQCostManager.BuildBOQDocument(doc);
+                using (var tx = new Transaction(doc, "STING BOQ — stamp IFC Qto + cost psets"))
+                {
+                    tx.Start();
+                    stamped = IfcQuantitySetWriter.StampAllElements(doc, boq);
+                    tx.Commit();
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("BOQExportIfcQtoCommand: stamp", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+
+            // 2) Export IFC4 with base quantities + the cost/classification psets.
+            var opts = new IFCExportOptions
+            {
+                FileVersion          = IFCVersion.IFC4,
+                SpaceBoundaryLevel   = 0,
+                ExportBaseQuantities = true,    // QTO — emit Qto_*BaseQuantities
+                WallAndColumnSplitting = false,
+            };
+            opts.AddOption("ExportUserDefinedPsets",       "true");   // carry Pset_StingCost (NRM2/ICMS + cost)
+            opts.AddOption("ExportIFCCommonPropertySets",  "true");
+            opts.AddOption("ExportSchedulesAsPsets",       "false");
+            opts.AddOption("ExportPartsAsBuildingElements","false");
+            opts.AddOption("ExportBoundingBox",            "false");
+            opts.AddOption("ExportLinkedFiles",            "false");
+            opts.AddOption("IncludeSiteElevation",         "false");
+            opts.AddOption("UseActiveViewGeometry",        "false");
+
+            using (var tx = new Transaction(doc, "STING BOQ — export QTO IFC"))
+            {
+                try
+                {
+                    tx.Start();
+                    bool ok = doc.Export(outDir, Path.GetFileName(path), opts);
+                    tx.RollBack(); // Export leaves no persistent changes; rollback defensively.
+                    if (!ok)
+                    {
+                        message = "Document.Export returned false";
+                        return Result.Failed;
+                    }
+                }
+                catch (Exception ex2)
+                {
+                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
+                    StingLog.Error("BOQExportIfcQtoCommand: export", ex2);
+                    message = ex2.Message;
+                    return Result.Failed;
+                }
+            }
+
+            var panel = StingResultPanel.Create("BOQ → QTO IFC (estimator feed)");
+            panel.SetSubtitle($"IFC4 written: {path}");
+            panel.AddSection("DETAILS")
+                 .Metric("Schema",            "IFC4 + base quantities")
+                 .Metric("Elements stamped",  stamped.ToString())
+                 .Metric("Quantities",        "Qto_*BaseQuantities (Revit-computed)")
+                 .Metric("Cost / class",      "Pset_StingCost (UnitRate, NRM2Section, …)");
+            panel.AddSection("NEXT STEPS")
+                 .Text("1. In CostX / iTWO: import the IFC4 file above as a BIM dimension source.")
+                 .Text("2. Map Qto_*BaseQuantities → workbook quantities; rates from your rate library.")
+                 .Text("3. Round-trip pricing back via the GUID-keyed XLSX (BOQ export → re-import).");
+            panel.AddSection("LIMITATIONS")
+                 .Text("• No literal Quantity-Takeoff MVD in Revit — IFC4 + base quantities is the equivalent.")
+                 .Text("• NRM2/ICMS rides Pset_StingCost; a true IfcClassificationReference needs a Revit")
+                 .Text("  classification-mapping file (not settable via headless IFCExportOptions) — future.")
+                 .Text("• Verify in Revit that the cost pset emits (ExportUserDefinedPsets may need a Pset file).");
+            panel.Show();
+            return Result.Succeeded;
+        }
+    }
+}

--- a/StingTools/BOQ/BOQExportIfcQtoCommand.cs
+++ b/StingTools/BOQ/BOQExportIfcQtoCommand.cs
@@ -127,23 +127,39 @@ namespace StingTools.BOQ
                 }
             }
 
-            var panel = StingResultPanel.Create("BOQ → QTO IFC (estimator feed)");
-            panel.SetSubtitle($"IFC4 written: {path}");
-            panel.AddSection("DETAILS")
+            var rp = StingResultPanel.Create("BOQ → QTO IFC (estimator feed)");
+            rp.SetSubtitle($"IFC4 written: {path}");
+            rp.AddSection("DETAILS")
                  .Metric("Schema",            "IFC4 + base quantities")
                  .Metric("Elements stamped",  stamped.ToString())
                  .Metric("Quantities",        "Qto_*BaseQuantities (Revit-computed)")
                  .Metric("Cost / class",      "Pset_StingCost (UnitRate, NRM2Section, …)");
-            panel.AddSection("NEXT STEPS")
+            rp.AddSection("NEXT STEPS")
                  .Text("1. In CostX / iTWO: import the IFC4 file above as a BIM dimension source.")
                  .Text("2. Map Qto_*BaseQuantities → workbook quantities; rates from your rate library.")
                  .Text("3. Round-trip pricing back via the GUID-keyed XLSX (BOQ export → re-import).");
-            panel.AddSection("LIMITATIONS")
+            rp.AddSection("LIMITATIONS")
                  .Text("• No literal Quantity-Takeoff MVD in Revit — IFC4 + base quantities is the equivalent.")
                  .Text("• NRM2/ICMS rides Pset_StingCost; a true IfcClassificationReference needs a Revit")
                  .Text("  classification-mapping file (not settable via headless IFCExportOptions) — future.")
                  .Text("• Verify in Revit that the cost pset emits (ExportUserDefinedPsets may need a Pset file).");
-            panel.Show();
+
+            // 5D-workspace inline convention (Slice 1): when invoked from the BOQ
+            // Cost Manager panel the InlineHost=1 ExtraParam routes the result into
+            // the panel's inline region instead of a popup window. Consume the flag
+            // so a later ribbon/workflow invocation doesn't inherit it. If no live
+            // panel sink is registered, fall back to the popup so ribbon callers
+            // still see the result.
+            bool inline = StingCommandHandler.GetExtraParam("InlineHost") == "1";
+            if (inline)
+            {
+                StingCommandHandler.ClearExtraParam("InlineHost");
+                if (!BOQInlineResults.Post(rp)) rp.Show();
+            }
+            else
+            {
+                rp.Show();
+            }
             return Result.Succeeded;
         }
     }

--- a/StingTools/BOQ/BOQModels.cs
+++ b/StingTools/BOQ/BOQModels.cs
@@ -110,11 +110,24 @@ namespace StingTools.BOQ
 
         /// <summary>
         /// INT-0 — the canonical 22-char IFC GlobalId, derived deterministically
-        /// from <see cref="UniqueId"/>. This is the single cross-platform join
-        /// key: COBie Component external identifier, Speckle applicationId, the
-        /// server's ExternalElementMapping, and the priced-BOQ round-trip all key
-        /// off it. Empty for manual / provisional-sum rows with no modelled
-        /// element. Encoder is the one shared resolver (IfcGuidEncoder).
+        /// from <see cref="UniqueId"/> via the one shared resolver
+        /// (<see cref="StingTools.IfcResults.IfcGuidEncoder"/>). This is the single
+        /// cross-platform join key: COBie Component external identifier, Speckle
+        /// applicationId, the server's ExternalElementMapping, and the priced-BOQ
+        /// round-trip all key off it. Empty for manual / provisional-sum rows with
+        /// no modelled element. The COBie writers use the same encoder on the same
+        /// UniqueId, so a BOQ row and the COBie Component for one element always
+        /// carry an identical GlobalId.
+        ///
+        /// STAGED FOLLOW-UP (INT-0 server audit): the server-ingest path
+        /// (<c>IFC_PushModelCommand</c>) keys ExternalElementMapping off the stored
+        /// <c>IFC_GLOBAL_ID_TXT</c> param, which <c>StabilizeIfcGuidsCommand</c>
+        /// fills from Revit's built-in IfcGUID. That equals this encoder value in
+        /// the default case, but DIVERGES when a user sets an explicit IFC-GUID
+        /// override or the element was never IFC-exported. To unify all four
+        /// surfaces under overrides, BOQ + COBie should prefer a stored
+        /// IFC_GLOBAL_ID_TXT when present and fall back to the encoder — threaded
+        /// through BOQ build into this field (the POCO has no live Element here).
         /// </summary>
         public string IfcGlobalId =>
             string.IsNullOrEmpty(UniqueId)

--- a/StingTools/BOQ/BOQModels.cs
+++ b/StingTools/BOQ/BOQModels.cs
@@ -107,6 +107,19 @@ namespace StingTools.BOQ
         public string SnapshotRef;
         public long RevitElementId = -1;    // -1 for manual/PS rows
         public string UniqueId;             // Revit UniqueId (cross-doc, survives Revit save/reopen)
+
+        /// <summary>
+        /// INT-0 — the canonical 22-char IFC GlobalId, derived deterministically
+        /// from <see cref="UniqueId"/>. This is the single cross-platform join
+        /// key: COBie Component external identifier, Speckle applicationId, the
+        /// server's ExternalElementMapping, and the priced-BOQ round-trip all key
+        /// off it. Empty for manual / provisional-sum rows with no modelled
+        /// element. Encoder is the one shared resolver (IfcGuidEncoder).
+        /// </summary>
+        public string IfcGlobalId =>
+            string.IsNullOrEmpty(UniqueId)
+                ? ""
+                : StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(UniqueId);
         public string Level;
         public string Location;             // room name or spatial code
         public string Zone;                 // ASS_ZONE_TXT — P2.2 zone grouping key

--- a/StingTools/BOQ/BOQModels.cs
+++ b/StingTools/BOQ/BOQModels.cs
@@ -64,7 +64,8 @@ namespace StingTools.BOQ
         Level,                  // by building level (flat locational bill)
         Zone,                   // by ASS_ZONE_TXT zone
         LevelThenWorkSection,   // by level, then NRM2 § within each level
-        Location               // by room / spatial location code
+        Location,              // by room / spatial location code
+        SourceModel            // by host vs each linked model
     }
 
     public enum BOQChangeType
@@ -103,6 +104,7 @@ namespace StingTools.BOQ
         public string ResolvedNRM2Paragraph;
         public string BOQLineRef;           // e.g. "14.3.2"
         public string Note;
+        public string SourceModel;          // "" / null = host; else the linked model Title (Group by Source model)
         public BOQRowSource Source;
         public string SnapshotRef;
         public long RevitElementId = -1;    // -1 for manual/PS rows
@@ -178,6 +180,7 @@ namespace StingTools.BOQ
                 ResolvedNRM2Paragraph = this.ResolvedNRM2Paragraph,
                 BOQLineRef = this.BOQLineRef,
                 Note = this.Note,
+                SourceModel = this.SourceModel,
                 Source = this.Source,
                 SnapshotRef = this.SnapshotRef,
                 RevitElementId = this.RevitElementId,

--- a/StingTools/BOQ/BOQProfessionalExportCommand.cs
+++ b/StingTools/BOQ/BOQProfessionalExportCommand.cs
@@ -1334,7 +1334,10 @@ namespace StingTools.BOQ
             ws.Row(r).Height = 36;
             r += 2;
 
-            string[] headers = { "Section", "Category", "Unit", "Qty", "Item / Size", "Level", "Location", "Revit ID" };
+            // INT-2 — the audit/takeoff sheet carries the stable join key so the
+            // priced professional export can also reconcile back to the model
+            // (the printed tender bill stays clean — no machine ids on it).
+            string[] headers = { "Section", "Category", "Unit", "Qty", "Item / Size", "Level", "Location", "Revit ID", "Ifc GlobalId" };
             for (int i = 0; i < headers.Length; i++)
             {
                 var c = ws.Cell(r, 2 + i);
@@ -1371,7 +1374,8 @@ namespace StingTools.BOQ
                     ws.Cell(r, 7).Value = item.Level ?? "";
                     ws.Cell(r, 8).Value = item.Location ?? "";
                     ws.Cell(r, 9).Value = item.RevitElementId > 0 ? item.RevitElementId.ToString() : "";
-                    for (int i = 2; i <= 9; i++)
+                    ws.Cell(r, 10).Value = item.IfcGlobalId ?? "";   // INT-2 round-trip join key
+                    for (int i = 2; i <= 10; i++)
                     {
                         ws.Cell(r, i).Style.Font.SetFontName(BodyFont).Font.SetFontSize(10)
                             .Border.SetBottomBorder(XLBorderStyleValues.Hair)

--- a/StingTools/BOQ/BOQProfessionalExportCommand.cs
+++ b/StingTools/BOQ/BOQProfessionalExportCommand.cs
@@ -1321,13 +1321,15 @@ namespace StingTools.BOQ
             ws.Column(7).Width = 18;   // Level
             ws.Column(8).Width = 22;   // Location
             ws.Column(9).Width = 14;   // Revit ID
+            ws.Column(10).Width = 16;  // Source Model (P1.1)
+            ws.Column(11).Width = 22;  // Ifc GlobalId
 
             SheetBanner(ws, "SCHEDULE OF SIZES", m);
             int r = 5;
 
             ws.Cell(r, 2).Value = "This schedule lists every instance of a repeated item type where the bill sheet carries a \"1 of N similar\" marker. "
                 + "Sizes, levels and locations allow the bidder to verify the quantity and price the extended works accurately.";
-            ws.Range(r, 2, r, 9).Merge().Style
+            ws.Range(r, 2, r, 11).Merge().Style
                 .Font.SetFontName(BodyFont).Font.SetFontSize(10).Font.SetItalic(true)
                 .Font.SetFontColor(XLColor.FromArgb(90, 90, 90))
                 .Alignment.SetWrapText(true).Alignment.SetIndent(1);
@@ -1337,7 +1339,7 @@ namespace StingTools.BOQ
             // INT-2 — the audit/takeoff sheet carries the stable join key so the
             // priced professional export can also reconcile back to the model
             // (the printed tender bill stays clean — no machine ids on it).
-            string[] headers = { "Section", "Category", "Unit", "Qty", "Item / Size", "Level", "Location", "Revit ID", "Ifc GlobalId" };
+            string[] headers = { "Section", "Category", "Unit", "Qty", "Item / Size", "Level", "Location", "Revit ID", "Source Model", "Ifc GlobalId" };
             for (int i = 0; i < headers.Length; i++)
             {
                 var c = ws.Cell(r, 2 + i);
@@ -1374,8 +1376,9 @@ namespace StingTools.BOQ
                     ws.Cell(r, 7).Value = item.Level ?? "";
                     ws.Cell(r, 8).Value = item.Location ?? "";
                     ws.Cell(r, 9).Value = item.RevitElementId > 0 ? item.RevitElementId.ToString() : "";
-                    ws.Cell(r, 10).Value = item.IfcGlobalId ?? "";   // INT-2 round-trip join key
-                    for (int i = 2; i <= 10; i++)
+                    ws.Cell(r, 10).Value = string.IsNullOrWhiteSpace(item.SourceModel) ? "Host" : item.SourceModel; // P1.1 provenance
+                    ws.Cell(r, 11).Value = item.IfcGlobalId ?? "";   // INT-2 round-trip join key
+                    for (int i = 2; i <= 11; i++)
                     {
                         ws.Cell(r, i).Style.Font.SetFontName(BodyFont).Font.SetFontSize(10)
                             .Border.SetBottomBorder(XLBorderStyleValues.Hair)

--- a/StingTools/BOQ/BOQQsRoundtripCommands.cs
+++ b/StingTools/BOQ/BOQQsRoundtripCommands.cs
@@ -104,19 +104,13 @@ namespace StingTools.BOQ
                 }
 
                 StingLog.Info($"QS Bill exported ({(priced ? "priced" : "unpriced")}): {path}");
-                var done = new TaskDialog("QS Bill export")
-                {
-                    MainInstruction = "QS Bill exported",
-                    MainContent = $"{(priced ? "Priced" : "Unpriced")} bill written to:\n{path}\n\n"
-                        + "Send to the QS to price; re-import the returned workbook via 'Import QS Bill'.",
-                    CommonButtons = TaskDialogCommonButtons.Ok
-                };
-                done.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Open containing folder");
-                if (done.Show() == TaskDialogResult.CommandLink1)
-                {
-                    try { System.Diagnostics.Process.Start("explorer.exe", $"/select,\"{path}\""); }
-                    catch (Exception ex) { StingLog.Warn($"open folder: {ex.Message}"); }
-                }
+                UI.StingResultPanel.Create("QS Bill exported")
+                    .SetSubtitle($"{(priced ? "Priced" : "Unpriced")} bill written")
+                    .SetCsvPath(path)
+                    .AddSection("EXPORT")
+                    .Text($"Path: {path}")
+                    .Text("Send to the QS to price; re-import the returned workbook via 'Import QS Bill'.")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex) { StingLog.Error("BOQQsExportCommand", ex); message = ex.Message; return Result.Failed; }
@@ -294,7 +288,10 @@ namespace StingTools.BOQ
                         ?? wb.Worksheets.FirstOrDefault();
                     if (ws == null)
                     {
-                        TaskDialog.Show("STING BOQ", "No worksheet found in the selected workbook.");
+                        UI.StingResultPanel.Create("Import QS Bill")
+                            .AddSection("INVALID WORKBOOK")
+                            .Text("No worksheet found in the selected workbook.")
+                            .Show();
                         return Result.Failed;
                     }
 
@@ -324,9 +321,11 @@ namespace StingTools.BOQ
                     }
                     if (hr == 0)
                     {
-                        TaskDialog.Show("STING BOQ",
-                            "This workbook is not a STING QS Bill (missing 'Ref' + '_key' header). "
-                            + "Export one via 'Export QS Bill' first.");
+                        UI.StingResultPanel.Create("Import QS Bill")
+                            .AddSection("NOT A QS BILL")
+                            .Text("This workbook is not a STING QS Bill (missing 'Ref' + '_key' header). "
+                                + "Export one via 'Export QS Bill' first.")
+                            .Show();
                         return Result.Failed;
                     }
 
@@ -396,8 +395,10 @@ namespace StingTools.BOQ
 
                 if (diffs.Count == 0)
                 {
-                    TaskDialog.Show("STING BOQ — QS Import",
-                        "No changes detected — the imported rates/quantities match the current bill.");
+                    UI.StingResultPanel.Create("QS Import")
+                        .AddSection("NO CHANGES")
+                        .Text("No changes detected — the imported rates/quantities match the current bill.")
+                        .Show();
                     return Result.Succeeded;
                 }
 
@@ -499,15 +500,17 @@ namespace StingTools.BOQ
                 // Pick up the new rate card + overrides on the next build.
                 Rates.RateProviderRegistry.Invalidate();
 
-                TaskDialog.Show("STING BOQ — QS Import",
-                    $"Applied:\n"
-                    + $"  • {appliedModel} model-row rate override(s) (RateSource=QS)\n"
-                    + $"  • {appliedManual} manual/PS/daywork rate update(s)\n"
-                    + $"  • {added} QS-added row(s) → manual store\n"
-                    + $"  • {flaggedQty} model-quantity drift(s) flagged for review (model qty preserved)\n"
-                    + (rateCardByCategory.Count > 0
-                        ? $"  • {rateCardByCategory.Count} category rate(s) seeded into rate_card.json\n" : "")
-                    + "\nRefresh the BOQ panel to see the updated bill.");
+                var rp = UI.StingResultPanel.Create("QS Import")
+                    .SetSubtitle("Applied")
+                    .AddSection("APPLIED")
+                    .Metric("Model-row rate overrides", appliedModel.ToString(), "RateSource=QS")
+                    .Metric("Manual/PS/daywork rate updates", appliedManual.ToString())
+                    .Metric("QS-added rows → manual store", added.ToString())
+                    .Metric("Model-quantity drifts flagged", flaggedQty.ToString(), "model qty preserved");
+                if (rateCardByCategory.Count > 0)
+                    rp.Metric("Category rates seeded", rateCardByCategory.Count.ToString(), "rate_card.json");
+                rp.Text("Refresh the BOQ panel to see the updated bill.");
+                rp.Show();
                 return Result.Succeeded;
             }
             catch (Exception ex) { StingLog.Error("BOQQsImportCommand", ex); message = ex.Message; return Result.Failed; }

--- a/StingTools/BOQ/BOQSupportCommands.cs
+++ b/StingTools/BOQ/BOQSupportCommands.cs
@@ -270,8 +270,14 @@ namespace StingTools.BOQ
                     int matched = 0, updated = 0, skipped = 0, manualAdded = 0;
                     var manualStore = BOQCostManager.LoadManualStore(ctx.Doc);
 
-                    // Build a ref → element index once so we don't collect per-row.
+                    // INT-2 — build stable join indexes once. Prefer the IFC GlobalId
+                    // (matches the "Ifc GlobalId" export column, computed by the same
+                    // encoder on the same UniqueId) → UniqueId → ASS_BOQ_LINE_REF.
+                    // GlobalId/UniqueId survive BOQLineRef churn (P3-1), so a priced
+                    // row re-joins to the right element even if line refs shifted.
                     var refToElement = new Dictionary<string, Element>(StringComparer.OrdinalIgnoreCase);
+                    var guidToElement = new Dictionary<string, Element>(StringComparer.OrdinalIgnoreCase);
+                    var uidToElement = new Dictionary<string, Element>(StringComparer.Ordinal);
                     var enums = SharedParamGuids.AllCategoryEnums;
                     var collector = new FilteredElementCollector(ctx.Doc).WhereElementIsNotElementType();
                     if (enums != null && enums.Length > 0)
@@ -280,6 +286,13 @@ namespace StingTools.BOQ
                     {
                         string refVal = ParameterHelpers.GetString(el, "ASS_BOQ_LINE_REF");
                         if (!string.IsNullOrEmpty(refVal)) refToElement[refVal] = el;
+                        string uid = el.UniqueId;
+                        if (!string.IsNullOrEmpty(uid))
+                        {
+                            uidToElement[uid] = el;
+                            string gid = StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(uid);
+                            if (!string.IsNullOrEmpty(gid)) guidToElement[gid] = el;
+                        }
                     }
 
                     using (var tx = new Transaction(ctx.Doc, "STING BOQ — import rate overrides"))
@@ -288,22 +301,43 @@ namespace StingTools.BOQ
                         for (int r = headerRow + 1; r <= sheet.LastRowUsed()?.RowNumber(); r++)
                         {
                             string refStr = sheet.Cell(r, colIdx.GetValueOrDefault("Line ref", 1)).GetString();
-                            if (string.IsNullOrWhiteSpace(refStr)) continue;
+                            // INT-2 — read the stable join keys when the columns exist
+                            // (guarded: ClosedXML cell indexes are 1-based, so don't
+                            // read column 0 when a header is absent).
+                            string gidStr = colIdx.TryGetValue("Ifc GlobalId", out int gidCol) ? sheet.Cell(r, gidCol).GetString() : "";
+                            string uidStr = colIdx.TryGetValue("Revit UniqueId", out int uidCol) ? sheet.Cell(r, uidCol).GetString() : "";
+                            if (string.IsNullOrWhiteSpace(refStr) && string.IsNullOrWhiteSpace(gidStr) && string.IsNullOrWhiteSpace(uidStr)) continue;
                             double rateUgx = sheet.Cell(r, colIdx.GetValueOrDefault("Rate UGX", 9)).GetDouble();
                             double rateUsd = sheet.Cell(r, colIdx.GetValueOrDefault("Rate USD", 11)).GetDouble();
                             string note = sheet.Cell(r, colIdx.GetValueOrDefault("Note", 14)).GetString();
                             string source = sheet.Cell(r, colIdx.GetValueOrDefault("Source", 13)).GetString();
 
-                            if (refToElement.TryGetValue(refStr, out Element el))
+                            // Resolve the element on the most stable key available:
+                            // IFC GlobalId → Revit UniqueId → ASS_BOQ_LINE_REF.
+                            Element el = null;
+                            if (!string.IsNullOrWhiteSpace(gidStr)) guidToElement.TryGetValue(gidStr.Trim(), out el);
+                            if (el == null && !string.IsNullOrWhiteSpace(uidStr)) uidToElement.TryGetValue(uidStr.Trim(), out el);
+                            if (el == null && !string.IsNullOrWhiteSpace(refStr)) refToElement.TryGetValue(refStr, out el);
+
+                            if (el != null)
                             {
                                 matched++;
                                 if (rateUgx > 0) ParameterHelpers.SetString(el, "CST_UNIT_RATE_UGX",
                                     rateUgx.ToString("F0", CultureInfo.InvariantCulture), overwrite: true);
                                 if (rateUsd > 0) ParameterHelpers.SetString(el, "CST_UNIT_RATE_USD",
                                     rateUsd.ToString("F2", CultureInfo.InvariantCulture), overwrite: true);
-                                ParameterHelpers.SetString(el, "CST_RATE_SOURCE", "Override", overwrite: true);
+                                // P3 — provenance: distinguish an estimator-priced import
+                                // from a hand-typed override so the rate-source heat-map
+                                // and the at-risk rollup can flag it. The rate still rides
+                                // the CST_UNIT_RATE_UGX override surface (provider priority
+                                // 100 — a priced bill IS the authoritative rate).
+                                ParameterHelpers.SetString(el, "CST_RATE_SOURCE", "estimator", overwrite: true);
+                                // P2-8 — write the description to ASS_NRM2_PARA_TXT, the
+                                // param BuildBOQDocument actually reads, so an edited
+                                // description survives the next BOQ refresh (previously
+                                // written to ASS_DESCRIPTION_TXT and silently dropped).
                                 if (!string.IsNullOrEmpty(note))
-                                    ParameterHelpers.SetString(el, "ASS_DESCRIPTION_TXT", note, overwrite: true);
+                                    ParameterHelpers.SetString(el, "ASS_NRM2_PARA_TXT", note, overwrite: true);
                                 updated++;
                             }
                             else if (source?.Contains("Manual") == true || source?.Contains("Provisional") == true)

--- a/StingTools/BOQ/BOQSupportCommands.cs
+++ b/StingTools/BOQ/BOQSupportCommands.cs
@@ -176,6 +176,13 @@ namespace StingTools.BOQ
                 };
                 store.ManualRows.Add(newRow);
                 BOQCostManager.SaveManualRows(ctx.Doc, store.ManualRows, store.ProjectBudgetUGX);
+                UI.StingResultPanel.Create("Manual row added")
+                    .AddSection("ROW")
+                    .Metric("Item", newRow.ItemName)
+                    .Metric("Type", newRow.Category)
+                    .Metric("Quantity", $"{newRow.Quantity:N3} {newRow.Unit}")
+                    .Metric("Rate", $"UGX {newRow.RateUGX:N0}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex) { StingLog.Error("BOQAddManualRow", ex); return Result.Failed; }
@@ -432,7 +439,10 @@ namespace StingTools.BOQ
                 var matches = BOQCostManager.ReconcileProvisionals(ctx.Doc, boq);
                 if (matches.Count == 0)
                 {
-                    TaskDialog.Show("STING BOQ", "No provisional sums could be automatically matched to modeled elements.");
+                    UI.StingResultPanel.Create("Reconcile Provisionals")
+                        .AddSection("NO MATCHES")
+                        .Text("No provisional sums could be automatically matched to modeled elements.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -473,7 +483,10 @@ namespace StingTools.BOQ
                     }
                     tx.Commit();
                 }
-                TaskDialog.Show("STING BOQ", $"Promoted {promoted.Count} provisional sum(s) to modeled rows.");
+                UI.StingResultPanel.Create("Reconcile Provisionals")
+                    .AddSection("RESULT")
+                    .Metric("Provisional sums promoted", promoted.Count.ToString(), "to modeled rows")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex) { StingLog.Error("BOQReconcileProvisionals", ex); return Result.Failed; }

--- a/StingTools/BOQ/BoqPrintProfile.cs
+++ b/StingTools/BOQ/BoqPrintProfile.cs
@@ -45,10 +45,11 @@ namespace StingTools.BOQ
 
     public sealed class BoqPrintProfileRegistry
     {
-        // The six toggleable columns the grid + profiles control. Core columns
+        // The toggleable columns the grid + profiles control. Core columns
         // (Ref/Item/Qty/Unit/Rate/Total) are always shown and never in this set.
+        // "Model" (P1.1) surfaces host-vs-linked-model provenance.
         public static readonly string[] ToggleableColumns =
-            { "Level", "Location", "Source", "Confidence", "Carbon", "Note" };
+            { "Level", "Location", "Source", "Model", "Confidence", "Carbon", "Note" };
 
         private static readonly ConcurrentDictionary<string, BoqPrintProfileRegistry> _cache
             = new ConcurrentDictionary<string, BoqPrintProfileRegistry>(StringComparer.OrdinalIgnoreCase);

--- a/StingTools/BOQ/IfcQuantitySetWriter.cs
+++ b/StingTools/BOQ/IfcQuantitySetWriter.cs
@@ -70,13 +70,39 @@ namespace StingTools.BOQ
                     string qtoSetName = ResolveQtoSetName(item.Category);
                     if (!string.IsNullOrEmpty(qtoSetName))
                     {
-                        StampQuantity(el, qtoSetName, "GrossArea", item.Unit == "m²" ? item.Quantity : 0);
-                        StampQuantity(el, qtoSetName, "NetArea",   item.Unit == "m²" ? item.Quantity : 0);
-                        StampQuantity(el, qtoSetName, "GrossVolume", item.Unit == "m³" ? item.Quantity : 0);
-                        StampQuantity(el, qtoSetName, "NetVolume",   item.Unit == "m³" ? item.Quantity : 0);
-                        StampQuantity(el, qtoSetName, "Length",      item.Unit == "m"  ? item.Quantity : 0);
-                        StampQuantity(el, qtoSetName, "GrossWeight", item.Unit == "kg" ? item.Quantity : 0);
-                        StampQuantity(el, qtoSetName, "NetWeight",   item.Unit == "kg" ? item.Quantity : 0);
+                        // P0-1 — item.Unit is ASCII ("m2"/"m3"/"each"), not the
+                        // Unicode glyphs ("m²"/"m³") the old comparisons used, so
+                        // every quantity was tested false and StampQuantity's
+                        // `value <= 0` guard skipped it. Canonicalise through the
+                        // BOQ engine's own table so both sides match.
+                        string u = BOQCostManager.NormaliseUnit(item.Unit);
+                        double q = item.Quantity;
+                        if (u == "m2")
+                        {
+                            StampQuantity(el, qtoSetName, "GrossArea", q);
+                            StampQuantity(el, qtoSetName, "NetArea",   q);
+                        }
+                        else if (u == "m3")
+                        {
+                            StampQuantity(el, qtoSetName, "GrossVolume", q);
+                            StampQuantity(el, qtoSetName, "NetVolume",   q);
+                        }
+                        else if (u == "m")
+                        {
+                            StampQuantity(el, qtoSetName, "Length", q);
+                        }
+                        else if (u == "kg")
+                        {
+                            StampQuantity(el, qtoSetName, "GrossWeight", q);
+                            StampQuantity(el, qtoSetName, "NetWeight",   q);
+                        }
+                        else if (u == "each")
+                        {
+                            // Count is integer-valued in IFC Qto sets but our
+                            // params are typically Double/String — StampQuantity
+                            // handles both storage types.
+                            StampQuantity(el, qtoSetName, "Count", q);
+                        }
                     }
 
                     // STING-specific cost property set.

--- a/StingTools/BOQ/Sync/BoqSnapshotHasher.cs
+++ b/StingTools/BOQ/Sync/BoqSnapshotHasher.cs
@@ -91,11 +91,21 @@ namespace StingTools.BOQ.Sync
                         nrm2 = s.NRM2Section ?? "",
                         name = s.Name ?? "",
                         disc = s.Discipline ?? "",
+                        // P0-2 — order by a STABLE key, never BOQLineItem.Id
+                        // (a fresh Guid.NewGuid() per build). UniqueId survives
+                        // save/reopen; RevitElementId + BOQLineRef + ItemName
+                        // disambiguate manual/PS rows that share an empty
+                        // UniqueId. The random Id is also dropped from the
+                        // hashed projection below so two builds of an unchanged
+                        // model produce the same checksum.
                         items = s.Items
-                            .OrderBy(i => i.Id, StringComparer.OrdinalIgnoreCase)
+                            .OrderBy(i => i.UniqueId ?? "", StringComparer.OrdinalIgnoreCase)
+                            .ThenBy(i => i.RevitElementId)
+                            .ThenBy(i => i.BOQLineRef ?? "", StringComparer.OrdinalIgnoreCase)
+                            .ThenBy(i => i.Category ?? "", StringComparer.OrdinalIgnoreCase)
+                            .ThenBy(i => i.ItemName ?? "", StringComparer.OrdinalIgnoreCase)
                             .Select(i => new
                             {
-                                id = i.Id ?? "",
                                 cat = i.Category ?? "",
                                 disc = i.Discipline ?? "",
                                 ref_ = i.BOQLineRef ?? "",

--- a/StingTools/BOQ/Sync/BoqSyncCoordinator.cs
+++ b/StingTools/BOQ/Sync/BoqSyncCoordinator.cs
@@ -205,7 +205,14 @@ namespace StingTools.BOQ.Sync
                 itemDescription = string.IsNullOrEmpty(item.ResolvedNRM2Paragraph)
                     ? (item.Category ?? "")
                     : item.ResolvedNRM2Paragraph,
-                ifcGlobalId = item.UniqueId ?? "",
+                // INT-0 — ship the canonical 22-char IFC GlobalId, not the
+                // 45-char Revit UniqueId. The field was previously named
+                // `ifcGlobalId` but carried the UniqueId, so server BOQ rows
+                // could never join ExternalElementMapping.IfcGlobalId (the real
+                // encoded GUID written by IFC ingest). Keep revitUniqueId as a
+                // secondary key for traceability / legacy joins.
+                ifcGlobalId = item.IfcGlobalId,
+                revitUniqueId = item.UniqueId ?? "",
                 ifcType = item.Category ?? "",
                 revitElementId = item.RevitElementId.ToString(System.Globalization.CultureInfo.InvariantCulture),
                 level = item.Level ?? "",

--- a/StingTools/Commands/Cost/CostCommands.cs
+++ b/StingTools/Commands/Cost/CostCommands.cs
@@ -31,6 +31,7 @@ using StingTools.Core.Storage;
 using StingTools.Core.Validation;
 using StingTools.Core.Validation.Cost;
 using StingTools.Select;
+using StingTools.UI;       // StingResultPanel
 
 namespace StingTools.Commands.Cost
 {
@@ -81,41 +82,45 @@ namespace StingTools.Commands.Cost
                 .OrderByDescending(g => g.Count())
                 .Take(10);
 
-            var sb = new System.Text.StringBuilder();
-            sb.AppendLine($"Cost validation — {rag}");
-            sb.AppendLine($"Errors: {errors}   Warnings: {warnings}   Info: {info}");
-            sb.AppendLine();
-            sb.AppendLine("Top findings by code:");
-            foreach (var g in byCode)
-                sb.AppendLine($"  {g.Key,-22} {g.Count(),5}");
-            sb.AppendLine();
-            if (results.Count > 0)
-                sb.AppendLine("First 10 issues:");
-            foreach (var r in results.Take(10))
-                sb.AppendLine($"  [{r.Severity}] {r.Code} — {r.Message}");
+            var rp = StingResultPanel.Create("Cost validation")
+                .SetSubtitle(rag);
+            rp.AddSection("SUMMARY")
+                .Metric("Errors", errors.ToString())
+                .Metric("Warnings", warnings.ToString())
+                .Metric("Info", info.ToString());
 
-            var td = new TaskDialog("STING — Cost validation")
+            if (byCode.Any())
             {
-                MainInstruction = $"Cost validation: {rag}",
-                MainContent = sb.ToString(),
-                CommonButtons = TaskDialogCommonButtons.Ok
-            };
-            if (errors > 0 || warnings > 0)
-            {
-                td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
-                    $"Select affected elements ({errors + warnings})",
-                    "Highlight every element flagged by a validator.");
+                var codeRows = byCode.Select(g => new[] { g.Key ?? "", g.Count().ToString() }).ToList();
+                rp.AddSection("TOP FINDINGS BY CODE")
+                    .Table(new[] { "Code", "Count" }, codeRows);
             }
-            var picked = td.Show();
-            if (picked == TaskDialogResult.CommandLink1 && uidoc != null)
+
+            if (results.Count > 0)
             {
-                var ids = results
-                    .Where(r => r.ElementId != null && r.ElementId.Value > 0)
-                    .Select(r => r.ElementId)
-                    .Distinct()
+                var issueRows = results.Take(10)
+                    .Select(r => new[] { r.Severity.ToString(), r.Code ?? "", r.Message ?? "" })
                     .ToList();
-                if (ids.Count > 0) uidoc.Selection.SetElementIds(ids);
+                rp.AddSection("FIRST 10 ISSUES")
+                    .Table(new[] { "Severity", "Code", "Message" }, issueRows);
             }
+
+            // Select-affected action — rendered only on the dialog (ribbon) path;
+            // the inline Actions pane ignores actions, surfacing just the report.
+            if ((errors > 0 || warnings > 0) && uidoc != null)
+            {
+                rp.Action($"Select affected elements ({errors + warnings})",
+                    "Highlight every element flagged by a validator.", _ =>
+                    {
+                        var ids = results
+                            .Where(r => r.ElementId != null && r.ElementId.Value > 0)
+                            .Select(r => r.ElementId)
+                            .Distinct()
+                            .ToList();
+                        if (ids.Count > 0) uidoc.Selection.SetElementIds(ids);
+                    });
+            }
+            rp.Show();
         }
     }
 
@@ -161,7 +166,10 @@ namespace StingTools.Commands.Cost
                     t.Commit();
                 }
                 StingCostStaleMarker.ResetRecentlyProcessed();
-                TaskDialog.Show("STING Cost", $"Cleared {cleared} stale flag(s).");
+                StingResultPanel.Create("Clear stale flags")
+                    .AddSection("RESULT")
+                    .Metric("Stale flags cleared", cleared.ToString())
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -193,8 +201,10 @@ namespace StingTools.Commands.Cost
                 var presets = DiscoverBoqPresets();
                 if (presets.Count == 0)
                 {
-                    TaskDialog.Show("STING Cost — Workflows",
-                        "No WORKFLOW_BOQ_*.json presets found in data folder.");
+                    StingResultPanel.Create("Run cost workflow")
+                        .AddSection("NO PRESETS")
+                        .Text("No WORKFLOW_BOQ_*.json presets found in data folder.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -288,7 +298,10 @@ namespace StingTools.Commands.Cost
         {
             bool target = !StingCostStaleMarker.IsEnabled;
             StingCostStaleMarker.SetEnabled(target);
-            TaskDialog.Show("STING Cost", $"Cost stale-marker is now {(target ? "ENABLED" : "DISABLED")}.");
+            StingResultPanel.Create("Toggle stale marker")
+                .AddSection("RESULT")
+                .Metric("Cost stale-marker", target ? "ENABLED" : "DISABLED")
+                .Show();
             return Result.Succeeded;
         }
     }
@@ -347,10 +360,12 @@ namespace StingTools.Commands.Cost
             }
             catch (Exception extEx) { StingLog.Warn($"Cost_ReloadRules external providers: {extEx.Message}"); }
 
-            TaskDialog.Show("STING Cost",
-                "Rate provider + take-off rule + default-cost-rates caches cleared (and CostStamp config). " +
-                "External rate providers (project rate card, BCIS HTTP if configured) re-registered. " +
-                "The next BOQ build will reload from disk.");
+            StingResultPanel.Create("Reload rules")
+                .AddSection("CACHES CLEARED")
+                .Text("Rate provider + take-off rule + default-cost-rates caches cleared (and CostStamp config). " +
+                      "External rate providers (project rate card, BCIS HTTP if configured) re-registered. " +
+                      "The next BOQ build will reload from disk.")
+                .Show();
             return Result.Succeeded;
         }
     }
@@ -416,9 +431,13 @@ namespace StingTools.Commands.Cost
                     t.Commit();
                 }
 
-                TaskDialog.Show("STING Cost — migration",
-                    $"Migrated:  {migrated}\nSkipped (already set):  {skipped}\nNo legacy rate:  {missing}\n\n" +
-                    $"FX rate captured: {fxRate} UGX per USD at {fxDate}.");
+                StingResultPanel.Create("Migrate UGX → Neutral")
+                    .AddSection("MIGRATION")
+                    .Metric("Migrated", migrated.ToString())
+                    .Metric("Skipped (already set)", skipped.ToString())
+                    .Metric("No legacy rate", missing.ToString())
+                    .Metric("FX rate captured", $"{fxRate} UGX per USD", $"at {fxDate}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -463,9 +482,11 @@ namespace StingTools.Commands.Cost
                     StingCostRateOverrideSchema.SchemaGuid);
                 if (v1 == null)
                 {
-                    TaskDialog.Show("STING Cost — migration",
-                        "No v1 Extensible Storage schema present in this document. " +
-                        "Either no overrides exist, or all are already v2.");
+                    StingResultPanel.Create("Migrate ES v1 → v2")
+                        .AddSection("NOTHING TO MIGRATE")
+                        .Text("No v1 Extensible Storage schema present in this document. " +
+                              "Either no overrides exist, or all are already v2.")
+                        .Show();
                     return Result.Succeeded;
                 }
 
@@ -527,9 +548,13 @@ namespace StingTools.Commands.Cost
                     t.Commit();
                 }
 
-                TaskDialog.Show("STING Cost — migration",
-                    $"v1 → v2 Extensible Storage migration complete.\n\n" +
-                    $"Migrated:  {migrated}\nAlready v2 (orphan v1 deleted):  {skipped}\nErrors:  {errors}");
+                StingResultPanel.Create("Migrate ES v1 → v2")
+                    .SetSubtitle("v1 → v2 Extensible Storage migration complete")
+                    .AddSection("MIGRATION")
+                    .Metric("Migrated", migrated.ToString())
+                    .Metric("Already v2 (orphan v1 deleted)", skipped.ToString())
+                    .Metric("Errors", errors.ToString())
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/StingTools/Commands/Cost/CostControlCommands.cs
+++ b/StingTools/Commands/Cost/CostControlCommands.cs
@@ -50,7 +50,10 @@ namespace StingTools.Commands.Cost
                 var boq = BOQCostManager.BuildBOQDocument(doc);
                 if (boq.Sections.Count == 0)
                 {
-                    TaskDialog.Show("STING — Set progress", "BOQ has no sections — build the BOQ first.");
+                    StingResultPanel.Create("Set % complete")
+                        .AddSection("NO DATA")
+                        .Text("BOQ has no sections — build the BOQ first.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -96,11 +99,16 @@ namespace StingTools.Commands.Cost
                 }
 
                 string note = missing > 0 && stamped == 0
-                    ? "\n\nNo element was stamped — bind ASS_PMT_PCT_COMPLETE_NR via Load Params first."
-                    : (missing > 0 ? $"\n\n{missing} element(s) skipped (param not bound / read-only)." : "");
-                TaskDialog.Show("STING — Progress set",
-                    $"Set {pct:0}% complete on {stamped} element(s) across {pickedSecs.Count} section(s)." + note +
-                    "\n\nIssue Cert + Calculate EVM now read this back.");
+                    ? "No element was stamped — bind ASS_PMT_PCT_COMPLETE_NR via Load Params first."
+                    : (missing > 0 ? $"{missing} element(s) skipped (param not bound / read-only)." : "");
+                var rp = StingResultPanel.Create("Progress set")
+                    .AddSection("RESULT")
+                    .Metric("% complete applied", $"{pct:0}%")
+                    .Metric("Elements stamped", stamped.ToString())
+                    .Metric("Sections", pickedSecs.Count.ToString());
+                if (!string.IsNullOrEmpty(note)) rp.Text(note);
+                rp.Text("Issue Cert + Calculate EVM now read this back.");
+                rp.Show();
                 return Result.Succeeded;
             }
             catch (Exception ex) { StingLog.Error("PaymentCert_SetProgress", ex); message = ex.Message; return Result.Failed; }
@@ -127,7 +135,10 @@ namespace StingTools.Commands.Cost
                 var paths = PaymentCertEngine.ListCerts(doc);
                 if (paths.Count == 0)
                 {
-                    TaskDialog.Show("STING — Cert document", "No certs found — issue one first (★ Issue Cert).");
+                    StingResultPanel.Create("Cert document")
+                        .AddSection("NO CERTS")
+                        .Text("No certs found — issue one first (★ Issue Cert).")
+                        .Show();
                     return Result.Cancelled;
                 }
                 var certs = paths.Select(PaymentCertEngine.Load).Where(c => c != null)
@@ -153,18 +164,13 @@ namespace StingTools.Commands.Cost
                 }
 
                 StingLog.Info($"Payment cert #{cert.CertNumber} document exported: {path}");
-                var done = new TaskDialog("STING — Certificate document")
-                {
-                    MainInstruction = $"Interim Certificate No. {cert.CertNumber} exported",
-                    MainContent = $"{cert.Currency} {cert.TotalPayable:N2} payable\n{path}",
-                    CommonButtons = TaskDialogCommonButtons.Ok
-                };
-                done.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Open containing folder");
-                if (done.Show() == TaskDialogResult.CommandLink1)
-                {
-                    try { System.Diagnostics.Process.Start("explorer.exe", $"/select,\"{path}\""); }
-                    catch (Exception ex) { StingLog.Warn($"open folder: {ex.Message}"); }
-                }
+                StingResultPanel.Create("Certificate document")
+                    .SetSubtitle($"Interim Certificate No. {cert.CertNumber} exported")
+                    .SetCsvPath(path)
+                    .AddSection("EXPORT")
+                    .Metric("Payable", $"{cert.Currency} {cert.TotalPayable:N2}")
+                    .Text($"Path: {path}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex) { StingLog.Error("PaymentCert_ExportDoc", ex); message = ex.Message; return Result.Failed; }

--- a/StingTools/Commands/Cost/CostPlanCommands.cs
+++ b/StingTools/Commands/Cost/CostPlanCommands.cs
@@ -22,6 +22,7 @@ using StingTools.BOQ;
 using StingTools.Core;
 using StingTools.Core.CostPlan;
 using StingTools.Select;
+using StingTools.UI;       // StingResultPanel
 
 namespace StingTools.Commands.Cost
 {
@@ -39,8 +40,10 @@ namespace StingTools.Commands.Cost
                 var registry = CostPlanRegistry.Get(doc);
                 if (registry.BuildingTypes.Count == 0)
                 {
-                    TaskDialog.Show("STING Cost Plan",
-                        "No NRM1 benchmarks loaded. Verify STING_NRM1_BENCHMARKS.csv is present in the data folder.");
+                    StingResultPanel.Create("New Cost Plan")
+                        .AddSection("NO BENCHMARKS")
+                        .Text("No NRM1 benchmarks loaded. Verify STING_NRM1_BENCHMARKS.csv is present in the data folder.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -62,15 +65,17 @@ namespace StingTools.Commands.Cost
                 var plan = CostPlanEngine.Create(doc, buildingType, gifa, label: "Concept");
                 string path = CostPlanEngine.Save(doc, plan);
 
-                TaskDialog.Show("STING — Cost plan created",
-                    $"Cost plan saved.\n\n" +
-                    $"Building type:      {buildingType}\n" +
-                    $"GIFA:               {gifa:N0} m²\n" +
-                    $"Lines:              {plan.Lines.Count}\n" +
-                    $"Subtotal (likely):  {plan.Currency} {plan.SubtotalLikely:N0}\n" +
-                    $"Grand total:        {plan.Currency} {plan.GrandTotalLikely:N0}\n" +
-                    $"Headline {plan.Currency}/m² GIFA: {plan.CostPerSqmLikely:N0}\n\n" +
-                    $"Path: {Path.GetFileName(path)}");
+                StingResultPanel.Create("Cost plan created")
+                    .SetSubtitle($"{buildingType} · {gifa:N0} m² GIFA")
+                    .AddSection("PLAN")
+                    .Metric("Building type", buildingType)
+                    .Metric("GIFA", $"{gifa:N0} m²")
+                    .Metric("Lines", plan.Lines.Count.ToString())
+                    .Metric("Subtotal (likely)", $"{plan.Currency} {plan.SubtotalLikely:N0}")
+                    .Metric("Grand total", $"{plan.Currency} {plan.GrandTotalLikely:N0}")
+                    .Metric($"Headline {plan.Currency}/m² GIFA", $"{plan.CostPerSqmLikely:N0}")
+                    .Text($"Path: {Path.GetFileName(path)}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -149,7 +154,10 @@ namespace StingTools.Commands.Cost
                 var paths = CostPlanEngine.ListPlans(doc);
                 if (paths.Count == 0)
                 {
-                    TaskDialog.Show("STING Cost Plan", "No saved cost plans found. Run CostPlan_Create first.");
+                    StingResultPanel.Create("Compare vs BOQ")
+                        .AddSection("NO PLANS")
+                        .Text("No saved cost plans found. Run CostPlan_Create first.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -195,19 +203,23 @@ namespace StingTools.Commands.Cost
             int amber = variances.Count(v => v.Status == "Amber");
             int green = variances.Count(v => v.Status == "Green");
 
-            var sb = new System.Text.StringBuilder();
-            sb.AppendLine($"Plan: {plan.Label}  ({plan.BuildingType}, {plan.GifaM2:N0} m² GIFA)");
-            sb.AppendLine($"Status:  Red {red}  /  Amber {amber}  /  Green {green}");
-            sb.AppendLine();
-            sb.AppendLine("Top 10 variances (by absolute %):");
-            foreach (var v in variances.OrderByDescending(x => Math.Abs(x.DeltaPct)).Take(10))
-            {
-                sb.AppendLine(
-                    $"  [{v.Status[0]}] {v.ElementCode,-5} {Trim(v.ElementName, 28),-28}  " +
-                    $"plan {v.PlannedLikely,12:N0}   actual {v.Actual,12:N0}   {v.DeltaPct,+6:F1}%");
-            }
+            var rp = StingResultPanel.Create("Cost plan compare")
+                .SetSubtitle($"{plan.Label}  ({plan.BuildingType}, {plan.GifaM2:N0} m² GIFA)");
+            rp.AddSection("STATUS")
+                .Metric("Red", red.ToString())
+                .Metric("Amber", amber.ToString())
+                .Metric("Green", green.ToString());
 
-            TaskDialog.Show("STING — Cost plan compare", sb.ToString());
+            var rows = variances.OrderByDescending(x => Math.Abs(x.DeltaPct)).Take(10)
+                .Select(v => new[]
+                {
+                    v.Status, v.ElementCode ?? "", Trim(v.ElementName, 28),
+                    $"{v.PlannedLikely:N0}", $"{v.Actual:N0}", $"{v.DeltaPct:+0.0;-0.0}%"
+                }).ToList();
+            rp.AddSection("TOP 10 VARIANCES (by absolute %)")
+                .Table(new[] { "Status", "Code", "Element", "Plan", "Actual", "Δ%" }, rows);
+
+            rp.Show();
         }
 
         private static string Trim(string s, int max) =>
@@ -228,7 +240,10 @@ namespace StingTools.Commands.Cost
                 var paths = CostPlanEngine.ListPlans(doc);
                 if (paths.Count == 0)
                 {
-                    TaskDialog.Show("STING Cost Plan", "No saved cost plans found.");
+                    StingResultPanel.Create("Export Cost Plan")
+                        .AddSection("NO PLANS")
+                        .Text("No saved cost plans found.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -315,7 +330,12 @@ namespace StingTools.Commands.Cost
                     wb.SaveAs(outPath);
                 }
 
-                TaskDialog.Show("STING — Cost plan exported", $"Saved to:\n{outPath}");
+                StingResultPanel.Create("Cost plan exported")
+                    .SetCsvPath(outPath)
+                    .AddSection("EXPORT")
+                    .Metric("Plan", plan.Label)
+                    .Text($"Saved to: {outPath}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/StingTools/Commands/Cost/IfcAndIcmsCommands.cs
+++ b/StingTools/Commands/Cost/IfcAndIcmsCommands.cs
@@ -19,6 +19,7 @@ using StingTools.BIMManager;
 using StingTools.BOQ;
 using StingTools.BOQ.MeasurementStandard;
 using StingTools.Core;
+using StingTools.UI;       // StingResultPanel
 
 namespace StingTools.Commands.Cost
 {
@@ -36,7 +37,10 @@ namespace StingTools.Commands.Cost
                 var boq = BOQCostManager.BuildBOQDocument(doc);
                 if (boq.AllItems.Count == 0)
                 {
-                    TaskDialog.Show("STING IFC Qto", "BOQ has no items — build the BOQ first.");
+                    StingResultPanel.Create("Stamp IFC Qto")
+                        .AddSection("NO DATA")
+                        .Text("BOQ has no items — build the BOQ first.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -48,10 +52,12 @@ namespace StingTools.Commands.Cost
                     t.Commit();
                 }
 
-                TaskDialog.Show("STING — IFC stamping",
-                    $"Stamped {stamped} element(s) with IFC4 Qto_* + Pset_StingCost.\n\n" +
-                    "The next IFC export will carry quantity + cost data so Cost-X, CostOS, " +
-                    "Candy and Bluebeam Revu can ingest without re-measuring.");
+                StingResultPanel.Create("Stamp IFC Qto")
+                    .AddSection("RESULT")
+                    .Metric("Elements stamped", stamped.ToString(), "IFC4 Qto_* + Pset_StingCost")
+                    .Text("The next IFC export will carry quantity + cost data so Cost-X, CostOS, " +
+                          "Candy and Bluebeam Revu can ingest without re-measuring.")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -77,7 +83,10 @@ namespace StingTools.Commands.Cost
                 var boq = BOQCostManager.BuildBOQDocument(doc);
                 if (boq.AllItems.Count == 0)
                 {
-                    TaskDialog.Show("STING ICMS3", "BOQ has no items.");
+                    StingResultPanel.Create("ICMS3 report")
+                        .AddSection("NO DATA")
+                        .Text("BOQ has no items.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -136,12 +145,15 @@ namespace StingTools.Commands.Cost
                         + overall.ToString("F2", CultureInfo.InvariantCulture));
                 }
 
-                TaskDialog.Show("STING — ICMS3 report",
-                    $"Cost + carbon ledger exported.\n\n" +
-                    $"Groups:     {grouped.Count}\n" +
-                    $"Total cost: {boq.Currency} {grouped.Sum(x => x.Value.cost):N0}\n" +
-                    $"Total carbon: {grouped.Sum(x => x.Value.carbon):N0} kgCO₂e\n\n" +
-                    $"Path: {outPath}");
+                StingResultPanel.Create("ICMS3 report")
+                    .SetSubtitle("Cost + carbon ledger exported")
+                    .SetCsvPath(outPath)
+                    .AddSection("LEDGER")
+                    .Metric("Groups", grouped.Count.ToString())
+                    .Metric("Total cost", $"{boq.Currency} {grouped.Sum(x => x.Value.cost):N0}")
+                    .Metric("Total carbon", $"{grouped.Sum(x => x.Value.carbon):N0} kgCO₂e")
+                    .Text($"Path: {outPath}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/StingTools/Commands/Cost/MeasurementStandardCommands.cs
+++ b/StingTools/Commands/Cost/MeasurementStandardCommands.cs
@@ -14,9 +14,11 @@ using System.Text;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using System.Collections.Generic;
 using StingTools.BOQ.MeasurementStandard;
 using StingTools.Core;
 using StingTools.Select;
+using StingTools.UI;       // StingResultPanel
 
 namespace StingTools.Commands.Cost
 {
@@ -46,10 +48,12 @@ namespace StingTools.Commands.Cost
                 // BOQDocument.MeasurementStandardId.
                 TagConfig.SetConfigValue("COST_MEASUREMENT_STANDARD", id);
 
-                TaskDialog.Show("STING — Measurement standard",
-                    $"Measurement standard set to {picked[0].Label} ({id}).\n\n" +
-                    "Future BOQ_Build runs will classify and describe rows per this standard. " +
-                    "Existing snapshots keep the standard they were saved with.");
+                StingResultPanel.Create("Measurement standard")
+                    .AddSection("RESULT")
+                    .Metric("Active standard", $"{picked[0].Label} ({id})")
+                    .Text("Future BOQ_Build runs will classify and describe rows per this standard. " +
+                          "Existing snapshots keep the standard they were saved with.")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -73,13 +77,11 @@ namespace StingTools.Commands.Cost
                                      "Pipes", "Electrical Equipment", "Lighting Fixtures",
                                      "Roads", "Reinforcement" };
 
-                var sb = new StringBuilder();
-                sb.AppendLine("Standard / Category → (Section, Unit)");
-                sb.AppendLine(new string('─', 60));
+                var rp = StingResultPanel.Create("Measurement standard preview")
+                    .SetSubtitle("How each standard classifies + measures common categories");
                 foreach (var std in MeasurementStandardRegistry.All())
                 {
-                    sb.AppendLine();
-                    sb.AppendLine($"━ {std.DisplayName}  [{std.Version}]");
+                    var rows = new List<string[]>();
                     foreach (var cat in samples)
                     {
                         var stubLine = new BOQ.BOQLineItem
@@ -97,11 +99,13 @@ namespace StingTools.Commands.Cost
                         };
                         string section = std.ClassifyRow(stubLine, null);
                         string unit = std.PreferredUnit(cat);
-                        sb.AppendLine($"  {cat,-22} → ({section,-6}, {unit})");
+                        rows.Add(new[] { cat, section, unit });
                     }
+                    rp.AddSection($"{std.DisplayName}  [{std.Version}]")
+                        .Table(new[] { "Category", "Section", "Unit" }, rows);
                 }
 
-                TaskDialog.Show("STING — Measurement standard preview", sb.ToString());
+                rp.Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/StingTools/Commands/Cost/PaymentCertCommands.cs
+++ b/StingTools/Commands/Cost/PaymentCertCommands.cs
@@ -21,6 +21,7 @@ using StingTools.BOQ;
 using StingTools.Core;
 using StingTools.Core.PaymentCert;
 using StingTools.Select;
+using StingTools.UI;       // StingResultPanel
 
 namespace StingTools.Commands.Cost
 {
@@ -43,7 +44,10 @@ namespace StingTools.Commands.Cost
                 var sov = PaymentCertEngine.SovFromSnapshot(boq);
                 if (sov.Count == 0)
                 {
-                    TaskDialog.Show("STING Payment Cert", "BOQ has no sections — build the BOQ first.");
+                    StingResultPanel.Create("Issue Cert")
+                        .AddSection("NO DATA")
+                        .Text("BOQ has no sections — build the BOQ first.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -72,15 +76,17 @@ namespace StingTools.Commands.Cost
                     StingLog.Info($"Payment cert {cert.CertNumber}: stamped {stamped} elements.");
                 }
 
-                TaskDialog.Show("STING — Payment cert issued",
-                    $"Cert #{cert.CertNumber} ({cert.ContractRef}, {cert.Form})\n\n" +
-                    $"Gross:      {cert.Currency} {cert.GrossValuation:N2}\n" +
-                    $"Retention:  {cert.Currency} {cert.RetentionAmount:N2}   ({cert.EffectiveRetentionPercent}%)\n" +
-                    $"Deductions: {cert.Currency} {cert.OtherDeductions:N2}\n" +
-                    $"Net:        {cert.Currency} {cert.NetThisCert:N2}\n" +
-                    $"VAT:        {cert.Currency} {cert.VatAmount:N2}\n" +
-                    $"Payable:    {cert.Currency} {cert.TotalPayable:N2}\n\n" +
-                    $"Path: {Path.GetFileName(path)}");
+                StingResultPanel.Create("Payment cert issued")
+                    .SetSubtitle($"Cert #{cert.CertNumber} ({cert.ContractRef}, {cert.Form})")
+                    .AddSection("VALUATION")
+                    .Metric("Gross", $"{cert.Currency} {cert.GrossValuation:N2}")
+                    .Metric("Retention", $"{cert.Currency} {cert.RetentionAmount:N2}", $"{cert.EffectiveRetentionPercent}%")
+                    .Metric("Deductions", $"{cert.Currency} {cert.OtherDeductions:N2}")
+                    .Metric("Net", $"{cert.Currency} {cert.NetThisCert:N2}")
+                    .Metric("VAT", $"{cert.Currency} {cert.VatAmount:N2}")
+                    .MetricHighlight("Payable", $"{cert.Currency} {cert.TotalPayable:N2}")
+                    .Text($"Path: {Path.GetFileName(path)}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -176,7 +182,10 @@ namespace StingTools.Commands.Cost
                 var paths = PaymentCertEngine.ListCerts(doc);
                 if (paths.Count == 0)
                 {
-                    TaskDialog.Show("STING Payment Cert", "No payment certs found.");
+                    StingResultPanel.Create("Approve Cert")
+                        .AddSection("NO CERTS")
+                        .Text("No payment certs found.")
+                        .Show();
                     return Result.Cancelled;
                 }
                 var certs = paths.Select(PaymentCertEngine.Load).Where(c => c != null).ToList();
@@ -190,7 +199,10 @@ namespace StingTools.Commands.Cost
                     }).ToList();
                 if (draftItems.Count == 0)
                 {
-                    TaskDialog.Show("STING Payment Cert", "No certs are in a state that can be approved.");
+                    StingResultPanel.Create("Approve Cert")
+                        .AddSection("NOTHING TO APPROVE")
+                        .Text("No certs are in a state that can be approved.")
+                        .Show();
                     return Result.Cancelled;
                 }
                 var picked = StingListPicker.Show("STING — Approve payment cert",
@@ -220,8 +232,10 @@ namespace StingTools.Commands.Cost
                 if (!string.IsNullOrEmpty(oldPath) && File.Exists(oldPath)) File.Delete(oldPath);
                 string newPath = PaymentCertEngine.Save(doc, cert);
 
-                TaskDialog.Show("STING — Cert advanced",
-                    $"Cert #{cert.CertNumber} is now {cert.Status}.");
+                StingResultPanel.Create("Cert advanced")
+                    .AddSection("RESULT")
+                    .Metric($"Cert #{cert.CertNumber}", cert.Status.ToString())
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -261,7 +275,10 @@ namespace StingTools.Commands.Cost
                 var paths = PaymentCertEngine.ListCerts(doc);
                 if (paths.Count == 0)
                 {
-                    TaskDialog.Show("STING Payment Cert", "No certs found.");
+                    StingResultPanel.Create("Cert Register")
+                        .AddSection("NO CERTS")
+                        .Text("No certs found.")
+                        .Show();
                     return Result.Cancelled;
                 }
                 var certs = paths.Select(PaymentCertEngine.Load).Where(c => c != null)
@@ -297,8 +314,12 @@ namespace StingTools.Commands.Cost
                         }));
                     }
                 }
-                TaskDialog.Show("STING — Register exported",
-                    $"{certs.Count} certificate(s) exported to:\n{outPath}");
+                StingResultPanel.Create("Cert register exported")
+                    .SetCsvPath(outPath)
+                    .AddSection("EXPORT")
+                    .Metric("Certificates", certs.Count.ToString())
+                    .Text($"Saved to: {outPath}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/StingTools/Commands/Cost/VariationAndEvmCommands.cs
+++ b/StingTools/Commands/Cost/VariationAndEvmCommands.cs
@@ -24,6 +24,7 @@ using StingTools.Core;
 using StingTools.Core.Evm;
 using StingTools.Core.Variation;
 using StingTools.Select;
+using StingTools.UI;       // StingResultPanel
 
 namespace StingTools.Commands.Cost
 {
@@ -44,8 +45,10 @@ namespace StingTools.Commands.Cost
                 var snapshots = BOQCostManager.ListSnapshots(doc);
                 if (snapshots.Count < 2)
                 {
-                    TaskDialog.Show("STING Variation",
-                        "Need at least two BOQ snapshots to mint a variation. Save snapshots before + after the change.");
+                    StingResultPanel.Create("Variation from Diff")
+                        .AddSection("NEED SNAPSHOTS")
+                        .Text("Need at least two BOQ snapshots to mint a variation. Save snapshots before + after the change.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -82,8 +85,10 @@ namespace StingTools.Commands.Cost
                 var diff = BOQCostManager.CompareSnapshots(snapA.Path, snapB.Path);
                 if (diff == null || diff.CategoryDiffs.Count == 0)
                 {
-                    TaskDialog.Show("STING Variation",
-                        "Snapshots are identical — no variation to mint.");
+                    StingResultPanel.Create("Variation from Diff")
+                        .AddSection("NO CHANGE")
+                        .Text("Snapshots are identical — no variation to mint.")
+                        .Show();
                     return Result.Cancelled;
                 }
 
@@ -184,14 +189,16 @@ namespace StingTools.Commands.Cost
                     contractForm: contractForm, currency: docB?.Currency ?? docA?.Currency ?? "UGX");
                 string path = VariationEngine.Save(doc, vo);
 
-                TaskDialog.Show("STING — Variation minted",
-                    $"{vo.Number}  ({vo.Kind}, {vo.Status})\n\n" +
-                    $"Contract:     {vo.ContractForm}\n" +
-                    $"Reason:       {vo.Reason}\n" +
-                    $"Liability:    {vo.Liability}\n" +
-                    $"Items:        {vo.Items.Count}\n" +
-                    $"Total value:  {vo.Currency} {vo.TotalValue:N2}\n\n" +
-                    $"Path: {Path.GetFileName(path)}");
+                StingResultPanel.Create("Variation minted")
+                    .SetSubtitle($"{vo.Number}  ({vo.Kind}, {vo.Status})")
+                    .AddSection("VARIATION")
+                    .Metric("Contract", vo.ContractForm.ToString())
+                    .Metric("Reason", vo.Reason.ToString())
+                    .Metric("Liability", vo.Liability.ToString())
+                    .Metric("Items", vo.Items.Count.ToString())
+                    .Metric("Total value", $"{vo.Currency} {vo.TotalValue:N2}")
+                    .Text($"Path: {Path.GetFileName(path)}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -334,16 +341,18 @@ namespace StingTools.Commands.Cost
                 string path = VariationEngine.SaveStarRate(doc, rate);
 
                 string cc = rate.Currency ?? "UGX";
-                TaskDialog.Show("STING — Star rate created",
-                    $"Star rate '{rate.Description}' saved.\n\n" +
-                    $"Labour:    {cc} {rate.LabourTotal:N2}\n" +
-                    $"Plant:     {cc} {rate.PlantTotal:N2}\n" +
-                    $"Materials: {cc} {rate.MaterialsTotal:N2}\n" +
-                    $"Subtotal:  {cc} {rate.Subtotal:N2}\n" +
-                    $"OH ({rate.OverheadPercent}%): {cc} {rate.OverheadAmount:N2}\n" +
-                    $"Profit ({rate.ProfitPercent}%): {cc} {rate.ProfitAmount:N2}\n" +
-                    $"FINAL:     {cc} {rate.FinalRate:N2}\n\n" +
-                    $"Edit at: {Path.GetFileName(path)}");
+                StingResultPanel.Create("Star rate created")
+                    .SetSubtitle($"Star rate '{rate.Description}' saved")
+                    .AddSection("BUILD-UP")
+                    .Metric("Labour", $"{cc} {rate.LabourTotal:N2}")
+                    .Metric("Plant", $"{cc} {rate.PlantTotal:N2}")
+                    .Metric("Materials", $"{cc} {rate.MaterialsTotal:N2}")
+                    .Metric("Subtotal", $"{cc} {rate.Subtotal:N2}")
+                    .Metric($"OH ({rate.OverheadPercent}%)", $"{cc} {rate.OverheadAmount:N2}")
+                    .Metric($"Profit ({rate.ProfitPercent}%)", $"{cc} {rate.ProfitAmount:N2}")
+                    .MetricHighlight("FINAL", $"{cc} {rate.FinalRate:N2}")
+                    .Text($"Edit at: {Path.GetFileName(path)}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -368,7 +377,10 @@ namespace StingTools.Commands.Cost
                 var paths = VariationEngine.ListVariations(doc);
                 if (paths.Count == 0)
                 {
-                    TaskDialog.Show("STING Variation", "No variations recorded.");
+                    StingResultPanel.Create("VO Register")
+                        .AddSection("NO VARIATIONS")
+                        .Text("No variations recorded.")
+                        .Show();
                     return Result.Cancelled;
                 }
                 var vos = paths.Select(VariationEngine.Load).Where(v => v != null)
@@ -407,8 +419,12 @@ namespace StingTools.Commands.Cost
                         }));
                     }
                 }
-                TaskDialog.Show("STING — Variation register",
-                    $"{vos.Count} variation(s) exported to:\n{outPath}");
+                StingResultPanel.Create("Variation register exported")
+                    .SetCsvPath(outPath)
+                    .AddSection("EXPORT")
+                    .Metric("Variations", vos.Count.ToString())
+                    .Text($"Saved to: {outPath}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -482,20 +498,24 @@ namespace StingTools.Commands.Cost
                 report.Periods.Add(period);
                 string path = EvmCalculator.Save(doc, report);
 
-                TaskDialog.Show("STING — EVM period",
-                    $"Period {period.PeriodLabel}\n\n" +
-                    $"BAC  {report.Currency} {period.Bac:N0}\n" +
-                    $"BCWS {report.Currency} {period.Bcws:N0}\n" +
-                    $"BCWP {report.Currency} {period.Bcwp:N0}\n" +
-                    $"ACWP {report.Currency} {period.Acwp:N0}\n\n" +
-                    $"CV   {period.Cv:N0}\n" +
-                    $"SV   {period.Sv:N0}\n" +
-                    $"CPI  {period.Cpi:F2}  ({period.CostHealth})\n" +
-                    $"SPI  {period.Spi:F2}  ({period.ScheduleHealth})\n" +
-                    $"EAC  {report.Currency} {period.Eac:N0}\n" +
-                    $"ETC  {report.Currency} {period.Etc:N0}\n" +
-                    $"VAC  {report.Currency} {period.Vac:N0}\n\n" +
-                    $"Saved: {Path.GetFileName(path)}");
+                StingResultPanel.Create("EVM period")
+                    .SetSubtitle($"Period {period.PeriodLabel}")
+                    .AddSection("BASELINE")
+                    .Metric("BAC", $"{report.Currency} {period.Bac:N0}")
+                    .Metric("BCWS", $"{report.Currency} {period.Bcws:N0}")
+                    .Metric("BCWP", $"{report.Currency} {period.Bcwp:N0}")
+                    .Metric("ACWP", $"{report.Currency} {period.Acwp:N0}")
+                    .AddSection("VARIANCE + INDICES")
+                    .Metric("CV", $"{period.Cv:N0}")
+                    .Metric("SV", $"{period.Sv:N0}")
+                    .Metric("CPI", $"{period.Cpi:F2}", period.CostHealth)
+                    .Metric("SPI", $"{period.Spi:F2}", period.ScheduleHealth)
+                    .AddSection("FORECAST")
+                    .Metric("EAC", $"{report.Currency} {period.Eac:N0}")
+                    .Metric("ETC", $"{report.Currency} {period.Etc:N0}")
+                    .Metric("VAC", $"{report.Currency} {period.Vac:N0}")
+                    .Text($"Saved: {Path.GetFileName(path)}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -544,18 +564,21 @@ namespace StingTools.Commands.Cost
                 if (!Directory.Exists(dir))
                 {
                     Directory.CreateDirectory(dir);
-                    TaskDialog.Show("STING EVM",
-                        $"Created actuals directory:\n{dir}\n\n" +
-                        "Drop CSV files named actuals_YYYYMMDD.csv with columns " +
-                        "Date,Section,Amount and re-run.");
+                    StingResultPanel.Create("Import Actuals")
+                        .AddSection("DIRECTORY CREATED")
+                        .Text($"Created actuals directory: {dir}")
+                        .Text("Drop CSV files named actuals_YYYYMMDD.csv with columns Date,Section,Amount and re-run.")
+                        .Show();
                     return Result.Succeeded;
                 }
 
                 var files = Directory.EnumerateFiles(dir, "actuals_*.csv").ToList();
                 if (files.Count == 0)
                 {
-                    TaskDialog.Show("STING EVM",
-                        $"No actuals CSV files found under {dir}.");
+                    StingResultPanel.Create("Import Actuals")
+                        .AddSection("NO FILES")
+                        .Text($"No actuals CSV files found under {dir}.")
+                        .Show();
                     return Result.Cancelled;
                 }
                 // B.5 — cumulative across ALL actuals files, deduped by content so
@@ -564,10 +587,13 @@ namespace StingTools.Commands.Cost
                     out int filesRead, out int dupSkipped);
                 string ccy = EvmCalculator.ListReports(doc).Select(EvmCalculator.Load)
                     .FirstOrDefault(r => r != null)?.Currency ?? "UGX";
-                TaskDialog.Show("STING — Actuals imported",
-                    $"Cumulative ACWP to {DateTime.UtcNow:yyyy-MM-dd}: {ccy} {total:N2}\n" +
-                    $"Files read: {filesRead}" +
-                    (dupSkipped > 0 ? $"   ·   {dupSkipped} duplicate file(s) skipped (identical content)" : ""));
+                var rp = StingResultPanel.Create("Actuals imported")
+                    .AddSection("RESULT")
+                    .Metric($"Cumulative ACWP to {DateTime.UtcNow:yyyy-MM-dd}", $"{ccy} {total:N2}")
+                    .Metric("Files read", filesRead.ToString());
+                if (dupSkipped > 0)
+                    rp.Metric("Duplicate files skipped", dupSkipped.ToString(), "identical content");
+                rp.Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -592,13 +618,19 @@ namespace StingTools.Commands.Cost
                 var reports = EvmCalculator.ListReports(doc);
                 if (reports.Count == 0)
                 {
-                    TaskDialog.Show("STING EVM", "No EVM reports saved. Run Evm_Calculate first.");
+                    StingResultPanel.Create("Export S-Curve")
+                        .AddSection("NO REPORTS")
+                        .Text("No EVM reports saved. Run Evm_Calculate first.")
+                        .Show();
                     return Result.Cancelled;
                 }
                 var rpt = EvmCalculator.Load(reports[0]);
                 if (rpt == null || rpt.Periods.Count == 0)
                 {
-                    TaskDialog.Show("STING EVM", "Latest report has no periods.");
+                    StingResultPanel.Create("Export S-Curve")
+                        .AddSection("NO PERIODS")
+                        .Text("Latest report has no periods.")
+                        .Show();
                     return Result.Cancelled;
                 }
                 string outDir = Path.Combine(BIMManagerEngine.GetBIMManagerDir(doc), "evm");
@@ -629,7 +661,12 @@ namespace StingTools.Commands.Cost
                         }));
                     }
                 }
-                TaskDialog.Show("STING — EVM exported", $"S-curve written to:\n{outPath}");
+                StingResultPanel.Create("EVM S-curve exported")
+                    .SetCsvPath(outPath)
+                    .AddSection("EXPORT")
+                    .Metric("Periods", rpt.Periods.Count.ToString())
+                    .Text($"S-curve written to: {outPath}")
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)
@@ -673,8 +710,10 @@ namespace StingTools.Commands.Cost
 
                 if (legacy.Count == 0)
                 {
-                    TaskDialog.Show("STING — Reclassify legacy variations",
-                        "Nothing to reclassify. Every variation has a non-default reason / liability assigned.");
+                    StingResultPanel.Create("Reclassify legacy variations")
+                        .AddSection("NOTHING TO RECLASSIFY")
+                        .Text("Every variation has a non-default reason / liability assigned.")
+                        .Show();
                     return Result.Succeeded;
                 }
 
@@ -733,8 +772,11 @@ namespace StingTools.Commands.Cost
                     reclassified++;
                 }
 
-                TaskDialog.Show("STING — Reclassification complete",
-                    $"Reclassified: {reclassified}\nSkipped (no reason picked): {skipped}");
+                StingResultPanel.Create("Reclassification complete")
+                    .AddSection("RESULT")
+                    .Metric("Reclassified", reclassified.ToString())
+                    .Metric("Skipped (no reason picked)", skipped.ToString())
+                    .Show();
                 return Result.Succeeded;
             }
             catch (Exception ex)

--- a/StingTools/Commands/Placement/LearnPlacementV4Command.cs
+++ b/StingTools/Commands/Placement/LearnPlacementV4Command.cs
@@ -56,11 +56,21 @@ namespace StingTools.Commands.Placement
         {
             var ctx = ParameterHelpers.GetContext(commandData);
             if (ctx == null) { message = "No active document."; return Result.Failed; }
-            var doc = ctx.Doc;
+            return RunLearn(ctx.Doc) >= 0 ? Result.Succeeded : Result.Cancelled;
+        }
+
+        /// <summary>
+        /// Core learn pass — also called from the Placement Centre's "Learn from
+        /// model" button. Returns the number of learned rules written, or -1 when
+        /// nothing was written (no saved project / no samples / error). Shows its
+        /// own TaskDialog feedback. Writes STING_PLACEMENT_RULES.learned.json.
+        /// </summary>
+        public static int RunLearn(Document doc)
+        {
             if (string.IsNullOrEmpty(doc?.PathName))
             {
                 TaskDialog.Show("STING — Learn Placement", "Save the project on disk first; the learned overrides land beside the .rvt.");
-                return Result.Cancelled;
+                return -1;
             }
 
             try
@@ -122,7 +132,7 @@ namespace StingTools.Commands.Placement
                 {
                     TaskDialog.Show("STING — Learn Placement",
                         "No placed instances of the learn-pass categories found in the model. Place a few real-world fixtures first.");
-                    return Result.Cancelled;
+                    return -1;
                 }
 
                 var rules = new List<PlacementRule>();
@@ -149,7 +159,7 @@ namespace StingTools.Commands.Placement
                 {
                     TaskDialog.Show("STING — Learn Placement",
                         $"Walked {clusters.Count} cluster(s) but every cluster had <2 samples. Place at least 2 instances of the same category in similarly-named rooms.");
-                    return Result.Cancelled;
+                    return -1;
                 }
 
                 string dir = Path.GetDirectoryName(doc.PathName);
@@ -174,13 +184,13 @@ namespace StingTools.Commands.Placement
                     CommonButtons = TaskDialogCommonButtons.Close,
                 };
                 td.Show();
-                return Result.Succeeded;
+                return rules.Count;
             }
             catch (Exception ex)
             {
                 StingLog.Error("LearnPlacementV4Command failed", ex);
-                message = ex.Message;
-                return Result.Failed;
+                TaskDialog.Show("STING — Learn Placement", $"Learn failed: {ex.Message}");
+                return -1;
             }
         }
 

--- a/StingTools/Commands/Placement/LearnPlacementV4Command.cs
+++ b/StingTools/Commands/Placement/LearnPlacementV4Command.cs
@@ -65,11 +65,21 @@ namespace StingTools.Commands.Placement
         /// nothing was written (no saved project / no samples / error). Shows its
         /// own TaskDialog feedback. Writes STING_PLACEMENT_RULES.learned.json.
         /// </summary>
-        public static int RunLearn(Document doc)
+        public static int RunLearn(Document doc) => RunLearn(doc, out _, showDialog: true);
+
+        /// <summary>
+        /// Overload that captures the user-facing feedback into
+        /// <paramref name="summary"/> and (when <paramref name="showDialog"/> is
+        /// false) suppresses the TaskDialog, so the Placement Centre can render
+        /// the result inline in its shared Report panel.
+        /// </summary>
+        public static int RunLearn(Document doc, out string summary, bool showDialog = true)
         {
+            summary = "";
             if (string.IsNullOrEmpty(doc?.PathName))
             {
-                TaskDialog.Show("STING — Learn Placement", "Save the project on disk first; the learned overrides land beside the .rvt.");
+                summary = "Save the project on disk first; the learned overrides land beside the .rvt.";
+                if (showDialog) TaskDialog.Show("STING — Learn Placement", summary);
                 return -1;
             }
 
@@ -130,8 +140,8 @@ namespace StingTools.Commands.Placement
 
                 if (clusters.Count == 0)
                 {
-                    TaskDialog.Show("STING — Learn Placement",
-                        "No placed instances of the learn-pass categories found in the model. Place a few real-world fixtures first.");
+                    summary = "No placed instances of the learn-pass categories found in the model. Place a few real-world fixtures first.";
+                    if (showDialog) TaskDialog.Show("STING — Learn Placement", summary);
                     return -1;
                 }
 
@@ -157,8 +167,8 @@ namespace StingTools.Commands.Placement
 
                 if (rules.Count == 0)
                 {
-                    TaskDialog.Show("STING — Learn Placement",
-                        $"Walked {clusters.Count} cluster(s) but every cluster had <2 samples. Place at least 2 instances of the same category in similarly-named rooms.");
+                    summary = $"Walked {clusters.Count} cluster(s) but every cluster had <2 samples. Place at least 2 instances of the same category in similarly-named rooms.";
+                    if (showDialog) TaskDialog.Show("STING — Learn Placement", summary);
                     return -1;
                 }
 
@@ -172,24 +182,27 @@ namespace StingTools.Commands.Placement
                 };
                 File.WriteAllText(path, JsonConvert.SerializeObject(set, Formatting.Indented));
 
-                var td = new TaskDialog("STING — Learn Placement")
-                {
-                    MainInstruction = $"Wrote {rules.Count} learned rule(s).",
-                    MainContent =
-                        $"Path: {path}\n\n" +
-                        "Review then either:\n" +
-                        "  · Open Placement Centre → Import… and pick this file, or\n" +
-                        "  · Rename to STING_PLACEMENT_RULES.project.json to make the rules win automatically.\n\n" +
-                        $"Clusters inspected: {clusters.Count}",
-                    CommonButtons = TaskDialogCommonButtons.Close,
-                };
-                td.Show();
+                summary =
+                    $"Wrote {rules.Count} learned rule(s).\n" +
+                    $"Path: {path}\n\n" +
+                    "Review then either:\n" +
+                    "  · Open Placement Centre → Import… and pick this file, or\n" +
+                    "  · Rename to STING_PLACEMENT_RULES.project.json to make the rules win automatically.\n\n" +
+                    $"Clusters inspected: {clusters.Count}";
+                if (showDialog)
+                    new TaskDialog("STING — Learn Placement")
+                    {
+                        MainInstruction = $"Wrote {rules.Count} learned rule(s).",
+                        MainContent = summary,
+                        CommonButtons = TaskDialogCommonButtons.Close,
+                    }.Show();
                 return rules.Count;
             }
             catch (Exception ex)
             {
                 StingLog.Error("LearnPlacementV4Command failed", ex);
-                TaskDialog.Show("STING — Learn Placement", $"Learn failed: {ex.Message}");
+                summary = $"Learn failed: {ex.Message}";
+                if (showDialog) TaskDialog.Show("STING — Learn Placement", summary);
                 return -1;
             }
         }

--- a/StingTools/Commands/Placement/NogginRequirementExportCommand.cs
+++ b/StingTools/Commands/Placement/NogginRequirementExportCommand.cs
@@ -31,69 +31,89 @@ namespace StingTools.Commands.Placement
             var doc = commandData?.Application?.ActiveUIDocument?.Document;
             if (doc == null) { message = "No active document."; return Result.Failed; }
 
-            var rows = new List<string[]>();
-            try
-            {
-                var col = new FilteredElementCollector(doc).OfClass(typeof(FamilyInstance))
-                    .WhereElementIsNotElementType();
-                foreach (var el in col)
-                {
-                    if (!(el is FamilyInstance fi)) continue;
-                    if (fi.Category == null) continue;
-                    var bic = (BuiltInCategory)fi.Category.Id.Value;
-                    if (bic != BuiltInCategory.OST_LightingFixtures
-                     && bic != BuiltInCategory.OST_ElectricalFixtures
-                     && bic != BuiltInCategory.OST_LightingDevices) continue;
-
-                    var pNoggin = fi.LookupParameter(ParamRegistry.NOGGIN_REQUIRED);
-                    if (pNoggin == null || !pNoggin.HasValue) continue;
-                    int v = pNoggin.StorageType == StorageType.Integer ? pNoggin.AsInteger()
-                          : pNoggin.StorageType == StorageType.Double  ? (int)pNoggin.AsDouble()
-                          : 0;
-                    if (v != 1) continue;
-
-                    XYZ pt = (fi.Location as LocationPoint)?.Point ?? XYZ.Zero;
-                    string room = "";
-                    try { room = fi.Room?.Name ?? ""; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
-                    string level = "";
-                    try { level = (doc.GetElement(fi.LevelId) as Level)?.Name ?? ""; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
-                    string typeName = doc.GetElement(fi.GetTypeId())?.Name ?? "";
-                    string catalogueRef = fi.LookupParameter("MK_CATALOGUE_REF")?.AsString() ?? "";
-                    rows.Add(new[] {
-                        room, level,
-                        (pt.X * FtToMm).ToString("F1"),
-                        (pt.Y * FtToMm).ToString("F1"),
-                        (pt.Z * FtToMm).ToString("F1"),
-                        typeName, catalogueRef,
-                        DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
-                    });
-                }
-            }
+            string text;
+            int count;
+            try { text = BuildReportText(doc, out _, out count); }
             catch (Exception ex)
             {
-                StingLog.Warn($"NogginRequirementExport collect: {ex.Message}");
+                StingLog.Warn($"NogginRequirementExport: {ex.Message}");
                 message = ex.Message;
                 return Result.Failed;
             }
 
+            int markersPlaced = PlaceMarkers(doc);
+            TaskDialog.Show("STING - Noggin Export",
+                text + $"\n\nMarkers placed: {markersPlaced}");
+            return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// Collect noggin-required fixtures and write the CSV (no model changes).
+        /// Shared by Execute and the Placement Centre's inline Report panel.
+        /// </summary>
+        public static string BuildReportText(Document doc, out string csvPath, out int count)
+        {
+            csvPath = "";
+            var rows = CollectRows(doc);
+            count = rows.Count;
+
             string outDir = OutputLocationHelper.GetOutputPath(doc, "NogginRequirements") ?? Path.GetTempPath();
             Directory.CreateDirectory(outDir);
-            string csvPath = Path.Combine(outDir,
+            csvPath = Path.Combine(outDir,
                 $"STING_NogginRequirements_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
-            try
-            {
-                var sb = new StringBuilder();
-                sb.AppendLine("Room,Level,X_mm,Y_mm,Z_mm,BoxType,CatalogueRef,FixingDate");
-                foreach (var row in rows) sb.AppendLine(string.Join(",", row.Select(Quote)));
-                File.WriteAllText(csvPath, sb.ToString());
-            }
-            catch (Exception ex)
-            {
-                message = $"CSV write failed: {ex.Message}";
-                return Result.Failed;
-            }
+            var sb = new StringBuilder();
+            sb.AppendLine("Room,Level,X_mm,Y_mm,Z_mm,BoxType,CatalogueRef,FixingDate");
+            foreach (var row in rows) sb.AppendLine(string.Join(",", row.Select(Quote)));
+            File.WriteAllText(csvPath, sb.ToString());
 
-            // Optionally drop marker generic-model instances if the family is loaded.
+            return $"{count} noggin requirement(s) exported.\n{csvPath}";
+        }
+
+        private static List<string[]> CollectRows(Document doc)
+        {
+            var rows = new List<string[]>();
+            var col = new FilteredElementCollector(doc).OfClass(typeof(FamilyInstance))
+                .WhereElementIsNotElementType();
+            foreach (var el in col)
+            {
+                if (!(el is FamilyInstance fi)) continue;
+                if (fi.Category == null) continue;
+                var bic = (BuiltInCategory)fi.Category.Id.Value;
+                if (bic != BuiltInCategory.OST_LightingFixtures
+                 && bic != BuiltInCategory.OST_ElectricalFixtures
+                 && bic != BuiltInCategory.OST_LightingDevices) continue;
+
+                var pNoggin = fi.LookupParameter(ParamRegistry.NOGGIN_REQUIRED);
+                if (pNoggin == null || !pNoggin.HasValue) continue;
+                int v = pNoggin.StorageType == StorageType.Integer ? pNoggin.AsInteger()
+                      : pNoggin.StorageType == StorageType.Double  ? (int)pNoggin.AsDouble()
+                      : 0;
+                if (v != 1) continue;
+
+                XYZ pt = (fi.Location as LocationPoint)?.Point ?? XYZ.Zero;
+                string room = "";
+                try { room = fi.Room?.Name ?? ""; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+                string level = "";
+                try { level = (doc.GetElement(fi.LevelId) as Level)?.Name ?? ""; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+                string typeName = doc.GetElement(fi.GetTypeId())?.Name ?? "";
+                string catalogueRef = fi.LookupParameter("MK_CATALOGUE_REF")?.AsString() ?? "";
+                rows.Add(new[] {
+                    room, level,
+                    (pt.X * FtToMm).ToString("F1"),
+                    (pt.Y * FtToMm).ToString("F1"),
+                    (pt.Z * FtToMm).ToString("F1"),
+                    typeName, catalogueRef,
+                    DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                });
+            }
+            return rows;
+        }
+
+        // Optionally drop marker generic-model instances if the family is loaded
+        // (model-modifying — ribbon path only; no-op when run read-only).
+        private static int PlaceMarkers(Document doc)
+        {
+            var rows = CollectRows(doc);
             int markersPlaced = 0;
             FamilySymbol marker = ResolveMarker(doc);
             if (marker != null && rows.Count > 0)
@@ -123,10 +143,7 @@ namespace StingTools.Commands.Placement
                     catch (Exception ex2) { StingLog.Warn($"Suppressed: {ex2.Message}"); if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack(); }
                 }
             }
-
-            TaskDialog.Show("STING - Noggin Export",
-                $"{rows.Count} noggin requirement(s) exported.\n\n{csvPath}\n\nMarkers placed: {markersPlaced}");
-            return Result.Succeeded;
+            return markersPlaced;
         }
 
         private static FamilySymbol ResolveMarker(Document doc)

--- a/StingTools/Commands/Placement/PlaceFixturesCommand.cs
+++ b/StingTools/Commands/Placement/PlaceFixturesCommand.cs
@@ -78,6 +78,14 @@ namespace StingTools.Commands.Placement
         public static bool HonourLearned          { get; set; } = true;
 
         /// <summary>
+        /// In-session building profile pushed by the Placement Centre before a
+        /// run so the live UI selection (building type / standards / wet-zone /
+        /// accessibility / coverage toggles) takes effect WITHOUT a Save first.
+        /// When null the engine falls back to the on-disk placement_profile.json.
+        /// </summary>
+        public static StingTools.Core.Placement.ProjectBuildingProfile SessionProfile { get; set; }
+
+        /// <summary>
         /// Return the set of Revit category names this command should
         /// consider, based on the discipline checkboxes. Used by
         /// FixturePlacementEngine to filter PlacementRule.CategoryFilter.

--- a/StingTools/Commands/Placement/PlacementDiagnoseCommand.cs
+++ b/StingTools/Commands/Placement/PlacementDiagnoseCommand.cs
@@ -27,6 +27,19 @@ namespace StingTools.Commands.Placement
             var doc = cd?.Application?.ActiveUIDocument?.Document;
             if (doc == null) { message = "No active document."; return Result.Failed; }
 
+            var (text, txtPath) = BuildReportText(doc);
+            string preview = text.Length > 4000 ? text.Substring(0, 4000) + "\n…(truncated, see file)" : text;
+            TaskDialog.Show("STING - Placement Diagnose", preview + $"\n\nFull report: {txtPath}");
+            return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// Build the diagnostic report text (and write it to disk). Shared by
+        /// Execute (which TaskDialogs it) and the Placement Centre (which renders
+        /// it inline in the shared Report panel). Returns (report, filePath).
+        /// </summary>
+        public static (string Text, string FilePath) BuildReportText(Document doc)
+        {
             var sb = new StringBuilder();
             sb.AppendLine($"Build: STING placement diagnostic — Phase 139.19 ({DateTime.UtcNow:O})");
             sb.AppendLine($"Document: {doc.Title}");
@@ -36,7 +49,7 @@ namespace StingTools.Commands.Placement
             sb.AppendLine();
 
             // 2. Active view + scope.
-            var view = cd.Application.ActiveUIDocument.ActiveView;
+            var view = doc.ActiveView;
             sb.AppendLine($"Active view: {view?.Name} ({view?.GetType().Name})");
             int roomsAll = new FilteredElementCollector(doc).OfCategory(BuiltInCategory.OST_Rooms).WhereElementIsNotElementType().Count();
             int roomsView = view is ViewPlan vp && vp.GenLevel != null
@@ -122,9 +135,7 @@ namespace StingTools.Commands.Placement
                 $"STING_PlacementDiagnose_{DateTime.Now:yyyyMMdd_HHmmss}.txt");
             try { File.WriteAllText(txtPath, sb.ToString()); } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
 
-            string preview = sb.Length > 4000 ? sb.ToString().Substring(0, 4000) + "\n…(truncated, see file)" : sb.ToString();
-            TaskDialog.Show("STING - Placement Diagnose", preview + $"\n\nFull report: {txtPath}");
-            return Result.Succeeded;
+            return (sb.ToString(), txtPath);
         }
     }
 }

--- a/StingTools/Commands/Placement/PlacementSetupAuditCommand.cs
+++ b/StingTools/Commands/Placement/PlacementSetupAuditCommand.cs
@@ -68,17 +68,12 @@ namespace StingTools.Commands.Placement
         {
             var doc = commandData?.Application?.ActiveUIDocument?.Document;
             if (doc == null) { message = "No active document."; return Result.Failed; }
-
-            var findings = new List<AuditFinding>();
             try
             {
-                AuditSharedParameters(doc, findings);
-                AuditFamilies(doc, findings);
-                AuditCategories(doc, findings);
-                AuditPhases(doc, findings);
-                AuditCatalogue(findings);
-                AuditRulePack(doc, findings);
-                AuditViewStylePack(findings);
+                string text = BuildReportText(doc, out _, out _, out string csvPath);
+                TaskDialog.Show("STING - Placement Setup Audit",
+                    text + (string.IsNullOrEmpty(csvPath) ? "" : $"\nCSV: {csvPath}"));
+                return Result.Succeeded;
             }
             catch (Exception ex)
             {
@@ -86,10 +81,27 @@ namespace StingTools.Commands.Placement
                 message = ex.Message;
                 return Result.Failed;
             }
+        }
+
+        /// <summary>
+        /// Run all audit passes and build the report text + CSV. Shared by
+        /// Execute (TaskDialog) and the Placement Centre (inline Report panel).
+        /// </summary>
+        public static string BuildReportText(Document doc, out int errs, out int warns, out string csvPath)
+        {
+            csvPath = "";
+            var findings = new List<AuditFinding>();
+            AuditSharedParameters(doc, findings);
+            AuditFamilies(doc, findings);
+            AuditCategories(doc, findings);
+            AuditPhases(doc, findings);
+            AuditCatalogue(findings);
+            AuditRulePack(doc, findings);
+            AuditViewStylePack(findings);
 
             // Build report.
-            int errs = findings.Count(f => f.Severity == AuditSeverity.Error);
-            int warns = findings.Count(f => f.Severity == AuditSeverity.Warning);
+            errs = findings.Count(f => f.Severity == AuditSeverity.Error);
+            warns = findings.Count(f => f.Severity == AuditSeverity.Warning);
             int info = findings.Count(f => f.Severity == AuditSeverity.Info);
 
             var sb = new StringBuilder();
@@ -108,7 +120,6 @@ namespace StingTools.Commands.Placement
             }
 
             // Always write CSV.
-            string csvPath = "";
             try
             {
                 string outDir = OutputLocationHelper.GetOutputPath(doc, "PlacementSetupAudit") ?? Path.GetTempPath();
@@ -122,9 +133,7 @@ namespace StingTools.Commands.Placement
             }
             catch (Exception ex) { StingLog.Warn($"PlacementSetupAudit CSV: {ex.Message}"); }
 
-            TaskDialog.Show("STING - Placement Setup Audit",
-                sb.ToString() + (string.IsNullOrEmpty(csvPath) ? "" : $"\nCSV: {csvPath}"));
-            return Result.Succeeded;
+            return sb.ToString();
         }
 
         // ── Audit passes ───────────────────────────────────────────

--- a/StingTools/Commands/Placement/RunWallChaseCommand.cs
+++ b/StingTools/Commands/Placement/RunWallChaseCommand.cs
@@ -14,6 +14,7 @@ using Autodesk.Revit.UI;
 using Autodesk.Revit.UI.Selection;
 using StingTools.Core;
 using StingTools.Core.Placement;
+using StingTools.UI;
 
 namespace StingTools.Commands.Placement
 {
@@ -23,83 +24,9 @@ namespace StingTools.Commands.Placement
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var uidoc = commandData?.Application?.ActiveUIDocument;
-            var doc = uidoc?.Document;
-            if (doc == null) { message = "No active document."; return Result.Failed; }
-
-            try
-            {
-                Reference wallRef = uidoc.Selection.PickObject(ObjectType.Element,
-                    new WallSelectionFilter(), "Pick the host wall for the chase route");
-                Wall wall = doc.GetElement(wallRef) as Wall;
-                if (wall == null) { message = "Selected element is not a wall."; return Result.Failed; }
-
-                XYZ p1 = uidoc.Selection.PickPoint("Pick the chase start point on the wall");
-                XYZ p2 = uidoc.Selection.PickPoint("Pick the chase end point on the wall");
-
-                var rules = PlacementRuleLoader.Load(doc.PathName);
-                var rule = rules.FirstOrDefault(r =>
-                    string.Equals(r.RoutingMode, "WALL_CHASE", StringComparison.OrdinalIgnoreCase));
-                if (rule == null)
-                {
-                    TaskDialog.Show("STING - Wall Chase",
-                        "No WALL_CHASE rule loaded. Ship STING_PLACEMENT_RULES.in-wall-chase.json or define one.");
-                    return Result.Cancelled;
-                }
-
-                var structural = new StructuralAwareness(doc);
-                var router = new InWallChaseRouter(doc, structural);
-                InWallChaseRouter.ChaseRouteResult outcome;
-
-                // Phase 139.4 — preview pass: route inside a TransactionGroup
-                // that we always roll back, so the user sees the depth-check
-                // verdict + warnings without committing. If they confirm, we
-                // run the live pass in a fresh Transaction.
-                using (var tg = new TransactionGroup(doc, "STING Chase Preview"))
-                {
-                    tg.Start();
-                    using (var ptx = new Transaction(doc, "STING Chase Preview Inner"))
-                    {
-                        ptx.Start();
-                        outcome = router.Route(wall, p1, p2, rule,
-                            ElementId.InvalidElementId, ElementId.InvalidElementId);
-                        ptx.RollBack();
-                    }
-                    tg.RollBack();
-                }
-
-                var confirmDialog = new TaskDialog("STING - Wall Chase Preview")
-                {
-                    MainInstruction = $"Preview: {outcome.CreatedSegments.Count} pipe(s), {outcome.RejectedSegments} rejected, {outcome.SleevesPlaced} sleeve(s).",
-                    MainContent = $"Available chase depth: {outcome.AvailableChaseDepthMm:F0} mm\nRequired: {outcome.RequiredChaseDepthMm:F0} mm\n\nCommit?",
-                    CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
-                    DefaultButton = TaskDialogResult.No,
-                };
-                if (confirmDialog.Show() != TaskDialogResult.Yes)
-                    return Result.Cancelled;
-
-                using (var tx = new Transaction(doc, "STING In-Wall Chase Route"))
-                {
-                    tx.Start();
-                    outcome = router.Route(wall, p1, p2, rule,
-                        ElementId.InvalidElementId, ElementId.InvalidElementId);
-                    if (outcome.CreatedSegments.Count == 0 && outcome.RejectedSegments > 0)
-                        tx.RollBack();
-                    else
-                        tx.Commit();
-                }
-
-                string warnText = outcome.Warnings.Count == 0
-                    ? "(no warnings)"
-                    : string.Join("\n  ", outcome.Warnings.Take(20));
-                TaskDialog.Show("STING - Wall Chase",
-                    $"Pipes:   {outcome.CreatedSegments.Count}  Rejected: {outcome.RejectedSegments}\n" +
-                    $"Sleeves: {outcome.SleevesPlaced}\n\n" +
-                    $"Available chase depth: {outcome.AvailableChaseDepthMm:F0} mm\n" +
-                    $"Required chase depth:  {outcome.RequiredChaseDepthMm:F0} mm\n\n" +
-                    $"Warnings:\n  {warnText}");
-                return Result.Succeeded;
-            }
+            var uiapp = commandData?.Application;
+            if (uiapp?.ActiveUIDocument?.Document == null) { message = "No active document."; return Result.Failed; }
+            try { RunInteractive(uiapp)?.Show(); return Result.Succeeded; }
             catch (Autodesk.Revit.Exceptions.OperationCanceledException) { return Result.Cancelled; }
             catch (Exception ex)
             {
@@ -107,6 +34,90 @@ namespace StingTools.Commands.Placement
                 message = ex.Message;
                 return Result.Failed;
             }
+        }
+
+        /// <summary>
+        /// Interactive chase route — pick a wall + two points, preview the
+        /// depth-check verdict in a rolled-back transaction, confirm, then commit.
+        /// Returns a result Builder so the Placement Centre can render it inline
+        /// (run via its action ExternalEvent so picking + transactions are on the
+        /// API thread). Throws OperationCanceledException if the user escapes a pick.
+        /// </summary>
+        public static StingResultPanel.Builder RunInteractive(UIApplication uiapp)
+        {
+            var uidoc = uiapp.ActiveUIDocument;
+            var doc = uidoc.Document;
+
+            Reference wallRef = uidoc.Selection.PickObject(ObjectType.Element,
+                new WallSelectionFilter(), "Pick the host wall for the chase route");
+            Wall wall = doc.GetElement(wallRef) as Wall;
+            if (wall == null)
+                return StingResultPanel.Create("STING — Wall Chase").AddSection("RESULT").Text("Selected element is not a wall.");
+
+            XYZ p1 = uidoc.Selection.PickPoint("Pick the chase start point on the wall");
+            XYZ p2 = uidoc.Selection.PickPoint("Pick the chase end point on the wall");
+
+            var rules = PlacementRuleLoader.Load(doc.PathName);
+            var rule = rules.FirstOrDefault(r =>
+                string.Equals(r.RoutingMode, "WALL_CHASE", StringComparison.OrdinalIgnoreCase));
+            if (rule == null)
+                return StingResultPanel.Create("STING — Wall Chase").AddSection("RESULT")
+                    .Text("No WALL_CHASE rule loaded. Ship STING_PLACEMENT_RULES.in-wall-chase.json or define one.");
+
+            var structural = new StructuralAwareness(doc);
+            var router = new InWallChaseRouter(doc, structural);
+            InWallChaseRouter.ChaseRouteResult outcome;
+
+            // Preview pass: route inside a TransactionGroup that we always roll
+            // back, so the user sees the depth-check verdict before committing.
+            using (var tg = new TransactionGroup(doc, "STING Chase Preview"))
+            {
+                tg.Start();
+                using (var ptx = new Transaction(doc, "STING Chase Preview Inner"))
+                {
+                    ptx.Start();
+                    outcome = router.Route(wall, p1, p2, rule,
+                        ElementId.InvalidElementId, ElementId.InvalidElementId);
+                    ptx.RollBack();
+                }
+                tg.RollBack();
+            }
+
+            var confirmDialog = new TaskDialog("STING - Wall Chase Preview")
+            {
+                MainInstruction = $"Preview: {outcome.CreatedSegments.Count} pipe(s), {outcome.RejectedSegments} rejected, {outcome.SleevesPlaced} sleeve(s).",
+                MainContent = $"Available chase depth: {outcome.AvailableChaseDepthMm:F0} mm\nRequired: {outcome.RequiredChaseDepthMm:F0} mm\n\nCommit?",
+                CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                DefaultButton = TaskDialogResult.No,
+            };
+            if (confirmDialog.Show() != TaskDialogResult.Yes)
+                return StingResultPanel.Create("STING — Wall Chase").AddSection("RESULT")
+                    .Text("Preview only — not committed.");
+
+            using (var tx = new Transaction(doc, "STING In-Wall Chase Route"))
+            {
+                tx.Start();
+                outcome = router.Route(wall, p1, p2, rule,
+                    ElementId.InvalidElementId, ElementId.InvalidElementId);
+                if (outcome.CreatedSegments.Count == 0 && outcome.RejectedSegments > 0)
+                    tx.RollBack();
+                else
+                    tx.Commit();
+            }
+
+            var panel = StingResultPanel.Create("STING — Wall Chase")
+                .AddSection("SUMMARY")
+                .Metric("Pipes", outcome.CreatedSegments.Count.ToString())
+                .Metric("Rejected", outcome.RejectedSegments.ToString())
+                .Metric("Sleeves", outcome.SleevesPlaced.ToString())
+                .Metric("Available chase depth (mm)", outcome.AvailableChaseDepthMm.ToString("F0"))
+                .Metric("Required chase depth (mm)", outcome.RequiredChaseDepthMm.ToString("F0"));
+            if (outcome.Warnings.Count > 0)
+            {
+                panel.AddSection("WARNINGS");
+                foreach (var w in outcome.Warnings.Take(20)) panel.Text(w);
+            }
+            return panel;
         }
 
         private sealed class WallSelectionFilter : ISelectionFilter

--- a/StingTools/Core/MergeRecoveryStubs.cs
+++ b/StingTools/Core/MergeRecoveryStubs.cs
@@ -146,14 +146,30 @@ namespace StingTools.UI.PlacementCenter
         public DateTime StartUtc { get; set; }
         public bool PrevStamp { get; set; }
         public bool PrevLearn { get; set; }
+        public bool DryRun { get; set; }
     }
 
-    /// <summary>Stub handler — wires up the modeless async-run pattern but does no work.</summary>
+    /// <summary>
+    /// Run-Placement ExternalEvent handler. Forwards to the Placement Centre's
+    /// ExecuteRun on the Revit API thread, which runs FixturePlacementEngine and
+    /// marshals the result back to OnRunCompleted on the WPF thread. (Replaces
+    /// the merge-recovery no-op stub that left Run Placement non-functional.)
+    /// </summary>
     public sealed class PlacementRunHandler : Autodesk.Revit.UI.IExternalEventHandler
     {
+        private readonly StingPlacementCenter _owner;
         public PlacementRunHandler() { }
-        public PlacementRunHandler(StingPlacementCenter owner) { }
-        public void Execute(Autodesk.Revit.UI.UIApplication app) { }
+        public PlacementRunHandler(StingPlacementCenter owner) { _owner = owner; }
+        public void Execute(Autodesk.Revit.UI.UIApplication app)
+        {
+            if (_owner == null)
+            {
+                StingTools.Core.StingLog.Warn("PlacementRunHandler: no owner — run skipped.");
+                return;
+            }
+            try { _owner.ExecuteRun(app); }
+            catch (Exception ex) { StingTools.Core.StingLog.Error("PlacementRunHandler.Execute", ex); }
+        }
         public string GetName() => "PlacementRunHandler";
     }
 }
@@ -396,7 +412,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void EnsureRunEvent()
         {
-            if (_runHandler == null) _runHandler = new PlacementRunHandler();
+            if (_runHandler == null) _runHandler = new PlacementRunHandler(this);
             if (_runEvent == null)   _runEvent   = Autodesk.Revit.UI.ExternalEvent.Create(_runHandler);
         }
 

--- a/StingTools/Core/Placement/CeilingGridSnap.cs
+++ b/StingTools/Core/Placement/CeilingGridSnap.cs
@@ -40,7 +40,7 @@ namespace StingTools.Core.Placement
         /// found the input points are returned unchanged and a Warn is
         /// logged once per room.
         /// </summary>
-        public static List<XYZ> SnapToCeilingGrid(Document doc, Room room, IList<XYZ> points)
+        public static List<XYZ> SnapToCeilingGrid(Document doc, SpatialElement room, IList<XYZ> points)
         {
             if (doc == null || room == null || points == null || points.Count == 0)
                 return points == null ? new List<XYZ>() : new List<XYZ>(points);
@@ -87,7 +87,7 @@ namespace StingTools.Core.Placement
         /// Find the Ceiling element directly above the room centroid.
         /// Uses BoundingBoxIntersectsFilter per N-G1 perf guidance.
         /// </summary>
-        private static Ceiling FindCeilingOverRoom(Document doc, Room room)
+        private static Ceiling FindCeilingOverRoom(Document doc, SpatialElement room)
         {
             var bb = room.get_BoundingBox(null);
             if (bb == null) return null;

--- a/StingTools/Core/Placement/CoverageGridGenerator.cs
+++ b/StingTools/Core/Placement/CoverageGridGenerator.cs
@@ -47,7 +47,7 @@ namespace StingTools.Core.Placement
         /// Generate coverage grid for a single room.  Returns ordered
         /// candidate XYZs at MountingHeight already applied at anchorZ.
         /// </summary>
-        public CoverageResult Generate(Room room, PlacementRule rule, double anchorZ)
+        public CoverageResult Generate(SpatialElement room, PlacementRule rule, double anchorZ)
         {
             var result = new CoverageResult();
             if (room == null || rule == null) return result;
@@ -109,7 +109,7 @@ namespace StingTools.Core.Placement
                             double y = bay.minY + (j + 0.5) * stepY;
                             var pt = new XYZ(x, y, anchorZ);
                             // Inside-room test
-                            try { if (!room.IsPointInRoom(new XYZ(x, y, room.Level?.Elevation ?? bb.Min.Z))) continue; }
+                            try { if (!FixturePlacementEngine.PointInSpatial(room, new XYZ(x, y, room.Level?.Elevation ?? bb.Min.Z))) continue; }
                             catch { /* IsPointInRoom can fail on unbounded rooms — accept */ }
                             rawCandidates.Add(pt);
                         }
@@ -161,7 +161,7 @@ namespace StingTools.Core.Placement
                             // Wall + obstruction clearance gates same as
                             // the base grid.
                             if (HasObstructionWithin(pt, obstructions, obsClearFt)) continue;
-                            try { if (!room.IsPointInRoom(new XYZ(pt.X, pt.Y, room.Level?.Elevation ?? bb.Min.Z))) continue; }
+                            try { if (!FixturePlacementEngine.PointInSpatial(room, new XYZ(pt.X, pt.Y, room.Level?.Elevation ?? bb.Min.Z))) continue; }
                             catch { /* unbounded room — accept */ }
                             // Reject points too close to the bay edge
                             // (wall clearance already trimmed the bay,
@@ -272,7 +272,7 @@ namespace StingTools.Core.Placement
         /// the room bbox, testing each sample point against the union of
         /// CoverageRadiusFt circles centred on placed points.
         /// </summary>
-        private double ComputeCoveragePercent(Room room, BoundingBoxXYZ bb, List<XYZ> placed,
+        private double ComputeCoveragePercent(SpatialElement room, BoundingBoxXYZ bb, List<XYZ> placed,
             double coverageRadiusFt, List<XYZ> uncoveredSamples)
         {
             if (placed == null || placed.Count == 0) return 0.0;
@@ -285,7 +285,7 @@ namespace StingTools.Core.Placement
                 for (double y = bb.Min.Y + 0.5; y <= bb.Max.Y; y += sampleStepFt)
                 {
                     bool inside = true;
-                    try { inside = room.IsPointInRoom(new XYZ(x, y, zSample)); } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+                    try { inside = FixturePlacementEngine.PointInSpatial(room, new XYZ(x, y, zSample)); } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
                     if (!inside) continue;
                     total++;
                     bool isCovered = false;

--- a/StingTools/Core/Placement/CoverageGridGenerator.cs
+++ b/StingTools/Core/Placement/CoverageGridGenerator.cs
@@ -276,7 +276,7 @@ namespace StingTools.Core.Placement
             double coverageRadiusFt, List<XYZ> uncoveredSamples)
         {
             if (placed == null || placed.Count == 0) return 0.0;
-            double sampleStepFt = 0.5 / 0.3048; // 0.5m
+            double sampleStepFt = 0.5 / 0.3048; // 0.5 m sample step, expressed in feet
             int total = 0, covered = 0;
             double cr2 = coverageRadiusFt * coverageRadiusFt;
             double zSample = room.Level?.Elevation ?? bb.Min.Z;

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -270,15 +270,15 @@ namespace StingTools.Core.Placement
                      (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0));
                 if (profileActive)
                 {
-                    // Phase 188 (review fix #5a) — the standards gate keys off the
-                    // structured ApplicableStandards field, but shipped rules cite
-                    // standards via free-text StandardRef instead. Warn when the
-                    // profile declares active standards yet no rule populates
-                    // ApplicableStandards — the standards filter is then inert.
+                    // The standards gate matches a rule's structured
+                    // ApplicableStandards, falling back to its free-text
+                    // StandardRef. Only warn that the filter is inert when no rule
+                    // carries EITHER field — then standards can't gate anything.
                     if (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0
-                        && !rules.Any(r => r != null && !string.IsNullOrEmpty(r.ApplicableStandards)))
+                        && !rules.Any(r => r != null
+                            && (!string.IsNullOrEmpty(r.ApplicableStandards) || !string.IsNullOrEmpty(r.StandardRef))))
                     {
-                        result.Warnings.Add("Building profile declares ActiveStandards but no rule populates the structured ApplicableStandards field (rules cite standards via free-text StandardRef) — the standards filter is inert. Populate ApplicableStandards on rules to enable standards-based filtering.");
+                        result.Warnings.Add("Building profile declares ActiveStandards but no rule carries ApplicableStandards or StandardRef — the standards filter is inert. Tag rules with standards to enable standards-based filtering.");
                     }
 
                     int before = rules.Count;
@@ -306,7 +306,7 @@ namespace StingTools.Core.Placement
             // STING runs (they carry a non-empty ASS_PLACEMENT_RULE_TXT). Seeded
             // into the per-room dedup so re-running the same rules doesn't double
             // fixtures. Skipped for dry-run previews (nothing is committed).
-            _priorPlaced = dryRun ? new List<XYZ>() : BuildPriorPlacedIndex(doc);
+            _priorPlaced = dryRun ? new List<XYZ>() : BuildPriorPlacedIndex(doc, ResolvePriorPlacedCategories(doc, rules));
             if (!dryRun && _priorPlaced.Count > 0)
                 result.Warnings.Add($"Idempotency: found {_priorPlaced.Count} fixture(s) from previous STING placement runs — coincident positions will be skipped so this re-run won't duplicate them. Use 'Undo last run' first if you intend to replace them.");
 
@@ -2214,15 +2214,31 @@ namespace StingTools.Core.Placement
         /// ASS_PLACEMENT_RULE_TXT param as a secondary signal. Used to make
         /// re-runs idempotent.
         /// </summary>
-        private static List<XYZ> BuildPriorPlacedIndex(Document doc)
+        private static List<XYZ> BuildPriorPlacedIndex(Document doc, ICollection<BuiltInCategory> cats)
         {
             var pts = new List<XYZ>();
             if (doc == null) return pts;
             try
             {
-                var col = new FilteredElementCollector(doc)
-                    .OfClass(typeof(FamilyInstance))
-                    .WhereElementIsNotElementType();
+                // Narrow the scan to the categories the active rules place into so a
+                // large model isn't walked in full every run. Falls back to all
+                // family instances when no category could be resolved, or if the
+                // category set isn't a valid multicategory filter.
+                FilteredElementCollector col = null;
+                if (cats != null && cats.Count > 0)
+                {
+                    try
+                    {
+                        col = new FilteredElementCollector(doc)
+                            .WherePasses(new ElementMulticategoryFilter(new List<BuiltInCategory>(cats)))
+                            .WhereElementIsNotElementType();
+                    }
+                    catch (Exception fex) { StingLog.Warn($"BuildPriorPlacedIndex multicat filter: {fex.Message}"); col = null; }
+                }
+                if (col == null)
+                    col = new FilteredElementCollector(doc)
+                        .OfClass(typeof(FamilyInstance))
+                        .WhereElementIsNotElementType();
                 foreach (var el in col)
                 {
                     bool sting = false;
@@ -2230,11 +2246,43 @@ namespace StingTools.Core.Placement
                     catch { }
                     if (!sting && string.IsNullOrEmpty(ParameterHelpers.GetString(el, "ASS_PLACEMENT_RULE_TXT")))
                         continue;
-                    if ((el.Location as LocationPoint)?.Point is XYZ p) pts.Add(p);
+                    if ((el.Location as LocationPoint)?.Point is XYZ p) { pts.Add(p); continue; }
+                    // Face / work-plane-hosted instances have no LocationPoint —
+                    // fall back to the instance transform origin so they're still
+                    // de-duped on re-run.
+                    if (el is FamilyInstance fiHosted)
+                    {
+                        try { var t = fiHosted.GetTransform(); if (t?.Origin != null) pts.Add(t.Origin); }
+                        catch { }
+                    }
                 }
             }
             catch (Exception ex) { StingLog.Warn($"BuildPriorPlacedIndex: {ex.Message}"); }
             return pts;
+        }
+
+        /// <summary>
+        /// Distinct BuiltInCategories the active rules place into, resolved from
+        /// each rule's CategoryBic (enum name) or CategoryFilter (display name).
+        /// Used to scope the idempotency scan; empty ⇒ caller scans all instances.
+        /// </summary>
+        private static List<BuiltInCategory> ResolvePriorPlacedCategories(Document doc, IList<PlacementRule> rules)
+        {
+            var set = new HashSet<BuiltInCategory>();
+            if (rules == null) return new List<BuiltInCategory>();
+            foreach (var r in rules)
+            {
+                if (r == null) continue;
+                BuiltInCategory bic = BuiltInCategory.INVALID;
+                if (!string.IsNullOrEmpty(r.CategoryBic)
+                    && Enum.TryParse<BuiltInCategory>(r.CategoryBic, true, out var parsed)
+                    && parsed != BuiltInCategory.INVALID)
+                    bic = parsed;
+                else if (!string.IsNullOrEmpty(r.CategoryFilter))
+                    try { bic = ResolveBuiltInCategoryByName(doc, r.CategoryFilter); } catch { }
+                if (bic != BuiltInCategory.INVALID) set.Add(bic);
+            }
+            return new List<BuiltInCategory>(set);
         }
 
         /// <summary>

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -792,7 +792,28 @@ namespace StingTools.Core.Placement
             }
 
             FamilySymbol symbol = ResolveSymbol(doc, effRule.CategoryFilter, effRule, perCategorySymbol, result);
-            if (symbol == null) return;
+            if (symbol == null)
+            {
+                // Make the silent "no symbol → 0 placements" case visible.
+                // Count every candidate this rule would have placed as skipped
+                // and surface a one-shot per-(rule, category, variant) warning so
+                // the user knows why the rule placed nothing.
+                if (diagRoom != null)
+                {
+                    diagRoom.SkippedNoSymbol += chosen.Count;
+                    if (string.IsNullOrEmpty(diagRoom.FirstSkipReason))
+                        diagRoom.FirstSkipReason = $"no family symbol resolved for category '{effRule.CategoryFilter}'" +
+                            (string.IsNullOrEmpty(effRule.VariantHint) ? "" : $" / variant '{effRule.VariantHint}'");
+                }
+                result.SkippedCount += chosen.Count;
+                string symWarnKey = $"NoSymbol:{effRule.CategoryFilter}:{effRule.VariantHint}:{effRule.MergeKey}";
+                if (!result.Warnings.Any(w => w.Contains(symWarnKey)))
+                    result.Warnings.Add($"{symWarnKey} — rule '{effRule.MergeKey}' resolved no family symbol for category " +
+                        $"'{effRule.CategoryFilter}'" +
+                        (string.IsNullOrEmpty(effRule.VariantHint) ? "" : $" / variant '{effRule.VariantHint}'") +
+                        $"; {chosen.Count} candidate(s) skipped. Load a matching family or adjust FamilyTypeRegex / VariantHint.");
+                return;
+            }
 
             // Phase 139.18 — warn once per (rule, family) when a wall- or
             // ceiling-anchored rule resolves to an un-hosted family. The

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -311,7 +311,8 @@ namespace StingTools.Core.Placement
             if (!dryRun && _priorPlaced.Count > 0)
                 result.Warnings.Add($"Idempotency: found {_priorPlaced.Count} fixture(s) from previous STING placement runs — coincident positions will be skipped so this re-run won't duplicate them. Use 'Undo last run' first if you intend to replace them.");
 
-            var rooms = CollectRooms(doc, roomIds, result);
+            var roomCtx = new Dictionary<SpatialElement, (Document src, Transform toHost)>();
+            var rooms = CollectRooms(doc, roomIds, result, roomCtx);
             result.RoomsVisited = rooms.Count;
             if (rooms.Count == 0) return result;
 
@@ -324,6 +325,11 @@ namespace StingTools.Core.Placement
                 // users expect fixtures not to sit inside walls.
                 RejectInsideWall = StingTools.Commands.Placement.PlaceFixturesOptions.RejectInsideWall,
             };
+            // One scorer per source document — host rooms use the host scorer;
+            // linked rooms get a scorer bound to their link document so room +
+            // wall / door geometry is read in the same coordinate space.
+            bool rejectInsideWall = StingTools.Commands.Placement.PlaceFixturesOptions.RejectInsideWall;
+            var scorerByDoc = new Dictionary<Document, PlacementScorer> { [doc] = scorer };
             var perCategorySymbol = new Dictionary<string, FamilySymbol>(StringComparer.OrdinalIgnoreCase);
 
             // Rule ordering: higher Priority first so specialised rules
@@ -422,6 +428,21 @@ namespace StingTools.Core.Placement
 
                     // PC-13 — per-room state so dependent rules see predecessors.
                     var roomState = new RoomState();
+
+                    // Resolve the room's source document + host transform. Linked
+                    // rooms use a link-bound scorer + the simpler linked path.
+                    var rc = roomCtx.TryGetValue(room, out var rcv) ? rcv : (src: doc, toHost: Transform.Identity);
+                    bool roomLinked = rc.toHost != null && !rc.toHost.IsIdentity;
+                    PlacementScorer roomScorer = scorer;
+                    if (rc.src != null && rc.src != doc)
+                    {
+                        if (!scorerByDoc.TryGetValue(rc.src, out roomScorer))
+                        {
+                            roomScorer = new PlacementScorer(rc.src) { RejectInsideWall = rejectInsideWall };
+                            scorerByDoc[rc.src] = roomScorer;
+                        }
+                    }
+
                     foreach (var rule in ordered)
                     {
                         var diag = result.Diag(rule.MergeKey);
@@ -455,6 +476,17 @@ namespace StingTools.Core.Placement
                             if (!string.IsNullOrEmpty(rule.DependsOn) && !roomState.PlacedByRule.ContainsKey(rule.DependsOn))
                             {
                                 result.Warnings.Add($"Room {room.Id} / {rule.MergeKey}: skipped — DependsOn '{rule.DependsOn}' has no placement in this room.");
+                                continue;
+                            }
+
+                            if (roomLinked)
+                            {
+                                // Linked-architecture room: score in link coords,
+                                // place non-hosted on the nearest host level at the
+                                // transformed point. (CoPlaceWith / RELATIVE_TO /
+                                // wet-zone are host-path-only in v1.)
+                                ProcessLinkedRoomRule(doc, room, rule, roomScorer, rc.toHost,
+                                    perCategorySymbol, result, dryRun);
                                 continue;
                             }
 
@@ -619,7 +651,12 @@ namespace StingTools.Core.Placement
             catch { return true; }
         }
 
-        private static List<SpatialElement> CollectRooms(Document doc, IList<ElementId> roomIds, PlacementResult result)
+        // Per-room source context: which document the room's geometry lives in
+        // and the transform from that document to host coordinates. Host rooms
+        // map to (host, Identity); linked rooms to (linkDoc, linkTransform).
+        private static List<SpatialElement> CollectRooms(
+            Document doc, IList<ElementId> roomIds, PlacementResult result,
+            Dictionary<SpatialElement, (Document src, Transform toHost)> ctx)
         {
             var rooms = new List<SpatialElement>();
             try
@@ -629,14 +666,28 @@ namespace StingTools.Core.Placement
                     foreach (var bic in new[] { BuiltInCategory.OST_Rooms, BuiltInCategory.OST_MEPSpaces })
                         foreach (var e in new FilteredElementCollector(doc)
                             .OfCategory(bic).WhereElementIsNotElementType())
-                            if (IsPlaceableSpatial(e)) rooms.Add((SpatialElement)e);
+                            if (IsPlaceableSpatial(e))
+                            {
+                                rooms.Add((SpatialElement)e);
+                                if (ctx != null) ctx[(SpatialElement)e] = (doc, Transform.Identity);
+                            }
+
+                    // Linked architecture: read Rooms/Spaces from each loaded link
+                    // and remember its transform so placement maps back to host
+                    // coordinates. Project-scope only (active-view/selection ids
+                    // are host ids and can't reference linked elements).
+                    CollectLinkedRooms(doc, rooms, ctx, result);
                 }
                 else
                 {
                     foreach (var id in roomIds)
                     {
                         var el = doc.GetElement(id);
-                        if (IsPlaceableSpatial(el)) rooms.Add((SpatialElement)el);
+                        if (IsPlaceableSpatial(el))
+                        {
+                            rooms.Add((SpatialElement)el);
+                            if (ctx != null) ctx[(SpatialElement)el] = (doc, Transform.Identity);
+                        }
                     }
                 }
             }
@@ -645,6 +696,59 @@ namespace StingTools.Core.Placement
                 result.Warnings.Add($"Room/Space collection failed: {ex.Message}");
             }
             return rooms;
+        }
+
+        /// <summary>Read Rooms/Spaces from every loaded Revit link and record each
+        /// one's source document + host transform.</summary>
+        private static void CollectLinkedRooms(
+            Document doc, List<SpatialElement> rooms,
+            Dictionary<SpatialElement, (Document src, Transform toHost)> ctx,
+            PlacementResult result)
+        {
+            if (ctx == null) return;
+            try
+            {
+                int linkedCount = 0;
+                foreach (var li in new FilteredElementCollector(doc)
+                    .OfClass(typeof(RevitLinkInstance)).Cast<RevitLinkInstance>())
+                {
+                    Document ld = null;
+                    try { ld = li.GetLinkDocument(); } catch { }
+                    if (ld == null) continue;                 // link unloaded
+                    Transform tf = Transform.Identity;
+                    try { tf = li.GetTotalTransform() ?? Transform.Identity; } catch { }
+                    foreach (var bic in new[] { BuiltInCategory.OST_Rooms, BuiltInCategory.OST_MEPSpaces })
+                        foreach (var e in new FilteredElementCollector(ld)
+                            .OfCategory(bic).WhereElementIsNotElementType())
+                            if (IsPlaceableSpatial(e))
+                            {
+                                var se = (SpatialElement)e;
+                                rooms.Add(se);
+                                ctx[se] = (ld, tf);
+                                linkedCount++;
+                            }
+                }
+                if (linkedCount > 0)
+                    result.Warnings.Add($"Linked architecture: read {linkedCount} room(s)/space(s) from loaded links. Fixtures place non-hosted on the nearest host level at the transformed location (orientation + face-hosting from a linked host are not applied — v1).");
+            }
+            catch (Exception ex) { StingLog.Warn($"CollectLinkedRooms: {ex.Message}"); }
+        }
+
+        /// <summary>Nearest host-document Level to a Z elevation (in host feet).</summary>
+        private static Level NearestHostLevel(Document hostDoc, double zFt)
+        {
+            Level best = null; double bestD = double.MaxValue;
+            try
+            {
+                foreach (var lv in new FilteredElementCollector(hostDoc)
+                    .OfClass(typeof(Level)).Cast<Level>())
+                {
+                    double d = Math.Abs(lv.Elevation - zFt);
+                    if (d < bestD) { bestD = d; best = lv; }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"NearestHostLevel: {ex.Message}"); }
+            return best;
         }
 
         /// <summary>PC-13 per-room state: maps RuleId/MergeKey → list of placed points,
@@ -1131,6 +1235,92 @@ namespace StingTools.Core.Placement
         /// point. Used by CoPlaceWith / RELATIVE_TO. Skips room-scope filters
         /// because the predecessor already validated the room.
         /// </summary>
+        // Linked-architecture room path (v1). Scores in the link document's
+        // coordinates (so room + wall/door geometry is correct), then transforms
+        // each chosen point to host coordinates and places a non-hosted instance
+        // on the nearest host level. CoPlaceWith / RELATIVE_TO / wet-zone /
+        // orientation / face-hosting are host-path-only here.
+        private static void ProcessLinkedRoomRule(
+            Document hostDoc, SpatialElement room, PlacementRule rule,
+            PlacementScorer linkScorer, Transform toHost,
+            Dictionary<string, FamilySymbol> perCategorySymbol,
+            PlacementResult result, bool dryRun)
+        {
+            if (toHost == null) return;
+            var diagRoom = result.Diag(rule.MergeKey);
+            string roomKey = $"{room.Id}::{SafeRoomName(room)}";
+
+            List<PlacementCandidate> candidates;
+            try { candidates = linkScorer.Score(room, rule, new List<XYZ>(), 0); }
+            catch (Exception ex) { result.Warnings.Add($"[linked {SafeRoomName(room)}] score: {ex.Message}"); return; }
+            if (candidates == null || candidates.Count == 0) return;
+            result.CandidatesEvaluated += candidates.Count;
+
+            int cap = ComputeCap(rule, room, candidates.Count, 0);
+            if (cap == 0) return;
+            var chosen = SelectWithSpacing(candidates, cap, rule.MinSpacingMm);
+            if (chosen.Count == 0) return;
+
+            if (dryRun)
+            {
+                result.CountsByRule[rule.MergeKey] =
+                    result.CountsByRule.TryGetValue(rule.MergeKey, out var dn) ? dn + chosen.Count : chosen.Count;
+                return;
+            }
+
+            var symbol = ResolveSymbol(hostDoc, rule.CategoryFilter, rule, perCategorySymbol, result);
+            if (symbol == null) return;
+            try { if (!symbol.IsActive) { symbol.Activate(); hostDoc.Regenerate(); } }
+            catch (Exception ex) { result.Warnings.Add($"[linked] activate {symbol.Name}: {ex.Message}"); return; }
+
+            var placedHost = new List<XYZ>();
+            double dedupFt = Math.Max(rule.ToleranceMm, 25.0) * MmToFt;
+            double dedupSq = dedupFt * dedupFt;
+
+            foreach (var c in chosen)
+            {
+                if (c?.Position == null) continue;
+                XYZ hostPos = toHost.OfPoint(c.Position);
+
+                bool tooClose = false;
+                foreach (var p in placedHost)
+                {
+                    double dx = p.X - hostPos.X, dy = p.Y - hostPos.Y, dz = p.Z - hostPos.Z;
+                    if (dx * dx + dy * dy + dz * dz < dedupSq) { tooClose = true; break; }
+                }
+                if (!tooClose && _priorPlaced != null)
+                    foreach (var p in _priorPlaced)
+                    {
+                        if (p == null) continue;
+                        double dx = p.X - hostPos.X, dy = p.Y - hostPos.Y, dz = p.Z - hostPos.Z;
+                        if (dx * dx + dy * dy + dz * dz < dedupSq) { tooClose = true; break; }
+                    }
+                if (tooClose) { result.SkippedCount++; if (diagRoom != null) diagRoom.CandidatesRejectedDedup++; continue; }
+
+                Level lvl = NearestHostLevel(hostDoc, hostPos.Z);
+                if (lvl == null) { result.Warnings.Add("[linked] no host Level found — cannot place."); result.SkippedCount++; continue; }
+
+                try
+                {
+                    var fi = hostDoc.Create.NewFamilyInstance(
+                        hostPos, symbol, lvl, StructuralType.NonStructural);
+                    if (fi == null) { result.SkippedCount++; continue; }
+                    WriteAnchorParameters(fi, rule);
+                    if (StingTools.Commands.Placement.PlaceFixturesOptions.StampProvenance)
+                        try { StingTools.Core.Storage.StingProvenanceSchema.Stamp(fi, "FixturePlacementEngine", rule?.MergeKey ?? ""); }
+                        catch (Exception pvEx) { result.Warnings.Add($"[linked] provenance: {pvEx.Message}"); }
+                    result.PlacedIds.Add(fi.Id);
+                    result.CountsByRule[rule.MergeKey] = result.CountsByRule.TryGetValue(rule.MergeKey, out var n) ? n + 1 : 1;
+                    result.CountsByRoom[roomKey] = result.CountsByRoom.TryGetValue(roomKey, out var m) ? m + 1 : 1;
+                    if (diagRoom != null) diagRoom.CandidatesPlaced++;
+                    placedHost.Add(hostPos);
+                    try { PostPlacementHooks.RunFor(fi, rule); }
+                    catch (Exception hkEx) { result.Warnings.Add($"[linked] post-hook {fi.Id}: {hkEx.Message}"); }
+                }
+                catch (Exception ex) { result.Warnings.Add($"[linked place {rule.CategoryFilter}] {ex.Message}"); result.SkippedCount++; }
+            }
+        }
+
         private static void ProcessRoomRuleAtPoint(
             Document doc,
             SpatialElement room,

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -1979,10 +1979,11 @@ namespace StingTools.Core.Placement
         /// connector joins and shipped to COBie / schedules as orphaned.
         /// </summary>
         /// <summary>
-        /// Bridge to the conduit-routing engine: run AutoConduitDrop
-        /// across every fixture placed under a rule whose RoutingMode
-        /// is "AUTO_CONDUIT". Returns the number of fixtures the drop
-        /// engine successfully routed. Errors are surfaced into
+        /// Bridge to the drop-routing engines: per rule, run the engine that
+        /// matches RoutingMode — AutoConduitDrop (AUTO_CONDUIT), AutoPipeDrop
+        /// (AUTO_PIPE) or AutoDuctDrop (AUTO_DUCT) — across every fixture
+        /// placed under that rule. Returns the number of elements the drop
+        /// engines successfully created. Errors are surfaced into
         /// result.Warnings so the placement-result panel still renders
         /// — a routing failure must never abort the placement run.
         ///
@@ -2015,33 +2016,78 @@ namespace StingTools.Core.Placement
                 }
                 if (fixtures.Count == 0) continue;
 
+                string rawMode = (rule.RoutingMode ?? "").ToUpperInvariant();
+                string mode = EffectiveRoutingMode(rule);
+                if (mode == "NONE") continue;
+                if (rawMode != mode)
+                    result.Warnings.Add($"[{rule.RuleId}] RoutingMode '{rawMode}' has no dedicated follower engine — routed via {mode} (drop) instead. Set RoutingMode to {mode} to silence this notice.");
                 try
                 {
-                    bool isChased = string.Equals(rule.MountingContext, "CHASED",
-                        StringComparison.OrdinalIgnoreCase);
-
-                    var engine = new StingTools.Core.Routing.AutoConduitDrop(doc)
+                    StingTools.Core.Routing.DropResult dr;
+                    switch (mode)
                     {
-                        ServiceId = "ELC_PWR",
-                        InstallMethod = isChased ? "CHASED" : "CLIPPED",
-                        UseChaseRoutingWhenAvailable = isChased,
-                        UsePathfinder = false,        // opt-in flag; placement bridge stays
-                                                      // on the safe L/Z path until the host
-                                                      // project explicitly requests A*.
-                    };
-                    var dr = engine.Execute(fixtures);
+                        case "AUTO_PIPE":
+                            dr = new StingTools.Core.Routing.AutoPipeDrop(doc).Execute(fixtures);
+                            break;
+                        case "AUTO_DUCT":
+                            dr = new StingTools.Core.Routing.AutoDuctDrop(doc).Execute(fixtures);
+                            break;
+                        case "AUTO_CONDUIT":
+                        default:
+                            bool isChased = string.Equals(rule.MountingContext, "CHASED",
+                                StringComparison.OrdinalIgnoreCase);
+                            dr = new StingTools.Core.Routing.AutoConduitDrop(doc)
+                            {
+                                ServiceId = "ELC_PWR",
+                                InstallMethod = isChased ? "CHASED" : "CLIPPED",
+                                UseChaseRoutingWhenAvailable = isChased,
+                                UsePathfinder = false,    // opt-in flag; placement bridge stays
+                                                          // on the safe L/Z path until the host
+                                                          // project explicitly requests A*.
+                            }.Execute(fixtures);
+                            break;
+                    }
                     totalRouted += dr.CreatedIds.Count;
                     foreach (var w in dr.Warnings)
                         result.Warnings.Add($"[{rule.RuleId}] {w}");
                 }
                 catch (Exception ex)
                 {
-                    result.Warnings.Add($"[{rule.RuleId}] AutoConduitDrop: {ex.Message}");
+                    result.Warnings.Add($"[{rule.RuleId}] auto-route ({mode}): {ex.Message}");
                 }
             }
 
             try { ComplianceScan.InvalidateCache(); } catch (Exception ex) { StingLog.Warn($"[FixturePlacementEngine] ComplianceScan.InvalidateCache: {ex.Message}"); }
             return totalRouted;
+        }
+
+        /// <summary>
+        /// Resolve a rule's RoutingMode to one of the three modes the engine
+        /// can actually execute (AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT) or NONE.
+        /// Legacy follow tokens (WALL_FOLLOW / CEILING_FOLLOW / FLOOR_FOLLOW /
+        /// CONDUIT_RUN / TRAY_RUN) shipped in older rule packs have no dedicated
+        /// follower router, so they map to the drop engine matching the rule's
+        /// RouteSegmentCategory — a real route rather than a silent no-op.
+        /// </summary>
+        private static string EffectiveRoutingMode(PlacementRule r)
+        {
+            string m = (r?.RoutingMode ?? "").ToUpperInvariant();
+            switch (m)
+            {
+                case "AUTO_CONDUIT":
+                case "AUTO_PIPE":
+                case "AUTO_DUCT":
+                    return m;
+                case "":
+                case "NONE":
+                    return "NONE";
+                default:
+                    // Legacy follow / run tokens → drop engine by segment category.
+                    string cat = (r?.RouteSegmentCategory ?? "").ToUpperInvariant();
+                    if (cat.Contains("PIPE")) return "AUTO_PIPE";
+                    if (cat.Contains("DUCT")) return "AUTO_DUCT";
+                    return "AUTO_CONDUIT"; // Conduit / CableTray / unspecified
+            }
         }
 
         private static void AutoJoinMepConnectors(
@@ -2062,35 +2108,31 @@ namespace StingTools.Core.Placement
             }
             if (!anyRouting) return;
 
-            // Wave B Wire 3 — bridge placement → routing.
-            // Previously, when a rule declared RoutingMode != NONE we
-            // landed here and ran the connector-join pass below, which
-            // only stitched fixtures within a 600 mm radius. The
-            // intended action — actually routing conduit from the
-            // placed fixtures up to a tray — was missing. The silent
-            // return on the original line 1770 has been replaced by a
-            // dispatch into AutoConduitDrop for any rule whose
-            // RoutingMode == "AUTO_CONDUIT". Other modes (NONE / TRAY /
-            // CABLE / CUSTOM) fall through to the legacy connector-
-            // join pass below, preserving existing behaviour.
+            // Bridge placement → routing. Any rule whose RoutingMode is one of
+            // the three real auto-route modes (AUTO_CONDUIT / AUTO_PIPE /
+            // AUTO_DUCT) is dispatched to the matching Core/Routing drop engine
+            // (AutoConduitDrop / AutoPipeDrop / AutoDuctDrop). NONE is a no-op.
+            // The UI dropdown is constrained to exactly these tokens so no
+            // visible mode is a silent no-op. The 600 mm connector-join pass
+            // below still runs afterwards as a secondary stitch for every
+            // routed rule.
             try
             {
-                var autoConduitRules = new List<PlacementRule>();
+                var autoRoutedRules = new List<PlacementRule>();
                 if (rules != null)
                 {
                     foreach (var r in rules)
                     {
                         if (r == null) continue;
-                        if (string.Equals(r.RoutingMode, "AUTO_CONDUIT",
-                                StringComparison.OrdinalIgnoreCase))
-                            autoConduitRules.Add(r);
+                        if (EffectiveRoutingMode(r) != "NONE")
+                            autoRoutedRules.Add(r);
                     }
                 }
-                if (autoConduitRules.Count > 0)
+                if (autoRoutedRules.Count > 0)
                 {
-                    int routed = RouteAfterPlacement(doc, autoConduitRules, result);
+                    int routed = RouteAfterPlacement(doc, autoRoutedRules, result);
                     if (routed > 0)
-                        result.Warnings.Add($"Auto-routed conduit drops for {routed} placed fixture(s).");
+                        result.Warnings.Add($"Auto-routed drops for {routed} placed fixture(s).");
                 }
             }
             catch (Exception ex)

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -251,13 +251,11 @@ namespace StingTools.Core.Placement
             }
             catch (Exception ex) { StingLog.Warn($"FixturePlacementEngine: building-profile filter: {ex.Message}"); }
 
-            // Phase 139.27 (C-03) — surface a one-shot warning at start
-            // of run when the user enabled "Tag every placement" but
-            // the reflection target is missing. RunFor() warns once per
-            // session via StingLog; mirroring it into result.Warnings
-            // means the run report shows it too.
-            if (PostPlacementHooks.RunDataTagPipeline && PostPlacementHooks.TagPipelineMissing)
-                result.Warnings.Add("Post-placement: 'Tag every placement' is on but TagPipelineHelper.RunFullPipeline could not be resolved by reflection — placed instances will NOT be tagged this session.");
+            // Reset per-run post-placement hook state (tag-pipeline context
+            // cache + MEP-connect counters + TagPipelineMissing flag) so
+            // consecutive runs are independent and pick up manual edits made
+            // between runs.
+            PostPlacementHooks.BeginRun();
 
             var rooms = CollectRooms(doc, roomIds, result);
             result.RoomsVisited = rooms.Count;
@@ -527,6 +525,16 @@ namespace StingTools.Core.Placement
             finally
             {
                 tx?.Dispose();
+            }
+
+            // Surface post-placement hook outcomes in the run report.
+            if (!dryRun)
+            {
+                if (PostPlacementHooks.RunDataTagPipeline && PostPlacementHooks.TagPipelineMissing)
+                    result.Warnings.Add("Post-placement: 'Run data-tag pipeline' is on but the tag population context was invalid (rooms / levels / shared parameters missing) — placed instances were NOT tagged this run.");
+                if (PostPlacementHooks.AssignMepSystem &&
+                    (PostPlacementHooks.MepConnectedCount > 0 || PostPlacementHooks.MepLeftOpenCount > 0))
+                    result.Warnings.Add($"Post-placement: MEP connect joined {PostPlacementHooks.MepConnectedCount} connector(s); {PostPlacementHooks.MepLeftOpenCount} left open (no coincident compatible connector within 600 mm).");
             }
 
             return result;
@@ -814,7 +822,7 @@ namespace StingTools.Core.Placement
 
                     // PC-17 — optional post-placement hook: data-tag pipeline + COBie seed.
                     try { PostPlacementHooks.RunFor(fi, effRule); }
-                    catch (Exception hkEx) { result.Warnings.Add($"PC-17 post-place hook for {fi.Id}: {hkEx.Message}"); }
+                    catch (Exception hkEx) { result.Warnings.Add($"Post-placement hook for {fi.Id}: {hkEx.Message}"); }
                 }
                 catch (Exception ex2)
                 {
@@ -1012,7 +1020,7 @@ namespace StingTools.Core.Placement
                     lst.Add(at);
                     state.LastPointByRule[rule.MergeKey] = at;
                 }
-                try { PostPlacementHooks.RunFor(pf.Placed, rule); } catch (Exception hkEx) { result.Warnings.Add($"PC-17 post-place hook (co): {hkEx.Message}"); }
+                try { PostPlacementHooks.RunFor(pf.Placed, rule); } catch (Exception hkEx) { result.Warnings.Add($"Post-placement hook (co-place): {hkEx.Message}"); }
             }
             catch (Exception ex)
             {
@@ -1223,7 +1231,7 @@ namespace StingTools.Core.Placement
                         }
                         if (first != null)
                         {
-                            result.Warnings.Add($"PC-16 auto-loaded '{System.IO.Path.GetFileName(path)}' for category '{categoryName}'.");
+                            result.Warnings.Add($"Auto-loaded '{System.IO.Path.GetFileName(path)}' for category '{categoryName}'.");
                             return first;
                         }
                     }

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.IO;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB.Mechanical;
 using Autodesk.Revit.DB.Structure;
 using StingTools.Core;
 using StingTools.Core.Routing;
@@ -593,31 +594,55 @@ namespace StingTools.Core.Placement
             return result;
         }
 
-        private static List<Room> CollectRooms(Document doc, IList<ElementId> roomIds, PlacementResult result)
+        // Both Rooms (architecture) and MEP Spaces are SpatialElements sharing the
+        // boundary / bbox / level / area API the engine uses, so it places into
+        // either. MEP models commonly carry Spaces (rooms live in a linked arch
+        // model) — supporting Spaces lets those models place without a host Room.
+        private static bool IsPlaceableSpatial(Element el)
+            => (el is Room r && r.Area > 0.0) || (el is Space sp && sp.Area > 0.0);
+
+        /// <summary>
+        /// Point-in-spatial test. Exact for Rooms (IsPointInRoom); for MEP Spaces
+        /// (no public point test) falls back to plan bounding-box containment.
+        /// Used by the coverage grid + lighting grid so they clip to either.
+        /// </summary>
+        public static bool PointInSpatial(SpatialElement se, XYZ p)
         {
-            var rooms = new List<Room>();
+            if (se == null || p == null) return false;
+            try { if (se is Room rm) return rm.IsPointInRoom(p); } catch { }
+            try
+            {
+                var bb = se.get_BoundingBox(null);
+                if (bb == null) return true;
+                return p.X >= bb.Min.X && p.X <= bb.Max.X && p.Y >= bb.Min.Y && p.Y <= bb.Max.Y;
+            }
+            catch { return true; }
+        }
+
+        private static List<SpatialElement> CollectRooms(Document doc, IList<ElementId> roomIds, PlacementResult result)
+        {
+            var rooms = new List<SpatialElement>();
             try
             {
                 if (roomIds == null || roomIds.Count == 0)
                 {
-                    var collector = new FilteredElementCollector(doc)
-                        .OfCategory(BuiltInCategory.OST_Rooms)
-                        .WhereElementIsNotElementType();
-                    foreach (var e in collector)
-                        if (e is Room r && r.Area > 0.0) rooms.Add(r);
+                    foreach (var bic in new[] { BuiltInCategory.OST_Rooms, BuiltInCategory.OST_MEPSpaces })
+                        foreach (var e in new FilteredElementCollector(doc)
+                            .OfCategory(bic).WhereElementIsNotElementType())
+                            if (IsPlaceableSpatial(e)) rooms.Add((SpatialElement)e);
                 }
                 else
                 {
                     foreach (var id in roomIds)
                     {
                         var el = doc.GetElement(id);
-                        if (el is Room r && r.Area > 0.0) rooms.Add(r);
+                        if (IsPlaceableSpatial(el)) rooms.Add((SpatialElement)el);
                     }
                 }
             }
             catch (Exception ex)
             {
-                result.Warnings.Add($"Room collection failed: {ex.Message}");
+                result.Warnings.Add($"Room/Space collection failed: {ex.Message}");
             }
             return rooms;
         }
@@ -642,7 +667,7 @@ namespace StingTools.Core.Placement
 
         private static void ProcessRoomRule(
             Document doc,
-            Room room,
+            SpatialElement room,
             PlacementRule rule,
             PlacementScorer scorer,
             Dictionary<string, FamilySymbol> perCategorySymbol,
@@ -975,7 +1000,7 @@ namespace StingTools.Core.Placement
         /// occupancy; Linear rules from perimeter. MaxPerRoom (when > 0) is a
         /// hard cap regardless of kind.
         /// </summary>
-        private static int ComputeCap(PlacementRule rule, Room room, int candidateCount, int alreadyInRoom)
+        private static int ComputeCap(PlacementRule rule, SpatialElement room, int candidateCount, int alreadyInRoom)
         {
             int cap;
             switch (rule.RuleKind)
@@ -1088,7 +1113,7 @@ namespace StingTools.Core.Placement
         /// rate is unset (≤ 0), the parameter is missing/empty, or the value
         /// is ≤ 0 — so it contributes nothing to the Math.Max chain.
         /// </summary>
-        private static int CountFromRoomRate(Room room, string paramName, double ratePerUnit)
+        private static int CountFromRoomRate(SpatialElement room, string paramName, double ratePerUnit)
         {
             if (ratePerUnit <= 0 || room == null || string.IsNullOrEmpty(paramName)) return 0;
             int count = 0;
@@ -1108,7 +1133,7 @@ namespace StingTools.Core.Placement
         /// </summary>
         private static void ProcessRoomRuleAtPoint(
             Document doc,
-            Room room,
+            SpatialElement room,
             PlacementRule rule,
             PlacementScorer scorer,
             Dictionary<string, FamilySymbol> perCategorySymbol,
@@ -1627,7 +1652,7 @@ namespace StingTools.Core.Placement
         ///     <c>flipFacing()</c> turns it around. This is what was making
         ///     switches face up / out of the door instead of into the room.
         /// </summary>
-        private static void OrientPlacedInstance(Document doc, FamilyInstance fi, PlacementRule rule, Room room)
+        private static void OrientPlacedInstance(Document doc, FamilyInstance fi, PlacementRule rule, SpatialElement room)
         {
             if (fi == null) return;
             try
@@ -1711,7 +1736,7 @@ namespace StingTools.Core.Placement
                         roomOnPositiveNormal = probe.X >= bb.Min.X && probe.X <= bb.Max.X
                                             && probe.Y >= bb.Min.Y && probe.Y <= bb.Max.Y;
                     }
-                    if (room != null && room.IsPointInRoom(probe)) roomOnPositiveNormal = true;
+                    if (room != null && PointInSpatial(room, probe)) roomOnPositiveNormal = true;
                 }
                 catch (Exception ex) { StingLog.Warn($"[FixturePlacementEngine] Room-side test for facing flip: {ex.Message}"); }
 
@@ -1857,7 +1882,7 @@ namespace StingTools.Core.Placement
 
         // Phase 139.5 Q15 — perimeter from boundary segments (any curve type)
         // with a bbox fallback when the room has no boundary. Result in metres.
-        private static double ComputeRoomPerimeterMetres(Room room)
+        private static double ComputeRoomPerimeterMetres(SpatialElement room)
         {
             try
             {
@@ -1889,7 +1914,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"ComputeRoomPerimeterMetres: {ex.Message}"); return 0; }
         }
 
-        private static int ReadRoomIntParam(Room room, string paramName)
+        private static int ReadRoomIntParam(SpatialElement room, string paramName)
         {
             if (room == null || string.IsNullOrWhiteSpace(paramName)) return 0;
             try
@@ -1908,7 +1933,7 @@ namespace StingTools.Core.Placement
             return 0;
         }
 
-        private static string SafeRoomName(Room room)
+        private static string SafeRoomName(SpatialElement room)
         {
             try
             {

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -113,6 +113,17 @@ namespace StingTools.Core.Placement
         private static bool _wetZoneEnabled;
         private static WetZoneExclusionChecker _wetZoneChecker;
 
+        // Per-run coverage-guarantee gate, set from the active building
+        // profile's "Coverage guarantee" toggle. When on, rules with
+        // GuaranteeCoverage=true route through CoverageGridGenerator.
+        private static bool _coverageEnabled;
+
+        // Per-run index of positions of fixtures placed by PREVIOUS STING runs
+        // (carry a non-empty ASS_PLACEMENT_RULE_TXT). Seeded into the per-room
+        // dedup so re-running the same rules is idempotent — coincident
+        // placements are skipped instead of doubled.
+        private static List<XYZ> _priorPlaced = new List<XYZ>();
+
         // Phase 139.21 — build stamp. Reads the assembly's PE-header
         // timestamp (the second the DLL was linked) so the Centre title
         // bar + result panel can surface it on every run. If two
@@ -219,6 +230,9 @@ namespace StingTools.Core.Placement
             _wetZoneEnabled = activeProfile == null || activeProfile.EnableWetZoneChecks;
             _wetZoneChecker = _wetZoneEnabled ? new WetZoneExclusionChecker(doc) : null;
 
+            // Coverage-guarantee gate (default ON unless the profile disables it).
+            _coverageEnabled = activeProfile == null || activeProfile.EnableCoverageGuarantee;
+
             // Accessibility / mounting-height validation against
             // STING_HEIGHT_STANDARDS.json — gated by the profile's
             // "Accessibility checks" toggle (default ON).
@@ -287,6 +301,14 @@ namespace StingTools.Core.Placement
             // consecutive runs are independent and pick up manual edits made
             // between runs.
             PostPlacementHooks.BeginRun();
+
+            // Idempotency: index the positions of fixtures placed by previous
+            // STING runs (they carry a non-empty ASS_PLACEMENT_RULE_TXT). Seeded
+            // into the per-room dedup so re-running the same rules doesn't double
+            // fixtures. Skipped for dry-run previews (nothing is committed).
+            _priorPlaced = dryRun ? new List<XYZ>() : BuildPriorPlacedIndex(doc);
+            if (!dryRun && _priorPlaced.Count > 0)
+                result.Warnings.Add($"Idempotency: found {_priorPlaced.Count} fixture(s) from previous STING placement runs — coincident positions will be skipped so this re-run won't duplicate them. Use 'Undo last run' first if you intend to replace them.");
 
             var rooms = CollectRooms(doc, roomIds, result);
             result.RoomsVisited = rooms.Count;
@@ -654,8 +676,31 @@ namespace StingTools.Core.Placement
             // PC-13 — RELATIVE_TO / EQUIPMENT_PAIR: short-circuit by stamping the
             // predecessor's last point as the only candidate.
             string anchor = (effRule.AnchorType ?? "").ToUpperInvariant();
+
+            // Coverage guarantee: when the rule sets GuaranteeCoverage=true (and
+            // the building profile's "Coverage guarantee" toggle is on), fill the
+            // room with a √2-spaced grid via CoverageGridGenerator so every floor
+            // point lies within CoverageRadiusMm of a device. The generator
+            // honours CoverageRadiusMm / MaxSpacingMm / MinSpacingMm /
+            // WallClearanceMm / ObstructionClearanceMm itself, so these points
+            // bypass the score-rank + spacing re-selection below.
+            bool coverageMode = _coverageEnabled && effRule.GuaranteeCoverage
+                                && effRule.CoverageRadiusMm > 0
+                                && anchor != "RELATIVE_TO" && anchor != "EQUIPMENT_PAIR";
+
             List<PlacementCandidate> candidates;
-            if ((anchor == "RELATIVE_TO" || anchor == "EQUIPMENT_PAIR")
+            if (coverageMode)
+            {
+                double anchorZ = scorer.ResolveAnchorZForRoom(room, effRule);
+                var cov = new CoverageGridGenerator(doc).Generate(room, effRule, anchorZ);
+                candidates = new List<PlacementCandidate>(cov.Points.Count);
+                foreach (var p in cov.Points)
+                    candidates.Add(new PlacementCandidate { Position = p, RoomId = room.Id, Rule = effRule, Score = 1.0 });
+                result.CandidatesEvaluated += candidates.Count;
+                foreach (var w in cov.Warnings)
+                    if (!string.IsNullOrEmpty(w)) result.Warnings.Add($"[{effRule.RuleId}] {w}");
+            }
+            else if ((anchor == "RELATIVE_TO" || anchor == "EQUIPMENT_PAIR")
                 && !string.IsNullOrEmpty(effRule.DependsOn)
                 && state.LastPointByRule.TryGetValue(effRule.DependsOn, out var prev))
             {
@@ -704,7 +749,11 @@ namespace StingTools.Core.Placement
 
             // PC-12 — derive the count for Density / Linear rules from the room's
             // area, occupancy or perimeter, capped by MaxPerRoom when set.
-            int cap = ComputeCap(effRule, room, candidates.Count, alreadyInRoom);
+            // Coverage mode wants ALL generated points placed (that IS the
+            // guarantee), limited only by an explicit MaxPerRoom.
+            int cap = coverageMode
+                ? (effRule.MaxPerRoom > 0 ? Math.Min(effRule.MaxPerRoom, candidates.Count) : candidates.Count)
+                : ComputeCap(effRule, room, candidates.Count, alreadyInRoom);
             if (cap == 0) return;
 
             // Phase 188 (review pass-2 #3) — enforce intra-rule MinSpacingMm at
@@ -715,7 +764,12 @@ namespace StingTools.Core.Placement
             // emits points every 600 mm but the rule asks for 1000 mm). Greedily
             // accept ranked candidates that clear MinSpacingMm from the ones
             // already accepted. MinSpacingMm <= 0 ⇒ legacy Take(cap).
-            var chosen = SelectWithSpacing(candidates, cap, effRule.MinSpacingMm);
+            // Coverage points are already √2-spaced + MinSpacing-floored by the
+            // generator, so take them straight (preserving grid order). Other
+            // rules go through the score-rank + greedy MinSpacing selection.
+            var chosen = coverageMode
+                ? candidates.GetRange(0, Math.Min(cap, candidates.Count))
+                : SelectWithSpacing(candidates, cap, effRule.MinSpacingMm);
 
             if (dryRun)
             {
@@ -796,6 +850,10 @@ namespace StingTools.Core.Placement
                 if (state?.PlacedByRule != null)
                     foreach (var lst in state.PlacedByRule.Values)
                         if (lst != null) existingNearby.AddRange(lst);
+                // Idempotency: also dedup against fixtures from previous runs so
+                // re-running the same rules doesn't double up.
+                if (_priorPlaced != null && _priorPlaced.Count > 0)
+                    existingNearby.AddRange(_priorPlaced);
             }
             catch (Exception ex) { StingLog.Warn($"[FixturePlacementEngine] Collect existing PlacedByRule for dedup: {ex.Message}"); }
             double dedupFt = Math.Max(effRule.ToleranceMm, 25.0) * MmToFt;
@@ -2066,10 +2124,19 @@ namespace StingTools.Core.Placement
                 {
                     var el = doc.GetElement(id);
                     if (el == null) continue;
-                    // Fixture's RuleId param (set by FixturePlacementEngine
-                    // post-place) ties it back to the rule we're routing.
+                    // Tie the fixture back to its rule. Provenance (stamped with
+                    // rule.MergeKey) is the authoritative link; fall back to the
+                    // ASS_PLACEMENT_RULE_TXT param when a project stamps it.
+                    // NOTE: the previous code matched the never-written
+                    // ASS_PLACEMENT_RULE_TXT param against rule.RuleId, so AUTO
+                    // routing matched zero fixtures.
+                    string provRule = null;
+                    try { provRule = StingTools.Core.Storage.StingProvenanceSchema.Read(el)?.RuleId; }
+                    catch { }
                     string fxRule = ParameterHelpers.GetString(el, "ASS_PLACEMENT_RULE_TXT");
-                    if (string.Equals(fxRule, rule.RuleId, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(provRule, rule.MergeKey, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(fxRule, rule.RuleId, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(fxRule, rule.MergeKey, StringComparison.OrdinalIgnoreCase))
                         fixtures.Add(el);
                 }
                 if (fixtures.Count == 0) continue;
@@ -2117,6 +2184,36 @@ namespace StingTools.Core.Placement
 
             try { ComplianceScan.InvalidateCache(); } catch (Exception ex) { StingLog.Warn($"[FixturePlacementEngine] ComplianceScan.InvalidateCache: {ex.Message}"); }
             return totalRouted;
+        }
+
+        /// <summary>
+        /// Scan the document for fixtures placed by previous STING runs and
+        /// return their plan positions. Detection is via the STING provenance
+        /// entity (authoritative, binding-independent) with the
+        /// ASS_PLACEMENT_RULE_TXT param as a secondary signal. Used to make
+        /// re-runs idempotent.
+        /// </summary>
+        private static List<XYZ> BuildPriorPlacedIndex(Document doc)
+        {
+            var pts = new List<XYZ>();
+            if (doc == null) return pts;
+            try
+            {
+                var col = new FilteredElementCollector(doc)
+                    .OfClass(typeof(FamilyInstance))
+                    .WhereElementIsNotElementType();
+                foreach (var el in col)
+                {
+                    bool sting = false;
+                    try { sting = StingTools.Core.Storage.StingProvenanceSchema.IsAutoCreated(el); }
+                    catch { }
+                    if (!sting && string.IsNullOrEmpty(ParameterHelpers.GetString(el, "ASS_PLACEMENT_RULE_TXT")))
+                        continue;
+                    if ((el.Location as LocationPoint)?.Point is XYZ p) pts.Add(p);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"BuildPriorPlacedIndex: {ex.Message}"); }
+            return pts;
         }
 
         /// <summary>

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -75,6 +75,7 @@ namespace StingTools.Core.Placement
         public int RoomsBlockedByDependsOn { get; set; }
         public int CandidatesGenerated { get; set; }
         public int CandidatesRejectedDedup { get; set; }
+        public int CandidatesRejectedWetZone { get; set; }
         public int CandidatesPlaced { get; set; }
         public int SkippedNoSymbol { get; set; }
         public int SkippedHostPreflight { get; set; }
@@ -85,7 +86,7 @@ namespace StingTools.Core.Placement
         {
             return $"{MergeKey}: rooms={RoomsConsidered}/-{RoomsFilteredByName}/-{RoomsFilteredByExclude} " +
                    $"cand={CandidatesGenerated} placed={CandidatesPlaced} " +
-                   $"skip(host={SkippedHostPreflight}, sym={SkippedNoSymbol}, dedup={CandidatesRejectedDedup}, " +
+                   $"skip(host={SkippedHostPreflight}, sym={SkippedNoSymbol}, dedup={CandidatesRejectedDedup}, wetzone={CandidatesRejectedWetZone}, " +
                    $"conflict={RoomsBlockedByConflict}, dep={RoomsBlockedByDependsOn}, mfr={ManufacturerMisses})" +
                    (string.IsNullOrEmpty(FirstSkipReason) ? "" : $" • first: {FirstSkipReason}");
         }
@@ -104,6 +105,13 @@ namespace StingTools.Core.Placement
         // "Pre-flight: two-phase first-fix" / "Per-room loop" instead of
         // an opaque elapsed-time counter.
         public static volatile string CurrentPhase = "";
+
+        // Per-run wet-zone exclusion state, set from the active building
+        // profile's "Wet-zone checks" toggle. ProcessRoomRule filters
+        // candidates through _wetZoneChecker when enabled and the rule
+        // declares a WetZoneExclusion level.
+        private static bool _wetZoneEnabled;
+        private static WetZoneExclusionChecker _wetZoneChecker;
 
         // Phase 139.21 — build stamp. Reads the assembly's PE-header
         // timestamp (the second the DLL was linked) so the Centre title
@@ -194,16 +202,37 @@ namespace StingTools.Core.Placement
             }
             catch (Exception ex) { StingLog.Warn($"[FixturePlacementEngine] Collect rule-loader validation warnings: {ex.Message}"); }
 
-            // Phase 139.27 (N-05) — accessibility / mounting-height validation
-            // against STING_HEIGHT_STANDARDS.json. Silent until 139.27.
+            // Resolve the active building profile once (in-session UI selection
+            // wins over the on-disk file so the gate works WITHOUT a Save first).
+            // Used by the accessibility / wet-zone / coverage toggles below and
+            // by the rule filter further down.
+            ProjectBuildingProfile activeProfile = null;
             try
             {
-                var hsw = HeightStandardsTable.ValidateRulesAgainstStandards(rules);
-                if (hsw != null)
-                    foreach (var w in hsw)
-                        if (!string.IsNullOrEmpty(w)) result.Warnings.Add(w);
+                activeProfile = StingTools.Commands.Placement.PlaceFixturesOptions.SessionProfile
+                                ?? ProjectBuildingProfileIO.Load(doc.PathName);
             }
-            catch (Exception hex) { StingLog.Warn($"HeightStandards validation: {hex.Message}"); }
+            catch (Exception ex) { StingLog.Warn($"FixturePlacementEngine: load building profile: {ex.Message}"); }
+
+            // Wet-zone exclusion state for ProcessRoomRule. Default ON unless the
+            // profile explicitly disables it.
+            _wetZoneEnabled = activeProfile == null || activeProfile.EnableWetZoneChecks;
+            _wetZoneChecker = _wetZoneEnabled ? new WetZoneExclusionChecker(doc) : null;
+
+            // Accessibility / mounting-height validation against
+            // STING_HEIGHT_STANDARDS.json — gated by the profile's
+            // "Accessibility checks" toggle (default ON).
+            if (activeProfile == null || activeProfile.EnableAccessibilityChecks)
+            {
+                try
+                {
+                    var hsw = HeightStandardsTable.ValidateRulesAgainstStandards(rules);
+                    if (hsw != null)
+                        foreach (var w in hsw)
+                            if (!string.IsNullOrEmpty(w)) result.Warnings.Add(w);
+                }
+                catch (Exception hex) { StingLog.Warn($"HeightStandards validation: {hex.Message}"); }
+            }
 
             if (rules.Count == 0)
             {
@@ -219,7 +248,9 @@ namespace StingTools.Core.Placement
             // + ActiveStandards → FilterByProfile returns the set unchanged).
             try
             {
-                var profile = ProjectBuildingProfileIO.Load(doc.PathName);
+                // Use the profile resolved above (in-session UI selection wins
+                // over the on-disk file so the gate works WITHOUT a Save first).
+                var profile = activeProfile;
                 bool profileActive = profile != null &&
                     (!string.IsNullOrEmpty(profile.BuildingType) ||
                      (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0));
@@ -643,6 +674,33 @@ namespace StingTools.Core.Placement
                 result.CandidatesEvaluated += candidates.Count;
             }
             if (candidates.Count == 0) return;
+
+            // Wet-zone exclusion (BS 7671 / IEC 60364-7-701) — gated by the
+            // building profile's "Wet-zone checks" toggle and the rule's
+            // WetZoneExclusion level. Drops candidates that fall inside a
+            // bath/shower/basin exclusion volume. No-op when the toggle is off
+            // or the rule sets no exclusion level.
+            if (_wetZoneEnabled && _wetZoneChecker != null
+                && !string.IsNullOrEmpty(effRule.WetZoneExclusion)
+                && !effRule.WetZoneExclusion.Equals("NONE", StringComparison.OrdinalIgnoreCase))
+            {
+                var keep = new List<PlacementCandidate>(candidates.Count);
+                foreach (var c in candidates)
+                {
+                    bool rejected = false;
+                    try { rejected = _wetZoneChecker.Check(room, c.Position, effRule.WetZoneExclusion).Rejected; }
+                    catch (Exception wzEx) { StingLog.Warn($"WetZone check ({effRule.RuleId}): {wzEx.Message}"); }
+                    if (!rejected) keep.Add(c);
+                }
+                int dropped = candidates.Count - keep.Count;
+                if (dropped > 0)
+                {
+                    StingLog.Info($"WetZone: rule '{effRule.RuleId}' dropped {dropped} candidate(s) in room {room.Id} (exclusion {effRule.WetZoneExclusion}).");
+                    diagRoom.CandidatesRejectedWetZone += dropped;
+                }
+                candidates = keep;
+                if (candidates.Count == 0) return;
+            }
 
             // PC-12 — derive the count for Density / Linear rules from the room's
             // area, occupancy or perimeter, capped by MaxPerRoom when set.

--- a/StingTools/Core/Placement/LightingGridCalculator.cs
+++ b/StingTools/Core/Placement/LightingGridCalculator.cs
@@ -95,14 +95,14 @@ namespace StingTools.Core.Placement
         /// </summary>
         public double DefaultMinimumUniformity { get; set; } = 0.40;
 
-        public LightingGridResult Compute(Room room) => Compute(room, null);
+        public LightingGridResult Compute(SpatialElement room) => Compute(room, null);
 
         /// <summary>
         /// Phase 139.2 — rule-aware grid compute. When the rule asks for
         /// CeilingTileSnap, StructuralFixingCheck or uniformity reporting,
         /// the corresponding post-processing pass runs after grid generation.
         /// </summary>
-        public LightingGridResult Compute(Room room, PlacementRule rule)
+        public LightingGridResult Compute(SpatialElement room, PlacementRule rule)
         {
             var r = new LightingGridResult();
             if (room == null) { r.Warnings.Add("Room is null"); return r; }
@@ -144,7 +144,7 @@ namespace StingTools.Core.Placement
             return r;
         }
 
-        private void GenerateGridPoints(Room room, LightingGridResult r)
+        private void GenerateGridPoints(SpatialElement room, LightingGridResult r)
         {
             var bb = room.get_BoundingBox(null);
             if (bb == null) { r.Warnings.Add("Room has no bounding box"); return; }
@@ -269,7 +269,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private string SafeRoomName(Room room)
+        private string SafeRoomName(SpatialElement room)
         {
             try
             {
@@ -281,7 +281,7 @@ namespace StingTools.Core.Placement
 
         // ── Phase 139.2 — post-processing passes ────────────────────
 
-        private void SnapToCeilingTileGrid(Room room, LightingGridResult r, PlacementRule rule)
+        private void SnapToCeilingTileGrid(SpatialElement room, LightingGridResult r, PlacementRule rule)
         {
             try
             {
@@ -379,7 +379,7 @@ namespace StingTools.Core.Placement
                     bool snappedInRoom = snappedInBbox;
                     if (snappedInBbox)
                     {
-                        try { snappedInRoom = room.IsPointInRoom(snapped); }
+                        try { snappedInRoom = FixturePlacementEngine.PointInSpatial(room, snapped); }
                         catch (Exception ex2) { StingLog.Warn($"Suppressed: {ex2.Message}"); snappedInRoom = true; }
                     }
 
@@ -394,7 +394,7 @@ namespace StingTools.Core.Placement
                         // generated from the room's own AABB so it should
                         // still be inside the polygon.
                         bool originalInRoom = false;
-                        try { originalInRoom = room.IsPointInRoom(p); } catch (Exception ex2) { StingLog.Warn($"Suppressed: {ex2.Message}"); }
+                        try { originalInRoom = FixturePlacementEngine.PointInSpatial(room, p); } catch (Exception ex2) { StingLog.Warn($"Suppressed: {ex2.Message}"); }
                         if (originalInRoom) { snappedList.Add(p); reverted++; }
                         else                { dropped++; }
                     }
@@ -416,7 +416,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void CheckStructuralFixing(Room room, LightingGridResult r, PlacementRule rule)
+        private void CheckStructuralFixing(SpatialElement room, LightingGridResult r, PlacementRule rule)
         {
             try
             {
@@ -472,7 +472,7 @@ namespace StingTools.Core.Placement
         /// outside the 600 mm exclusion ring of every sprinkler in scope;
         /// when no clear nudge is possible, drop the point and warn.
         /// </summary>
-        private void CheckSprinklerSeparation(Room room, LightingGridResult r)
+        private void CheckSprinklerSeparation(SpatialElement room, LightingGridResult r)
         {
             try
             {
@@ -604,7 +604,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"LightingGridCalculator.EnforceMinSpacing: {ex.Message}"); }
         }
 
-        private void ComputeUniformityRatio(Room room, LightingGridResult r, PlacementRule rule)
+        private void ComputeUniformityRatio(SpatialElement room, LightingGridResult r, PlacementRule rule)
         {
             try
             {
@@ -683,7 +683,7 @@ namespace StingTools.Core.Placement
         /// this pass is the last word before placement.
         /// </summary>
 
-        private void ComputeUniformityRatio(Room room, LightingGridResult r)
+        private void ComputeUniformityRatio(SpatialElement room, LightingGridResult r)
         {
             try
             {

--- a/StingTools/Core/Placement/ObstructionIndex.cs
+++ b/StingTools/Core/Placement/ObstructionIndex.cs
@@ -92,7 +92,7 @@ namespace StingTools.Core.Placement
         /// </summary>
         public static List<ExclusionRect> BuildForRoom(
             Document doc,
-            Room room,
+            SpatialElement room,
             double bufferFt = DefaultBufferFt,
             IEnumerable<BuiltInCategory> extraCats = null)
         {

--- a/StingTools/Core/Placement/PlacementHostPreflight.cs
+++ b/StingTools/Core/Placement/PlacementHostPreflight.cs
@@ -86,7 +86,7 @@ namespace StingTools.Core.Placement
         public static PlacementHostPreflightResult Place(
             Document doc,
             FamilySymbol symbol,
-            Room room,
+            SpatialElement room,
             XYZ position,
             PlacementRule rule)
         {
@@ -151,7 +151,7 @@ namespace StingTools.Core.Placement
         private static PlacementHostPreflightResult TryHostedPlace(
             Document doc,
             FamilySymbol symbol,
-            Room room,
+            SpatialElement room,
             XYZ position,
             PlacementRule rule,
             FamilyPlacementType fpt)
@@ -246,7 +246,7 @@ namespace StingTools.Core.Placement
         public static PlacementHostPreflightResult PlaceOnCeilingSoffit(
             Document doc,
             FamilySymbol symbol,
-            Room room,
+            SpatialElement room,
             XYZ ceilingSoffitPoint,
             PlacementRule rule,
             double ceilingVoidDepthFt)
@@ -343,7 +343,7 @@ namespace StingTools.Core.Placement
         // back to the level-based overload when no wall/ceiling is
         // nearby (free-standing face-based families).
         private static PlacementHostPreflightResult TryFaceBasedPlace(
-            Document doc, FamilySymbol symbol, Room room, XYZ position, PlacementRule rule)
+            Document doc, FamilySymbol symbol, SpatialElement room, XYZ position, PlacementRule rule)
         {
             var r = new PlacementHostPreflightResult();
             try

--- a/StingTools/Core/Placement/PlacementRule.cs
+++ b/StingTools/Core/Placement/PlacementRule.cs
@@ -192,7 +192,7 @@ namespace StingTools.Core.Placement
 
         // ── Integrated routing (PC-15) ───────────────────────────────
 
-        /// <summary>PC-15 — NONE / AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT / WALL_FOLLOWER. If set, the engine routes from each placed fixture after placement.</summary>
+        /// <summary>NONE / AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT. If set (non-NONE), the engine routes from each placed fixture after placement via the matching Core/Routing drop engine.</summary>
         public string RoutingMode { get; set; } = "NONE";
 
         /// <summary>PC-15 — vertical offset in mm from the fixture connector to where the route begins (negative = below connector).</summary>

--- a/StingTools/Core/Placement/PlacementRuleLoader.cs
+++ b/StingTools/Core/Placement/PlacementRuleLoader.cs
@@ -39,6 +39,17 @@ namespace StingTools.Core.Placement
             ("STING_PLACEMENT_RULES.electrical.json", "Electrical"),
             ("STING_PLACEMENT_RULES.healthcare-education.json", "Healthcare-Education"),
             ("STING_PLACEMENT_RULES.toilet-fixtures.json", "Toilet-Fixtures"),  // Phase 177 — full toilet-room fixture coverage
+            // These general packs were authored but never registered, so
+            // residential lighting (ceiling-pendants → living/dining/bedroom),
+            // residential MK sockets/switches, the extended baselines and the
+            // accessibility + glazing rules never loaded. Registered so dwelling
+            // projects place lights/sockets, not just commercial ones.
+            ("STING_PLACEMENT_RULES.ceiling-pendants.json", "Lighting-Pendants"),
+            ("STING_PLACEMENT_RULES.mk-electrical.json", "MK-Electrical"),
+            ("STING_PLACEMENT_RULES.baseline-extensions.json", "Baseline-Ext"),
+            ("STING_PLACEMENT_RULES.baseline-extensions2.json", "Baseline-Ext2"),
+            ("STING_PLACEMENT_RULES.accessibility.json", "Accessibility"),
+            ("STING_PLACEMENT_RULES.windows-glazing.json", "Windows-Glazing"),
         };
 
         /// <summary>

--- a/StingTools/Core/Placement/PlacementRuleLoader.cs
+++ b/StingTools/Core/Placement/PlacementRuleLoader.cs
@@ -12,6 +12,7 @@ using StingTools.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace StingTools.Core.Placement
@@ -277,16 +278,14 @@ namespace StingTools.Core.Placement
                     StingLog.Info($"PlacementRuleLoader: rule '{r.MergeKey}' is Density with MaxPerRoom=0 — placement count is bounded only by PerAreaM2/PerOccupant.");
                 }
 
-                // Phase 188 (review fix #3a, Option B) — GuaranteeCoverage is only
-                // half-wired: PlacementScorer relaxes its score-threshold gate for
-                // such rules, but the count is NOT expanded to actually guarantee
-                // coverage. CoverageGridGenerator implements the ≥99 % fill but is
-                // not invoked by the engine (deferred — see the DEFERRED note on
-                // that class). Warn so the rule's behaviour isn't mistaken for the
-                // documented coverage guarantee.
-                if (r.GuaranteeCoverage)
+                // GuaranteeCoverage is wired through CoverageGridGenerator (the
+                // engine fills the room with a √2-spaced grid when the building
+                // profile's Coverage-guarantee toggle is on). The generator needs
+                // CoverageRadiusMm > 0 to size the grid — warn when it's missing,
+                // since GuaranteeCoverage then only relaxes the score threshold.
+                if (r.GuaranteeCoverage && r.CoverageRadiusMm <= 0)
                 {
-                    string msg = $"PlacementRuleLoader: rule '{r.MergeKey}' sets GuaranteeCoverage=true, but coverage-guarantee count expansion is not active — only score-threshold relaxation applies. Achieve coverage via a grid anchor (LIGHTING_GRID) + CoverageRadiusMm/MaxSpacingMm instead.";
+                    string msg = $"PlacementRuleLoader: rule '{r.MergeKey}' sets GuaranteeCoverage=true but CoverageRadiusMm<=0 — the coverage grid can't be sized, so only score-threshold relaxation applies. Set CoverageRadiusMm (and optionally MaxSpacingMm) to enable the fill.";
                     sink?.Add(msg);
                     StingLog.Warn(msg);
                 }
@@ -306,6 +305,91 @@ namespace StingTools.Core.Placement
                     StingLog.Warn(msg);
                 }
             }
+
+            // D.3 — detect dependency cycles. DependsOn / RelativeTo / CoPlaceWith
+            // chains are honoured per-room at runtime but a cycle (A→B→A) makes
+            // every rule in the cycle skip silently with no output. Surface it.
+            DetectDependencyCycles(rules, sink);
+        }
+
+        /// <summary>
+        /// Build the rule dependency graph (DependsOn + RelativeTo + CoPlaceWith
+        /// edges, resolved by RuleId or MergeKey) and report any cycle. Edges to
+        /// unknown rules are ignored here (dangling refs are a separate concern).
+        /// </summary>
+        private static void DetectDependencyCycles(IEnumerable<PlacementRule> rules, List<string> sink)
+        {
+            if (rules == null) return;
+            var list = rules.Where(r => r != null && !string.IsNullOrEmpty(r.MergeKey)).ToList();
+            if (list.Count == 0) return;
+
+            // Map every recognised identifier (MergeKey + RuleId) to the canonical
+            // MergeKey so edges resolve regardless of which form a rule cites.
+            var idToKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in list)
+            {
+                idToKey[r.MergeKey] = r.MergeKey;
+                if (!string.IsNullOrEmpty(r.RuleId) && !idToKey.ContainsKey(r.RuleId))
+                    idToKey[r.RuleId] = r.MergeKey;
+            }
+
+            var adj = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in list)
+            {
+                var edges = new List<string>();
+                void Add(string target)
+                {
+                    if (string.IsNullOrEmpty(target)) return;
+                    if (idToKey.TryGetValue(target, out var k)
+                        && !string.Equals(k, r.MergeKey, StringComparison.OrdinalIgnoreCase))
+                        edges.Add(k);
+                }
+                Add(r.DependsOn);
+                Add(r.RelativeTo);
+                if (r.CoPlaceWith != null) foreach (var t in r.CoPlaceWith) Add(t);
+                adj[r.MergeKey] = edges;
+            }
+
+            // DFS with white(0)/grey(1)/black(2) colouring.
+            var color = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var stack = new List<string>();
+            var reported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            void Dfs(string node)
+            {
+                color[node] = 1;
+                stack.Add(node);
+                if (adj.TryGetValue(node, out var nbrs))
+                {
+                    foreach (var n in nbrs)
+                    {
+                        int c = color.TryGetValue(n, out var cc) ? cc : 0;
+                        if (c == 1)
+                        {
+                            int idx = stack.FindIndex(s => string.Equals(s, n, StringComparison.OrdinalIgnoreCase));
+                            var cyc = idx >= 0 ? new List<string>(stack.GetRange(idx, stack.Count - idx)) : new List<string> { node };
+                            cyc.Add(n);
+                            string sig = string.Join("|", cyc.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
+                            if (reported.Add(sig))
+                            {
+                                string msg = $"PlacementRuleLoader: rule dependency cycle detected: {string.Join(" → ", cyc)}. These rules will silently skip each other at runtime — break the DependsOn/RelativeTo/CoPlaceWith chain.";
+                                sink?.Add(msg);
+                                StingLog.Warn(msg);
+                            }
+                        }
+                        else if (c == 0)
+                        {
+                            Dfs(n);
+                        }
+                    }
+                }
+                color[node] = 2;
+                stack.RemoveAt(stack.Count - 1);
+            }
+
+            foreach (var r in list)
+                if ((color.TryGetValue(r.MergeKey, out var c) ? c : 0) == 0)
+                    Dfs(r.MergeKey);
         }
 
         /// <summary>

--- a/StingTools/Core/Placement/PlacementRuleLoader.cs
+++ b/StingTools/Core/Placement/PlacementRuleLoader.cs
@@ -97,17 +97,31 @@ namespace StingTools.Core.Placement
                         continue;
                 }
 
-                // ApplicableStandards gate
-                if (r.ApplicableStandards != null && r.ApplicableStandards.Length > 0 && actSet.Count > 0)
+                // Standards gate — match the rule's structured ApplicableStandards
+                // (CSV) when present, else fall back to its free-text StandardRef so
+                // rules that cite standards only via StandardRef are still gated
+                // rather than silently passing (the standards filter was inert for
+                // such rules before). Matching is case-insensitive and
+                // contains-either-direction so a profile "BS 6465" matches a rule
+                // "BS 6465-1:2006" and vice-versa.
+                string ruleStds = !string.IsNullOrEmpty(r.ApplicableStandards)
+                    ? r.ApplicableStandards
+                    : (r.StandardRef ?? "");
+                if (actSet.Count > 0 && !string.IsNullOrWhiteSpace(ruleStds))
                 {
-                    // ApplicableStandards is a string (CSV) on the runtime POCO,
-                    // not a string[]; split on comma/semicolon then match.
                     bool any = false;
-                    var parts = r.ApplicableStandards.ToString().Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    var parts = ruleStds.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
                     foreach (var raw in parts)
                     {
                         var s = raw.Trim();
-                        if (!string.IsNullOrEmpty(s) && actSet.Contains(s)) { any = true; break; }
+                        if (string.IsNullOrEmpty(s)) continue;
+                        foreach (var a in actSet)
+                        {
+                            if (string.IsNullOrEmpty(a)) continue;
+                            if (s.IndexOf(a, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                a.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0) { any = true; break; }
+                        }
+                        if (any) break;
                     }
                     if (!any) continue;
                 }

--- a/StingTools/Core/Placement/PlacementScorer.AnchorTypes.cs
+++ b/StingTools/Core/Placement/PlacementScorer.AnchorTypes.cs
@@ -631,28 +631,41 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitBeamSoffit: {ex.Message}"); }
         }
 
+        // Document-wide column locations, collected once per scorer (per run).
+        // EmitColumnFaceNearest is called once per (room, rule); without this
+        // cache each call re-ran two full-model collectors.
+        private List<XYZ> _columnLocsCache;
+
+        private List<XYZ> GetColumnLocations()
+        {
+            if (_columnLocsCache != null) return _columnLocsCache;
+            _columnLocsCache = new List<XYZ>();
+            try
+            {
+                foreach (var cat in new[] { BuiltInCategory.OST_StructuralColumns, BuiltInCategory.OST_Columns })
+                    foreach (var el in new FilteredElementCollector(_doc)
+                        .OfCategory(cat).WhereElementIsNotElementType())
+                        if ((el.Location as LocationPoint)?.Point is XYZ p) _columnLocsCache.Add(p);
+            }
+            catch (Exception ex) { StingLog.Warn($"GetColumnLocations: {ex.Message}"); }
+            return _columnLocsCache;
+        }
+
         private void EmitColumnFaceNearest(Room room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
-            // Reuse legacy COLUMN_FACE logic by calling the existing path indirectly.
             try
             {
                 var bb = room.get_BoundingBox(null);
                 if (bb == null) return;
                 XYZ centroid = (bb.Min + bb.Max) * 0.5;
-                var cats = new[] { BuiltInCategory.OST_StructuralColumns, BuiltInCategory.OST_Columns };
                 XYZ best = null; double bestSq = double.MaxValue;
-                foreach (var cat in cats)
+                foreach (var pt in GetColumnLocations())
                 {
-                    foreach (var el in new FilteredElementCollector(_doc)
-                        .OfCategory(cat).WhereElementIsNotElementType())
-                    {
-                        XYZ pt = (el.Location as LocationPoint)?.Point;
-                        if (pt == null) continue;
-                        double dx = pt.X - centroid.X, dy = pt.Y - centroid.Y;
-                        double sq = dx * dx + dy * dy;
-                        if (sq < bestSq) { bestSq = sq; best = pt; }
-                    }
+                    if (pt == null) continue;
+                    double dx = pt.X - centroid.X, dy = pt.Y - centroid.Y;
+                    double sq = dx * dx + dy * dy;
+                    if (sq < bestSq) { bestSq = sq; best = pt; }
                 }
                 if (best != null)
                     points.Add(new XYZ(best.X + offsetXFt, best.Y + offsetYFt, anchorZ));

--- a/StingTools/Core/Placement/PlacementScorer.AnchorTypes.cs
+++ b/StingTools/Core/Placement/PlacementScorer.AnchorTypes.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB.Mechanical;
 using System.Text.RegularExpressions;
 
 namespace StingTools.Core.Placement
@@ -34,7 +35,7 @@ namespace StingTools.Core.Placement
         /// fall through to legacy ROOM_CENTRE), false when unknown.
         /// </summary>
         internal bool TryEmitPhase139Anchor(
-            string anchor, Room room, PlacementRule rule,
+            string anchor, SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             if (string.IsNullOrEmpty(anchor)) return false;
@@ -187,7 +188,7 @@ namespace StingTools.Core.Placement
         /// without windows, where the WC is placed by the fallback no-window rule).
         /// </summary>
         private void EmitWindowSideWall(
-            Room room,
+            SpatialElement room,
             PlacementRule rule,
             double anchorZ,
             double offsetXFt,
@@ -280,7 +281,7 @@ namespace StingTools.Core.Placement
 
         // ── Phase 139.2 Q — new anchor implementations ────────────────
 
-        private void EmitStructuralSoffit(Room room, PlacementRule rule,
+        private void EmitStructuralSoffit(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -310,7 +311,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitStructuralSoffit: {ex.Message}"); }
         }
 
-        private void EmitCeilingTileCentre(Room room, PlacementRule rule,
+        private void EmitCeilingTileCentre(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -331,7 +332,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitCeilingTileCentre: {ex.Message}"); }
         }
 
-        private void EmitWallFaceOffset(Room room, PlacementRule rule,
+        private void EmitWallFaceOffset(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Mirror WALL_MIDPOINT but apply the rule's plaster offset along the inward wall normal.
@@ -357,7 +358,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitWallFaceOffset: {ex.Message}"); points.AddRange(prev); }
         }
 
-        private void EmitDoorLatchSide(Room room, PlacementRule rule,
+        private void EmitDoorLatchSide(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -374,7 +375,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitDoorHingeSide150(Room room, PlacementRule rule,
+        private void EmitDoorHingeSide150(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -402,7 +403,7 @@ namespace StingTools.Core.Placement
         private readonly Dictionary<ElementId, List<BoxIndexEntry>> _boxIndexCache
             = new Dictionary<ElementId, List<BoxIndexEntry>>();
 
-        private List<BoxIndexEntry> GetBoxIndexForRoom(Room room, string paramName)
+        private List<BoxIndexEntry> GetBoxIndexForRoom(SpatialElement room, string paramName)
         {
             if (_boxIndexCache.TryGetValue(room.Id, out var cached)) return cached;
             var list = new List<BoxIndexEntry>();
@@ -441,7 +442,7 @@ namespace StingTools.Core.Placement
             return list;
         }
 
-        private void EmitConduitBoxMatched(Room room, PlacementRule rule,
+        private void EmitConduitBoxMatched(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -468,7 +469,7 @@ namespace StingTools.Core.Placement
         private readonly Dictionary<ElementId, List<XYZ>> _outletCache
             = new Dictionary<ElementId, List<XYZ>>();
 
-        private List<XYZ> GetOutletPositions(Room room)
+        private List<XYZ> GetOutletPositions(SpatialElement room)
         {
             if (_outletCache.TryGetValue(room.Id, out var hit)) return hit;
             var outlets = new List<XYZ>();
@@ -497,7 +498,7 @@ namespace StingTools.Core.Placement
             return outlets;
         }
 
-        private void EmitCeilingVoidAboveBox(Room room, PlacementRule rule,
+        private void EmitCeilingVoidAboveBox(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -515,7 +516,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitCeilingVoidAboveBox: {ex.Message}"); }
         }
 
-        private void EmitFloorSlabPenetration(Room room, PlacementRule rule,
+        private void EmitFloorSlabPenetration(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -531,7 +532,7 @@ namespace StingTools.Core.Placement
 
         // ── Implementations (simplified) ────────────────────────────
 
-        private void EmitWindowVariantSill(Room room, PlacementRule rule, string anchor,
+        private void EmitWindowVariantSill(SpatialElement room, PlacementRule rule, string anchor,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -549,7 +550,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitWindowHead(Room room, PlacementRule rule,
+        private void EmitWindowHead(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -565,7 +566,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitDoorStrikeSide(Room room, PlacementRule rule,
+        private void EmitDoorStrikeSide(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Strike side is opposite hinge; we approximate with door origin shifted by 150mm + leaf width.
@@ -583,7 +584,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitDoorCloserZone(Room room, PlacementRule rule,
+        private void EmitDoorCloserZone(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -597,7 +598,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitBeamSoffit(Room room, PlacementRule rule,
+        private void EmitBeamSoffit(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -651,7 +652,7 @@ namespace StingTools.Core.Placement
             return _columnLocsCache;
         }
 
-        private void EmitColumnFaceNearest(Room room, PlacementRule rule,
+        private void EmitColumnFaceNearest(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -673,7 +674,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitColumnFaceNearest: {ex.Message}"); }
         }
 
-        private void EmitCeilingTileCorner(Room room, PlacementRule rule,
+        private void EmitCeilingTileCorner(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Approximation: 4 corners of every 600mm tile in room bbox.
@@ -699,7 +700,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitCurtainPanelCentre(Room room, PlacementRule rule,
+        private void EmitCurtainPanelCentre(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -724,14 +725,14 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitCurtainPanelCentre: {ex.Message}"); }
         }
 
-        private void EmitSlabPerimeterEdge(Room room, PlacementRule rule,
+        private void EmitSlabPerimeterEdge(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Use room boundary segments at the floor level.
             EmitPerimeterAnchor(room, rule, anchorZ, offsetXFt, offsetYFt, points);
         }
 
-        private void EmitEscapeDoorBothSides(Room room, PlacementRule rule,
+        private void EmitEscapeDoorBothSides(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -749,33 +750,33 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitStairLandingEdge(Room room, PlacementRule rule,
+        private void EmitStairLandingEdge(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             EmitStairNosingAnchor(room, rule, anchorZ, offsetXFt, offsetYFt, points);
         }
 
-        private void EmitStairFlightMid(Room room, PlacementRule rule,
+        private void EmitStairFlightMid(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             EmitStairNosingAnchor(room, rule, anchorZ, offsetXFt, offsetYFt, points);
         }
 
-        private void EmitCorridorJunction(Room room, PlacementRule rule,
+        private void EmitCorridorJunction(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Approximation: corridor junctions are room corners; emit corner points.
             EmitWallCorners(room, rule, anchorZ, offsetXFt, offsetYFt, points);
         }
 
-        private void EmitDoorJambSeeds(Room room, PlacementRule rule,
+        private void EmitDoorJambSeeds(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             EmitDoorAnchor(room, rule, anchorZ, offsetXFt, offsetYFt, points,
                 hingeSide: false, overDoor: false);
         }
 
-        private void EmitRaisedFloorTileEdge(Room room, PlacementRule rule,
+        private void EmitRaisedFloorTileEdge(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Sample a coarse 600mm grid along bbox edges.
@@ -795,7 +796,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitNearestMepSystemNode(Room room, PlacementRule rule,
+        private void EmitNearestMepSystemNode(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // v1 simplification: connector points of any MEP equipment in the room.
@@ -820,7 +821,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"EmitNearestMepSystemNode: {ex.Message}"); }
         }
 
-        private void EmitZoneBoundary(Room room, PlacementRule rule,
+        private void EmitZoneBoundary(SpatialElement room, PlacementRule rule,
             double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // TODO-VERIFY-API: HVAC Zone collection — falls back to room centroid.

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB.Mechanical;
 
 namespace StingTools.Core.Placement
 {
@@ -129,7 +130,7 @@ namespace StingTools.Core.Placement
         /// match the room name, or if no candidate clears ScoreThreshold.
         /// </summary>
         public List<PlacementCandidate> Score(
-            Room room,
+            SpatialElement room,
             PlacementRule rule,
             IList<XYZ> alreadyPlaced,
             int countInRoomSoFar)
@@ -171,7 +172,7 @@ namespace StingTools.Core.Placement
         /// Falls back to the room's location point when boundary
         /// inspection fails.
         /// </summary>
-        private List<XYZ> GenerateAnchorPoints(Room room, PlacementRule rule)
+        private List<XYZ> GenerateAnchorPoints(SpatialElement room, PlacementRule rule)
         {
             var points = new List<XYZ>();
             XYZ roomPt = null;
@@ -313,7 +314,7 @@ namespace StingTools.Core.Placement
         /// height + Z offset), measured from the room's floor level. Mirrors
         /// the per-candidate anchorZ formula in Score().
         /// </summary>
-        public double ResolveAnchorZForRoom(Room room, PlacementRule rule)
+        public double ResolveAnchorZForRoom(SpatialElement room, PlacementRule rule)
         {
             if (room == null || rule == null) return 0.0;
             double baseZ;
@@ -325,7 +326,7 @@ namespace StingTools.Core.Placement
                  + (rule.OffsetZMm * MmToFt);
         }
 
-        private double ResolveMountingDatumZ(Room room, PlacementRule rule, XYZ roomPt)
+        private double ResolveMountingDatumZ(SpatialElement room, PlacementRule rule, XYZ roomPt)
         {
             string r = (rule?.MountingReference ?? "FFL").ToUpperInvariant();
             if (r == "FFL" || r == "SLAB" || string.IsNullOrEmpty(r)) return roomPt.Z;
@@ -363,7 +364,7 @@ namespace StingTools.Core.Placement
         /// </summary>
         public IReadOnlyDictionary<(ElementId, string), LightingGridResult> GridResults => _gridCache;
 
-        private void EmitLightingGridPoints(Room room, PlacementRule rule, XYZ roomPt,
+        private void EmitLightingGridPoints(SpatialElement room, PlacementRule rule, XYZ roomPt,
             double offsetXFt, double offsetYFt, double anchorZ, List<XYZ> points)
         {
             try
@@ -392,7 +393,7 @@ namespace StingTools.Core.Placement
         }
 
         private PlacementCandidate BuildCandidate(
-            Room room,
+            SpatialElement room,
             PlacementRule rule,
             XYZ anchor,
             IList<XYZ> alreadyPlaced)
@@ -500,7 +501,7 @@ namespace StingTools.Core.Placement
         /// engines to consume — zero-impact for families that declared
         /// nothing.
         /// </summary>
-        private void ApplyPlacementHints(PlacementCandidate c, Room room, PlacementRule rule)
+        private void ApplyPlacementHints(PlacementCandidate c, SpatialElement room, PlacementRule rule)
         {
             // PlacementRule-bound families: the scorer doesn't own a
             // FamilySymbol reference, so read hints from any instance of
@@ -552,7 +553,7 @@ namespace StingTools.Core.Placement
         /// FamilySymbol the caller already chose; deferred to keep this
         /// wiring small.
         /// </summary>
-        private Element ResolveSampleInstanceForRule(Room room, PlacementRule rule)
+        private Element ResolveSampleInstanceForRule(SpatialElement room, PlacementRule rule)
         {
             if (rule == null || _doc == null || string.IsNullOrEmpty(rule.CategoryFilter)) return null;
 
@@ -683,7 +684,7 @@ namespace StingTools.Core.Placement
         /// Within one buffer distance of an edge → linear penalty
         /// 0..1 across the buffer. Outside all exclusions → 1.0.
         /// </summary>
-        private (double score, int flags) ComputeCollisionScore(Room room, XYZ pt)
+        private (double score, int flags) ComputeCollisionScore(SpatialElement room, XYZ pt)
         {
             if (room == null || pt == null) return (1.0, 0);
 
@@ -732,7 +733,7 @@ namespace StingTools.Core.Placement
         /// around the candidate point — cheaper than computing each
         /// wall's 3D geometry and doing the intersection manually.
         /// </summary>
-        private bool IsInsideWall(Room room, XYZ pt)
+        private bool IsInsideWall(SpatialElement room, XYZ pt)
         {
             if (room == null || pt == null) return false;
 
@@ -799,7 +800,7 @@ namespace StingTools.Core.Placement
             return false;
         }
 
-        private List<(ElementId wallId, Solid solid)> CollectWallSolidsNearRoom(Room room)
+        private List<(ElementId wallId, Solid solid)> CollectWallSolidsNearRoom(SpatialElement room)
         {
             var list = new List<(ElementId, Solid)>();
             if (_doc == null || room == null) return list;
@@ -919,7 +920,7 @@ namespace StingTools.Core.Placement
             return best;
         }
 
-        private string SafeRoomName(Room room)
+        private string SafeRoomName(SpatialElement room)
         {
             try
             {
@@ -944,7 +945,7 @@ namespace StingTools.Core.Placement
         private readonly Dictionary<ElementId, RoomBoundaryCache> _boundaryCache
             = new Dictionary<ElementId, RoomBoundaryCache>();
 
-        private RoomBoundaryCache GetBoundary(Room room)
+        private RoomBoundaryCache GetBoundary(SpatialElement room)
         {
             if (room == null) return null;
             if (_boundaryCache.TryGetValue(room.Id, out var cached)) return cached;
@@ -1005,7 +1006,7 @@ namespace StingTools.Core.Placement
         // collector is too greedy and grabs doors of adjacent rooms.
         // Falls back to bbox-intersect when both FromRoom and ToRoom
         // are null (door's spatial context not yet computed).
-        private static List<FamilyInstance> FilterDoorsForRoom(List<FamilyInstance> all, Room room)
+        private static List<FamilyInstance> FilterDoorsForRoom(List<FamilyInstance> all, SpatialElement room)
         {
             if (all == null || room == null) return all ?? new List<FamilyInstance>();
             var keep = new List<FamilyInstance>();
@@ -1056,7 +1057,7 @@ namespace StingTools.Core.Placement
 
         // ── PC-04 — wall midpoints / corners from real boundary segments ─
 
-        private void EmitWallMidpoints(Room room, PlacementRule rule, double anchorZ,
+        private void EmitWallMidpoints(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -1077,7 +1078,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitWallCorners(Room room, PlacementRule rule, double anchorZ,
+        private void EmitWallCorners(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -1097,7 +1098,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitDoorAnchor(Room room, PlacementRule rule, double anchorZ,
+        private void EmitDoorAnchor(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points,
             bool hingeSide, bool overDoor)
         {
@@ -1154,7 +1155,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitWindowSills(Room room, PlacementRule rule, double anchorZ,
+        private void EmitWindowSills(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             var b = GetBoundary(room);
@@ -1178,7 +1179,7 @@ namespace StingTools.Core.Placement
             return null;
         }
 
-        private XYZ ComputeInwardFromWall(Wall w, Room room)
+        private XYZ ComputeInwardFromWall(Wall w, SpatialElement room)
         {
             try
             {
@@ -1207,14 +1208,14 @@ namespace StingTools.Core.Placement
             catch { return null; }
         }
 
-        private XYZ ComputeInward(Line line, Room room)
+        private XYZ ComputeInward(Line line, SpatialElement room)
             => ComputeInwardFromCurve(line, room);
 
         // Phase 139.5 Q3 — generalised inward-normal computation for any
         // boundary curve (Line, Arc, NurbSpline). Tangent comes from the
         // first derivative at the midpoint parameter; the normal is the
         // 90° rotation of the planar tangent.
-        private XYZ ComputeInwardFromCurve(Curve curve, Room room)
+        private XYZ ComputeInwardFromCurve(Curve curve, SpatialElement room)
         {
             try
             {
@@ -1242,7 +1243,7 @@ namespace StingTools.Core.Placement
             catch { return XYZ.BasisY; }
         }
 
-        private void Fallback(Room room, double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
+        private void Fallback(SpatialElement room, double anchorZ, double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
             {
@@ -1255,7 +1256,7 @@ namespace StingTools.Core.Placement
 
         // ── PC-09 — additional anchor types ──────────────────────────
 
-        private void EmitOppositeWallAnchor(Room room, PlacementRule rule, double anchorZ,
+        private void EmitOppositeWallAnchor(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Find the longest boundary edge on the wall opposite the first door.
@@ -1280,7 +1281,7 @@ namespace StingTools.Core.Placement
             points.Add(new XYZ(midOpp.X + inward.X * offsetXFt, midOpp.Y + inward.Y * offsetXFt, anchorZ));
         }
 
-        private void EmitGridIntersectionAnchor(Room room, PlacementRule rule, double anchorZ,
+        private void EmitGridIntersectionAnchor(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -1333,7 +1334,7 @@ namespace StingTools.Core.Placement
             catch { return null; }
         }
 
-        private void EmitColumnFaceAnchor(Room room, PlacementRule rule, double anchorZ,
+        private void EmitColumnFaceAnchor(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -1362,7 +1363,7 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"ColumnFaceAnchor: {ex.Message}"); Fallback(room, anchorZ, offsetXFt, offsetYFt, points); }
         }
 
-        private void EmitPerimeterAnchor(Room room, PlacementRule rule, double anchorZ,
+        private void EmitPerimeterAnchor(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             // Sample every PerLinearMetre or every 1.5m along all boundary lines.
@@ -1390,7 +1391,7 @@ namespace StingTools.Core.Placement
             }
         }
 
-        private void EmitFloorTileAnchor(Room room, PlacementRule rule, double anchorZ,
+        private void EmitFloorTileAnchor(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points, double tileMm = 600.0)
         {
             var bb = room.get_BoundingBox(null);
@@ -1402,7 +1403,7 @@ namespace StingTools.Core.Placement
             points.Add(new XYZ(gx + offsetXFt, gy + offsetYFt, anchorZ));
         }
 
-        private void EmitStairNosingAnchor(Room room, PlacementRule rule, double anchorZ,
+        private void EmitStairNosingAnchor(SpatialElement room, PlacementRule rule, double anchorZ,
             double offsetXFt, double offsetYFt, List<XYZ> points)
         {
             try
@@ -1440,7 +1441,7 @@ namespace StingTools.Core.Placement
         /// Empty / 0 means "no filter" — preserves legacy behaviour for
         /// rules that don't set the new fields.
         /// </summary>
-        private bool RoomMatchesScope(Room room, PlacementRule rule)
+        private bool RoomMatchesScope(SpatialElement room, PlacementRule rule)
         {
             if (room == null || rule == null) return false;
 

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -307,6 +307,24 @@ namespace StingTools.Core.Placement
         /// (legacy alias). CEILING / SOFFIT → room top + 0 (caller adds
         /// MountingHeight as an *offset* below the ceiling face).
         /// </summary>
+        /// <summary>
+        /// Public helper used by the coverage-grid path: resolve the placement
+        /// anchor Z for a rule in a room (mounting datum + signed mounting
+        /// height + Z offset), measured from the room's floor level. Mirrors
+        /// the per-candidate anchorZ formula in Score().
+        /// </summary>
+        public double ResolveAnchorZForRoom(Room room, PlacementRule rule)
+        {
+            if (room == null || rule == null) return 0.0;
+            double baseZ;
+            try { baseZ = room.Level?.Elevation ?? (room.get_BoundingBox(null)?.Min.Z ?? 0.0); }
+            catch { baseZ = 0.0; }
+            var roomPt = new XYZ(0.0, 0.0, baseZ);
+            return ResolveMountingDatumZ(room, rule, roomPt)
+                 + MountingHeightSign(rule) * (rule.MountingHeightMm * MmToFt)
+                 + (rule.OffsetZMm * MmToFt);
+        }
+
         private double ResolveMountingDatumZ(Room room, PlacementRule rule, XYZ roomPt)
         {
             string r = (rule?.MountingReference ?? "FFL").ToUpperInvariant();

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -877,6 +877,12 @@ namespace StingTools.Core.Placement
             }
         }
 
+        // NOTE: during Score() the engine passes an EMPTY already-placed list
+        // (placedPoints is filled only after placement), so this returns 1.0 for
+        // every candidate and spacing does NOT influence the ranking. MinSpacing
+        // is instead enforced as a post-rank GATE in
+        // FixturePlacementEngine.SelectWithSpacing. This is intentional — see the
+        // comment at that call site.
         private double ComputeSpacingScore(XYZ pt, IList<XYZ> placed, double minSpacingMm)
         {
             if (placed == null || placed.Count == 0) return 1.0;

--- a/StingTools/Core/Placement/PlacementScorer.cs
+++ b/StingTools/Core/Placement/PlacementScorer.cs
@@ -226,9 +226,18 @@ namespace StingTools.Core.Placement
                     break;
 
                 case "CEILING_CENTRE":
-                    points.Add(new XYZ(roomPt.X + offsetXFt, roomPt.Y + offsetYFt,
-                        Math.Max(anchorZ, roomPt.Z + 2.8 / 0.3048)));
+                {
+                    double ceilZ = Math.Max(anchorZ, roomPt.Z + 2.8 / 0.3048);
+                    // Density / spacing rules (fire alarms, sprinklers, emergency
+                    // lights, area-based ceiling lights) intend MULTIPLE devices —
+                    // emit a ceiling grid. Without a density signal it stays a
+                    // single centre point (legacy behaviour preserved).
+                    if (rule != null && (rule.MaxSpacingMm > 0 || rule.PerAreaM2 > 0))
+                        EmitCeilingGrid(room, rule, roomPt, offsetXFt, offsetYFt, ceilZ, points);
+                    else
+                        points.Add(new XYZ(roomPt.X + offsetXFt, roomPt.Y + offsetYFt, ceilZ));
                     break;
+                }
 
                 case "LIGHTING_GRID":
                 case "LUX_GRID":
@@ -363,6 +372,46 @@ namespace StingTools.Core.Placement
         /// instances after the per-room loop.
         /// </summary>
         public IReadOnlyDictionary<(ElementId, string), LightingGridResult> GridResults => _gridCache;
+
+        /// <summary>
+        /// Uniform ceiling grid for density / max-spacing rules on a CEILING_CENTRE
+        /// anchor. Spacing is MaxSpacingMm when set, else √(PerAreaM2) (1 device per
+        /// PerAreaM2 m²). Points are clipped to the room/space and capped. Falls back
+        /// to the single centre point on any failure or empty result.
+        /// </summary>
+        private void EmitCeilingGrid(SpatialElement room, PlacementRule rule, XYZ roomPt,
+            double offsetXFt, double offsetYFt, double anchorZ, List<XYZ> points)
+        {
+            try
+            {
+                var bb = room.get_BoundingBox(null);
+                double spacingFt;
+                if (rule.MaxSpacingMm > 0)        spacingFt = rule.MaxSpacingMm / 304.8;
+                else if (rule.PerAreaM2 > 0)      spacingFt = Math.Sqrt(rule.PerAreaM2) / 0.3048;
+                else { points.Add(new XYZ(roomPt.X + offsetXFt, roomPt.Y + offsetYFt, anchorZ)); return; }
+                if (spacingFt < 0.5) spacingFt = 0.5;
+                if (bb == null) { points.Add(new XYZ(roomPt.X + offsetXFt, roomPt.Y + offsetYFt, anchorZ)); return; }
+
+                double w = bb.Max.X - bb.Min.X, d = bb.Max.Y - bb.Min.Y;
+                int nx = Math.Max(1, (int)Math.Ceiling(w / spacingFt));
+                int ny = Math.Max(1, (int)Math.Ceiling(d / spacingFt));
+                double stepX = w / nx, stepY = d / ny;
+                int emitted = 0;
+                for (int i = 0; i < nx && emitted < 400; i++)
+                    for (int j = 0; j < ny && emitted < 400; j++)
+                    {
+                        var p = new XYZ(bb.Min.X + stepX * (i + 0.5) + offsetXFt,
+                                        bb.Min.Y + stepY * (j + 0.5) + offsetYFt, anchorZ);
+                        if (FixturePlacementEngine.PointInSpatial(room, p)) { points.Add(p); emitted++; }
+                    }
+                if (emitted == 0) points.Add(new XYZ(roomPt.X + offsetXFt, roomPt.Y + offsetYFt, anchorZ));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"PlacementScorer.EmitCeilingGrid {room.Id}: {ex.Message}");
+                points.Add(new XYZ(roomPt.X + offsetXFt, roomPt.Y + offsetYFt, anchorZ));
+            }
+        }
 
         private void EmitLightingGridPoints(SpatialElement room, PlacementRule rule, XYZ roomPt,
             double offsetXFt, double offsetYFt, double anchorZ, List<XYZ> points)

--- a/StingTools/Core/Placement/PostPlacementHooks.cs
+++ b/StingTools/Core/Placement/PostPlacementHooks.cs
@@ -11,11 +11,14 @@ using StingTools.Core;
 //    the placed instance lands fully tagged, ISO-19650 8-segment.
 //  * SeedCobieComponent — copy the rule's StandardRef / Notes onto
 //    COBIE_COMPONENT_NAME / COBIE_COMPONENT_DESCRIPTION when present.
-//  * AssignMepSystem — placeholder for MEPSystemBuilder.Connect, which
-//    requires deeper system traversal; for now records a warning if
-//    enabled and the instance has unconnected connectors.
+//  * AssignMepSystem — for every open connector on the placed instance,
+//    find the nearest coincident compatible (same-domain, unconnected)
+//    connector within a small search radius and ConnectTo it. Connectors
+//    that can't be joined are counted and reported (never silently
+//    dropped).
 
 using System;
+using System.Collections.Generic;
 using Autodesk.Revit.DB;
 
 namespace StingTools.Core.Placement
@@ -25,16 +28,49 @@ namespace StingTools.Core.Placement
         /// <summary>Run TagPipelineHelper.RunFullPipeline on every placed instance.</summary>
         public static bool RunDataTagPipeline { get; set; } = false;
 
-        /// <summary>Set to true when the tag pipeline assembly could not be located
-        /// at startup. Checked by the Fixtures UI to show a tooltip explaining why
-        /// data-tagging is unavailable for this session.</summary>
+        /// <summary>Set to true when the tag pipeline could not build a valid
+        /// population context for this document (rooms/levels/shared-params
+        /// missing). Checked by the Fixtures UI to show a tooltip explaining
+        /// why data-tagging produced nothing for this session.</summary>
         public static bool TagPipelineMissing { get; set; } = false;
 
         /// <summary>Seed COBIE_* parameters from the rule's StandardRef / Notes.</summary>
         public static bool SeedCobieComponent { get; set; } = false;
 
-        /// <summary>Probe MEP connectors and warn when any are unconnected.</summary>
+        /// <summary>Auto-connect open MEP connectors to the nearest compatible
+        /// connector and report any left open.</summary>
         public static bool AssignMepSystem { get; set; } = false;
+
+        /// <summary>Connectors joined during the current run (reset by BeginRun).</summary>
+        public static int MepConnectedCount { get; private set; }
+
+        /// <summary>Connectors left open during the current run (reset by BeginRun).</summary>
+        public static int MepLeftOpenCount { get; private set; }
+
+        // 600 mm legacy join radius, in Revit internal feet.
+        private const double MepSearchRadiusFt = 600.0 / 304.8;
+
+        // Per-run tag-pipeline context (built once, reused for every placed
+        // instance). Reset by BeginRun so a fresh run picks up manual edits
+        // made between runs.
+        private static Document _tagDoc;
+        private static TokenAutoPopulator.PopulationContext _tagCtx;
+        private static HashSet<string> _tagIndex;
+        private static Dictionary<string, int> _tagSeq;
+        private static List<Temp.FormulaEngine.FormulaDefinition> _tagFormulas;
+        private static List<Grid> _tagGrids;
+
+        /// <summary>
+        /// Called by the engine at the start of a run. Clears per-run caches
+        /// and counters so consecutive runs are independent.
+        /// </summary>
+        public static void BeginRun()
+        {
+            _tagDoc = null; _tagCtx = null; _tagIndex = null;
+            _tagSeq = null; _tagFormulas = null; _tagGrids = null;
+            MepConnectedCount = 0; MepLeftOpenCount = 0;
+            TagPipelineMissing = false;
+        }
 
         /// <summary>
         /// Entry point invoked by the engine. Each toggle is independent.
@@ -53,17 +89,50 @@ namespace StingTools.Core.Placement
         {
             try
             {
-                // Reflection guard: the tagging pipeline lives in another
-                // assembly module and we don't want a hard dependency
-                // edge between Placement and Core. If TagPipelineHelper
-                // moves or is renamed we just skip silently.
-                var t = Type.GetType("StingTools.Core.TagPipelineHelper, StingTools");
-                if (t == null) { TagPipelineMissing = true; return; }
-                var m = t.GetMethod("RunFullPipeline", new[] { typeof(Document), typeof(Element) });
-                if (m == null) { TagPipelineMissing = true; return; }
-                m.Invoke(null, new object[] { fi.Document, fi });
+                var doc = fi.Document;
+                if (!EnsureTagContext(doc)) return;   // TagPipelineMissing already set
+                // Direct typed call — TagPipelineHelper is internal to this
+                // assembly. RunFullPipeline takes the full canonical context
+                // (population context + tag index + seq counters + formulas +
+                // grid lines); there is no 2-arg overload, which is why the
+                // old reflection probe silently no-op'd.
+                TagPipelineHelper.RunFullPipeline(
+                    doc, fi, _tagCtx, _tagIndex, _tagSeq, _tagFormulas, _tagGrids,
+                    overwrite: false, skipComplete: true,
+                    collisionMode: TagCollisionMode.AutoIncrement);
             }
             catch (Exception ex) { StingLog.Warn($"PostPlacementHooks.RunTagPipeline {fi.Id}: {ex.Message}"); }
+        }
+
+        /// <summary>Build the tag-pipeline context once per document/run.</summary>
+        private static bool EnsureTagContext(Document doc)
+        {
+            if (doc == null) return false;
+            if (ReferenceEquals(_tagDoc, doc) && _tagCtx != null) return true;
+            try
+            {
+                var (idx, seq) = TagConfig.BuildTagIndexAndCounters(doc);
+                var ctx = TokenAutoPopulator.PopulationContext.Build(doc);
+                if (ctx == null || !ctx.IsValid())
+                {
+                    TagPipelineMissing = true;
+                    StingLog.Warn("PostPlacementHooks: tag population context invalid — data-tag pipeline skipped this run.");
+                    return false;
+                }
+                _tagIndex = idx;
+                _tagSeq = seq;
+                _tagCtx = ctx;
+                _tagFormulas = TagPipelineHelper.LoadFormulas();
+                _tagGrids = TagPipelineHelper.LoadGridLines(doc);
+                _tagDoc = doc;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                TagPipelineMissing = true;
+                StingLog.Warn($"PostPlacementHooks.EnsureTagContext: {ex.Message}");
+                return false;
+            }
         }
 
         private static void SeedCobieSafe(FamilyInstance fi, PlacementRule rule)
@@ -83,16 +152,102 @@ namespace StingTools.Core.Placement
             {
                 var mgr = fi.MEPModel?.ConnectorManager;
                 if (mgr == null) return;
-                int unconnected = 0;
-                foreach (Connector c in mgr.Connectors)
+                var doc = fi.Document;
+                var ownerId = fi.Id;
+
+                int connected = 0, leftOpen = 0;
+                foreach (Connector src in mgr.Connectors)
                 {
-                    if (c == null) continue;
-                    if (!c.IsConnected) unconnected++;
+                    if (src == null) continue;
+                    bool isConn;
+                    try { isConn = src.IsConnected; } catch { continue; }
+                    if (isConn) continue;
+
+                    Domain dom;
+                    try { dom = src.Domain; } catch { dom = Domain.DomainUndefined; }
+                    // Only attempt physical MEP joins; logical/undefined domains
+                    // (e.g. electrical-power circuiting) are out of scope here.
+                    if (dom != Domain.DomainHvac && dom != Domain.DomainPiping &&
+                        dom != Domain.DomainCableTrayConduit)
+                    { leftOpen++; continue; }
+
+                    var mate = FindNearestCompatibleConnector(doc, src, dom, ownerId, MepSearchRadiusFt);
+                    if (mate != null && TryConnect(src, mate)) connected++;
+                    else leftOpen++;
                 }
-                if (unconnected > 0)
-                    StingLog.Info($"PostPlacementHooks.AssignMepSystem: {fi.Id} has {unconnected} unconnected connector(s); MEP join deferred to MEPSystemBuilder.");
+
+                MepConnectedCount += connected;
+                MepLeftOpenCount += leftOpen;
+                if (connected > 0 || leftOpen > 0)
+                    StingLog.Info($"PostPlacementHooks.AssignMepSystem: {fi.Id} connected {connected}, {leftOpen} left open.");
             }
             catch (Exception ex) { StingLog.Warn($"PostPlacementHooks.AssignMep {fi.Id}: {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// Find the nearest unconnected connector of the same domain within
+        /// radiusFt of <paramref name="src"/>, on a different element.
+        /// Bounded by a bounding-box filter so the search stays local.
+        /// </summary>
+        private static Connector FindNearestCompatibleConnector(
+            Document doc, Connector src, Domain dom, ElementId ownerId, double radiusFt)
+        {
+            XYZ o;
+            try { o = src.Origin; } catch { return null; }
+            if (o == null) return null;
+
+            try
+            {
+                var min = new XYZ(o.X - radiusFt, o.Y - radiusFt, o.Z - radiusFt);
+                var max = new XYZ(o.X + radiusFt, o.Y + radiusFt, o.Z + radiusFt);
+                var bbFilter = new BoundingBoxIntersectsFilter(new Outline(min, max));
+
+                Connector best = null;
+                double bestDist = radiusFt;
+                var collector = new FilteredElementCollector(doc)
+                    .WherePasses(bbFilter)
+                    .WhereElementIsNotElementType();
+
+                foreach (var el in collector)
+                {
+                    if (el == null || el.Id == ownerId) continue;
+                    ConnectorManager cm = null;
+                    if (el is MEPCurve mc) cm = mc.ConnectorManager;
+                    else if (el is FamilyInstance other) cm = other.MEPModel?.ConnectorManager;
+                    if (cm == null) continue;
+
+                    foreach (Connector c in cm.Connectors)
+                    {
+                        if (c == null) continue;
+                        bool conn;
+                        try { conn = c.IsConnected; } catch { continue; }
+                        if (conn) continue;
+                        Domain d;
+                        try { d = c.Domain; } catch { continue; }
+                        if (d != dom) continue;
+                        XYZ co;
+                        try { co = c.Origin; } catch { continue; }
+                        if (co == null) continue;
+                        double dist = co.DistanceTo(o);
+                        if (dist < bestDist) { bestDist = dist; best = c; }
+                    }
+                }
+                return best;
+            }
+            catch (Exception ex) { StingLog.Warn($"PostPlacementHooks.FindConnector: {ex.Message}"); return null; }
+        }
+
+        private static bool TryConnect(Connector a, Connector b)
+        {
+            try
+            {
+                // ConnectTo refuses mismatched domains / non-coincident
+                // connectors; it never throws-and-corrupts, so a failed join
+                // simply leaves both ends open (counted as left-open).
+                a.ConnectTo(b);
+                try { return a.IsConnected && b.IsConnected; } catch { return false; }
+            }
+            catch (Exception ex) { StingLog.Warn($"PostPlacementHooks.TryConnect: {ex.Message}"); return false; }
         }
 
         private static void TrySetText(Element el, string paramName, string value)

--- a/StingTools/Core/Placement/PostPlacementHooks.cs
+++ b/StingTools/Core/Placement/PostPlacementHooks.cs
@@ -47,8 +47,12 @@ namespace StingTools.Core.Placement
         /// <summary>Connectors left open during the current run (reset by BeginRun).</summary>
         public static int MepLeftOpenCount { get; private set; }
 
-        // 600 mm legacy join radius, in Revit internal feet.
-        private const double MepSearchRadiusFt = 600.0 / 304.8;
+        // Connector.ConnectTo only succeeds for physically coincident connectors,
+        // so the search is a tight coincidence tolerance (in Revit internal feet),
+        // not a routing radius — a wider search would just return near-but-not-
+        // coincident connectors that ConnectTo rejects, inflating the left-open
+        // count. 25 mm absorbs minor float drift between snapped origins.
+        private const double MepCoincidenceTolFt = 25.0 / 304.8;
 
         // Per-run tag-pipeline context (built once, reused for every placed
         // instance). Reset by BeginRun so a fresh run picks up manual edits
@@ -171,7 +175,7 @@ namespace StingTools.Core.Placement
                         dom != Domain.DomainCableTrayConduit)
                     { leftOpen++; continue; }
 
-                    var mate = FindNearestCompatibleConnector(doc, src, dom, ownerId, MepSearchRadiusFt);
+                    var mate = FindNearestCompatibleConnector(doc, src, dom, ownerId, MepCoincidenceTolFt);
                     if (mate != null && TryConnect(src, mate)) connected++;
                     else leftOpen++;
                 }

--- a/StingTools/Core/Placement/WetZoneExclusionChecker.cs
+++ b/StingTools/Core/Placement/WetZoneExclusionChecker.cs
@@ -66,7 +66,7 @@ namespace StingTools.Core.Placement
         /// names looking for "bath", "shower", "basin", "sink", "wc"
         /// keywords.
         /// </summary>
-        public List<ExclusionZone> BuildForRoom(Room room)
+        public List<ExclusionZone> BuildForRoom(SpatialElement room)
         {
             if (room == null) return new List<ExclusionZone>();
             if (_cache.TryGetValue(room.Id, out var cached)) return cached;
@@ -153,7 +153,7 @@ namespace StingTools.Core.Placement
         /// Returns Rejected=true when the candidate falls in a zone
         /// covered by the rule's exclusion level.
         /// </summary>
-        public CheckResult Check(Room room, XYZ candidate, string wetZoneExclusion)
+        public CheckResult Check(SpatialElement room, XYZ candidate, string wetZoneExclusion)
         {
             var result = new CheckResult();
             if (candidate == null || string.IsNullOrEmpty(wetZoneExclusion) ||

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -421,7 +421,12 @@ namespace StingTools.Core
                 catch (Exception ex) { StingLog.Warn($"DocumentClosing LodMatrixRegistry.InvalidateCache: {ex.Message}"); }
                 try { Validation.OwnerStandardsRegistry.InvalidateCache(e.Document); }
                 catch (Exception ex) { StingLog.Warn($"DocumentClosing OwnerStandardsRegistry.InvalidateCache: {ex.Message}"); }
-                StingLog.Info("DocumentClosing: cleared parameter, compliance, formula, selection, deferred, workset, level, drawing-type, and tag-scheme caches");
+                // P1.2 — drop the BOQ per-link takeoff cache so the next document
+                // (or a reopen with changed links) re-walks links rather than
+                // serving stale rows.
+                try { StingTools.BOQ.BOQCostManager.InvalidateLinkCache(); }
+                catch (Exception ex) { StingLog.Warn($"DocumentClosing BOQCostManager.InvalidateLinkCache: {ex.Message}"); }
+                StingLog.Info("DocumentClosing: cleared parameter, compliance, formula, selection, deferred, workset, level, drawing-type, tag-scheme, and BOQ link caches");
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/Validation/SeparationValidator.cs
+++ b/StingTools/Core/Validation/SeparationValidator.cs
@@ -148,6 +148,62 @@ namespace StingTools.Core.Validation
             return results;
         }
 
+        /// <summary>
+        /// Document-level entry point used by the Placement Centre validator
+        /// checklist and RunAllValidators. Runs <see cref="ValidateElement"/>
+        /// against every MEP curve / containment element in the model, so the
+        /// "Separation" checkbox actually produces findings (previously the
+        /// reflection probe looked for an instance Validate(Document) that did
+        /// not exist on this static class and silently no-op'd). Exact-duplicate
+        /// findings (same element + message) are de-duped.
+        /// </summary>
+        public static List<ValidationResult> Validate(Document doc)
+        {
+            var results = new List<ValidationResult>();
+            if (doc == null) return results;
+            if (LoadRules().Count == 0) return results;
+
+            var cats = new List<BuiltInCategory>
+            {
+                BuiltInCategory.OST_Conduit,
+                BuiltInCategory.OST_CableTray,
+                BuiltInCategory.OST_PipeCurves,
+                BuiltInCategory.OST_DuctCurves,
+                BuiltInCategory.OST_FlexPipeCurves,
+                BuiltInCategory.OST_FlexDuctCurves,
+                BuiltInCategory.OST_Wire,
+            };
+
+            List<Element> sources;
+            try
+            {
+                sources = new FilteredElementCollector(doc)
+                    .WhereElementIsNotElementType()
+                    .WherePasses(new ElementMulticategoryFilter(cats))
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"SeparationValidator.Validate collect: {ex.Message}");
+                return results;
+            }
+
+            var seen = new HashSet<string>();
+            foreach (var src in sources)
+            {
+                try
+                {
+                    foreach (var r in ValidateElement(doc, src))
+                    {
+                        string key = (r?.ElementId?.Value ?? 0L) + "|" + (r?.Message ?? "");
+                        if (seen.Add(key)) results.Add(r);
+                    }
+                }
+                catch (Exception ex) { StingTools.Core.StingLog.Warn($"SeparationValidator.Validate {src?.Id}: {ex.Message}"); }
+            }
+            return results;
+        }
+
         private static bool Match(string rulePattern, string actual)
             => rulePattern == "*" || string.Equals(rulePattern, actual, StringComparison.OrdinalIgnoreCase);
 

--- a/StingTools/Data/Placement/STING_CATEGORY_TO_SEED_MAP.json
+++ b/StingTools/Data/Placement/STING_CATEGORY_TO_SEED_MAP.json
@@ -1,0 +1,40 @@
+{
+  "version": "v1",
+  "description": "Explicit map from a placement rule's CategoryFilter to the default STING seed family (Data/Seeds/<seedId>.json) that the engine should build/load when the project has no manufacturer family for that category. This is the missing link that lets 'tick a category, run, and place even with no family loaded' work end-to-end. Mirrors the tag-family seed convention (category -> seed -> stamp -> load). The engine's ResolveSymbol consults this AFTER (a) already-loaded families and (b) FamilyTypeRegex/VariantHint, and BEFORE skipping with SkippedNoSymbol.",
+  "notes": [
+    "seedId is the file stem under StingTools/Data/Seeds/ (without .json).",
+    "Built seed families land in <project>/_BIM_COORD/Families/Seeds/ and are stamped STING_SEED_FAMILY_TXT = seedId so SwapToManufacturer can later swap them.",
+    "Categories with seed=null are intentionally seedless: Conduits/Pipes are MEP curves (routing, not family instances); Stairs are structural host elements."
+  ],
+  "map": [
+    { "category": "Lighting Fixtures",         "seed": "STING_SEED_LightingFixture" },
+    { "category": "Lighting Devices",          "seed": "STING_SEED_LightingDevice" },
+    { "category": "Electrical Fixtures",       "seed": "STING_SEED_ElectricalFixture" },
+    { "category": "Electrical Equipment",      "seed": "STING_SEED_ElectricalEquipment" },
+    { "category": "Junction Boxes",            "seed": "STING_SEED_JunctionBox" },
+    { "category": "Communication Devices",     "seed": "STING_SEED_CommunicationDevice" },
+    { "category": "Data Devices",              "seed": "STING_SEED_DataDevice" },
+    { "category": "Telephone Devices",         "seed": "STING_SEED_TelephoneDevice" },
+    { "category": "Security Devices",          "seed": "STING_SEED_SecurityDevice" },
+    { "category": "Fire Alarm Devices",        "seed": "STING_SEED_FireAlarmDevice" },
+    { "category": "Nurse Call Devices",        "seed": "STING_SEED_NurseCallDevice" },
+    { "category": "Air Terminals",             "seed": "STING_SEED_AirTerminal" },
+    { "category": "Sprinklers",                "seed": "STING_SEED_Sprinkler" },
+    { "category": "Mechanical Equipment",      "seed": "STING_SEED_MechanicalEquipment" },
+    { "category": "Mechanical Control Devices", "seed": "STING_SEED_MechanicalControlDevice" },
+    { "category": "Duct Accessories",          "seed": "STING_SEED_DuctAccessory" },
+    { "category": "Plumbing Fixtures",         "seed": "STING_SEED_PlumbingFixture" },
+    { "category": "Plumbing Equipment",        "seed": "STING_SEED_PlumbingEquipment" },
+    { "category": "Fire Protection",           "seed": "STING_SEED_FireProtection" },
+    { "category": "Specialty Equipment",       "seed": "STING_SEED_SpecialityEquipment" },
+    { "category": "Furniture",                 "seed": "STING_SEED_Furniture" },
+    { "category": "Casework",                  "seed": "STING_SEED_Casework" },
+    { "category": "Doors",                     "seed": "STING_SEED_Door" },
+    { "category": "Windows",                   "seed": "STING_SEED_Window" },
+    { "category": "Parking",                   "seed": "STING_SEED_Parking" },
+    { "category": "Generic Models",            "seed": "STING_SEED_GenericModel" },
+    { "category": "Conduits",                  "seed": null },
+    { "category": "Pipes",                     "seed": null },
+    { "category": "Stairs",                    "seed": null }
+  ]
+}

--- a/StingTools/Data/Placement/STING_PLACEMENT_RULES.mk-electrical.json
+++ b/StingTools/Data/Placement/STING_PLACEMENT_RULES.mk-electrical.json
@@ -168,6 +168,7 @@
     {
       "RuleId": "mk-switch-1g-light",
       "CategoryFilter": "Lighting Devices",
+      "FamilyTypeRegex": "(?i)switch|1.?gang|1g|single|sp\\b",
       "RoomFilter": "(?i).*",
       "AnchorType": "DOOR_LATCH_SIDE",
       "MountingHeightMm": 1350,
@@ -191,6 +192,7 @@
     {
       "RuleId": "mk-switch-2g-light",
       "CategoryFilter": "Lighting Devices",
+      "FamilyTypeRegex": "(?i)switch|2.?gang|2g|twin|double",
       "RoomFilter": "(?i)living|kitchen|hall|bedroom|dining",
       "AnchorType": "DOOR_LATCH_SIDE",
       "MountingHeightMm": 1350,
@@ -214,6 +216,7 @@
     {
       "RuleId": "mk-switch-3g-light",
       "CategoryFilter": "Lighting Devices",
+      "FamilyTypeRegex": "(?i)switch|3.?gang|3g|triple",
       "RoomFilter": "(?i)hall|landing|conference|board|office",
       "AnchorType": "DOOR_LATCH_SIDE",
       "MountingHeightMm": 1350,

--- a/StingTools/Docs/DocAutomationExtCommands.cs
+++ b/StingTools/Docs/DocAutomationExtCommands.cs
@@ -3126,7 +3126,7 @@ namespace StingTools.Docs
 
                         // INT-0 — ExternalIdentifier is the stable 22-char IFC
                         // GlobalId, not the volatile Revit ElementId.
-                        string globalId = StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(el.UniqueId);
+                        string globalId = StingTools.IfcResults.IfcGuidEncoder.FromElementGoldStandard(el);
                         WriteRow(wsComp, compRow++,
                             assetName, createdBy, createdOn, typeName, roomName,
                             assetName, "Revit", "IfcElement", globalId,

--- a/StingTools/Docs/DocAutomationExtCommands.cs
+++ b/StingTools/Docs/DocAutomationExtCommands.cs
@@ -3124,9 +3124,12 @@ namespace StingTools.Docs
                         string assetId = ParameterHelpers.GetString(el, ParamRegistry.ASSET_ID);
                         if (string.IsNullOrEmpty(assetId)) assetId = tag1;
 
+                        // INT-0 — ExternalIdentifier is the stable 22-char IFC
+                        // GlobalId, not the volatile Revit ElementId.
+                        string globalId = StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(el.UniqueId);
                         WriteRow(wsComp, compRow++,
                             assetName, createdBy, createdOn, typeName, roomName,
-                            assetName, "Revit", "IfcElement", el.Id.ToString(),
+                            assetName, "Revit", "IfcElement", globalId,
                             serial, installDate, warrStart,
                             tag1, barcode, assetId);
                         cobieComponentCount++;

--- a/StingTools/Docs/HandoverExportCommands.cs
+++ b/StingTools/Docs/HandoverExportCommands.cs
@@ -147,7 +147,14 @@ namespace StingTools.Docs
                     string mark = HandoverHelper.Gp(el, BuiltInParameter.ALL_MODEL_MARK);
                     string sysName = HandoverHelper.Gs(el, ParamRegistry.SYS);
 
-                    compLines.Add($"{Esc(tag1)},STING Tools,{DateTime.Now:yyyy-MM-dd},{Esc(typeKey)},{Esc(space)},{Esc(desc)},,,,{Esc(tag1)},{el.Id},{Esc(sysName)}");
+                    // INT-0 — the COBie Component external identifier must be the
+                    // stable 22-char IFC GlobalId, not the volatile Revit
+                    // ElementId (which changes across sessions/exports). This is
+                    // the join key that lets COBie reconcile against the IFC,
+                    // Speckle applicationId, and the server identity map.
+                    string assetId = StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(el.UniqueId);
+
+                    compLines.Add($"{Esc(tag1)},STING Tools,{DateTime.Now:yyyy-MM-dd},{Esc(typeKey)},{Esc(space)},{Esc(desc)},,,,{Esc(tag1)},{Esc(assetId)},{Esc(sysName)}");
                 }
 
                 // ── System sheet ──

--- a/StingTools/Docs/HandoverExportCommands.cs
+++ b/StingTools/Docs/HandoverExportCommands.cs
@@ -152,7 +152,9 @@ namespace StingTools.Docs
                     // ElementId (which changes across sessions/exports). This is
                     // the join key that lets COBie reconcile against the IFC,
                     // Speckle applicationId, and the server identity map.
-                    string assetId = StingTools.IfcResults.IfcGuidEncoder.FromRevitUniqueId(el.UniqueId);
+                    // Prefer Revit's own exporter GUID (gold standard) for a live
+                    // Element; falls back to the canonical string encoder off-Revit.
+                    string assetId = StingTools.IfcResults.IfcGuidEncoder.FromElementGoldStandard(el);
 
                     compLines.Add($"{Esc(tag1)},STING Tools,{DateTime.Now:yyyy-MM-dd},{Esc(typeKey)},{Esc(space)},{Esc(desc)},,,,{Esc(tag1)},{Esc(assetId)},{Esc(sysName)}");
                 }

--- a/StingTools/IfcResults/IfcGuidEncoder.cs
+++ b/StingTools/IfcResults/IfcGuidEncoder.cs
@@ -1,34 +1,40 @@
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace StingTools.IfcResults
 {
     /// <summary>
-    /// Canonical IFC GlobalId encoding per the buildingSMART specification —
-    /// the exact algorithm Autodesk's RevitIFC <c>GUIDUtil.ConvertToIFCGuid</c>,
-    /// IfcOpenShell, and xbim all implement. Converts a 128-bit .NET
-    /// <see cref="Guid"/> to the 22-character base64-ish string over the
-    /// alphabet <c>0-9 A-Z a-z _ $</c>, grouping the 16 bytes as
+    /// IFC GlobalId encoding per the buildingSMART specification. Converts a
+    /// 128-bit .NET <see cref="Guid"/> to the 22-character base64-ish string over
+    /// the alphabet <c>0-9 A-Z a-z _ $</c>, grouping the 16 bytes as
     /// <c>1 / 3 / 3 / 3 / 3 / 3</c> bytes → <c>2 / 4 / 4 / 4 / 4 / 4</c> chars.
+    /// The base64 compression (<see cref="FromGuid"/>) is the canonical
+    /// algorithm — identical to Autodesk RevitIFC <c>GUIDUtil.ConvertToIFCGuid</c>,
+    /// IfcOpenShell, and xbim — and is pinned by an independently-verified
+    /// reference vector in <c>StingTools.Boq.Tests/IfcGuidEncoderTests.cs</c>.
     ///
     /// <para><b>Revit UniqueId → IFC GlobalId.</b> A Revit
     /// <c>Element.UniqueId</c> is a 45-char string:
-    /// <c>&lt;36-char episode GUID&gt;-&lt;8-hex element id&gt;</c>. It is NOT a
-    /// valid <c>IfcGloballyUniqueId</c>. Revit's IFC exporter derives the
-    /// GlobalId by XOR-folding the trailing element id into the low 4 bytes of
-    /// the episode GUID and then base64-compressing the result — so the element
-    /// id MUST be folded in (two elements created in the same episode share the
-    /// GUID part and differ only in the suffix). <see cref="FromRevitUniqueId"/>
-    /// reproduces that, so the value matches what an actual Revit IFC export
-    /// writes for the same element (verified by a pinned test vector in
-    /// <c>StingTools.Boq.Tests/IfcGuidEncoderTests.cs</c>).</para>
+    /// <c>&lt;36-char episode GUID&gt;-&lt;8-hex suffix&gt;</c>. It is NOT a valid
+    /// <c>IfcGloballyUniqueId</c>. <see cref="FromRevitUniqueId"/> reconstructs the
+    /// export GUID per the documented relationship — the suffix is XOR-folded into
+    /// the GUID's low 4 bytes (because <c>suffix = origLow4 XOR elementId</c>, the
+    /// fold places the true element id in those bytes), then base64-compressed. The
+    /// fold MUST happen: two elements created in the same episode share the GUID
+    /// part and differ only in the suffix.</para>
     ///
-    /// <para>For a live <c>Element</c> the gold-standard is
-    /// <c>Autodesk.Revit.DB.IFC.ExporterIFCUtils.CreateGUID(el)</c>; this
-    /// string encoder is the equivalent for the BOQ snapshot path (which only
-    /// carries a UniqueId string) and is intentionally the single resolver so
-    /// BOQ rows and COBie Components for the same element produce identical
-    /// GlobalIds.</para>
+    /// <para><b>Verification scope (read before trusting for external interop).</b>
+    /// The compression is proven canonical. The UniqueId→GUID *reconstruction*
+    /// follows the documented episode+XOR-suffix algorithm and is element-id
+    /// sensitive, but is NOT pinned against a real Revit IFC export, so exact
+    /// equality with what Revit's exporter writes is asserted only at the
+    /// compression layer. For a guaranteed match where a live <c>Element</c> is
+    /// available, use <see cref="FromElementGoldStandard"/>, which calls
+    /// <c>ExporterIFCUtils.CreateGUID(el)</c> at runtime via reflection. This
+    /// string encoder is the equivalent for the BOQ snapshot path (UniqueId string
+    /// only) and is the single resolver so BOQ rows and COBie Components for the
+    /// same element produce identical GlobalIds.</para>
     /// </summary>
     public static class IfcGuidEncoder
     {
@@ -61,21 +67,25 @@ namespace StingTools.IfcResults
             if (!Guid.TryParse(guidPart, out var g))
                 return SanitiseFallback(uniqueId);
 
-            // Parse the trailing element-id hex (chars after the '-' at index 36).
-            uint elementId = 0;
+            // Parse the trailing suffix hex (chars after the '-' at index 36).
+            // NOTE: this value is the UniqueId *suffix*, not the element id itself
+            // (suffix = original-low-4-bytes XOR elementId). XOR-folding the suffix
+            // into the GUID's low 4 bytes therefore yields the true element id in
+            // those bytes — exactly the export-GUID reconstruction.
+            uint suffix = 0;
             if (uniqueId.Length > 37 && uniqueId[36] == '-')
             {
                 string idHex = uniqueId.Substring(37);
-                // 64-bit element ids (Revit 2024+) can exceed 8 hex chars; fold
+                // 64-bit element ids (Revit 2024+) can give a longer suffix; fold
                 // the low 32 bits, matching the documented 32-bit XOR.
-                // TODO-VERIFY-API: confirm >32-bit element-id folding against a
-                // real Revit 2024+ export; the live-element gold standard is
-                // ExporterIFCUtils.CreateGUID(el).
+                // TODO-VERIFY-API: confirm >32-bit suffix folding against a real
+                // Revit 2024+ export; the live-element gold standard is
+                // FromElementGoldStandard (ExporterIFCUtils.CreateGUID).
                 if (long.TryParse(idHex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out long parsed))
-                    elementId = unchecked((uint)parsed);
+                    suffix = unchecked((uint)parsed);
             }
 
-            return FromGuid(FoldElementId(g, elementId));
+            return FromGuid(FoldSuffix(g, suffix));
         }
 
         /// <summary>
@@ -115,21 +125,85 @@ namespace StingTools.IfcResults
         }
 
         /// <summary>
-        /// XOR an element id into the low 4 bytes of a GUID (big-endian), the
-        /// fold Revit's exporter applies before compressing. Returns the GUID
-        /// unchanged for element id 0.
+        /// XOR the UniqueId suffix into the low 4 bytes of a GUID (big-endian),
+        /// the fold Revit's exporter applies before compressing. Because
+        /// <c>suffix = origLow4 XOR elementId</c>, the result carries the true
+        /// element id in those bytes. Returns the GUID unchanged for suffix 0.
         /// </summary>
-        private static Guid FoldElementId(Guid g, uint elementId)
+        private static Guid FoldSuffix(Guid g, uint suffix)
         {
-            if (elementId == 0) return g;
+            if (suffix == 0) return g;
             byte[] b = g.ToByteArray();
             // The GUID's logical last 4 bytes are Data4[4..7] = b[12..15],
             // stored big-endian in .NET's array.
-            b[12] ^= (byte)((elementId >> 24) & 0xFF);
-            b[13] ^= (byte)((elementId >> 16) & 0xFF);
-            b[14] ^= (byte)((elementId >> 8) & 0xFF);
-            b[15] ^= (byte)(elementId & 0xFF);
+            b[12] ^= (byte)((suffix >> 24) & 0xFF);
+            b[13] ^= (byte)((suffix >> 16) & 0xFF);
+            b[14] ^= (byte)((suffix >> 8) & 0xFF);
+            b[15] ^= (byte)(suffix & 0xFF);
             return new Guid(b);
+        }
+
+        /// <summary>
+        /// Gold-standard IFC GlobalId for a live Revit <c>Element</c>: calls
+        /// <c>Autodesk.Revit.DB.IFC.ExporterIFCUtils.CreateGUID(Element)</c> at
+        /// runtime via reflection, returning the EXACT GlobalId Revit's IFC
+        /// exporter assigns. <c>RevitAPIIFC.dll</c> is loaded inside Revit but is
+        /// intentionally NOT a compile-time reference of StingTools (mirrors the
+        /// policy in <c>ClashExportContext.TryGetIfcGuid</c>), so this resolves the
+        /// type by name. Falls back to <see cref="FromRevitUniqueId"/> (the
+        /// canonical string reconstruction) when RevitAPIIFC is unavailable — e.g.
+        /// in unit tests or a non-Revit host.
+        /// <para><paramref name="element"/> is typed <see cref="object"/> so this
+        /// assembly needs no IFC reference and the fallback is unit-testable with a
+        /// stub exposing a string <c>UniqueId</c> property.</para>
+        /// </summary>
+        public static string FromElementGoldStandard(object element)
+        {
+            if (element == null) return "";
+            string uniqueId = element.GetType().GetProperty("UniqueId")?.GetValue(element) as string ?? "";
+            try
+            {
+                // TODO-VERIFY-API: confirm the ExporterIFCUtils.CreateGUID(Element)
+                // overload + the "RevitAPIIFC" assembly name on the target Revit
+                // (2025/2026/2027) — both have been stable but are version-sensitive.
+                var t = Type.GetType("Autodesk.Revit.DB.IFC.ExporterIFCUtils, RevitAPIIFC");
+                var m = t?.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                    .FirstOrDefault(x => x.Name == "CreateGUID"
+                        && x.GetParameters().Length == 1
+                        && x.GetParameters()[0].ParameterType.Name == "Element");
+                if (m != null && m.Invoke(null, new[] { element }) is string s && !string.IsNullOrEmpty(s))
+                    return s;
+            }
+            catch (Exception ex)
+            {
+                WarnGoldStandardOnce(ex.Message);
+            }
+            // Canonical string reconstruction (compression verified; fold per the
+            // documented episode + XOR-suffix algorithm).
+            return FromRevitUniqueId(uniqueId);
+        }
+
+        private static bool _goldStandardWarned;
+
+        private static void WarnGoldStandardOnce(string msg)
+        {
+            if (_goldStandardWarned) return;
+            _goldStandardWarned = true;
+            // Log via reflection so this file stays dependency-free — it is linked
+            // standalone into StingTools.Boq.Tests (no StingTools.Core reference).
+            // Resolves StingLog inside the real plugin; silently no-ops in tests.
+            // Logging must never break a COBie/handover export.
+            try
+            {
+                Type.GetType("StingTools.Core.StingLog, StingTools")?
+                    .GetMethod("Warn", new[] { typeof(string) })?
+                    .Invoke(null, new object[]
+                    {
+                        "IfcGuidEncoder.FromElementGoldStandard: ExporterIFCUtils.CreateGUID " +
+                        "unavailable; using canonical string encoder. " + msg
+                    });
+            }
+            catch { }
         }
 
         private static string SanitiseFallback(string raw)

--- a/StingTools/IfcResults/IfcGuidEncoder.cs
+++ b/StingTools/IfcResults/IfcGuidEncoder.cs
@@ -1,26 +1,38 @@
 using System;
+using System.Globalization;
 
 namespace StingTools.IfcResults
 {
     /// <summary>
-    /// Canonical IFC GUID encoding per buildingSMART specification (the
-    /// algorithm that IfcOpenShell, xbim, and Revit's own
-    /// ExporterIFCUtils.CreateGUID all implement). Converts a 128-bit
-    /// .NET <see cref="Guid"/> or 16-byte buffer to a 22-character
-    /// base64-ish string using the alphabet
-    /// <c>0-9 A-Z a-z _ $</c>.
+    /// Canonical IFC GlobalId encoding per the buildingSMART specification —
+    /// the exact algorithm Autodesk's RevitIFC <c>GUIDUtil.ConvertToIFCGuid</c>,
+    /// IfcOpenShell, and xbim all implement. Converts a 128-bit .NET
+    /// <see cref="Guid"/> to the 22-character base64-ish string over the
+    /// alphabet <c>0-9 A-Z a-z _ $</c>, grouping the 16 bytes as
+    /// <c>1 / 3 / 3 / 3 / 3 / 3</c> bytes → <c>2 / 4 / 4 / 4 / 4 / 4</c> chars.
     ///
-    /// Why this matters: Revit's <c>Element.UniqueId</c> is a 45-char
-    /// string (32-hex GUID + dash + 8-hex episode counter) which is NOT
-    /// a valid <c>IfcGloballyUniqueId</c>. DIALux evo silently rewrites
-    /// malformed GUIDs on import, breaking STING's Phase 181 round-trip
-    /// match-by-GUID logic. This encoder produces a 22-char string DIALux
-    /// preserves verbatim, so the imported IFC's <c>IfcSpace.GlobalId</c>
-    /// matches the original Revit element on the way back.
+    /// <para><b>Revit UniqueId → IFC GlobalId.</b> A Revit
+    /// <c>Element.UniqueId</c> is a 45-char string:
+    /// <c>&lt;36-char episode GUID&gt;-&lt;8-hex element id&gt;</c>. It is NOT a
+    /// valid <c>IfcGloballyUniqueId</c>. Revit's IFC exporter derives the
+    /// GlobalId by XOR-folding the trailing element id into the low 4 bytes of
+    /// the episode GUID and then base64-compressing the result — so the element
+    /// id MUST be folded in (two elements created in the same episode share the
+    /// GUID part and differ only in the suffix). <see cref="FromRevitUniqueId"/>
+    /// reproduces that, so the value matches what an actual Revit IFC export
+    /// writes for the same element (verified by a pinned test vector in
+    /// <c>StingTools.Boq.Tests/IfcGuidEncoderTests.cs</c>).</para>
+    ///
+    /// <para>For a live <c>Element</c> the gold-standard is
+    /// <c>Autodesk.Revit.DB.IFC.ExporterIFCUtils.CreateGUID(el)</c>; this
+    /// string encoder is the equivalent for the BOQ snapshot path (which only
+    /// carries a UniqueId string) and is intentionally the single resolver so
+    /// BOQ rows and COBie Components for the same element produce identical
+    /// GlobalIds.</para>
     /// </summary>
     public static class IfcGuidEncoder
     {
-        /// <summary>Conversion alphabet (64 characters) per IFC base64 spec.</summary>
+        /// <summary>Conversion alphabet (64 characters) per the IFC base64 spec.</summary>
         private static readonly char[] Alphabet =
         {
             '0','1','2','3','4','5','6','7','8','9',
@@ -34,74 +46,96 @@ namespace StingTools.IfcResults
         };
 
         /// <summary>
-        /// Encode a Revit Element.UniqueId into a 22-char IFC GUID.
-        /// The UniqueId's GUID component is used; the trailing
-        /// "-XXXXXXXX" episode counter is ignored (it identifies
-        /// linked-document instances, which DIALux doesn't carry).
+        /// Encode a Revit <c>Element.UniqueId</c> into its canonical 22-char IFC
+        /// GlobalId — the same value Revit's IFC exporter assigns. The 8-hex
+        /// element-id suffix is XOR-folded into the GUID's low 4 bytes before
+        /// compression (this is what makes per-element GlobalIds distinct within
+        /// one episode).
         /// </summary>
         public static string FromRevitUniqueId(string uniqueId)
         {
             if (string.IsNullOrEmpty(uniqueId)) return "";
-            // The GUID is the first 36 chars: 8-4-4-4-12 hex digits.
+
+            // The episode GUID is the first 36 chars: 8-4-4-4-12 hex digits.
             string guidPart = uniqueId.Length >= 36 ? uniqueId.Substring(0, 36) : uniqueId;
             if (!Guid.TryParse(guidPart, out var g))
                 return SanitiseFallback(uniqueId);
-            return FromGuid(g);
+
+            // Parse the trailing element-id hex (chars after the '-' at index 36).
+            uint elementId = 0;
+            if (uniqueId.Length > 37 && uniqueId[36] == '-')
+            {
+                string idHex = uniqueId.Substring(37);
+                // 64-bit element ids (Revit 2024+) can exceed 8 hex chars; fold
+                // the low 32 bits, matching the documented 32-bit XOR.
+                // TODO-VERIFY-API: confirm >32-bit element-id folding against a
+                // real Revit 2024+ export; the live-element gold standard is
+                // ExporterIFCUtils.CreateGUID(el).
+                if (long.TryParse(idHex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out long parsed))
+                    elementId = unchecked((uint)parsed);
+            }
+
+            return FromGuid(FoldElementId(g, elementId));
         }
 
-        /// <summary>Encode a System.Guid as a 22-char IFC GUID.</summary>
+        /// <summary>
+        /// Encode a <see cref="Guid"/> as a 22-char IFC GlobalId using the
+        /// canonical 2/4/4/4/4/4 grouping (Autodesk RevitIFC
+        /// <c>ConvertToIFCGuid</c>).
+        /// </summary>
         public static string FromGuid(Guid g)
         {
-            // IFC GUID encoding takes the 128-bit value MSB-first and packs it
-            // into 22 base64-alphabet digits via three groups of 32 / 64 / 32 bits.
-            byte[] bytes = g.ToByteArray();
-            // Convert from .NET's little-endian first-three-fields layout to MSB-first.
-            byte[] msb = new byte[16];
-            msb[0] = bytes[3]; msb[1] = bytes[2]; msb[2] = bytes[1]; msb[3] = bytes[0];
-            msb[4] = bytes[5]; msb[5] = bytes[4];
-            msb[6] = bytes[7]; msb[7] = bytes[6];
-            for (int i = 8; i < 16; i++) msb[i] = bytes[i];
+            // .NET stores Data1/2/3 little-endian and Data4 big-endian in the
+            // 16-byte array. The index pattern below reconstructs the GUID's
+            // logical big-endian value, identical to RevitIFC GUIDUtil and the
+            // original buildingSMART CreateGuid_64.c.
+            byte[] b = g.ToByteArray();
+            ulong[] num = new ulong[6];
+            num[0] = b[3];
+            num[1] = (ulong)b[2] * 65536 + (ulong)b[1] * 256 + b[0];
+            num[2] = (ulong)b[5] * 65536 + (ulong)b[4] * 256 + b[7];
+            num[3] = (ulong)b[6] * 65536 + (ulong)b[8] * 256 + b[9];
+            num[4] = (ulong)b[10] * 65536 + (ulong)b[11] * 256 + b[12];
+            num[5] = (ulong)b[13] * 65536 + (ulong)b[14] * 256 + b[15];
 
-            // Three packs: 2 / 6 / 8 bytes → 3 / 9 / 12 base-64 digits respectively
-            // (3 + 9 + 12 = 24 source digits, but the 22-char form drops the
-            // leading 2 high-order bits → output 22 chars).
-            char[] result = new char[22];
-            int idx = 0;
-            idx += PackBytesToBase64(msb, 0, 3, result, idx);   // 24 bits → 4 chars (drop leading 0)
-            idx += PackBytesToBase64(msb, 3, 6, result, idx);   // 48 bits → 8 chars
-            idx += PackBytesToBase64(msb, 9, 7, result, idx);   // 56 bits but encode as 64-bit pad to 10 chars
-            // The above produces 22 chars exactly when called as a 4 + 8 + 10 split.
-            return new string(result);
+            char[] buf = new char[22];
+            int offset = 0;
+            for (int i = 0; i < 6; i++)
+            {
+                int len = (i == 0) ? 2 : 4;   // 2 + 5×4 = 22
+                ulong value = num[i];
+                for (int jj = 0; jj < len; jj++)
+                {
+                    buf[offset + len - jj - 1] = Alphabet[(int)(value % 64)];
+                    value /= 64;
+                }
+                offset += len;
+            }
+            return new string(buf);
         }
 
-        private static int PackBytesToBase64(byte[] src, int srcStart, int byteCount,
-            char[] dest, int destStart)
+        /// <summary>
+        /// XOR an element id into the low 4 bytes of a GUID (big-endian), the
+        /// fold Revit's exporter applies before compressing. Returns the GUID
+        /// unchanged for element id 0.
+        /// </summary>
+        private static Guid FoldElementId(Guid g, uint elementId)
         {
-            ulong value = 0;
-            for (int i = 0; i < byteCount; i++)
-                value = (value << 8) | src[srcStart + i];
-
-            // Each base-64 digit consumes 6 bits → ceil(byteCount * 8 / 6) digits.
-            int digitCount = (byteCount * 8 + 5) / 6;
-            // The IFC convention drops leading zero digits so 3 bytes (24 bits)
-            // produce 4 digits, 6 bytes → 8 digits, 7 bytes → 10 digits.
-            if (byteCount == 3) digitCount = 4;
-            else if (byteCount == 6) digitCount = 8;
-            else if (byteCount == 7) digitCount = 10;
-
-            char[] tmp = new char[digitCount];
-            for (int i = digitCount - 1; i >= 0; i--)
-            {
-                tmp[i] = Alphabet[(int)(value & 0x3F)];
-                value >>= 6;
-            }
-            for (int i = 0; i < digitCount; i++) dest[destStart + i] = tmp[i];
-            return digitCount;
+            if (elementId == 0) return g;
+            byte[] b = g.ToByteArray();
+            // The GUID's logical last 4 bytes are Data4[4..7] = b[12..15],
+            // stored big-endian in .NET's array.
+            b[12] ^= (byte)((elementId >> 24) & 0xFF);
+            b[13] ^= (byte)((elementId >> 16) & 0xFF);
+            b[14] ^= (byte)((elementId >> 8) & 0xFF);
+            b[15] ^= (byte)(elementId & 0xFF);
+            return new Guid(b);
         }
 
         private static string SanitiseFallback(string raw)
         {
-            // Last-resort: hash the raw string into a Guid and encode that.
+            // Last-resort for malformed input: hash the raw string into a Guid
+            // and encode that through the same canonical path.
             using var md5 = System.Security.Cryptography.MD5.Create();
             byte[] bytes = md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(raw ?? ""));
             return FromGuid(new Guid(bytes));

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -321,21 +321,10 @@ namespace StingTools.UI
             // Header actions
             var actions = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 14, 0),
                 VerticalAlignment = VerticalAlignment.Center };
-            // Linked-models toggle — quantify loaded Revit links too. Read-only:
-            // linked rows carry no host id, so they're not cost-stamped or
-            // selectable in the host (tagged "[Linked: <model>]" in the Note).
-            var linkChk = new System.Windows.Controls.CheckBox
-            {
-                Content = "Incl. links",
-                IsChecked = StingTools.BOQ.BOQCostManager.IncludeLinkedModels,
-                VerticalAlignment = VerticalAlignment.Center,
-                Margin = new Thickness(0, 0, 12, 0),
-                ToolTip = "Include quantities from loaded Revit links. Linked rows are read-only " +
-                          "(not cost-stamped or selectable in the host) and tagged \"[Linked: <model>]\"."
-            };
-            linkChk.Checked   += (s, e) => { StingTools.BOQ.BOQCostManager.IncludeLinkedModels = true;  DispatchAction("BOQRefresh"); };
-            linkChk.Unchecked += (s, e) => { StingTools.BOQ.BOQCostManager.IncludeLinkedModels = false; DispatchAction("BOQRefresh"); };
-            actions.Children.Add(linkChk);
+            // Per-link takeoff chooser. Persisted per project — flexible (pick
+            // which links) + sustainable (survives reopen). Linked rows are
+            // read-only (not cost-stamped / selectable in host).
+            actions.Children.Add(BuildHeaderBtn("⛓ Links", () => ChooseLinkedModels()));
 
             actions.Children.Add(BuildHeaderBtn("↻ Refresh", () => DispatchAction("BOQRefresh")));
             actions.Children.Add(BuildHeaderBtn("Set Budget", () => ShowBudgetDialog()));
@@ -343,6 +332,67 @@ namespace StingTools.UI
             grid.Children.Add(actions);
 
             return grid;
+        }
+
+        /// <summary>
+        /// Per-link takeoff chooser: lists the loaded Revit links, pre-ticks the
+        /// persisted selection, and on OK saves it (per project) + refreshes.
+        /// Reuses the multi-select StingListPicker (checkbox list). Reading links
+        /// is read-only — safe from the dockable-pane UI thread.
+        /// </summary>
+        private void ChooseLinkedModels()
+        {
+            try
+            {
+                var doc = Doc;
+                if (doc == null) return;
+
+                var loaded = new List<string>();
+                try
+                {
+                    var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    var links = new FilteredElementCollector(doc)
+                        .OfClass(typeof(RevitLinkInstance)).Cast<RevitLinkInstance>();
+                    foreach (var rli in links)
+                    {
+                        Document ld = null; try { ld = rli.GetLinkDocument(); } catch { }
+                        if (ld == null) continue;                 // unloaded
+                        string t; try { t = ld.Title; } catch { continue; }
+                        if (!string.IsNullOrWhiteSpace(t) && seen.Add(t)) loaded.Add(t);
+                    }
+                }
+                catch (Exception ex) { StingLog.Warn($"ChooseLinkedModels enum: {ex.Message}"); }
+
+                if (loaded.Count == 0)
+                {
+                    TaskDialog.Show("STING — Linked models",
+                        "No loaded Revit links found in this model.\n\n" +
+                        "Link a model and load it (Manage → Links), then choose it here.");
+                    return;
+                }
+
+                var current = StingTools.BOQ.BOQCostManager.GetIncludedLinkTitles(doc);
+                var items = loaded
+                    .OrderBy(t => t, StringComparer.OrdinalIgnoreCase)
+                    .Select(t => new StingTools.Select.StingListPicker.ListItem
+                    {
+                        Label = t,
+                        Detail = current.Contains(t) ? "included" : "",
+                        IsSelected = current.Contains(t)
+                    })
+                    .ToList();
+
+                var picked = StingTools.Select.StingListPicker.Show(
+                    "STING — Linked models in takeoff",
+                    "Tick the links whose quantities to include. Linked rows are read-only — " +
+                    "not cost-stamped or selectable in the host (tagged \"[Linked: <model>]\").",
+                    items, allowMultiSelect: true);
+                if (picked == null) return;   // cancelled — leave selection unchanged
+
+                StingTools.BOQ.BOQCostManager.SetIncludedLinkTitles(doc, picked.Select(p => p.Label));
+                DispatchAction("BOQRefresh");
+            }
+            catch (Exception ex) { StingLog.Error("BOQ ChooseLinkedModels", ex); }
         }
 
         private Button BuildHeaderBtn(string text, Action click)

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -1050,6 +1050,14 @@ namespace StingTools.UI
         {
             try
             {
+                // P0.2 — defensively clear any stale inline registration left over by
+                // a prior aborted run (command that threw before the dispatcher's
+                // finally cleared the statics) so we never inherit a foreign sink.
+                StingTools.Select.StingListPicker.InlineHost = null;
+                StingTools.Select.StingListPicker.InlineHostDoc = null;
+                StingTools.Select.StingListPicker.InlineTitleSink = null;
+                StingResultPanel.InlineSink = null;
+
                 HighlightActionButton(btn);
                 if (_actionReportTitle != null) _actionReportTitle.Text = label;
                 if (_actionReportHost != null)
@@ -1064,6 +1072,7 @@ namespace StingTools.UI
                 // clears these in StingCommandHandler.Execute's finally, once the
                 // (synchronous) command has run.
                 StingTools.Select.StingListPicker.InlineHost = _actionReportHost;
+                StingTools.Select.StingListPicker.InlineHostDoc = Doc;   // P0.1 — txn-state guard target
                 StingTools.Select.StingListPicker.InlineTitleSink = t => { if (_actionReportTitle != null) _actionReportTitle.Text = t; };
                 StingResultPanel.InlineSink = b => ShowInlineResult(b);
 

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -88,6 +88,105 @@ namespace StingTools.UI
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private string _activeProfileId = "";
 
+        // P1.3 — per-project UI state persistence. Grouping mode, display currency,
+        // hidden-column set and the expand/collapse sets reset every session unless
+        // we persist them to <project>/_BIM_COORD/boq_ui_state.json. Best-effort:
+        // a read/write failure logs a warning and never blocks the UI. The flag
+        // gates SaveUiState so a write can't fire mid-load (during Build) and
+        // clobber the file we're still reading.
+        private bool _uiStateLoaded;
+        // Set when a persisted OpenSections set was loaded so the first RefreshAsync
+        // doesn't auto-expand-all over a deliberately-empty (collapse-all) state.
+        private bool _suppressAutoOpenOnce;
+
+        private sealed class BoqUiState
+        {
+            public string GroupingMode { get; set; }
+            public string DisplayCurrency { get; set; }
+            public List<string> HiddenColumns { get; set; }
+            public List<string> OpenSections { get; set; }
+            public List<string> OpenMaterialSections { get; set; }
+        }
+
+        private string UiStatePath()
+        {
+            try
+            {
+                string parent = System.IO.Path.GetDirectoryName(Doc?.PathName ?? "");
+                if (string.IsNullOrEmpty(parent)) return null;   // unsaved doc — no persistence
+                return System.IO.Path.Combine(parent, "_BIM_COORD", "boq_ui_state.json");
+            }
+            catch { return null; }
+        }
+
+        /// <summary>Load persisted UI state into the fields before Build() so the
+        /// combos/toggles/columns open in the user's last configuration. Best-effort.</summary>
+        private void LoadUiState()
+        {
+            try
+            {
+                string path = UiStatePath();
+                if (path != null && System.IO.File.Exists(path))
+                {
+                    var st = Newtonsoft.Json.JsonConvert.DeserializeObject<BoqUiState>(
+                        System.IO.File.ReadAllText(path));
+                    if (st != null)
+                    {
+                        if (!string.IsNullOrWhiteSpace(st.GroupingMode)
+                            && Enum.TryParse<BoqGroupingMode>(st.GroupingMode, out var gm))
+                            _groupingMode = gm;
+                        if (string.Equals(st.DisplayCurrency, "USD", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(st.DisplayCurrency, "UGX", StringComparison.OrdinalIgnoreCase))
+                            _displayCurrency = st.DisplayCurrency.ToUpperInvariant();
+                        if (st.HiddenColumns != null)
+                        {
+                            _hiddenColumns.Clear();
+                            foreach (var c in st.HiddenColumns)
+                                if (!string.IsNullOrWhiteSpace(c)) _hiddenColumns.Add(c.Trim());
+                        }
+                        if (st.OpenSections != null)
+                        {
+                            _openSections.Clear();
+                            foreach (var s in st.OpenSections)
+                                if (!string.IsNullOrWhiteSpace(s)) _openSections.Add(s);
+                            _suppressAutoOpenOnce = true;   // honour a persisted collapse-all
+                        }
+                        if (st.OpenMaterialSections != null)
+                        {
+                            _openMaterialSections.Clear();
+                            foreach (var s in st.OpenMaterialSections)
+                                if (!string.IsNullOrWhiteSpace(s)) _openMaterialSections.Add(s);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"BOQ LoadUiState: {ex.Message}"); }
+            _uiStateLoaded = true;
+        }
+
+        /// <summary>Persist the current UI state. Best-effort, fired on each change.</summary>
+        private void SaveUiState()
+        {
+            if (!_uiStateLoaded) return;   // don't write a partial state during Build
+            try
+            {
+                string path = UiStatePath();
+                if (path == null) return;
+                var st = new BoqUiState
+                {
+                    GroupingMode = _groupingMode.ToString(),
+                    DisplayCurrency = _displayCurrency,
+                    HiddenColumns = _hiddenColumns.ToList(),
+                    OpenSections = _openSections.ToList(),
+                    OpenMaterialSections = _openMaterialSections.ToList()
+                };
+                System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path));
+                System.IO.File.WriteAllText(path,
+                    Newtonsoft.Json.JsonConvert.SerializeObject(st, Newtonsoft.Json.Formatting.Indented));
+            }
+            catch (Exception ex) { StingLog.Warn($"BOQ SaveUiState: {ex.Message}"); }
+        }
+
         // Phase 108d: transient status-bar message support. FlashHint() writes
         // a short amber line into _paragraphCoverage for 4s, then restores the
         // coverage summary. Used when we cancel an edit on a model-derived cell.
@@ -128,6 +227,7 @@ namespace StingTools.UI
         public BOQCostManagerPanel(Document doc)
         {
             Doc = doc;
+            LoadUiState();   // P1.3 — restore grouping / currency / columns / expand sets before Build
             Build();
             // Register the inline-result sink so panel-driven commands render their
             // results in-panel. Cleared on Unloaded so a closed panel can't capture
@@ -310,10 +410,13 @@ namespace StingTools.UI
             // Currency toggle
             var ccyPanel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 10, 0),
                 VerticalAlignment = VerticalAlignment.Center };
-            _ugxToggle = new ToggleButton { Content = "UGX", IsChecked = true, Width = 52, Height = 26, Margin = new Thickness(0, 0, 4, 0) };
-            _usdToggle = new ToggleButton { Content = "USD", IsChecked = false, Width = 52, Height = 26 };
-            _ugxToggle.Checked += (s, e) => { _usdToggle.IsChecked = false; _displayCurrency = "UGX"; RefreshDisplay(); };
-            _usdToggle.Checked += (s, e) => { _ugxToggle.IsChecked = false; _displayCurrency = "USD"; RefreshDisplay(); };
+            // P1.3 — reflect the persisted currency (handlers attach AFTER the
+            // initializer, so setting IsChecked here doesn't fire RefreshDisplay).
+            bool usd = _displayCurrency == "USD";
+            _ugxToggle = new ToggleButton { Content = "UGX", IsChecked = !usd, Width = 52, Height = 26, Margin = new Thickness(0, 0, 4, 0) };
+            _usdToggle = new ToggleButton { Content = "USD", IsChecked = usd, Width = 52, Height = 26 };
+            _ugxToggle.Checked += (s, e) => { _usdToggle.IsChecked = false; _displayCurrency = "UGX"; SaveUiState(); RefreshDisplay(); };
+            _usdToggle.Checked += (s, e) => { _ugxToggle.IsChecked = false; _displayCurrency = "USD"; SaveUiState(); RefreshDisplay(); };
             ccyPanel.Children.Add(_ugxToggle);
             ccyPanel.Children.Add(_usdToggle);
             Grid.SetColumn(ccyPanel, 1);
@@ -550,6 +653,7 @@ namespace StingTools.UI
                 // works on whichever tab is active (mirrors the BOQ set pattern).
                 _openMaterialSections.Clear();
                 foreach (var k in MaterialCategoryKeys()) _openMaterialSections.Add(k);
+                SaveUiState();
                 RebuildSectionsView();
                 RebuildMaterialsTab();
             }));
@@ -557,6 +661,7 @@ namespace StingTools.UI
             {
                 _openSections.Clear();
                 _openMaterialSections.Clear();
+                SaveUiState();
                 RebuildSectionsView();
                 RebuildMaterialsTab();
             }));
@@ -596,13 +701,18 @@ namespace StingTools.UI
                 ("Source model",        BoqGroupingMode.SourceModel),
             })
                 groupCombo.Items.Add(new ComboBoxItem { Content = opt.Item1, Tag = opt.Item2 });
-            groupCombo.SelectedIndex = 0;
+            // P1.3 — preselect the persisted grouping (before the handler attaches, so
+            // it doesn't fire a redundant RefreshAsync during Build).
+            var preSel = groupCombo.Items.Cast<ComboBoxItem>()
+                .FirstOrDefault(ci => ci.Tag is BoqGroupingMode gm && gm == _groupingMode);
+            groupCombo.SelectedItem = preSel ?? groupCombo.Items[0];
             groupCombo.SelectionChanged += (s, e) =>
             {
                 if (groupCombo.SelectedItem is ComboBoxItem ci && ci.Tag is BoqGroupingMode m && m != _groupingMode)
                 {
                     _groupingMode = m;
                     _openSections.Clear();   // section keys change — let RefreshAsync re-open all
+                    SaveUiState();
                     RefreshAsync();          // re-aggregate + re-group from the model
                 }
             };
@@ -686,6 +796,7 @@ namespace StingTools.UI
                 mi.Click += (s, e) =>
                 {
                     if (mi.IsChecked) _hiddenColumns.Remove(key); else _hiddenColumns.Add(key);
+                    SaveUiState();
                     RebuildSectionsView();
                 };
                 menu.Items.Add(mi);
@@ -721,6 +832,7 @@ namespace StingTools.UI
                 }
                 catch (Exception ex) { StingLog.Warn($"ApplyPrintProfile({profileId}): {ex.Message}"); }
             }
+            SaveUiState();   // P1.3 — a profile sets the visible-column set; persist it
             RebuildSectionsView();
         }
 
@@ -1168,9 +1280,12 @@ namespace StingTools.UI
                 _boq = BOQCostManager.BuildBOQDocument(Doc, null, _groupingMode);
                 _health = BOQCostManager.ComputeBOQHealth(_boq);
                 LoadSnapshotDropdown();
-                // On first load open every section; subsequent refreshes preserve state
-                if (_openSections.Count == 0 && _boq != null)
+                // On first load open every section; subsequent refreshes preserve
+                // state. P1.3 — suppress the auto-open-all once, so a persisted
+                // "collapse all" (empty OpenSections) isn't immediately re-expanded.
+                if (_openSections.Count == 0 && _boq != null && !_suppressAutoOpenOnce)
                     foreach (var s in _boq.Sections) _openSections.Add(SectionKey(s));
+                _suppressAutoOpenOnce = false;
                 RefreshDisplay();
             }
             catch (Exception ex)
@@ -1409,8 +1524,8 @@ namespace StingTools.UI
             };
             // Capture the stable key — sec will be a new instance on next rebuild
             string capturedKey = secKey;
-            expander.Expanded  += (s, e) => _openSections.Add(capturedKey);
-            expander.Collapsed += (s, e) => _openSections.Remove(capturedKey);
+            expander.Expanded  += (s, e) => { _openSections.Add(capturedKey); SaveUiState(); };
+            expander.Collapsed += (s, e) => { _openSections.Remove(capturedKey); SaveUiState(); };
             return expander;
         }
 
@@ -2076,8 +2191,8 @@ namespace StingTools.UI
                     Background = Brushes.White
                 };
                 string matKey = grp.Key;   // capture — grp is reused by the loop
-                expander.Expanded  += (s, e) => _openMaterialSections.Add(matKey);
-                expander.Collapsed += (s, e) => _openMaterialSections.Remove(matKey);
+                expander.Expanded  += (s, e) => { _openMaterialSections.Add(matKey); SaveUiState(); };
+                expander.Collapsed += (s, e) => { _openMaterialSections.Remove(matKey); SaveUiState(); };
 
                 var grid = new DataGrid
                 {

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -212,6 +212,11 @@ namespace StingTools.UI
         private UIElement _actionReportEmpty;    // "select an action" placeholder
         private Button _selectedActionBtn;       // for highlight reset
         private Button _linksBtn;                 // header "⛓ Links (N)" badge
+        private bool _inlineResultPosted;        // did the current action render inline?
+        // Invoked by StingCommandHandler.Execute's finally when a dispatched action
+        // completes, so the Actions pane can resolve its "Running…" placeholder even
+        // when the command reported via its own TaskDialog (not StingResultPanel).
+        internal static Action PendingActionResolve;
         private ToggleButton _ugxToggle, _usdToggle;
 
         // Slice 1 (5D workspace) — inline result region. Panel-driven actions set
@@ -1191,10 +1196,18 @@ namespace StingTools.UI
                 // into the Actions report pane instead of popups. The dispatcher
                 // clears these in StingCommandHandler.Execute's finally, once the
                 // (synchronous) command has run.
+                _inlineResultPosted = false;   // set true by the sink if a result lands inline
                 StingTools.Select.StingListPicker.InlineHost = _actionReportHost;
                 StingTools.Select.StingListPicker.InlineHostDoc = Doc;   // P0.1 — txn-state guard target
                 StingTools.Select.StingListPicker.InlineTitleSink = t => { if (_actionReportTitle != null) _actionReportTitle.Text = t; };
-                StingResultPanel.InlineSink = b => ShowInlineResult(b);
+                StingResultPanel.InlineSink = b => { _inlineResultPosted = true; ShowInlineResult(b); };
+
+                // Resolve the "Running…" placeholder when the command finishes. Some
+                // actions still report via their own TaskDialog (Slice-3 conversion
+                // pending) — without this the pane would sit on "Running…" forever
+                // and look broken. The dispatcher invokes + clears this in its finally.
+                string lbl = label;
+                PendingActionResolve = () => ResolveActionPane(lbl);
 
                 StingCommandHandler.SetExtraParam("InlineHost", "1");
                 DispatchAction(tag);
@@ -2584,6 +2597,37 @@ namespace StingTools.UI
                     };
                 if (_inlineResultRegion != null) _inlineResultRegion.Visibility = Visibility.Visible;
             }
+        }
+
+        /// <summary>Called when a dispatched Actions command finishes. If it
+        /// already rendered a result inline (StingResultPanel-based), do nothing.
+        /// Otherwise the action reported via its own TaskDialog (Slice-3 conversion
+        /// pending), so replace the "Running…" placeholder with a completion note
+        /// rather than leaving the pane stuck.</summary>
+        private void ResolveActionPane(string label)
+        {
+            try
+            {
+                if (_inlineResultPosted) return;                 // result already shown inline
+                if (_actionReportHost == null) return;
+                if (_actionReportTitle != null) _actionReportTitle.Text = label;
+                var sp = new StackPanel { Margin = new Thickness(14) };
+                sp.Children.Add(new TextBlock
+                {
+                    Text = $"✓  “{label}” completed.",
+                    FontWeight = FontWeights.SemiBold, Foreground = NavyBrush,
+                    FontSize = 12, TextWrapping = TextWrapping.Wrap
+                });
+                sp.Children.Add(new TextBlock
+                {
+                    Text = "This action reported in its own dialog. Inline reporting for every " +
+                           "action is being rolled out — those already converted render here directly.",
+                    Foreground = Brushes.Gray, FontSize = 11, TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 6, 0, 0)
+                });
+                _actionReportHost.Child = sp;
+            }
+            catch (Exception ex) { StingLog.Warn($"ResolveActionPane: {ex.Message}"); }
         }
 
         // ══════════════════════════════════════════════════════════════════

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -1488,6 +1488,12 @@ namespace StingTools.UI
                 Header = "Src", Binding = new Binding(nameof(BOQItemViewModel.SourceLabel)),
                 Width = new DataGridLength(48), IsReadOnly = true
             });
+            // P1.1 — host vs linked-model provenance ("Host" / link Title).
+            AddIfVisible("Model", new DataGridTextColumn
+            {
+                Header = "Model", Binding = new Binding(nameof(BOQItemViewModel.ModelDisplay)),
+                Width = new DataGridLength(120), IsReadOnly = true
+            });
             AddIfVisible("Confidence", BuildConfidenceColumn());
             AddIfVisible("Carbon", new DataGridTextColumn
             {
@@ -2690,6 +2696,12 @@ namespace StingTools.UI
         // P2.1 — spatial columns.
         public string LevelDisplay => _item.Level ?? "";
         public string LocationDisplay => _item.Location ?? "";
+
+        // P1.1 — provenance as a first-class column. SourceModel is "" / null for
+        // host elements and the linked model's Title for linked rows; surface it as
+        // "Host" so a QS can sort/filter host-vs-link without parsing the Note text.
+        public string ModelDisplay
+            => string.IsNullOrWhiteSpace(_item.SourceModel) ? "Host" : _item.SourceModel;
 
         public string LineRef => _item.BOQLineRef ?? "";
 

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -321,6 +321,22 @@ namespace StingTools.UI
             // Header actions
             var actions = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 14, 0),
                 VerticalAlignment = VerticalAlignment.Center };
+            // Linked-models toggle — quantify loaded Revit links too. Read-only:
+            // linked rows carry no host id, so they're not cost-stamped or
+            // selectable in the host (tagged "[Linked: <model>]" in the Note).
+            var linkChk = new System.Windows.Controls.CheckBox
+            {
+                Content = "Incl. links",
+                IsChecked = StingTools.BOQ.BOQCostManager.IncludeLinkedModels,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 12, 0),
+                ToolTip = "Include quantities from loaded Revit links. Linked rows are read-only " +
+                          "(not cost-stamped or selectable in the host) and tagged \"[Linked: <model>]\"."
+            };
+            linkChk.Checked   += (s, e) => { StingTools.BOQ.BOQCostManager.IncludeLinkedModels = true;  DispatchAction("BOQRefresh"); };
+            linkChk.Unchecked += (s, e) => { StingTools.BOQ.BOQCostManager.IncludeLinkedModels = false; DispatchAction("BOQRefresh"); };
+            actions.Children.Add(linkChk);
+
             actions.Children.Add(BuildHeaderBtn("↻ Refresh", () => DispatchAction("BOQRefresh")));
             actions.Children.Add(BuildHeaderBtn("Set Budget", () => ShowBudgetDialog()));
             Grid.SetColumn(actions, 2);

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -989,6 +989,14 @@ namespace StingTools.UI
                         Foreground = Brushes.Gray, FontSize = 11, TextWrapping = TextWrapping.Wrap,
                         Margin = new Thickness(14)
                     };
+                // Slice 1.5 — route this command's input pickers AND result panels
+                // into the Actions report pane instead of popups. The dispatcher
+                // clears these in StingCommandHandler.Execute's finally, once the
+                // (synchronous) command has run.
+                StingTools.Select.StingListPicker.InlineHost = _actionReportHost;
+                StingTools.Select.StingListPicker.InlineTitleSink = t => { if (_actionReportTitle != null) _actionReportTitle.Text = t; };
+                StingResultPanel.InlineSink = b => ShowInlineResult(b);
+
                 StingCommandHandler.SetExtraParam("InlineHost", "1");
                 DispatchAction(tag);
             }

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -112,6 +112,7 @@ namespace StingTools.UI
         private TextBlock _actionReportTitle;    // right-pane header (= action label)
         private UIElement _actionReportEmpty;    // "select an action" placeholder
         private Button _selectedActionBtn;       // for highlight reset
+        private Button _linksBtn;                 // header "⛓ Links (N)" badge
         private ToggleButton _ugxToggle, _usdToggle;
 
         // Slice 1 (5D workspace) — inline result region. Panel-driven actions set
@@ -324,7 +325,8 @@ namespace StingTools.UI
             // Per-link takeoff chooser. Persisted per project — flexible (pick
             // which links) + sustainable (survives reopen). Linked rows are
             // read-only (not cost-stamped / selectable in host).
-            actions.Children.Add(BuildHeaderBtn("⛓ Links", () => ChooseLinkedModels()));
+            _linksBtn = BuildHeaderBtn("⛓ Links", () => ChooseLinkedModels());
+            actions.Children.Add(_linksBtn);
 
             actions.Children.Add(BuildHeaderBtn("↻ Refresh", () => DispatchAction("BOQRefresh")));
             actions.Children.Add(BuildHeaderBtn("Set Budget", () => ShowBudgetDialog()));
@@ -390,6 +392,7 @@ namespace StingTools.UI
                 if (picked == null) return;   // cancelled — leave selection unchanged
 
                 StingTools.BOQ.BOQCostManager.SetIncludedLinkTitles(doc, picked.Select(p => p.Label));
+                UpdateLinksBadge();
                 DispatchAction("BOQRefresh");
             }
             catch (Exception ex) { StingLog.Error("BOQ ChooseLinkedModels", ex); }
@@ -590,6 +593,7 @@ namespace StingTools.UI
                 ("Level → work section",BoqGroupingMode.LevelThenWorkSection),
                 ("Zone",                BoqGroupingMode.Zone),
                 ("Location",            BoqGroupingMode.Location),
+                ("Source model",        BoqGroupingMode.SourceModel),
             })
                 groupCombo.Items.Add(new ComboBoxItem { Content = opt.Item1, Tag = opt.Item2 });
             groupCombo.SelectedIndex = 0;
@@ -1181,9 +1185,20 @@ namespace StingTools.UI
         private void RefreshDisplay()
         {
             RefreshMetrics();
+            UpdateLinksBadge();
             if (_boq == null) return;
             RebuildSectionsView();
             RebuildMaterialsTab();
+        }
+
+        /// <summary>Show the count of included links on the header button —
+        /// "⛓ Links" when none, "⛓ Links (N)" when N are in the takeoff.</summary>
+        private void UpdateLinksBadge()
+        {
+            if (_linksBtn == null) return;
+            int n = 0;
+            try { if (Doc != null) n = StingTools.BOQ.BOQCostManager.GetIncludedLinkTitles(Doc).Count; } catch { }
+            _linksBtn.Content = n > 0 ? $"⛓ Links ({n})" : "⛓ Links";
         }
 
         /// <summary>

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -102,10 +102,32 @@ namespace StingTools.UI
         private TabItem _materialsTab;
         private ToggleButton _ugxToggle, _usdToggle;
 
+        // Slice 1 (5D workspace) — inline result region. Panel-driven actions set
+        // the InlineHost=1 ExtraParam so commands route their result here via
+        // BOQInlineResults.Post() instead of StingResultPanel.Show(). This is the
+        // "zero external reporting popups" convention the rest of the workspace
+        // (Schedule / cash-flow / sweep) follows.
+        private Border _inlineResultRegion;   // collapsed by default
+        private Border _inlineResultHost;     // receives BuildInlineContent output
+        private TextBlock _inlineResultTitle;
+        private Action<StingResultPanel.Builder> _inlineSink;  // stable delegate for sink (de)registration
+
         public BOQCostManagerPanel(Document doc)
         {
             Doc = doc;
             Build();
+            // Register the inline-result sink so panel-driven commands render their
+            // results in-panel. Cleared on Unloaded so a closed panel can't capture
+            // a later ribbon/workflow invocation (those fall back to .Show()).
+            // Hold the delegate in a field — a method-group re-conversion would be a
+            // fresh instance, so ReferenceEquals must compare the stored delegate.
+            _inlineSink = PostInlineResult;
+            BOQInlineResults.Sink = _inlineSink;
+            this.Unloaded += (s, e) =>
+            {
+                if (ReferenceEquals(BOQInlineResults.Sink, _inlineSink))
+                    BOQInlineResults.Sink = null;
+            };
             RefreshAsync();
         }
 
@@ -206,6 +228,12 @@ namespace StingTools.UI
             DockPanel.SetDock(root.Children[3], Dock.Top);
             root.Children.Add(BuildFooter());
             DockPanel.SetDock(root.Children[4], Dock.Bottom);
+
+            // Inline result region — sits directly above the footer, collapsed
+            // until a panel-driven command posts a result (no popup).
+            var resultRegion = BuildInlineResultRegion();
+            root.Children.Add(resultRegion);
+            DockPanel.SetDock(resultRegion, Dock.Bottom);
 
             // Main content — TabControl with Bill of Quantities + Materials tabs
             _sectionsPanel = new StackPanel { Margin = new Thickness(0) };
@@ -869,6 +897,16 @@ namespace StingTools.UI
             right.Children.Add(BuildActionBtn("Reconcile PS", AmberBrush));
             right.Children.Add(BuildActionBtn("Import Excel", NavyBrush));
             right.Children.Add(BuildActionBtn("Export ↗", GreenBrush));
+
+            // Slice 1 — QTO IFC export (estimator feed). Routes its result inline
+            // via the InlineHost convention rather than a StingResultPanel window.
+            var qtoBtn = BuildActionBtn("⛁ QTO IFC", NavyBrush);
+            qtoBtn.ToolTip = "Export an IFC4 file with base quantities + Pset_StingCost "
+                + "(NRM2 / unit rate) so an external estimator (CostX / iTWO / Candy) can "
+                + "ingest measured quantities. Result shows inline below — no popup.";
+            qtoBtn.Click += (s, e) => ExportQtoIfcInline();
+            right.Children.Add(qtoBtn);
+
             var tenderBtn = BuildActionBtn("★ Tender BOQ", OrangeBrush);
             tenderBtn.ToolTip = "Export a tender-grade NRM2 Bill of Quantities with cover, document control, "
                 + "preliminaries, preambles, bills, collections and grand summary — QS presentation format.";
@@ -2054,6 +2092,101 @@ namespace StingTools.UI
         }
 
         // ══════════════════════════════════════════════════════════════════
+        //  Slice 1 — inline result region (the no-popup convention)
+        //  A panel-driven command sets InlineHost=1, runs on the Revit thread,
+        //  builds a StingResultPanel.Builder, and calls BOQInlineResults.Post().
+        //  That invokes PostInlineResult below, which marshals to the UI thread
+        //  and renders the SAME section/metric/table tree via
+        //  StingResultPanel.BuildInlineContent — no window appears.
+        // ══════════════════════════════════════════════════════════════════
+
+        private Border BuildInlineResultRegion()
+        {
+            _inlineResultRegion = new Border
+            {
+                Background = Brushes.White,
+                BorderBrush = BorderColor,
+                BorderThickness = new Thickness(0, 1, 0, 0),
+                Padding = new Thickness(12, 8, 12, 10),
+                Visibility = Visibility.Collapsed
+            };
+
+            var dock = new DockPanel { LastChildFill = true };
+
+            // Header row: title + close ✕
+            var headerGrid = new Grid();
+            headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            _inlineResultTitle = new TextBlock
+            {
+                Text = "Result", FontSize = 12, FontWeight = FontWeights.Bold,
+                Foreground = NavyBrush, VerticalAlignment = VerticalAlignment.Center
+            };
+            headerGrid.Children.Add(_inlineResultTitle);
+            var closeBtn = new Button
+            {
+                Content = "✕", Width = 24, Height = 22, Padding = new Thickness(0),
+                Background = Brushes.Transparent, Foreground = Brushes.Gray,
+                BorderThickness = new Thickness(0), Cursor = Cursors.Hand, FontSize = 12,
+                ToolTip = "Dismiss result"
+            };
+            closeBtn.Click += (s, e) =>
+            {
+                if (_inlineResultRegion != null) _inlineResultRegion.Visibility = Visibility.Collapsed;
+                if (_inlineResultHost != null) _inlineResultHost.Child = null;
+            };
+            Grid.SetColumn(closeBtn, 1);
+            headerGrid.Children.Add(closeBtn);
+            DockPanel.SetDock(headerGrid, Dock.Top);
+            dock.Children.Add(headerGrid);
+
+            _inlineResultHost = new Border { Margin = new Thickness(0, 6, 0, 0) };
+            dock.Children.Add(_inlineResultHost);
+
+            _inlineResultRegion.Child = dock;
+            return _inlineResultRegion;
+        }
+
+        /// <summary>
+        /// Sink target for BOQInlineResults.Post — called on the Revit API thread
+        /// by panel-driven commands. Marshals to the UI thread and renders the
+        /// result inline. Safe if the region hasn't been built yet (no-op).
+        /// </summary>
+        private void PostInlineResult(StingResultPanel.Builder b)
+        {
+            if (b == null) return;
+            try
+            {
+                Dispatcher.BeginInvoke(new Action(() => ShowInlineResult(b)));
+            }
+            catch (Exception ex) { StingLog.Error("BOQ PostInlineResult", ex); }
+        }
+
+        private void ShowInlineResult(StingResultPanel.Builder b)
+        {
+            if (_inlineResultRegion == null || _inlineResultHost == null) return;
+            try
+            {
+                if (_inlineResultTitle != null)
+                    _inlineResultTitle.Text = string.IsNullOrEmpty(b.Title) ? "Result" : b.Title;
+                _inlineResultHost.Child = StingResultPanel.BuildInlineContent(b);
+                _inlineResultRegion.Visibility = Visibility.Visible;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("BOQ ShowInlineResult", ex);
+                // Last-ditch fallback so the user still sees something.
+                if (_inlineResultHost != null)
+                    _inlineResultHost.Child = new TextBlock
+                    {
+                        Text = b.Subtitle ?? "Action completed.", TextWrapping = TextWrapping.Wrap,
+                        Foreground = NavyBrush
+                    };
+                if (_inlineResultRegion != null) _inlineResultRegion.Visibility = Visibility.Visible;
+            }
+        }
+
+        // ══════════════════════════════════════════════════════════════════
         //  Phase 108j — inline tender-setup view
         //  Swaps the BOQ/Materials TabControl for the 4-tab tender setup
         //  built via BOQTenderDialog.CreateInlineTabs. Avoids a modal
@@ -2183,6 +2316,23 @@ namespace StingTools.UI
         }
 
         /// <summary>
+        /// Slice 1 — QTO IFC export driven inline. Sets InlineHost=1 so
+        /// BOQExportIfcQtoCommand posts its result to the inline region instead
+        /// of opening a StingResultPanel window. refreshAfter:false — the export
+        /// doesn't mutate the BOQ view (it stamps + writes a file, then rolls the
+        /// export transaction back), so a 300ms rebuild would only churn the grid.
+        /// </summary>
+        private void ExportQtoIfcInline()
+        {
+            try
+            {
+                StingCommandHandler.SetExtraParam("InlineHost", "1");
+                DispatchAction("BOQExportIfcQto", refreshAfter: false);
+            }
+            catch (Exception ex) { StingLog.Error("BOQ ExportQtoIfcInline", ex); }
+        }
+
+        /// <summary>
         /// Fire-and-forget dispatch of a command tag to the shared ExternalEvent.
         /// When refreshAfter=true (default) schedules a 300ms RefreshAsync so
         /// the panel picks up side effects of the command (spatial changes,
@@ -2202,6 +2352,34 @@ namespace StingTools.UI
                 }
             }
             catch (Exception ex) { StingLog.Error($"BOQ DispatchAction({tag})", ex); }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  BOQInlineResults — static mailbox bridging Revit-thread commands to the
+    //  panel's inline result region. A command that was invoked with the
+    //  InlineHost=1 ExtraParam builds a StingResultPanel.Builder and calls
+    //  Post(builder) instead of builder.Show(). When a BOQCostManagerPanel is
+    //  alive it has registered Sink; otherwise Post returns false and the caller
+    //  falls back to the popup (ribbon / workflow callers keep working).
+    // ══════════════════════════════════════════════════════════════════════
+    internal static class BOQInlineResults
+    {
+        // Set by BOQCostManagerPanel on construction, cleared on Unloaded.
+        public static Action<StingResultPanel.Builder> Sink;
+
+        public static bool Active => Sink != null;
+
+        /// <summary>
+        /// Hand a built result to the live panel. Returns true if a sink consumed
+        /// it (caller must NOT also .Show()); false if no panel is hosting.
+        /// </summary>
+        public static bool Post(StingResultPanel.Builder b)
+        {
+            var s = Sink;
+            if (s == null || b == null) return false;
+            try { s(b); return true; }
+            catch (Exception ex) { StingLog.Error("BOQInlineResults.Post", ex); return false; }
         }
     }
 

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -61,6 +61,10 @@ namespace StingTools.UI
         // open/closed set after every rate edit. Composite (Discipline|NRM2|Name)
         // is stable across rebuilds.
         private readonly HashSet<string> _openSections = new HashSet<string>();
+        // Slice 1.5 — Materials tab expand state, mirrors _openSections so the
+        // Expand-all / Collapse-all toolbar buttons (and per-section chevrons)
+        // drive the Materials tab too and survive a rebuild.
+        private readonly HashSet<string> _openMaterialSections = new HashSet<string>();
         private string _activeSnapshotLabel = "";
         private readonly Dictionary<string, double> _snapshotDeltas = new Dictionary<string, double>();
 
@@ -100,6 +104,14 @@ namespace StingTools.UI
         private StackPanel _sectionsPanel;
         private TabControl _mainTabs;
         private TabItem _materialsTab;
+        // Slice 1.5 — Actions tab master-detail: buttons on the left, a single
+        // inline report pane on the right that renders the last-clicked action's
+        // result (no popup). Reuses the BOQInlineResults sink via ShowInlineResult.
+        private TabItem _actionsTab;
+        private Border _actionReportHost;        // right-pane content holder
+        private TextBlock _actionReportTitle;    // right-pane header (= action label)
+        private UIElement _actionReportEmpty;    // "select an action" placeholder
+        private Button _selectedActionBtn;       // for highlight reset
         private ToggleButton _ugxToggle, _usdToggle;
 
         // Slice 1 (5D workspace) — inline result region. Panel-driven actions set
@@ -253,7 +265,8 @@ namespace StingTools.UI
             // command from P0 → P8 inline. Replaces the fragmented dock-
             // panel sub-sections so users have one place to find every
             // cost workflow.
-            _mainTabs.Items.Add(new TabItem { Header = "Actions", Content = BuildActionsTab() });
+            _actionsTab = new TabItem { Header = "Actions", Content = BuildActionsTab() };
+            _mainTabs.Items.Add(_actionsTab);
 
             // Phase 108j — wrap the main TabControl in a Grid host so
             // ShowTenderSetupInline can stack the tender-setup UI on top,
@@ -464,12 +477,19 @@ namespace StingTools.UI
             {
                 _openSections.Clear();
                 if (_boq != null) foreach (var s2 in _boq.Sections) _openSections.Add(SectionKey(s2));
+                // Slice 1.5 — also expand every Materials category so the button
+                // works on whichever tab is active (mirrors the BOQ set pattern).
+                _openMaterialSections.Clear();
+                foreach (var k in MaterialCategoryKeys()) _openMaterialSections.Add(k);
                 RebuildSectionsView();
+                RebuildMaterialsTab();
             }));
             sp.Children.Add(MakeToolbarButton("⊟ Collapse all", () =>
             {
                 _openSections.Clear();
+                _openMaterialSections.Clear();
                 RebuildSectionsView();
+                RebuildMaterialsTab();
             }));
 
             // Phase 108c: toggle hides/shows the NRM2 description strip on
@@ -778,13 +798,83 @@ namespace StingTools.UI
                      "Export ICMS3 cost + carbon ledger — £ + kgCO₂e + £/kgCO₂e per ICMS group", true),
                 }));
 
-            return new ScrollViewer
+            var leftRail = new ScrollViewer
             {
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
                 Content = sp,
                 Padding = new Thickness(0)
             };
+
+            // Slice 1.5 — master-detail: action buttons on the left, one inline
+            // report pane on the right rendering the last-clicked action's result
+            // (no popup). A draggable splitter lets the user size the panes.
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1.35, GridUnitType.Star), MinWidth = 360 });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(5) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star), MinWidth = 280 });
+
+            Grid.SetColumn(leftRail, 0);
+            grid.Children.Add(leftRail);
+
+            var splitter = new GridSplitter
+            {
+                Width = 5,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                Background = BorderColor,
+                ResizeBehavior = GridResizeBehavior.PreviousAndNext
+            };
+            Grid.SetColumn(splitter, 1);
+            grid.Children.Add(splitter);
+
+            grid.Children.Add(BuildActionReportPane());   // sets _actionReportHost/Title; column 2
+            return grid;
+        }
+
+        /// <summary>Slice 1.5 — the Actions tab's right-hand inline report pane.
+        /// Header (= action label) + scrollable content host seeded with an
+        /// empty-state hint. Populated by RunActionInline / ShowInlineResult.</summary>
+        private UIElement BuildActionReportPane()
+        {
+            var root = new DockPanel { LastChildFill = true, Margin = new Thickness(8, 0, 0, 0) };
+
+            var header = new Border
+            {
+                Background = NavyBrush,
+                Padding = new Thickness(12, 8, 12, 8),
+                BorderThickness = new Thickness(0, 0, 0, 1),
+                BorderBrush = BorderColor
+            };
+            _actionReportTitle = new TextBlock
+            {
+                Text = "Action result", Foreground = Brushes.White,
+                FontSize = 12, FontWeight = FontWeights.Bold
+            };
+            header.Child = _actionReportTitle;
+            DockPanel.SetDock(header, Dock.Top);
+            root.Children.Add(header);
+
+            _actionReportEmpty = new TextBlock
+            {
+                Text = "Select an action on the left — its result appears here, inline (no popup).",
+                Foreground = Brushes.Gray, FontSize = 11, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(14), VerticalAlignment = VerticalAlignment.Top
+            };
+            _actionReportHost = new Border
+            {
+                Background = Brushes.White, Padding = new Thickness(0),
+                Child = _actionReportEmpty
+            };
+            root.Children.Add(new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Content = _actionReportHost
+            });
+
+            Grid.SetColumn(root, 2);
+            return root;
         }
 
         /// <summary>
@@ -873,8 +963,52 @@ namespace StingTools.UI
                 btn.BorderThickness = new Thickness(1);
             }
 
-            btn.Click += (s, e) => DispatchAction(tag);
+            btn.Click += (s, e) => RunActionInline(btn, label, tag);
             return btn;
+        }
+
+        /// <summary>
+        /// Slice 1.5 — run an Actions-tab command and route its result to the
+        /// right-hand report pane instead of a popup. Highlights the clicked
+        /// button, shows a running placeholder, and sets InlineHost=1 so commands
+        /// that support the inline gate post here (BOQInlineResults →
+        /// ShowInlineResult → the Actions pane). Commands not yet converted still
+        /// pop their own dialog (that's the Slice 3 sweep); the pane still
+        /// responds per-button so the surface is never dead.
+        /// </summary>
+        private void RunActionInline(Button btn, string label, string tag)
+        {
+            try
+            {
+                HighlightActionButton(btn);
+                if (_actionReportTitle != null) _actionReportTitle.Text = label;
+                if (_actionReportHost != null)
+                    _actionReportHost.Child = new TextBlock
+                    {
+                        Text = $"Running “{label}” …\nThe result appears here when the action completes.",
+                        Foreground = Brushes.Gray, FontSize = 11, TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(14)
+                    };
+                StingCommandHandler.SetExtraParam("InlineHost", "1");
+                DispatchAction(tag);
+            }
+            catch (Exception ex) { StingLog.Error("BOQ RunActionInline", ex); }
+        }
+
+        private void HighlightActionButton(Button btn)
+        {
+            try
+            {
+                if (_selectedActionBtn != null && !ReferenceEquals(_selectedActionBtn, btn))
+                {
+                    _selectedActionBtn.BorderBrush = BorderColor;
+                    _selectedActionBtn.BorderThickness = new Thickness(1);
+                }
+                _selectedActionBtn = btn;
+                btn.BorderBrush = NavyBrush;
+                btn.BorderThickness = new Thickness(2);
+            }
+            catch { /* highlight is cosmetic — never break a dispatch */ }
         }
 
         private UIElement BuildFooter()
@@ -1787,6 +1921,17 @@ namespace StingTools.UI
             _materialsTab.Content = BuildMaterialsContent();
         }
 
+        /// <summary>Distinct Materials-tab category keys — must match the
+        /// GroupBy in BuildMaterialsContent so Expand-all seeds the right set.</summary>
+        private IEnumerable<string> MaterialCategoryKeys()
+        {
+            if (_boq == null) return System.Linq.Enumerable.Empty<string>();
+            return _boq.AllItems
+                .Where(i => i.Source == BOQRowSource.Model && i.Quantity > 0)
+                .Select(i => i.Category ?? "(uncategorised)")
+                .Distinct();
+        }
+
         private FrameworkElement BuildMaterialsContent()
         {
             if (_boq == null)
@@ -1818,12 +1963,17 @@ namespace StingTools.UI
                 var expander = new Expander
                 {
                     Header = BuildMaterialSectionHeader(grp.Key, disc, grp.Count(), totalUGX, totalCarbon),
-                    IsExpanded = false,
+                    // Slice 1.5 — seed from the persisted set so Expand-all /
+                    // Collapse-all and manual toggles survive a rebuild.
+                    IsExpanded = _openMaterialSections.Contains(grp.Key),
                     Margin = new Thickness(0, 0, 0, 4),
                     BorderThickness = new Thickness(1),
                     BorderBrush = BorderColor,
                     Background = Brushes.White
                 };
+                string matKey = grp.Key;   // capture — grp is reused by the loop
+                expander.Expanded  += (s, e) => _openMaterialSections.Add(matKey);
+                expander.Collapsed += (s, e) => _openMaterialSections.Remove(matKey);
 
                 var grid = new DataGrid
                 {
@@ -2164,6 +2314,29 @@ namespace StingTools.UI
 
         private void ShowInlineResult(StingResultPanel.Builder b)
         {
+            // Slice 1.5 — when the user is on the Actions tab, render into its
+            // master-detail right pane instead of the global footer region.
+            if (_actionReportHost != null && _mainTabs != null
+                && ReferenceEquals(_mainTabs.SelectedItem, _actionsTab))
+            {
+                try
+                {
+                    if (_actionReportTitle != null && !string.IsNullOrEmpty(b.Title))
+                        _actionReportTitle.Text = b.Title;
+                    _actionReportHost.Child = StingResultPanel.BuildInlineContent(b);
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Error("BOQ ShowInlineResult (actions)", ex);
+                    _actionReportHost.Child = new TextBlock
+                    {
+                        Text = b.Subtitle ?? "Action completed.", TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(14), Foreground = NavyBrush
+                    };
+                }
+                return;
+            }
+
             if (_inlineResultRegion == null || _inlineResultHost == null) return;
             try
             {

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -431,7 +431,15 @@ namespace StingTools.UI
             _linksBtn = BuildHeaderBtn("⛓ Links", () => ChooseLinkedModels());
             actions.Children.Add(_linksBtn);
 
-            actions.Children.Add(BuildHeaderBtn("↻ Refresh", () => DispatchAction("BOQRefresh")));
+            // Explicit Refresh forces a full recompute incl. reloaded links — the
+            // per-link takeoff cache (P1.2) is only auto-invalidated on document
+            // close, so a link Reloaded mid-session would otherwise stay stale.
+            // Passive refreshes (filter / rate edit) keep using the cache for speed.
+            actions.Children.Add(BuildHeaderBtn("↻ Refresh", () =>
+            {
+                try { StingTools.BOQ.BOQCostManager.InvalidateLinkCache(); } catch { }
+                DispatchAction("BOQRefresh");
+            }));
             actions.Children.Add(BuildHeaderBtn("Set Budget", () => ShowBudgetDialog()));
             Grid.SetColumn(actions, 2);
             grid.Children.Add(actions);

--- a/StingTools/UI/BOQCostManagerWindow.cs
+++ b/StingTools/UI/BOQCostManagerWindow.cs
@@ -24,7 +24,17 @@ namespace StingTools.UI
             WindowStartupLocation = WindowStartupLocation.CenterScreen;
             Panel = new BOQCostManagerPanel(doc);
             Content = Panel;
-            Closed += (s, e) => { if (ReferenceEquals(_current, this)) _current = null; };
+            Closed += (s, e) =>
+            {
+                if (ReferenceEquals(_current, this)) _current = null;
+                // P0.2 — the Actions pane is gone; null the process-global inline
+                // sinks so a later command from another surface can't render into
+                // (or pump against) this disposed pane.
+                StingTools.Select.StingListPicker.InlineHost = null;
+                StingTools.Select.StingListPicker.InlineHostDoc = null;
+                StingTools.Select.StingListPicker.InlineTitleSink = null;
+                StingResultPanel.InlineSink = null;
+            };
         }
 
         /// <summary>

--- a/StingTools/UI/PlacementCenter/PlacementCenterBridge.cs
+++ b/StingTools/UI/PlacementCenter/PlacementCenterBridge.cs
@@ -129,11 +129,17 @@ namespace StingTools.UI.PlacementCenter
         }
 
         /// <summary>
-        /// PC-23 — run a user-selected mask of validators. Empty / null mask
-        /// runs the legacy pair (Clearance + Maintenance) so existing call
-        /// sites keep working unchanged. Recognised tokens (case-insensitive):
+        /// Run a user-selected mask of validators. Empty / null mask runs the
+        /// legacy pair (Clearance + Maintenance) so existing call sites keep
+        /// working unchanged. Recognised tokens (case-insensitive):
         /// "Clearance", "Maintenance", "Connectivity", "Fill", "Spec",
         /// "Termination", "Slope", "Separation".
+        ///
+        /// All eight validators live in this assembly (StingTools.Core.Validation),
+        /// so they are called directly with compile-time types — the previous
+        /// reflection path silently no-op'd for "Separation" (a static class
+        /// with no instance Validate(Document)) and would hide any future
+        /// rename behind a runtime miss.
         /// </summary>
         public static List<ValidationResult> RunValidators(Document doc, ISet<string> mask = null)
         {
@@ -142,19 +148,19 @@ namespace StingTools.UI.PlacementCenter
 
             bool wants(string token) => mask == null || mask.Count == 0 || mask.Contains(token);
 
-            if (wants("Clearance"))
-                Try(() => new ClearanceValidator().Validate(doc), all, "ClearanceValidator");
-            if (wants("Maintenance"))
-                Try(() => new MaintenanceClashValidator().Validate(doc), all, "MaintenanceClashValidator");
-
-            // The remaining validators may live in v4/v6 modules — invoke via
-            // reflection so a missing assembly never crashes the panel.
-            if (wants("Connectivity")) RunValidatorReflect("StingTools.Core.Validation.ConnectivityValidator",  doc, all);
-            if (wants("Fill"))         RunValidatorReflect("StingTools.Core.Validation.FillValidator",          doc, all);
-            if (wants("Spec"))         RunValidatorReflect("StingTools.Core.Validation.SpecValidator",          doc, all);
-            if (wants("Termination"))  RunValidatorReflect("StingTools.Core.Validation.TerminationValidator",   doc, all);
-            if (wants("Slope"))        RunValidatorReflect("StingTools.Core.Validation.SlopeValidator",         doc, all);
-            if (wants("Separation"))   RunValidatorReflect("StingTools.Core.Validation.SeparationValidator",    doc, all);
+            if (wants("Clearance"))    Try(() => new ClearanceValidator().Validate(doc),        all, "ClearanceValidator");
+            // "Maintenance" maps to the clash validator (maintenance-clearance
+            // overlap). MaintenanceAccessValidator covers door/route access and
+            // is run by RunAllValidators, not this checklist token.
+            if (wants("Maintenance"))  Try(() => new MaintenanceClashValidator().Validate(doc), all, "MaintenanceClashValidator");
+            if (wants("Connectivity")) Try(() => new ConnectivityValidator().Validate(doc),     all, "ConnectivityValidator");
+            if (wants("Fill"))         Try(() => new FillValidator().Validate(doc),             all, "FillValidator");
+            if (wants("Spec"))         Try(() => new SpecValidator().Validate(doc),             all, "SpecValidator");
+            if (wants("Termination"))  Try(() => new TerminationValidator().Validate(doc),      all, "TerminationValidator");
+            if (wants("Slope"))        Try(() => new SlopeValidator().Validate(doc),            all, "SlopeValidator");
+            // SeparationValidator is a static class — call its Validate(Document)
+            // entry point directly.
+            if (wants("Separation"))   Try(() => SeparationValidator.Validate(doc),             all, "SeparationValidator");
 
             return all;
         }
@@ -163,23 +169,6 @@ namespace StingTools.UI.PlacementCenter
         {
             try { sink.AddRange(action()); }
             catch (Exception ex) { StingLog.Warn($"{name}: {ex.Message}"); }
-        }
-
-        private static void RunValidatorReflect(string typeFullName, Document doc, List<ValidationResult> sink)
-        {
-            try
-            {
-                var t = Type.GetType(typeFullName + ", StingTools");
-                if (t == null) return;
-                var ctor = t.GetConstructor(Type.EmptyTypes);
-                if (ctor == null) return;
-                var inst = ctor.Invoke(null);
-                var m = t.GetMethod("Validate", new[] { typeof(Document) });
-                if (m == null) return;
-                var res = m.Invoke(inst, new object[] { doc }) as IEnumerable<ValidationResult>;
-                if (res != null) sink.AddRange(res);
-            }
-            catch (Exception ex) { StingLog.Warn($"{typeFullName} reflect: {ex.Message}"); }
         }
     }
 }

--- a/StingTools/UI/PlacementCenter/PlacementCenterBridge.cs
+++ b/StingTools/UI/PlacementCenter/PlacementCenterBridge.cs
@@ -37,23 +37,27 @@ namespace StingTools.UI.PlacementCenter
             if (uiDoc?.Document == null) return ids;
             var doc = uiDoc.Document;
 
+            // Both architecture Rooms and MEP Spaces are placeable spatial
+            // elements — collect either so MEP models (rooms in a linked arch
+            // model, Spaces in the host) resolve a non-empty scope.
+            var spatialCats = new[] { BuiltInCategory.OST_Rooms, BuiltInCategory.OST_MEPSpaces };
+            bool IsSpatial(Element el) =>
+                el?.Category != null &&
+                (el.Category.Id.Value == (long)BuiltInCategory.OST_Rooms ||
+                 el.Category.Id.Value == (long)BuiltInCategory.OST_MEPSpaces);
+
             try
             {
                 switch ((scope ?? "ActiveView").ToUpperInvariant())
                 {
                     case "SELECTION":
                         foreach (var id in uiDoc.Selection.GetElementIds())
-                        {
-                            var el = doc.GetElement(id);
-                            if (el != null && el.Category != null &&
-                                el.Category.Id.Value == (long)BuiltInCategory.OST_Rooms)
-                                ids.Add(id);
-                        }
+                            if (IsSpatial(doc.GetElement(id))) ids.Add(id);
                         break;
 
                     case "PROJECT":
                         foreach (var r in new FilteredElementCollector(doc)
-                            .OfCategory(BuiltInCategory.OST_Rooms)
+                            .WherePasses(new ElementMulticategoryFilter(spatialCats))
                             .WhereElementIsNotElementType())
                             ids.Add(r.Id);
                         break;
@@ -62,14 +66,14 @@ namespace StingTools.UI.PlacementCenter
                     default:
                         var view = doc.ActiveView;
                         if (view == null) break;
-                        // 3D / perspective views contain no Room elements —
-                        // warn early so the user isn't left with a silent "0 rooms" result.
+                        // 3D / perspective views contain no Room/Space elements —
+                        // warn early so the user isn't left with a silent "0" result.
                         if (view.ViewType == ViewType.ThreeD || view.ViewType == ViewType.Undefined)
                         {
-                            StingLog.Warn("PlacementCenterBridge.ResolveScope: active view is a 3D/perspective view — rooms resolve to empty. Switch to a plan or section view, or change scope to Project.");
+                            StingLog.Warn("PlacementCenterBridge.ResolveScope: active view is a 3D/perspective view — rooms/spaces resolve to empty. Switch to a plan or section view, or change scope to Project.");
                         }
                         foreach (var r in new FilteredElementCollector(doc, view.Id)
-                            .OfCategory(BuiltInCategory.OST_Rooms)
+                            .WherePasses(new ElementMulticategoryFilter(spatialCats))
                             .WhereElementIsNotElementType())
                             ids.Add(r.Id);
                         break;

--- a/StingTools/UI/PlacementCenter/PlacementRulesViewModel.cs
+++ b/StingTools/UI/PlacementCenter/PlacementRulesViewModel.cs
@@ -89,11 +89,16 @@ namespace StingTools.UI.PlacementCenter
                 "NONE", "BS7671_Z1", "BS7671_Z2", "IEC60364_Z0", "IEC60364_Z1",
             };
 
+        // Constrained to the tokens the engine actually dispatches on
+        // (FixturePlacementEngine.RouteAfterPlacement). NONE is a no-op;
+        // AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT route via the matching
+        // Core/Routing drop engine. WALL/CEILING/FLOOR-follow + CONDUIT_RUN /
+        // TRAY_RUN were removed — no backing router exists and they silently
+        // did nothing.
         public ObservableCollection<string> RoutingModes { get; }
             = new ObservableCollection<string>
             {
-                "NONE", "WALL_FOLLOW", "CEILING_FOLLOW", "FLOOR_FOLLOW",
-                "CONDUIT_RUN", "TRAY_RUN",
+                "NONE", "AUTO_CONDUIT", "AUTO_PIPE", "AUTO_DUCT",
             };
 
         public ObservableCollection<string> RouteFaces { get; }

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -143,6 +143,8 @@
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Heat-map"        Click="OnHeatmap_Click"/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Save view preset" Click="OnSaveViewPreset_Click"
                         ToolTip="Stamp a view preset onto the active view so its scope/template/scale travel with the model."/>
+                <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Learn from model" Click="OnLearnFromModel_Click"
+                        ToolTip="Inspect already-placed fixtures and write STING_PLACEMENT_RULES.learned.json (anchor + mounting height per category/room). Reloads so 'Honour learned offsets' picks it up."/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="GD Study"        Click="OnGDStudy_Click"/>
             </DockPanel>
         </Border>

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -1170,9 +1170,9 @@
                                 Content="Import Rules (Excel)"
                                 ToolTip="Merge rules from an .xlsx workbook into the current set (override on MergeKey match)."/>
                         <Button Style="{StaticResource ToolBtnSecondary}" Width="168" Height="30" Margin="4,3"
-                                Tag="Placement_AutoPopulateCatalogue" Click="OnToolButton_Click"
+                                Click="OnAutoPopulateCatalogue_Click"
                                 Content="Auto-populate Catalogue"
-                                ToolTip="Scan loaded families and auto-populate the placement catalogue with detected fixture types."/>
+                                ToolTip="Scan loaded families and auto-populate the placement catalogue with detected fixture types. Renders in the Report panel."/>
                         <Button Style="{StaticResource ToolBtnSecondary}" Width="100" Height="30" Margin="4,3"
                                 Click="OnAuditSetup_Click"
                                 Content="Audit Setup"
@@ -1191,9 +1191,9 @@
                                 Content="Wall Chase Routing"
                                 ToolTip="Plan wall-chase routing for conduit and pipe in masonry walls."/>
                         <Button Style="{StaticResource ToolBtnSecondary}" Width="168" Height="30" Margin="4,3"
-                                Tag="Placement_ExportNogginRequirements" Click="OnToolButton_Click"
+                                Click="OnNoggin_Click"
                                 Content="Noggin Requirements"
-                                ToolTip="Export noggin / blocking requirements for bracket-mounted fixtures to CSV."/>
+                                ToolTip="Export noggin / blocking requirements for bracket-mounted fixtures to CSV. Renders in the Report panel."/>
                     </WrapPanel>
                 </GroupBox>
 

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -1174,13 +1174,13 @@
                                 Content="Auto-populate Catalogue"
                                 ToolTip="Scan loaded families and auto-populate the placement catalogue with detected fixture types."/>
                         <Button Style="{StaticResource ToolBtnSecondary}" Width="100" Height="30" Margin="4,3"
-                                Tag="Placement_AuditSetup" Click="OnToolButton_Click"
+                                Click="OnAuditSetup_Click"
                                 Content="Audit Setup"
-                                ToolTip="Detect missing DependsOn targets, invalid MergeKeys, and orphaned rules."/>
+                                ToolTip="Detect missing DependsOn targets, invalid MergeKeys, and orphaned rules. Renders in the Report panel."/>
                         <Button Style="{StaticResource ToolBtnSecondary}" Width="100" Height="30" Margin="4,3"
-                                Tag="Placement_Diagnose" Click="OnToolButton_Click"
+                                Click="OnDiagnose_Click"
                                 Content="Diagnose"
-                                ToolTip="Engine trace: anchor resolution stats, room filter match report, placement decision log."/>
+                                ToolTip="Engine trace: anchor resolution stats, room filter match report, placement decision log. Renders in the Report panel."/>
                     </WrapPanel>
                 </GroupBox>
 

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -480,7 +480,7 @@
 
                             <TextBlock Grid.Row="0" Grid.Column="0" Style="{StaticResource LabelStyle}" Text="Routing mode"/>
                             <ComboBox  Grid.Row="0" Grid.Column="1" x:Name="cmbRoutingMode" Margin="0,2"
-                                       ToolTip="NONE / AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT / WALL_FOLLOWER. Engine routes from each placed fixture after placement."/>
+                                       ToolTip="NONE / AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT. Engine routes from each placed fixture after placement via the matching Core/Routing drop engine."/>
                             <TextBlock Grid.Row="0" Grid.Column="2" Style="{StaticResource LabelStyle}" Text="Segment category"/>
                             <ComboBox  Grid.Row="0" Grid.Column="3" x:Name="cmbRouteSegmentCategory" Margin="0,2"
                                        ToolTip="PIPE / CONDUIT / CABLE_TRAY / DUCT. Must match an available Revit system category when Routing Mode ≠ NONE."/>

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -1187,9 +1187,9 @@
                 <GroupBox Header="Construction Coordination" Style="{StaticResource GroupBoxStyle}">
                     <WrapPanel>
                         <Button Style="{StaticResource ToolBtn}" Width="148" Height="30" Margin="4,3"
-                                Tag="Placement_RunWallChase" Click="OnToolButton_Click"
+                                Click="OnWallChase_Click"
                                 Content="Wall Chase Routing"
-                                ToolTip="Plan wall-chase routing for conduit and pipe in masonry walls."/>
+                                ToolTip="Pick a wall + two points, preview the depth check, confirm, then route conduit/pipe. Result renders in the Report panel."/>
                         <Button Style="{StaticResource ToolBtnSecondary}" Width="168" Height="30" Margin="4,3"
                                 Click="OnNoggin_Click"
                                 Content="Noggin Requirements"
@@ -1200,13 +1200,13 @@
                 <GroupBox Header="Batch Data Exchange" Style="{StaticResource GroupBoxStyle}">
                     <WrapPanel>
                         <Button Style="{StaticResource ToolBtn}" Width="168" Height="30" Margin="4,3"
-                                Tag="Placement_ExportExcel" Click="OnToolButton_Click"
-                                Content="Export Results (Excel)"
-                                ToolTip="Export last placement result to .xlsx: element IDs, room, rule, world position."/>
+                                Click="OnExportRulesExcel_Click"
+                                Content="Export Rules (Excel)"
+                                ToolTip="Export all loaded placement rules to an .xlsx workbook. Renders in the Report panel."/>
                         <Button Style="{StaticResource ToolBtn}" Width="168" Height="30" Margin="4,3"
-                                Tag="Placement_ImportExcel" Click="OnToolButton_Click"
-                                Content="Import Overrides (Excel)"
-                                ToolTip="Apply position and mounting-height overrides from .xlsx to placed fixtures."/>
+                                Click="OnImportRulesExcel_Click"
+                                Content="Import Rules (Excel)"
+                                ToolTip="Import rules from an .xlsx workbook, write the project overlay, and refresh the grid live. Renders in the Report panel."/>
                     </WrapPanel>
                 </GroupBox>
 
@@ -1252,6 +1252,15 @@
             </DockPanel>
         </Border>
         </Grid>
+
+        <!-- Transient status toast (guard / progress messages) -->
+        <Border x:Name="bdrToast" Grid.Row="2" Panel.ZIndex="100"
+                HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                Margin="0,0,0,16" Padding="14,8" CornerRadius="4"
+                Background="#323232" Visibility="Collapsed">
+            <TextBlock x:Name="txtToast" Foreground="White" FontSize="12"
+                       TextWrapping="Wrap" MaxWidth="520"/>
+        </Border>
 
         <!-- Status bar -->
         <Border Grid.Row="3" Background="{DynamicResource HeaderBg}" Padding="8,4">

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -1162,13 +1162,13 @@
                 <GroupBox Header="Rule File Management" Style="{StaticResource GroupBoxStyle}">
                     <WrapPanel>
                         <Button Style="{StaticResource ToolBtn}" Width="148" Height="30" Margin="4,3"
-                                Tag="Placement_ExportRulesExcel" Click="OnToolButton_Click"
+                                Click="OnExportRulesExcel_Click"
                                 Content="Export Rules (Excel)"
-                                ToolTip="Export all loaded placement rules to an .xlsx workbook for bulk review / editing."/>
+                                ToolTip="Export all loaded placement rules to an .xlsx workbook for bulk review / editing. Renders in the Report panel."/>
                         <Button Style="{StaticResource ToolBtn}" Width="148" Height="30" Margin="4,3"
-                                Tag="Placement_ImportRulesExcel" Click="OnToolButton_Click"
+                                Click="OnImportRulesExcel_Click"
                                 Content="Import Rules (Excel)"
-                                ToolTip="Merge rules from an .xlsx workbook into the current set (override on MergeKey match)."/>
+                                ToolTip="Import rules from an .xlsx workbook, write the project overlay, and refresh the grid live. Renders in the Report panel."/>
                         <Button Style="{StaticResource ToolBtnSecondary}" Width="168" Height="30" Margin="4,3"
                                 Click="OnAutoPopulateCatalogue_Click"
                                 Content="Auto-populate Catalogue"
@@ -1237,6 +1237,13 @@
                                    Text="Report" TextTrimming="CharacterEllipsis"/>
                     </DockPanel>
                 </Border>
+                <DockPanel DockPanel.Dock="Top" Margin="8,3,8,4" LastChildFill="True">
+                    <TextBlock DockPanel.Dock="Left" Text="Recent" VerticalAlignment="Center"
+                               Margin="0,0,6,0" FontSize="11" Foreground="#607D8B"/>
+                    <ComboBox x:Name="cmbRecentReports" FontSize="11"
+                              SelectionChanged="OnRecentReport_Changed"
+                              ToolTip="Re-open a recent report (Run / Validation / Diagnose / Audit / …)"/>
+                </DockPanel>
                 <Border x:Name="reportHost" Padding="8">
                     <TextBlock x:Name="txtReportEmpty" Foreground="#90A4AE" FontSize="11"
                                TextWrapping="Wrap" VerticalAlignment="Top"

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -206,9 +206,15 @@
                               ToolTip="Ctrl+click / Shift+click to multi-select. Right-click for bulk actions.">
                         <DataGrid.RowStyle>
                             <Style TargetType="DataGridRow">
-                                <!-- Phase 139 I1 — RAG status colour from VM -->
+                                <!-- RAG status colour from VM -->
                                 <Setter Property="Background"
                                         Value="{Binding StatusColorHex, Converter={StaticResource HexToBrushConverter}, FallbackValue=#FFFFFF}"/>
+                                <Style.Triggers>
+                                    <!-- Invalid rows explain why on hover. -->
+                                    <DataTrigger Binding="{Binding IsValid}" Value="False">
+                                        <Setter Property="ToolTip" Value="{Binding ErrorMessage}"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
                             </Style>
                         </DataGrid.RowStyle>
                         <DataGrid.ContextMenu>
@@ -891,7 +897,7 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Style="{StaticResource LabelStyle}" Text="Auto-place"
-                                           ToolTip="Tick the categories the run should auto-place. Empty = every category."/>
+                                           ToolTip="Tick the categories the run should auto-place. Empty = every category in the active rule pack. Ticking a category with no matching rule places nothing. Conduits / Pipes / Cable Trays are routing outputs (see Integrated Routing), not point-placement targets."/>
                                 <WrapPanel Grid.Column="1">
                                     <CheckBox x:Name="cbCatElec"   Content="Electrical Fixtures"  Margin="0,0,8,2"/>
                                     <CheckBox x:Name="cbCatLtgDev" Content="Lighting Devices"     Margin="0,0,8,2"/>
@@ -904,13 +910,18 @@
                                     <CheckBox x:Name="cbCatHvac"   Content="Air Terminals"        Margin="0,0,8,2"/>
                                     <CheckBox x:Name="cbCatSpr"    Content="Sprinklers"           Margin="0,0,8,2"/>
                                     <CheckBox x:Name="cbCatMech"   Content="Mechanical Equipment" Margin="0,0,8,2"/>
-                                    <CheckBox x:Name="cbCatCond"   Content="Conduits"             Margin="0,0,8,2"/>
+                                    <CheckBox x:Name="cbCatCond"   Content="Conduits"             Margin="0,0,8,2"
+                                              ToolTip="Routing output, not a point-placement target — conduit is created by Integrated Routing (AUTO_CONDUIT), not placed here. Used only as an obstruction during placement."/>
                                     <CheckBox x:Name="cbCatJBox"   Content="Junction Boxes"       Margin="0,0,8,2"/>
-                                    <CheckBox x:Name="cbCatPipe"   Content="Pipes"                Margin="0,0,8,2"/>
-                                    <CheckBox x:Name="cbCatTray"   Content="Cable Trays"          Margin="0,0,8,2"/>
-                                    <CheckBox x:Name="cbCatSpec"   Content="Specialty Equipment"  Margin="0,0,8,2"/>
+                                    <CheckBox x:Name="cbCatPipe"   Content="Pipes"                Margin="0,0,8,2"
+                                              ToolTip="Routing output, not a point-placement target — pipe is created by Integrated Routing (AUTO_PIPE), not placed here. Used only as an obstruction during placement."/>
+                                    <CheckBox x:Name="cbCatTray"   Content="Cable Trays"          Margin="0,0,8,2"
+                                              ToolTip="Routing output, not a point-placement target — cable tray is created by Integrated Routing, not placed here. Used only as an obstruction during placement."/>
+                                    <CheckBox x:Name="cbCatSpec"   Content="Specialty Equipment"  Margin="0,0,8,2"
+                                              ToolTip="No baseline rules ship for this category — only places when a project / specialty rule pack covers it."/>
                                     <CheckBox x:Name="cbCatFurn"   Content="Furniture"            Margin="0,0,8,2"/>
-                                    <CheckBox x:Name="cbCatNurse"  Content="Nurse Call Devices"   Margin="0,0,8,2"/>
+                                    <CheckBox x:Name="cbCatNurse"  Content="Nurse Call Devices"   Margin="0,0,8,2"
+                                              ToolTip="Requires the healthcare rule pack — no baseline rules or anchor support ship for this category."/>
                                     <Button x:Name="btnCatAll"  Content="All"  Padding="8,2" Margin="6,0,4,2"/>
                                     <Button x:Name="btnCatNone" Content="None" Padding="8,2" Margin="0,0,4,2"/>
                                 </WrapPanel>

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -127,9 +127,9 @@
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Export…"          Click="OnExportRules_Click"
                         ToolTip="Export the current rule set to a portable JSON file you can share or version-control."/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Export Excel"     Click="OnExportExcel_Click"
-                        ToolTip="Phase 139 — Export every rule to an .xlsx workbook (one sheet per discipline pack)."/>
+                        ToolTip="Export every rule to an .xlsx workbook (one sheet per discipline pack)."/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Import Excel"     Click="OnImportExcel_Click"
-                        ToolTip="Phase 139 — Import rules back from .xlsx; replaces the project overlay."/>
+                        ToolTip="Import rules back from .xlsx; replaces the project overlay."/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Save Project"     Click="OnSaveProject_Click"
                         ToolTip="Save valid rules to &lt;project&gt;/STING_PLACEMENT_RULES.project.json (Ctrl+S)."/>
                 <Separator Width="8" Visibility="Hidden"/>
@@ -142,7 +142,7 @@
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Push to Families" Click="OnPushFamilies_Click"/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Heat-map"        Click="OnHeatmap_Click"/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="Save view preset" Click="OnSaveViewPreset_Click"
-                        ToolTip="Stamp a Pack 125/M view preset onto the active view so its scope/template/scale travel with the model."/>
+                        ToolTip="Stamp a view preset onto the active view so its scope/template/scale travel with the model."/>
                 <Button DockPanel.Dock="Left"  Style="{StaticResource ToolBtnSecondary}" Content="GD Study"        Click="OnGDStudy_Click"/>
             </DockPanel>
         </Border>
@@ -170,7 +170,7 @@
                                 Content="+" Width="32" Click="OnAdd_Click" ToolTip="Add a new rule"/>
                         <TextBox x:Name="txtSearch" Padding="3"
                                  TextChanged="OnSearch_TextChanged"
-                                 ToolTip="Phase 139 — search RuleId / category / variant / room / notes / standard / pack"/>
+                                 ToolTip="Search RuleId / category / variant / room / notes / standard / pack"/>
                     </DockPanel>
                     <DockPanel DockPanel.Dock="Top" LastChildFill="False" Margin="0,0,0,6">
                         <ToggleButton x:Name="chipDirty"   DockPanel.Dock="Left" Margin="0,0,4,0"
@@ -183,7 +183,7 @@
                                       ToolTip="Show only rules failing validation (missing CategoryFilter, bad Priority, …)."/>
                         <ComboBox x:Name="cmbSourcePack" DockPanel.Dock="Left" Margin="6,0,0,0"
                                   Width="130" SelectionChanged="OnSourcePack_SelectionChanged"
-                                  ToolTip="Phase 139 — filter by discipline pack."/>
+                                  ToolTip="Filter by discipline pack."/>
                     </DockPanel>
 
                     <!-- Rule grid -->
@@ -288,7 +288,7 @@
 
                             <TextBlock Grid.Row="3" Grid.Column="0" Style="{StaticResource LabelStyle}" Text="Family Type Regex"/>
                             <TextBox   Grid.Row="3" Grid.Column="1" x:Name="txtFamilyTypeRegex" Margin="0,2"
-                                       ToolTip="PC-08 — FamilySymbol.Name regex for refining variant resolution. Applied after VariantHint when both are set (e.g. '^IP6[5-7]$')."/>
+                                       ToolTip="FamilySymbol.Name regex for refining variant resolution. Applied after VariantHint when both are set (e.g. '^IP6[5-7]$')."/>
                             <TextBlock Grid.Row="3" Grid.Column="2" Style="{StaticResource LabelStyle}" Text="Source Pack"/>
                             <TextBox   Grid.Row="3" Grid.Column="3" x:Name="txtSourcePack" IsReadOnly="True" Margin="0,2"
                                        Foreground="#888" FontStyle="Italic"
@@ -316,20 +316,20 @@
                             <TextBox   Grid.Row="0" Grid.Column="1" x:Name="txtOffsetX" Margin="0,2"/>
                             <TextBlock Grid.Row="0" Grid.Column="2" Style="{StaticResource LabelStyle}" Text="Offset Y (mm)"/>
                             <TextBox   Grid.Row="0" Grid.Column="3" x:Name="txtOffsetY" Margin="0,2"
-                                       ToolTip="PC-06 — signed Y offset from the anchor's +Y axis."/>
+                                       ToolTip="Signed Y offset from the anchor's +Y axis."/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Style="{StaticResource LabelStyle}" Text="Offset Z (mm)"/>
                             <TextBox   Grid.Row="1" Grid.Column="1" x:Name="txtOffsetZ" Margin="0,2"
-                                       ToolTip="PC-06 — signed Z offset, separate from MountingHeight."/>
+                                       ToolTip="Signed Z offset, separate from MountingHeight."/>
                             <TextBlock Grid.Row="1" Grid.Column="2" Style="{StaticResource LabelStyle}" Text="Mount Height (mm)"/>
                             <TextBox   Grid.Row="1" Grid.Column="3" x:Name="txtMountH"  Margin="0,2"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Style="{StaticResource LabelStyle}" Text="Mount Reference"/>
                             <ComboBox  Grid.Row="2" Grid.Column="1" x:Name="cmbMountRef" Margin="0,2"
-                                       ToolTip="PC-06 — FFL / SOFFIT / SLAB / CEILING. Default FFL preserves legacy behaviour."/>
+                                       ToolTip="FFL / SOFFIT / SLAB / CEILING. Default FFL preserves legacy behaviour."/>
                             <TextBlock Grid.Row="2" Grid.Column="2" Style="{StaticResource LabelStyle}" Text="Rotation (°)"/>
                             <TextBox   Grid.Row="2" Grid.Column="3" x:Name="txtRotation" Margin="0,2"
-                                       ToolTip="PC-06 — rotation about Z in degrees."/>
+                                       ToolTip="Rotation about Z in degrees."/>
 
                             <TextBlock Grid.Row="3" Grid.Column="0" Style="{StaticResource LabelStyle}" Text="Min Spacing (mm)"/>
                             <TextBox   Grid.Row="3" Grid.Column="1" x:Name="txtSpacing" Margin="0,2"/>
@@ -338,14 +338,14 @@
 
                             <TextBlock Grid.Row="4" Grid.Column="0" Style="{StaticResource LabelStyle}" Text="Tolerance (mm)"/>
                             <TextBox   Grid.Row="4" Grid.Column="1" x:Name="txtToleranceMm" Margin="0,2"
-                                       ToolTip="PC-06 — candidates within this radius of the best position are treated as equivalent (default 25 mm)."/>
+                                       ToolTip="Candidates within this radius of the best position are treated as equivalent (default 25 mm)."/>
                             <TextBlock Grid.Row="4" Grid.Column="2" Style="{StaticResource LabelStyle}" Text="Max Spacing (mm)"/>
                             <TextBox   Grid.Row="4" Grid.Column="3" x:Name="txtMaxSpacing" Margin="0,2"
                                        ToolTip="Max centre-to-centre spacing for coverage-grid fixtures (BS EN 12464 / BS 5839). 0 = no maximum."/>
                         </Grid>
                     </GroupBox>
 
-                    <GroupBox Header="Room Scoping (PC-07)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Room Scoping" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -382,7 +382,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <GroupBox Header="Rule Kind / Density / Linear (PC-12)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Rule Kind / Density / Linear" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -432,7 +432,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <GroupBox Header="Coverage Grid (PC-14)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Coverage Grid" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -457,7 +457,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <GroupBox Header="Integrated Routing (PC-15)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Integrated Routing" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -483,7 +483,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <GroupBox Header="Construction Phasing (PC-16) / Cluster (PC-17)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Construction Phasing / Cluster" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -512,7 +512,7 @@
                         </Grid>
                     </GroupBox>
 
-                    <GroupBox Header="Rule Dependencies (PC-13)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Rule Dependencies" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -569,7 +569,7 @@
                                  ToolTip="Free-text note attached to this rule. Surfaced in placement reports and pushed to STING_PLACEMENT_NOTES_TXT on family types when Push to Families runs."/>
                     </GroupBox>
 
-                    <GroupBox Header="Clearance / Envelope / Weight (PC-11, push to family types)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Clearance / Envelope / Weight (push to family types)" Style="{StaticResource GroupBoxStyle}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -788,7 +788,7 @@
                     </StackPanel> <!-- /pnlRuleDetail -->
 
                     <!-- Phase 139 I3 — Building Profile header -->
-                    <GroupBox Header="Building Profile (Phase 139)" Style="{StaticResource GroupBoxStyle}">
+                    <GroupBox Header="Building Profile" Style="{StaticResource GroupBoxStyle}">
                         <StackPanel>
                             <Border BorderBrush="#E2A04A" BorderThickness="1" Padding="6"
                                     Background="#FFF7E6" Margin="0,0,0,8"
@@ -834,21 +834,21 @@
 
                     <GroupBox Header="Run Options" Style="{StaticResource GroupBoxStyle}">
                         <StackPanel>
-                            <CheckBox x:Name="chkProvenance"   Content="Stamp provenance on each placement (Pack 123/E)" Margin="0,3"
+                            <CheckBox x:Name="chkProvenance"   Content="Stamp provenance on each placement" Margin="0,3"
                                       ToolTip="When ON, every placed instance carries a StingProvenance entity so 'Undo last run' and provenance-scoped validation can find them. OFF skips the stamp — useful for one-off non-tracked placements."/>
-                            <CheckBox x:Name="chkLearned"      Content="Honour learned offsets per category (Pack 10 / PC-14)" Margin="0,3"
-                                      ToolTip="When ON and a STING_PLACEMENT_RULES.learned.json sits next to the .rvt, learned overrides win over the shipped baseline. PC-14 LearnPlacementV4Command writes that file."/>
+                            <CheckBox x:Name="chkLearned"      Content="Honour learned offsets per category" Margin="0,3"
+                                      ToolTip="When ON and a STING_PLACEMENT_RULES.learned.json sits next to the .rvt, learned overrides win over the shipped baseline. The 'Learn from model' tool writes that file."/>
                             <CheckBox x:Name="chkValidators"   Content="Run validators after placement"                  Margin="0,3"
                                       ToolTip="Run ClearanceValidator + MaintenanceClashValidator immediately after the placement commits, scoped to elements just placed."/>
                             <CheckBox x:Name="chkAutoHeatmap"  Content="Auto-paint AVF compliance heat-map on commit"    Margin="0,3"
                                       ToolTip="When ON and at least one fixture was placed, paint the AVF compliance heat-map on the active view immediately after the run commits."/>
-                            <CheckBox x:Name="chkRunTags"      Content="Run data-tag pipeline on each placement (PC-17)" Margin="0,3"
+                            <CheckBox x:Name="chkRunTags"      Content="Run data-tag pipeline on each placement" Margin="0,3"
                                       ToolTip="Invoke TagPipelineHelper.RunFullPipeline on every placed instance so the placement lands ISO-19650 tagged."/>
-                            <CheckBox x:Name="chkSeedCobie"    Content="Seed COBie component fields from the rule (PC-17)" Margin="0,3"
+                            <CheckBox x:Name="chkSeedCobie"    Content="Seed COBie component fields from the rule" Margin="0,3"
                                       ToolTip="Copy StandardRef / Notes / UniclassPr onto the placed instance's COBIE_COMPONENT_* parameters."/>
-                            <CheckBox x:Name="chkAssignMep"    Content="Probe MEP connectors after placement (PC-17)" Margin="0,3"
-                                      ToolTip="Log any unconnected connectors so MEPSystemBuilder can pick them up."/>
-                            <CheckBox x:Name="chkLivePreview"  Content="Live preview while editing rules (PC-21)" Margin="0,3"
+                            <CheckBox x:Name="chkAssignMep"    Content="Connect MEP systems after placement" Margin="0,3"
+                                      ToolTip="After placement, auto-connect each fixture's open connectors to the nearest compatible MEP connector and report any left unconnected."/>
+                            <CheckBox x:Name="chkLivePreview"  Content="Live preview while editing rules" Margin="0,3"
                                       ToolTip="Auto-refresh the on-canvas preview 500 ms after each rule edit."/>
                             <Grid Margin="0,8,0,0">
                                 <Grid.ColumnDefinitions>
@@ -1032,7 +1032,7 @@
                                     ToolTip="Place fixtures using all loaded rules. Respects scope and dry-run settings."/>
                             <Button Style="{StaticResource ToolBtn}" Width="118" Height="30" Margin="4,3"
                                     Content="Toilet Rooms" Click="OnRunToiletRooms_Click"
-                                    ToolTip="BS 6465-1: occupant-based provision + WC at window + all toilet accessories (Phase 177)."/>
+                                    ToolTip="BS 6465-1: occupant-based provision + WC at window + all toilet accessories."/>
                             <Button Style="{StaticResource ToolBtn}" Width="118" Height="30" Margin="4,3"
                                     Content="Lighting Grid" Click="OnRunLightingGrid_Click"
                                     ToolTip="IES RP-1 luminaire grid layout (LightingGridCommand)."/>
@@ -1055,7 +1055,7 @@
                                     ToolTip="Plan-level branch, panel, and riser layout (GenerateLayoutCommand)."/>
                             <Button Style="{StaticResource ToolBtn}" Width="118" Height="30" Margin="4,3"
                                     Content="Plumbing Router" Click="OnPlumbingRouter_Click"
-                                    ToolTip="Phase 177: auto-route soil/waste + CWS/HWS for toilet-room fixtures (BS EN 12056-2)."/>
+                                    ToolTip="Auto-route soil/waste + CWS/HWS for toilet-room fixtures (BS EN 12056-2)."/>
                             <Button Style="{StaticResource ToolBtnSecondary}" Width="118" Height="30" Margin="4,3"
                                     Content="Validate Fills" Click="OnValidateFills_Click"
                                     ToolTip="Fill-rate compliance check: panel capacity, duct velocity, pipe velocity."/>

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml
@@ -149,8 +149,15 @@
             </DockPanel>
         </Border>
 
-        <!-- Body: Rules / Run & Routing / Tools (Option A consolidation) -->
-        <TabControl Grid.Row="2" x:Name="tabCentre">
+        <!-- Body: tabs (commands, left) + shared inline Report panel (right) -->
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" MinWidth="620"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition x:Name="colReport" Width="360" MinWidth="0"/>
+            </Grid.ColumnDefinitions>
+
+        <TabControl Grid.Column="0" x:Name="tabCentre">
 
         <!-- ═══════════════════════════ TAB 1 — RULES ═══════════════════════════ -->
         <TabItem Header="Rules">
@@ -1208,6 +1215,36 @@
         </TabItem>
 
         </TabControl>
+
+        <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch"
+                      VerticalAlignment="Stretch" Background="#CFD8DC" ShowsPreview="True"/>
+
+        <!-- Shared inline Report panel — every reporting button renders its
+             result here instead of opening an external window. -->
+        <Border Grid.Column="2" x:Name="bdrReport" Background="{DynamicResource SecondaryBg}"
+                BorderBrush="#CFD8DC" BorderThickness="1,0,0,0">
+            <DockPanel LastChildFill="True">
+                <Border DockPanel.Dock="Top" Background="{DynamicResource HeaderBg}" Padding="8,5">
+                    <DockPanel LastChildFill="True">
+                        <Button DockPanel.Dock="Right" x:Name="btnReportPopOut" Content="⤢"
+                                Width="26" Margin="2,0,0,0" Click="OnReportPopOut_Click"
+                                ToolTip="Open this report in a separate window"/>
+                        <Button DockPanel.Dock="Right" x:Name="btnReportClear" Content="✕"
+                                Width="26" Margin="2,0,0,0" Click="OnReportClear_Click"
+                                ToolTip="Clear the report panel"/>
+                        <TextBlock x:Name="txtReportTitle" Foreground="{DynamicResource HeaderFg}"
+                                   FontWeight="SemiBold" VerticalAlignment="Center"
+                                   Text="Report" TextTrimming="CharacterEllipsis"/>
+                    </DockPanel>
+                </Border>
+                <Border x:Name="reportHost" Padding="8">
+                    <TextBlock x:Name="txtReportEmpty" Foreground="#90A4AE" FontSize="11"
+                               TextWrapping="Wrap" VerticalAlignment="Top"
+                               Text="Run a placement, validate, audit, diagnose, learn, or import/export — results appear here instead of a pop-up window."/>
+                </Border>
+            </DockPanel>
+        </Border>
+        </Grid>
 
         <!-- Status bar -->
         <Border Grid.Row="3" Background="{DynamicResource HeaderBg}" Padding="8,4">

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -767,6 +767,7 @@ namespace StingTools.UI.PlacementCenter
                 StartUtc     = startUtc,
                 PrevStamp    = prevStamp,
                 PrevLearn    = prevLearn,
+                DryRun       = (chkRunDryRun?.IsChecked == true),
             };
             try
             {
@@ -792,6 +793,38 @@ namespace StingTools.UI.PlacementCenter
             // handler will invoke OnRunCompleted on the WPF thread when
             // done.
             return;
+        }
+
+        // Real Run-Placement execution on the Revit API thread. The
+        // PlacementRunHandler ExternalEvent (MergeRecoveryStubs) forwards here;
+        // this runs the engine and marshals the result back to OnRunCompleted on
+        // the WPF thread via Dispatcher.BeginInvoke.
+        internal void ExecuteRun(UIApplication app)
+        {
+            var req = _runRequest;
+            if (req == null) return;
+            PlacementResult result = null;
+            Exception err = null;
+            try
+            {
+                var roomIds = (req.RoomIds != null && req.RoomIds.Count > 0)
+                    ? new List<ElementId>(req.RoomIds) : null;
+                var prog = req.Progress;
+                // Engine calls this once per room with cumulative (done,total);
+                // advance the modeless progress dialog and abort on cancel/Esc.
+                Func<int, int, bool> onProgress = (done, total) =>
+                {
+                    try { prog?.Increment(); return prog?.IsCancelled ?? false; }
+                    catch { return false; }
+                };
+                result = FixturePlacementEngine.PlaceFixturesInScope(
+                    req.Doc, roomIds, req.Rules, req.DryRun, onProgress);
+            }
+            catch (Exception ex) { err = ex; StingLog.Error("PlacementCenter.ExecuteRun", ex); }
+
+            var r = result; var e2 = err;
+            try { Dispatcher.BeginInvoke(new Action(() => OnRunCompleted(req, r, e2))); }
+            catch (Exception ex) { StingLog.Error("PlacementCenter.ExecuteRun dispatch", ex); }
         }
 
         // Phase 139.13 — completion callback. Runs on the WPF thread

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -2063,7 +2063,92 @@ namespace StingTools.UI.PlacementCenter
             => ShowFindings(false, "Clearance scan");
 
         private void OnPenetrationCoverage_Click(object sender, RoutedEventArgs e)
-            => StingDockPanel.DispatchCommand("Validation_PenetrationCoverage");
+        {
+            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            try
+            {
+                var findings = StingTools.Core.Validation.PenetrationCoverageValidator.Validate(_doc);
+                int errors   = findings.Count(f => f.Severity == ValidationSeverity.Error);
+                int warnings = findings.Count(f => f.Severity == ValidationSeverity.Warning);
+                var panel = StingResultPanel.Create("STING — Penetration Coverage Audit")
+                    .SetSubtitle("Firestop register integrity + structural review (beams)")
+                    .AddSection("SUMMARY")
+                    .Metric("Errors", errors.ToString())
+                    .Metric("Warnings", warnings.ToString())
+                    .Metric("Total findings", findings.Count.ToString());
+                if (findings.Count > 0)
+                {
+                    panel.AddSection("FINDINGS (top 50) — click to select in model");
+                    foreach (var f in findings.OrderByDescending(x => x.Severity).Take(50))
+                    {
+                        var fid = f.ElementId;
+                        if (fid != null && fid != ElementId.InvalidElementId)
+                            panel.Finding(f.ToString(), () => SelectInModel(fid));
+                        else
+                            panel.Text(f.ToString());
+                    }
+                    if (findings.Count > 50) panel.Text($"(+{findings.Count - 50} more — see StingLog)");
+                }
+                Report("Penetration Coverage", panel);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnPenetrationCoverage", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Penetration coverage failed: {ex.Message}");
+            }
+        }
+
+        private void OnAutoPopulateCatalogue_Click(object sender, RoutedEventArgs e)
+        {
+            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            try
+            {
+                var (created, updated, contributing) =
+                    StingTools.Core.Placement.ManufacturerCatalogueRegistry.AutoPopulateFromFamilies(_doc);
+                var panel = StingResultPanel.Create("STING — Manufacturer Catalogue")
+                    .AddSection("SUMMARY")
+                    .Metric("New entries", created.ToString())
+                    .Metric("Updated entries", updated.ToString());
+                if (contributing != null && contributing.Count > 0)
+                {
+                    panel.AddSection("CONTRIBUTING FAMILIES");
+                    foreach (var c in contributing.Take(40)) panel.Text(c);
+                    if (contributing.Count > 40) panel.Text($"(+{contributing.Count - 40} more)");
+                }
+                else
+                {
+                    panel.AddSection("RESULT")
+                         .Text("No families carrying MK_* shared parameters were found in this project.");
+                }
+                Report("Catalogue", panel);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnAutoPopulateCatalogue", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Auto-populate failed: {ex.Message}");
+            }
+        }
+
+        private void OnNoggin_Click(object sender, RoutedEventArgs e)
+        {
+            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            try
+            {
+                string text = StingTools.Commands.Placement.NogginRequirementExportCommand
+                    .BuildReportText(_doc, out string csvPath, out int count);
+                var panel = StingResultPanel.Create("STING — Noggin Requirements")
+                    .SetSubtitle(string.IsNullOrEmpty(csvPath) ? "" : $"CSV: {csvPath}")
+                    .AddSection("RESULT")
+                    .Metric("Noggin requirements", count.ToString())
+                    .Text(text);
+                Report("Noggin Requirements", panel);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnNoggin", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Noggin export failed: {ex.Message}");
+            }
+        }
 
         private void OnScoreThreshold_Changed(object sender, RoutedEventArgs e)
         {

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -1115,6 +1115,37 @@ namespace StingTools.UI.PlacementCenter
             }
         }
 
+        private void OnLearnFromModel_Click(object sender, RoutedEventArgs e)
+        {
+            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            try
+            {
+                // RunLearn only reads elements + writes a JSON file (no Revit
+                // transaction), so it is safe to call directly on the dockable
+                // panel's API thread. It shows its own result TaskDialog.
+                int n = StingTools.Commands.Placement.LearnPlacementV4Command.RunLearn(_doc);
+                if (n > 0 && !string.IsNullOrEmpty(_doc.PathName))
+                {
+                    // Reload the just-written learned rules into the grid so they
+                    // are reviewable and "Honour learned offsets" picks them up.
+                    string dir = System.IO.Path.GetDirectoryName(_doc.PathName);
+                    string learnedPath = System.IO.Path.Combine(dir ?? "", "STING_PLACEMENT_RULES.learned.json");
+                    if (System.IO.File.Exists(learnedPath))
+                    {
+                        int imported = VM.ImportFromFile(learnedPath);
+                        VM.ApplyFilter();
+                        VM.Status = $"Learned {n} rule(s); imported {imported} into the grid for review (Save Project to persist).";
+                        UpdateStatus();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnLearnFromModel", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Learn from model failed: {ex.Message}");
+            }
+        }
+
         private void OnGDStudy_Click(object sender, RoutedEventArgs e)
         {
             string path = "Data\\GenerativeDesign\\STING_FIXTURE_PLACEMENT.dyn";

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -705,6 +705,12 @@ namespace StingTools.UI.PlacementCenter
             bool prevLearn = StingTools.Commands.Placement.PlaceFixturesOptions.HonourLearned;
             StingTools.Commands.Placement.PlaceFixturesOptions.StampProvenance = VM.RunOpts.StampProvenance;
             StingTools.Commands.Placement.PlaceFixturesOptions.HonourLearned   = VM.RunOpts.HonourLearned;
+            // Push the live building-profile selection so the building-type /
+            // standards gate + wet-zone / accessibility / coverage toggles take
+            // effect WITHOUT requiring a Save first. Cleared in OnRunCompleted /
+            // the error path below.
+            try { SyncProfileToVm(); StingTools.Commands.Placement.PlaceFixturesOptions.SessionProfile = VM.Profile?.Clone(); }
+            catch (Exception pex) { StingLog.Warn($"PlacementCenter: push session profile: {pex.Message}"); }
 
             DateTime startUtc = DateTime.UtcNow;
             // Show a modeless progress dialog so the user can see per-room
@@ -773,6 +779,7 @@ namespace StingTools.UI.PlacementCenter
                 try { progress?.Close(); } catch { }
                 StingTools.Commands.Placement.PlaceFixturesOptions.StampProvenance = prevStamp;
                 StingTools.Commands.Placement.PlaceFixturesOptions.HonourLearned   = prevLearn;
+                StingTools.Commands.Placement.PlaceFixturesOptions.SessionProfile  = null;
                 try { if (btnRunPlacement != null) btnRunPlacement.IsEnabled = true; } catch { }
                 return;
             }
@@ -790,6 +797,7 @@ namespace StingTools.UI.PlacementCenter
             try { req?.Progress?.Close(); } catch { }
             StingTools.Commands.Placement.PlaceFixturesOptions.StampProvenance = req?.PrevStamp ?? false;
             StingTools.Commands.Placement.PlaceFixturesOptions.HonourLearned   = req?.PrevLearn ?? false;
+            StingTools.Commands.Placement.PlaceFixturesOptions.SessionProfile  = null;
 
             try { if (btnRunPlacement != null) btnRunPlacement.IsEnabled = true; } catch { }
             if (err != null)
@@ -905,6 +913,10 @@ namespace StingTools.UI.PlacementCenter
                     $"Scope '{VM.RunOpts.Scope}' resolved zero rooms — preview cancelled.");
                 return;
             }
+            // Preview honours the live building-profile selection too (dry-run,
+            // so no commit). Set the session override; the next Run resets it.
+            try { SyncProfileToVm(); StingTools.Commands.Placement.PlaceFixturesOptions.SessionProfile = VM.Profile?.Clone(); }
+            catch (Exception pex) { StingLog.Warn($"PlacementCenter preview: push session profile: {pex.Message}"); }
             try
             {
                 var src = new PlacementPreviewSource(_doc, roomIds, rules);

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -98,6 +98,11 @@ namespace StingTools.UI.PlacementCenter
             _uiDoc = uiApp?.ActiveUIDocument;
             _doc = _uiDoc?.Document;
 
+            // Findings parsed out of report text (Diagnose/Audit) carry an
+            // ElementId payload; route their clicks to this window's selector.
+            StingResultPanel.ElementSelectAction =
+                id => { try { SelectInModel(new ElementId(id)); } catch { } };
+
             // Combo data sources
             cmbCategory.ItemsSource          = VM.Categories;
             cmbAnchor.ItemsSource            = VM.AnchorTypes;
@@ -1322,8 +1327,22 @@ namespace StingTools.UI.PlacementCenter
         // keeps the builder so the pop-out button can still show the full
         // windowed version on demand.
         private StingResultPanel.Builder _lastReport;
+        private readonly List<(string Title, StingResultPanel.Builder Builder)> _recentReports = new();
+        private bool _suppressRecentSel;
 
         private void Report(string title, StingResultPanel.Builder b)
+        {
+            RenderReport(title, b);
+            try
+            {
+                _recentReports.Insert(0, (title ?? "Report", b));
+                if (_recentReports.Count > 12) _recentReports.RemoveRange(12, _recentReports.Count - 12);
+                RefreshRecentCombo(selectIndex0: true);
+            }
+            catch (Exception ex) { StingLog.Warn($"PlacementCenter.Report recent: {ex.Message}"); }
+        }
+
+        private void RenderReport(string title, StingResultPanel.Builder b)
         {
             try
             {
@@ -1334,9 +1353,31 @@ namespace StingTools.UI.PlacementCenter
             }
             catch (Exception ex)
             {
-                StingLog.Warn($"PlacementCenter.Report: {ex.Message}");
+                StingLog.Warn($"PlacementCenter.RenderReport: {ex.Message}");
                 try { b?.Show(); } catch { }   // last-resort fallback so the result is still visible
             }
+        }
+
+        private void RefreshRecentCombo(bool selectIndex0)
+        {
+            if (cmbRecentReports == null) return;
+            _suppressRecentSel = true;
+            try
+            {
+                cmbRecentReports.Items.Clear();
+                foreach (var r in _recentReports) cmbRecentReports.Items.Add(r.Title);
+                if (selectIndex0 && cmbRecentReports.Items.Count > 0) cmbRecentReports.SelectedIndex = 0;
+            }
+            finally { _suppressRecentSel = false; }
+        }
+
+        private void OnRecentReport_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressRecentSel) return;
+            int i = cmbRecentReports?.SelectedIndex ?? -1;
+            if (i < 0 || i >= _recentReports.Count) return;
+            var r = _recentReports[i];
+            RenderReport(r.Title, r.Builder);   // re-show without re-pushing onto the recent list
         }
 
         private void OnReportClear_Click(object sender, RoutedEventArgs e)
@@ -1374,6 +1415,29 @@ namespace StingTools.UI.PlacementCenter
                 try { _uiDoc.ShowElements(id); } catch { }
             }
             catch (Exception ex) { StingLog.Warn($"PlacementCenter.SelectInModel: {ex.Message}"); }
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex _idRx =
+            new System.Text.RegularExpressions.Regex(@"\b\d{5,}\b",
+                System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>
+        /// Render report text line-by-line; a line containing a 5+ digit token
+        /// (an ElementId in a real model — counts / dimensions are shorter)
+        /// becomes a clickable Finding that selects it. Non-element numbers
+        /// resolve to nothing on click and are harmless.
+        /// </summary>
+        private void AddTextWithIds(StingResultPanel.Builder panel, string text)
+        {
+            if (panel == null || string.IsNullOrEmpty(text)) return;
+            foreach (var line in text.Replace("\r", "").Split('\n'))
+            {
+                var m = _idRx.Match(line);
+                if (m.Success && long.TryParse(m.Value, out long id))
+                    panel.Finding(line, id);
+                else
+                    panel.Text(line);
+            }
         }
 
         // ── List + add/delete ────────────────────────────────────────
@@ -2190,6 +2254,81 @@ namespace StingTools.UI.PlacementCenter
                 StingDockPanel.DispatchCommand(tag);
         }
 
+        private void OnExportRulesExcel_Click(object sender, RoutedEventArgs e)
+        {
+            var rules = PlacementCenterBridge.ToRules(VM.Rules);
+            if (rules == null || rules.Count == 0) { TaskDialog.Show("STING — Placement Centre", "No rules to export."); return; }
+            var dlg = new Microsoft.Win32.SaveFileDialog
+            {
+                Title = "STING — Export placement rules to Excel",
+                Filter = "Excel workbook (*.xlsx)|*.xlsx",
+                FileName = "STING_PLACEMENT_RULES.xlsx",
+            };
+            if (dlg.ShowDialog(this) != true) return;
+            try
+            {
+                StingTools.Core.Placement.Excel.PlacementRulesExcelExporter.Export(rules, dlg.FileName);
+                var panel = StingResultPanel.Create("STING — Export Rules (Excel)")
+                    .SetSubtitle(dlg.FileName)
+                    .AddSection("RESULT")
+                    .Metric("Rules exported", rules.Count.ToString())
+                    .Text($"Saved to {dlg.FileName}");
+                Report("Export Rules (Excel)", panel);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnExportRulesExcel", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Excel export failed: {ex.Message}");
+            }
+        }
+
+        private void OnImportRulesExcel_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new Microsoft.Win32.OpenFileDialog
+            {
+                Title = "STING — Import placement rules from Excel",
+                Filter = "Excel workbook (*.xlsx)|*.xlsx|All files (*.*)|*.*",
+            };
+            if (dlg.ShowDialog(this) != true) return;
+            try
+            {
+                var (rules, errors) = StingTools.Core.Placement.Excel.PlacementRulesExcelImporter.Import(dlg.FileName);
+                int imported = 0;
+                // Write the project overlay beside the .rvt then reload the grid so
+                // the import is live (closes the round-trip refresh gap).
+                if (rules != null && rules.Count > 0 && !string.IsNullOrEmpty(_doc?.PathName))
+                {
+                    string dir = System.IO.Path.GetDirectoryName(_doc.PathName);
+                    string overridePath = System.IO.Path.Combine(dir ?? "", "STING_PLACEMENT_RULES.project.json");
+                    var set = new PlacementRuleSet { Version = "v4", Rules = rules };
+                    System.IO.File.WriteAllText(overridePath,
+                        Newtonsoft.Json.JsonConvert.SerializeObject(set, Newtonsoft.Json.Formatting.Indented));
+                    imported = VM.ImportFromFile(overridePath);
+                    VM.ApplyFilter();
+                    UpdateStatus();
+                }
+                var panel = StingResultPanel.Create("STING — Import Rules (Excel)")
+                    .SetSubtitle(dlg.FileName)
+                    .AddSection("RESULT")
+                    .Metric("Rules in workbook", (rules?.Count ?? 0).ToString())
+                    .Metric("Imported into grid", imported.ToString())
+                    .Metric("Warnings", (errors?.Count ?? 0).ToString());
+                if (errors != null && errors.Count > 0)
+                {
+                    panel.AddSection("WARNINGS (top 20)");
+                    foreach (var w in errors.Take(20)) panel.Text(w);
+                }
+                if (string.IsNullOrEmpty(_doc?.PathName))
+                    panel.AddSection("NOTE").Text("Project not saved on disk — rules were read but not written to a project overlay. Save the .rvt then re-import to persist.");
+                Report("Import Rules (Excel)", panel);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnImportRulesExcel", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Excel import failed: {ex.Message}");
+            }
+        }
+
         private void OnDiagnose_Click(object sender, RoutedEventArgs e)
         {
             if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
@@ -2197,8 +2336,9 @@ namespace StingTools.UI.PlacementCenter
             {
                 var (text, path) = StingTools.Commands.Placement.PlacementDiagnoseCommand.BuildReportText(_doc);
                 var panel = StingResultPanel.Create("STING — Placement Diagnose");
-                if (!string.IsNullOrEmpty(path)) panel.SetSubtitle($"Full report: {path}");
-                panel.AddSection("DIAGNOSTIC").Text(text);
+                if (!string.IsNullOrEmpty(path)) panel.SetSubtitle($"Full report: {path}  ·  click a line with an element id to select it");
+                panel.AddSection("DIAGNOSTIC");
+                AddTextWithIds(panel, text);
                 Report("Diagnose", panel);
             }
             catch (Exception ex)
@@ -2219,7 +2359,8 @@ namespace StingTools.UI.PlacementCenter
                      .AddSection("SUMMARY")
                      .Metric("Errors", errs.ToString())
                      .Metric("Warnings", warns.ToString())
-                     .AddSection("DETAIL").Text(text);
+                     .AddSection("DETAIL");
+                AddTextWithIds(panel, text);
                 Report("Audit Setup", panel);
             }
             catch (Exception ex)

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -73,7 +73,7 @@ namespace StingTools.UI.PlacementCenter
             // Revit cached the old DLL).
             try
             {
-                this.Title = $"STING — Placement Centre  [build {StingTools.Core.Placement.FixturePlacementEngine.BuildStamp}  {StingTools.Core.Placement.FixturePlacementEngine.PhaseTag}]";
+                this.Title = $"STING — Placement Centre  [build {StingTools.Core.Placement.FixturePlacementEngine.BuildStamp}]";
             }
             catch { }
             ThemeManager.InitialiseResources();
@@ -561,7 +561,7 @@ namespace StingTools.UI.PlacementCenter
                     }
                     else if (doorsTotal > 0 && doorsWithSpatial < doorsTotal / 2)
                     {
-                        helpfulHints.Add($"~{doorsTotal - doorsWithSpatial} of {doorsTotal} doors have no FromRoom/ToRoom — those will be skipped by Phase 139.18 filter.");
+                        helpfulHints.Add($"~{doorsTotal - doorsWithSpatial} of {doorsTotal} doors have no FromRoom/ToRoom — those will be skipped by the spatial filter.");
                     }
                 }
 
@@ -582,7 +582,7 @@ namespace StingTools.UI.PlacementCenter
                     {
                         MainInstruction = $"{blockers.Count} prerequisite(s) failed — run aborted.",
                         MainContent = string.Join("\n\n", blockers)
-                            + "\n\nPhase 139.21 hard-fails the run when these are present so we don't produce silently-wrong placements. "
+                            + "\n\nThe run is hard-failed when these are present so we don't produce silently-wrong placements. "
                             + (helpfulHints.Count > 0 ? "\n\nAlso noted:\n  " + string.Join("\n  ", helpfulHints) : ""),
                         CommonButtons = TaskDialogCommonButtons.Close,
                     };
@@ -814,7 +814,7 @@ namespace StingTools.UI.PlacementCenter
             try
             {
                 var panel = StingResultPanel.Create("STING — Placement Centre · Run");
-                panel.SetSubtitle($"{placed} placed · {skipped} skipped · {warns} warning(s) · build {StingTools.Core.Placement.FixturePlacementEngine.BuildStamp} ({StingTools.Core.Placement.FixturePlacementEngine.PhaseTag})");
+                panel.SetSubtitle($"{placed} placed · {skipped} skipped · {warns} warning(s) · build {StingTools.Core.Placement.FixturePlacementEngine.BuildStamp}");
 
                 // Phase 139.20 — surface which categories were actually
                 // allowed by the checklist, alongside the categories that
@@ -1232,7 +1232,7 @@ namespace StingTools.UI.PlacementCenter
             string presetName = $"PlacementCentre/{VM.RunOpts.Scope}/{DateTime.UtcNow:yyyyMMdd-HHmm}";
             try
             {
-                using (var t = new Transaction(_doc, "STING — Save view preset (Pack 125/M)"))
+                using (var t = new Transaction(_doc, "STING — Save view preset"))
                 {
                     t.Start();
                     StingTools.Core.Storage.StingViewPresetSchema.Write(view, presetName, "");

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -873,8 +873,7 @@ namespace StingTools.UI.PlacementCenter
                     if (result.Warnings.Count > 30)
                         panel.Text($"(+{result.Warnings.Count - 30} more — see StingLog)");
                 }
-                RaiseRevitToFront();
-                panel.Show();
+                Report("Run", panel);
             }
             catch (Exception pEx) { StingLog.Warn($"PlacementCenter post-run panel: {pEx.Message}"); }
 
@@ -887,13 +886,12 @@ namespace StingTools.UI.PlacementCenter
                 catch (Exception hmEx) { StingLog.Warn($"PlacementCenter auto-heatmap: {hmEx.Message}"); }
             }
 
+            // RunValidators overwrites the inline Run report with the validation
+            // findings (the more useful final view). Otherwise the Run summary
+            // built above is already showing in the shared Report panel — no
+            // pop-up needed.
             if (VM.RunOpts.RunValidators)
                 ShowFindings(scopeToProvenance: true, headline: "Run + post-validation");
-            else
-                TaskDialog.Show("STING — Placement Centre",
-                    $"Placement run complete.\n\n" +
-                    $"Placed: {placed}\nSkipped: {skipped}\nWarnings: {warns}\n\n" +
-                    "Run Validate now to audit the result, or click Undo last run to revert.");
         }
 
         private void OnPreview_Click(object sender, RoutedEventArgs e)
@@ -991,7 +989,7 @@ namespace StingTools.UI.PlacementCenter
                     foreach (var f in findings.OrderByDescending(x => x.Severity).Take(40))
                         panel.Text(f.ToString());
                 }
-                panel.Show();
+                Report("Validation", panel);
 
                 VM.Status = $"Validate complete · {errs}e {warns}w {infos}i";
                 UpdateStatus();
@@ -1292,6 +1290,50 @@ namespace StingTools.UI.PlacementCenter
         }
 
         private void OnClose_Click(object sender, RoutedEventArgs e) => Close();
+
+        // ── Shared inline Report panel ────────────────────────────────
+        // Every reporting button renders into the right-hand panel via
+        // Report(...) instead of opening an external window. _lastReport
+        // keeps the builder so the pop-out button can still show the full
+        // windowed version on demand.
+        private StingResultPanel.Builder _lastReport;
+
+        private void Report(string title, StingResultPanel.Builder b)
+        {
+            try
+            {
+                _lastReport = b;
+                if (txtReportTitle != null) txtReportTitle.Text = title ?? "Report";
+                if (reportHost != null)
+                    reportHost.Child = StingResultPanel.BuildInlineContent(b, double.PositiveInfinity);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"PlacementCenter.Report: {ex.Message}");
+                try { b?.Show(); } catch { }   // last-resort fallback so the result is still visible
+            }
+        }
+
+        private void OnReportClear_Click(object sender, RoutedEventArgs e)
+        {
+            _lastReport = null;
+            if (txtReportTitle != null) txtReportTitle.Text = "Report";
+            if (reportHost != null)
+                reportHost.Child = new TextBlock
+                {
+                    Foreground = System.Windows.Media.Brushes.Gray,
+                    FontSize = 11,
+                    TextWrapping = TextWrapping.Wrap,
+                    VerticalAlignment = VerticalAlignment.Top,
+                    Text = "Run a placement, validate, audit, diagnose, learn, or import/export — results appear here instead of a pop-up window."
+                };
+        }
+
+        private void OnReportPopOut_Click(object sender, RoutedEventArgs e)
+        {
+            try { _lastReport?.Show(); }
+            catch (Exception ex) { StingLog.Warn($"PlacementCenter.ReportPopOut: {ex.Message}"); }
+        }
 
         // ── List + add/delete ────────────────────────────────────────
 

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -632,7 +632,10 @@ namespace StingTools.UI.PlacementCenter
             if (roomIds.Count == 0)
             {
                 TaskDialog.Show("STING — Placement Centre",
-                    $"Scope '{VM.RunOpts.Scope}' resolved zero rooms. Switch scope or open a view that contains rooms.");
+                    $"Scope '{VM.RunOpts.Scope}' resolved zero rooms or MEP spaces.\n\n" +
+                    "• Try scope = Project, or open a plan view that shows the rooms/spaces.\n" +
+                    "• If this is an MEP model, place MEP Spaces (Analyze → Space) — the engine now places into Spaces as well as Rooms.\n" +
+                    "• Rooms that live only in a LINKED architecture model are not read yet — place Spaces in this model to drive placement.");
                 return;
             }
 

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -935,20 +935,30 @@ namespace StingTools.UI.PlacementCenter
             ShowFindings(scopeToProvenance: false, headline: "Project-wide validation");
         }
 
-        private void ShowFindings(bool scopeToProvenance, string headline)
+        private void ShowFindings(bool scopeToProvenance, string headline, ISet<string> forceMask = null)
         {
             try
             {
-                // PC-23 — collect picked validators.
-                var mask = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                if (vClearance.IsChecked   == true) mask.Add("Clearance");
-                if (vMaintenance.IsChecked == true) mask.Add("Maintenance");
-                if (vConnectivity.IsChecked == true) mask.Add("Connectivity");
-                if (vFill.IsChecked        == true) mask.Add("Fill");
-                if (vSpec.IsChecked        == true) mask.Add("Spec");
-                if (vTermination.IsChecked == true) mask.Add("Termination");
-                if (vSlope.IsChecked       == true) mask.Add("Slope");
-                if (vSeparation.IsChecked  == true) mask.Add("Separation");
+                // Collect picked validators (or use the caller's forced mask, e.g.
+                // "All Validators" runs the full set regardless of the checklist).
+                ISet<string> mask;
+                if (forceMask != null)
+                {
+                    mask = forceMask;
+                }
+                else
+                {
+                    var picked = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    if (vClearance.IsChecked   == true) picked.Add("Clearance");
+                    if (vMaintenance.IsChecked == true) picked.Add("Maintenance");
+                    if (vConnectivity.IsChecked == true) picked.Add("Connectivity");
+                    if (vFill.IsChecked        == true) picked.Add("Fill");
+                    if (vSpec.IsChecked        == true) picked.Add("Spec");
+                    if (vTermination.IsChecked == true) picked.Add("Termination");
+                    if (vSlope.IsChecked       == true) picked.Add("Slope");
+                    if (vSeparation.IsChecked  == true) picked.Add("Separation");
+                    mask = picked;
+                }
                 var findings = PlacementCenterBridge.RunValidators(_doc, mask);
                 if (scopeToProvenance && _lastRunUtc.HasValue)
                 {
@@ -985,9 +995,15 @@ namespace StingTools.UI.PlacementCenter
 
                 if (findings.Count > 0)
                 {
-                    panel.AddSection("FINDINGS (top 40)");
+                    panel.AddSection("FINDINGS (top 40) — click to select in model");
                     foreach (var f in findings.OrderByDescending(x => x.Severity).Take(40))
-                        panel.Text(f.ToString());
+                    {
+                        var fid = f.ElementId;
+                        if (fid != null && fid != ElementId.InvalidElementId)
+                            panel.Finding(f.ToString(), () => SelectInModel(fid));
+                        else
+                            panel.Text(f.ToString());
+                    }
                 }
                 Report("Validation", panel);
 
@@ -1119,9 +1135,11 @@ namespace StingTools.UI.PlacementCenter
             try
             {
                 // RunLearn only reads elements + writes a JSON file (no Revit
-                // transaction), so it is safe to call directly on the dockable
-                // panel's API thread. It shows its own result TaskDialog.
-                int n = StingTools.Commands.Placement.LearnPlacementV4Command.RunLearn(_doc);
+                // transaction), so it is safe on the modeless window's thread.
+                // showDialog:false suppresses its own TaskDialog so the result
+                // renders inline in the shared Report panel instead.
+                int n = StingTools.Commands.Placement.LearnPlacementV4Command.RunLearn(_doc, out string summary, showDialog: false);
+                int imported = 0;
                 if (n > 0 && !string.IsNullOrEmpty(_doc.PathName))
                 {
                     // Reload the just-written learned rules into the grid so they
@@ -1130,12 +1148,19 @@ namespace StingTools.UI.PlacementCenter
                     string learnedPath = System.IO.Path.Combine(dir ?? "", "STING_PLACEMENT_RULES.learned.json");
                     if (System.IO.File.Exists(learnedPath))
                     {
-                        int imported = VM.ImportFromFile(learnedPath);
+                        imported = VM.ImportFromFile(learnedPath);
                         VM.ApplyFilter();
                         VM.Status = $"Learned {n} rule(s); imported {imported} into the grid for review (Save Project to persist).";
                         UpdateStatus();
                     }
                 }
+
+                var panel = StingResultPanel.Create("STING — Learn from model")
+                    .AddSection("RESULT")
+                    .Text(string.IsNullOrEmpty(summary) ? $"Learned {n} rule(s)." : summary);
+                if (imported > 0)
+                    panel.Text($"Imported {imported} learned rule(s) into the grid for review (Save Project to persist).");
+                Report("Learn", panel);
             }
             catch (Exception ex)
             {
@@ -1333,6 +1358,22 @@ namespace StingTools.UI.PlacementCenter
         {
             try { _lastReport?.Show(); }
             catch (Exception ex) { StingLog.Warn($"PlacementCenter.ReportPopOut: {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// Select + zoom an element in the model from a clicked report finding.
+        /// Selection / ShowElements need no transaction and are safe from this
+        /// modeless window (same pattern as the History double-click select).
+        /// </summary>
+        private void SelectInModel(ElementId id)
+        {
+            if (_uiDoc == null || id == null || id == ElementId.InvalidElementId) return;
+            try
+            {
+                _uiDoc.Selection.SetElementIds(new List<ElementId> { id });
+                try { _uiDoc.ShowElements(id); } catch { }
+            }
+            catch (Exception ex) { StingLog.Warn($"PlacementCenter.SelectInModel: {ex.Message}"); }
         }
 
         // ── List + add/delete ────────────────────────────────────────
@@ -1986,7 +2027,12 @@ namespace StingTools.UI.PlacementCenter
             => StingDockPanel.DispatchCommand("Routing_PlaceHangers");
 
         private void OnRunAllValidators_Click(object sender, RoutedEventArgs e)
-            => StingDockPanel.DispatchCommand("Validation_RunAll");
+        {
+            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            var all = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                { "Clearance", "Maintenance", "Connectivity", "Fill", "Spec", "Termination", "Slope", "Separation" };
+            ShowFindings(false, "All validators", all);
+        }
 
         private void OnBS6465Audit_Click(object sender, RoutedEventArgs e)
         {
@@ -2059,23 +2105,59 @@ namespace StingTools.UI.PlacementCenter
                 StingDockPanel.DispatchCommand(tag);
         }
 
+        private void OnDiagnose_Click(object sender, RoutedEventArgs e)
+        {
+            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            try
+            {
+                var (text, path) = StingTools.Commands.Placement.PlacementDiagnoseCommand.BuildReportText(_doc);
+                var panel = StingResultPanel.Create("STING — Placement Diagnose");
+                if (!string.IsNullOrEmpty(path)) panel.SetSubtitle($"Full report: {path}");
+                panel.AddSection("DIAGNOSTIC").Text(text);
+                Report("Diagnose", panel);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnDiagnose", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Diagnose failed: {ex.Message}");
+            }
+        }
+
+        private void OnAuditSetup_Click(object sender, RoutedEventArgs e)
+        {
+            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            try
+            {
+                var text = StingTools.Commands.Placement.PlacementSetupAuditCommand.BuildReportText(_doc, out int errs, out int warns, out string csv);
+                var panel = StingResultPanel.Create("STING — Placement Setup Audit");
+                panel.SetSubtitle((string.IsNullOrEmpty(csv) ? "" : $"CSV: {csv}"))
+                     .AddSection("SUMMARY")
+                     .Metric("Errors", errs.ToString())
+                     .Metric("Warnings", warns.ToString())
+                     .AddSection("DETAIL").Text(text);
+                Report("Audit Setup", panel);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("PlacementCenter.OnAuditSetup", ex);
+                TaskDialog.Show("STING — Placement Centre", $"Audit Setup failed: {ex.Message}");
+            }
+        }
+
         // ── Inline result panel ──────────────────────────────────────
 
         private void ShowInlineResult(string headline,
                                       IEnumerable<string> metrics,
                                       IEnumerable<string> findings)
         {
-            if (txtRunResultHeadline != null)
-                txtRunResultHeadline.Text = headline ?? "";
-
-            if (lstRunMetrics != null)
-                lstRunMetrics.ItemsSource = metrics?.ToList() ?? new List<string>();
-
-            if (lstRunFindings != null)
-                lstRunFindings.ItemsSource = findings?.ToList() ?? new List<string>();
-
-            if (grpRunResult != null)
-                grpRunResult.Visibility = System.Windows.Visibility.Visible;
+            // Route through the shared right-hand Report panel so every button
+            // reports in one place (was: the separate grpRunResult group).
+            var panel = StingResultPanel.Create(headline);
+            var m = metrics?.ToList() ?? new List<string>();
+            if (m.Count > 0) { panel.AddSection("SUMMARY"); foreach (var s in m) panel.Text(s); }
+            var f = findings?.ToList() ?? new List<string>();
+            if (f.Count > 0) { panel.AddSection("DETAIL"); foreach (var s in f) panel.Text(s); }
+            Report(headline, panel);
         }
 
         // ── DrawingType context strip ────────────────────────────────

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -1390,6 +1390,7 @@ namespace StingTools.UI.PlacementCenter
                     added++;
                 }
                 VM.RebuildCategories();
+                VM.ApplyFilter();   // re-evaluate the live grid filter so imported rows appear under any active pack/search filter
                 VM.Status = $"Imported {added} rule(s) from Excel (Save Project to persist).";
             }
             catch (Exception ex)

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -468,7 +468,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnRunPlacement_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
 
             var rules = PlacementCenterBridge.ToRules(VM.Rules);
             if (rules.Count == 0)
@@ -901,12 +901,12 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnPreview_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
 
             var rules = PlacementCenterBridge.ToRules(VM.Rules);
             if (rules.Count == 0)
             {
-                TaskDialog.Show("STING — Placement Centre", "No valid rules to preview.");
+                Toast("No valid rules to preview."); 
                 return;
             }
             var roomIds = PlacementCenterBridge.ResolveScope(_uiDoc, VM.RunOpts.Scope);
@@ -936,7 +936,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnValidate_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             ShowFindings(scopeToProvenance: false, headline: "Project-wide validation");
         }
 
@@ -1025,7 +1025,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnInspectFamily_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             if (VM.Selected == null || string.IsNullOrEmpty(VM.Selected.CategoryFilter))
             {
                 VM.SetFamilyHints(null);
@@ -1050,10 +1050,10 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnPushFamilies_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             if (VM.Selected == null)
             {
-                TaskDialog.Show("STING — Placement Centre", "Pick a rule first.");
+                Toast("Pick a rule first."); 
                 return;
             }
             if (string.IsNullOrEmpty(VM.Selected.CategoryFilter))
@@ -1114,7 +1114,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnHeatmap_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             try
             {
                 using (var t = new Transaction(_doc, "STING — Placement Centre · AVF compliance heat-map"))
@@ -1136,7 +1136,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnLearnFromModel_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             try
             {
                 // RunLearn only reads elements + writes a JSON file (no Revit
@@ -1239,7 +1239,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnUndoLast_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
 
             // Prefer the in-memory _lastPlacedIds when this centre instance ran a
             // placement; fall back to the most-recent provenance bucket otherwise.
@@ -1296,7 +1296,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnSaveViewPreset_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             var view = _doc.ActiveView;
             if (view == null) { TaskDialog.Show("STING — Placement Centre", "No active view."); return; }
 
@@ -1399,6 +1399,84 @@ namespace StingTools.UI.PlacementCenter
         {
             try { _lastReport?.Show(); }
             catch (Exception ex) { StingLog.Warn($"PlacementCenter.ReportPopOut: {ex.Message}"); }
+        }
+
+        // ── Transient status toast (replaces one-line guard TaskDialogs) ──
+        private System.Windows.Threading.DispatcherTimer _toastTimer;
+
+        private void Toast(string msg)
+        {
+            try
+            {
+                if (txtToast == null || bdrToast == null) { VM.Status = msg; UpdateStatus(); return; }
+                txtToast.Text = msg ?? "";
+                bdrToast.Visibility = System.Windows.Visibility.Visible;
+                if (_toastTimer == null)
+                {
+                    _toastTimer = new System.Windows.Threading.DispatcherTimer { Interval = TimeSpan.FromSeconds(3.5) };
+                    _toastTimer.Tick += (s, e) =>
+                    {
+                        _toastTimer.Stop();
+                        if (bdrToast != null) bdrToast.Visibility = System.Windows.Visibility.Collapsed;
+                    };
+                }
+                _toastTimer.Stop();
+                _toastTimer.Start();
+            }
+            catch (Exception ex) { StingLog.Warn($"PlacementCenter.Toast: {ex.Message}"); }
+        }
+
+        // ── Generic API-thread action (real ExternalEvent) ──────────────
+        // The placement run handler in MergeRecoveryStubs is a no-op stub, so
+        // model-modifying / interactive actions (e.g. Wall Chase) get their own
+        // real event. The work returns a result Builder which is reported inline.
+        private ExternalEvent _actionEvent;
+        private PlacementActionHandler _actionHandler;
+        private Func<UIApplication, StingResultPanel.Builder> _pendingAction;
+        private string _pendingActionTitle;
+
+        private void RunInlineAction(string title, Func<UIApplication, StingResultPanel.Builder> work)
+        {
+            if (work == null) return;
+            try
+            {
+                if (_actionHandler == null) _actionHandler = new PlacementActionHandler(this);
+                if (_actionEvent == null)   _actionEvent   = ExternalEvent.Create(_actionHandler);
+                _pendingActionTitle = title;
+                _pendingAction = work;
+                Toast($"{title}…");
+                _actionEvent.Raise();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error($"PlacementCenter.RunInlineAction {title}", ex);
+                Toast($"{title} could not start: {ex.Message}");
+            }
+        }
+
+        private sealed class PlacementActionHandler : IExternalEventHandler
+        {
+            private readonly StingPlacementCenter _o;
+            public PlacementActionHandler(StingPlacementCenter o) { _o = o; }
+            public string GetName() => "STING Placement Centre Action";
+            public void Execute(UIApplication app)
+            {
+                var work = _o._pendingAction;
+                var title = _o._pendingActionTitle;
+                _o._pendingAction = null;
+                if (work == null) return;
+                StingResultPanel.Builder builder;
+                try { builder = work(app); }
+                catch (Autodesk.Revit.Exceptions.OperationCanceledException)
+                { builder = StingResultPanel.Create(title).AddSection("RESULT").Text("Cancelled."); }
+                catch (Exception ex)
+                {
+                    StingLog.Error($"PlacementCenter action '{title}'", ex);
+                    builder = StingResultPanel.Create(title).AddSection("ERROR").Text(ex.Message);
+                }
+                var b = builder;
+                try { _o.Dispatcher.BeginInvoke(new Action(() => { if (b != null) _o.Report(title, b); })); } catch { }
+            }
         }
 
         /// <summary>
@@ -2092,7 +2170,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnRunAllValidators_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             var all = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 { "Clearance", "Maintenance", "Connectivity", "Fill", "Spec", "Termination", "Slope", "Separation" };
             ShowFindings(false, "All validators", all);
@@ -2128,7 +2206,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnPenetrationCoverage_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             try
             {
                 var findings = StingTools.Core.Validation.PenetrationCoverageValidator.Validate(_doc);
@@ -2164,7 +2242,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnAutoPopulateCatalogue_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             try
             {
                 var (created, updated, contributing) =
@@ -2195,7 +2273,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnNoggin_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             try
             {
                 string text = StingTools.Commands.Placement.NogginRequirementExportCommand
@@ -2252,6 +2330,16 @@ namespace StingTools.UI.PlacementCenter
         {
             if (sender is Button btn && btn.Tag is string tag && !string.IsNullOrEmpty(tag))
                 StingDockPanel.DispatchCommand(tag);
+        }
+
+        private void OnWallChase_Click(object sender, RoutedEventArgs e)
+        {
+            if (_doc == null) { Toast("No document open."); return; }
+            // Interactive + model-modifying: runs on the API thread via the real
+            // action event; the mid-flow Yes/No confirm stays, the final result
+            // renders inline in the Report panel.
+            RunInlineAction("Wall Chase",
+                app => StingTools.Commands.Placement.RunWallChaseCommand.RunInteractive(app));
         }
 
         private void OnExportRulesExcel_Click(object sender, RoutedEventArgs e)
@@ -2331,7 +2419,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnDiagnose_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             try
             {
                 var (text, path) = StingTools.Commands.Placement.PlacementDiagnoseCommand.BuildReportText(_doc);
@@ -2350,7 +2438,7 @@ namespace StingTools.UI.PlacementCenter
 
         private void OnAuditSetup_Click(object sender, RoutedEventArgs e)
         {
-            if (_doc == null) { TaskDialog.Show("STING — Placement Centre", "No document open."); return; }
+            if (_doc == null) { Toast("No document open."); return; }
             try
             {
                 var text = StingTools.Commands.Placement.PlacementSetupAuditCommand.BuildReportText(_doc, out int errs, out int warns, out string csv);

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -4018,6 +4018,12 @@ namespace StingTools.UI
                     // (e.g., ElbowMode from tag command bleeding into next selection command)
                     ClearAllExtraParams();
 
+                    // Resolve the BOQ Actions pane's "Running…" placeholder (no-op
+                    // if the command already rendered inline). Runs before the
+                    // statics are cleared so the pane reflects the just-finished run.
+                    try { var r = BOQCostManagerPanel.PendingActionResolve; BOQCostManagerPanel.PendingActionResolve = null; r?.Invoke(); }
+                    catch (Exception exR) { StingLog.Warn($"BOQ PendingActionResolve: {exR.Message}"); }
+
                     // Slice 1.5 — tear down the BOQ Cost Manager inline-routing
                     // hooks so a later ribbon/other-panel command's pickers + result
                     // panels don't render into the (possibly closed) Actions pane.

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -4022,6 +4022,7 @@ namespace StingTools.UI
                     // hooks so a later ribbon/other-panel command's pickers + result
                     // panels don't render into the (possibly closed) Actions pane.
                     StingTools.Select.StingListPicker.InlineHost = null;
+                    StingTools.Select.StingListPicker.InlineHostDoc = null;   // P0.1
                     StingTools.Select.StingListPicker.InlineTitleSink = null;
                     StingResultPanel.InlineSink = null;
 

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -3508,6 +3508,7 @@ namespace StingTools.UI
                     case "BOQAddManualRow":         RunCommand<BOQ.BOQAddManualRowCommand>(app); break;
                     case "SelectInRevit":           RunCommand<BOQ.BOQSelectInRevitCommand>(app); break;
                     case "BOQExport":               RunCommand<BOQ.BOQExportCommand>(app); break;
+                    case "BOQExportIfcQto":         RunCommand<BOQ.BOQExportIfcQtoCommand>(app); break;
                     case "BOQImport":               RunCommand<BOQ.BOQImportCommand>(app); break;
                     case "BOQQsExport":             RunCommand<BOQ.BOQQsExportCommand>(app); break;
                     case "BOQQsImport":             RunCommand<BOQ.BOQQsImportCommand>(app); break;

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -4018,6 +4018,13 @@ namespace StingTools.UI
                     // (e.g., ElbowMode from tag command bleeding into next selection command)
                     ClearAllExtraParams();
 
+                    // Slice 1.5 — tear down the BOQ Cost Manager inline-routing
+                    // hooks so a later ribbon/other-panel command's pickers + result
+                    // panels don't render into the (possibly closed) Actions pane.
+                    StingTools.Select.StingListPicker.InlineHost = null;
+                    StingTools.Select.StingListPicker.InlineTitleSink = null;
+                    StingResultPanel.InlineSink = null;
+
                     // FIX-UI03: Notify panel that command completed so Tag Studio
                     // sub-tabs are unfrozen. AdjustElbows / SetArrows were permanently
                     // freezing the Leader & Elbow sub-tab because UnfreezeTagSubTabs()

--- a/StingTools/UI/StingListPicker.cs
+++ b/StingTools/UI/StingListPicker.cs
@@ -53,7 +53,34 @@ namespace StingTools.Select
         // each command runs. Null ⇒ legacy modal behaviour everywhere.
         public static System.Windows.Controls.Border InlineHost;
         public static Action<string> InlineTitleSink;
+        // P0.1 — the Document whose Actions pane is hosting inline pickers. When a
+        // Revit transaction is open on it (IsModifiable), pumping a nested
+        // DispatcherFrame is unsafe and can corrupt document state, so we fall back
+        // to a modal dialog. Set by BOQCostManagerPanel.RunActionInline alongside
+        // InlineHost; cleared in StingCommandHandler.Execute's finally.
+        public static Autodesk.Revit.DB.Document InlineHostDoc;
         private System.Windows.Threading.DispatcherFrame _inlineFrame;
+
+        /// <summary>True when an inline host is registered AND it is safe to pump a
+        /// nested WPF message loop — i.e. no Revit transaction is open on the host
+        /// document. Mirrors the IsModifiable guard in DrawingTypeStamper.StampCrop.
+        /// Logs once when it forces a modal fallback so the human can see which
+        /// command needed it.</summary>
+        private static bool InlineSafe(string title)
+        {
+            if (InlineHost == null) return false;
+            try
+            {
+                if (InlineHostDoc != null && InlineHostDoc.IsModifiable)
+                {
+                    StingLog.Info($"StingListPicker: transaction open on host doc — "
+                        + $"\"{title}\" picker falling back to modal (no nested pump).");
+                    return false;
+                }
+            }
+            catch { /* if we can't tell, prefer the safe modal path */ return false; }
+            return true;
+        }
 
         /// <summary>OK/Cancel/Esc end-point: unwind the nested pump when hosted
         /// inline, else close the modal window. Never calls Close() on a
@@ -68,6 +95,20 @@ namespace StingTools.Select
         /// loop until OK/Cancel sets _result and stops the frame.</summary>
         private List<ListItem> ShowInline(string title)
         {
+            // P0.1 defensive guard — never pump a nested loop while a transaction is
+            // open on the host doc. The two Show gates already check InlineSafe, but
+            // any future direct caller is covered here too: fall back to modal.
+            try
+            {
+                if (InlineHostDoc != null && InlineHostDoc.IsModifiable)
+                {
+                    StingTools.UI.StingWindowHelper.ApplyOwner(this);
+                    ShowDialog();
+                    return _result;
+                }
+            }
+            catch { }
+
             var host = InlineHost;
             try { InlineTitleSink?.Invoke(string.IsNullOrEmpty(title) ? "Select" : title); } catch { }
 
@@ -486,7 +527,7 @@ namespace StingTools.Select
             // Re-populate to apply validation coloring
             picker.PopulateList(items);
 
-            if (InlineHost != null) return picker.ShowInline(title);   // Slice 1.5 — no popup
+            if (InlineSafe(title)) return picker.ShowInline(title);   // Slice 1.5 — no popup
 
             // Phase 98: prefer BCC as owner when it's open so the picker stacks
             // above the coordination centre (was falling behind with raw Revit HWND).
@@ -501,7 +542,7 @@ namespace StingTools.Select
         {
             var dlg = new StingListPicker(title, subtitle, items, allowMultiSelect);
 
-            if (InlineHost != null) return dlg.ShowInline(title);   // Slice 1.5 — no popup
+            if (InlineSafe(title)) return dlg.ShowInline(title);   // Slice 1.5 — no popup
 
             // Phase 98: prefer BCC as owner when open so the picker stacks above
             // the coordination centre; falls back to Revit main HWND otherwise.

--- a/StingTools/UI/StingListPicker.cs
+++ b/StingTools/UI/StingListPicker.cs
@@ -43,6 +43,50 @@ namespace StingTools.Select
         private readonly Border _searchBorder;
         private readonly TextBlock _validationHint;
         private List<ListItem> _result;
+
+        // ── Inline hosting (Slice 1.5) ───────────────────────────────────────
+        // When InlineHost is set, Show(...) renders the picker INTO that host
+        // (the BOQ Cost Manager Actions pane) using a nested DispatcherFrame
+        // instead of a modal Window — so command code that calls
+        // StingListPicker.Show(...) still gets its result synchronously, but the
+        // user sees an inline panel, not a popup. Cleared by the dispatcher after
+        // each command runs. Null ⇒ legacy modal behaviour everywhere.
+        public static System.Windows.Controls.Border InlineHost;
+        public static Action<string> InlineTitleSink;
+        private System.Windows.Threading.DispatcherFrame _inlineFrame;
+
+        /// <summary>OK/Cancel/Esc end-point: unwind the nested pump when hosted
+        /// inline, else close the modal window. Never calls Close() on a
+        /// never-shown window (which would throw and hang the frame).</summary>
+        private void FinishInlineOrClose()
+        {
+            if (_inlineFrame != null) _inlineFrame.Continue = false;
+            else Close();
+        }
+
+        /// <summary>Render this picker into InlineHost and pump a nested message
+        /// loop until OK/Cancel sets _result and stops the frame.</summary>
+        private List<ListItem> ShowInline(string title)
+        {
+            var host = InlineHost;
+            try { InlineTitleSink?.Invoke(string.IsNullOrEmpty(title) ? "Select" : title); } catch { }
+
+            var content = this.Content as System.Windows.UIElement;
+            this.Content = null;                 // detach from the (never-shown) window
+            host.Child = content;                // host inline
+
+            _inlineFrame = new System.Windows.Threading.DispatcherFrame();
+            try
+            {
+                System.Windows.Threading.Dispatcher.PushFrame(_inlineFrame); // pumps until Continue=false
+            }
+            finally
+            {
+                _inlineFrame = null;
+                if (host.Child == content) host.Child = null; // clear unless a result already replaced it
+            }
+            return _result;
+        }
         private HashSet<string> _validCodes;
 
         private StingListPicker(string title, string subtitle, List<ListItem> items, bool allowMultiSelect)
@@ -209,7 +253,7 @@ namespace StingTools.Select
             }
 
             var cancelBtn = CreateButton("Cancel", false);
-            cancelBtn.Click += (s, e) => { _result = null; Close(); };
+            cancelBtn.Click += (s, e) => { _result = null; FinishInlineOrClose(); };
             cancelBtn.Margin = new Thickness(0, 0, 8, 0);
             buttonStack.Children.Add(cancelBtn);
 
@@ -226,7 +270,7 @@ namespace StingTools.Select
             // Keyboard shortcuts
             KeyDown += (s, e) =>
             {
-                if (e.Key == Key.Escape) { _result = null; Close(); }
+                if (e.Key == Key.Escape) { _result = null; FinishInlineOrClose(); }
                 else if (e.Key == Key.Enter) AcceptSelection();
             };
 
@@ -382,7 +426,7 @@ namespace StingTools.Select
                     if (first?.Tag is ListItem fi) _result.Add(fi);
                 }
             }
-            Close();
+            FinishInlineOrClose();
         }
 
         private static Button CreateButton(string text, bool isPrimary)
@@ -441,6 +485,8 @@ namespace StingTools.Select
             // Re-populate to apply validation coloring
             picker.PopulateList(items);
 
+            if (InlineHost != null) return picker.ShowInline(title);   // Slice 1.5 — no popup
+
             // Phase 98: prefer BCC as owner when it's open so the picker stacks
             // above the coordination centre (was falling behind with raw Revit HWND).
             StingTools.UI.StingWindowHelper.ApplyOwner(picker);
@@ -453,6 +499,8 @@ namespace StingTools.Select
             List<ListItem> items, bool allowMultiSelect = false)
         {
             var dlg = new StingListPicker(title, subtitle, items, allowMultiSelect);
+
+            if (InlineHost != null) return dlg.ShowInline(title);   // Slice 1.5 — no popup
 
             // Phase 98: prefer BCC as owner when open so the picker stacks above
             // the coordination centre; falls back to Revit main HWND otherwise.

--- a/StingTools/UI/StingListPicker.cs
+++ b/StingTools/UI/StingListPicker.cs
@@ -405,6 +405,7 @@ namespace StingTools.Select
                     Background = invalid ? BrushLightRedBg : Brushes.Transparent
                 };
                 _listBox.Items.Add(lbi);
+                if (item.IsSelected) lbi.IsSelected = true;   // honour pre-checked state
             }
             _countText.Text = $"{items.Count}/{_allItems.Count}";
         }

--- a/StingTools/UI/StingResultPanel.cs
+++ b/StingTools/UI/StingResultPanel.cs
@@ -120,6 +120,21 @@ namespace StingTools.UI
                 return this;
             }
 
+            /// <summary>
+            /// A clickable finding carrying an ElementId payload; the click is
+            /// wired by <see cref="StingResultPanel.ElementSelectAction"/> at
+            /// render time (so report-text parsers don't need a selector).
+            /// </summary>
+            public Builder Finding(string text, long elementId, SolidColorBrush brush = null)
+            {
+                EnsureSection();
+                _cur.Items.Add(new ResultItem
+                {
+                    Type = ItemType.Finding, Label = text, ValueBrush = brush, ElementIdPayload = elementId
+                });
+                return this;
+            }
+
             public Builder PassFail(string label, bool passed, string detail = null)
             {
                 EnsureSection();
@@ -216,7 +231,16 @@ namespace StingTools.UI
             public string[] TableHeaders;
             public List<string[]> TableRows;
             public Action OnClick;
+            public long? ElementIdPayload;
         }
+
+        /// <summary>
+        /// Optional host hook: when a Finding carries an ElementIdPayload (rather
+        /// than a baked-in OnClick action), clicking it invokes this. The
+        /// Placement Centre sets it to select + zoom the element in the model, so
+        /// findings parsed out of plain report text become clickable too.
+        /// </summary>
+        public static Action<long> ElementSelectAction;
 
         internal enum ItemType
         {
@@ -553,6 +577,12 @@ namespace StingTools.UI
                 ToolTip = "Click to select this element in the model"
             };
             var click = item.OnClick;
+            if (click == null && item.ElementIdPayload.HasValue)
+            {
+                long id = item.ElementIdPayload.Value;
+                var sel = ElementSelectAction;
+                if (sel != null) click = () => sel(id);
+            }
             if (click != null)
                 tb.MouseLeftButtonUp += (s, e) => { try { click(); } catch { } };
             return tb;

--- a/StingTools/UI/StingResultPanel.cs
+++ b/StingTools/UI/StingResultPanel.cs
@@ -269,7 +269,7 @@ namespace StingTools.UI
                 stack.Children.Add(BuildSection(section));
             }
 
-            return new ScrollViewer
+            var scroller = new ScrollViewer
             {
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
@@ -277,6 +277,52 @@ namespace StingTools.UI
                 MaxHeight = 380,
                 Padding = new Thickness(0)
             };
+
+            // Inline action bar. The dialog footer (Open-Export via SetCsvPath +
+            // any Action(...) buttons) was previously dropped inline, so an export
+            // run from the Actions pane had no way to open its file. Render those
+            // buttons in a compact always-visible bottom bar.
+            var actionBar = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 6, 0, 0)
+            };
+            if (!string.IsNullOrEmpty(b.CsvExportPath))
+            {
+                string path = b.CsvExportPath;
+                var openBtn = new Button { Content = "Open file", Margin = new Thickness(6, 0, 0, 0), Padding = new Thickness(10, 3, 10, 3) };
+                openBtn.Click += (s, e) =>
+                {
+                    try { System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(path) { UseShellExecute = true }); }
+                    catch (Exception ex) { StingTools.Core.StingLog.Warn($"Inline open file: {ex.Message}"); }
+                };
+                actionBar.Children.Add(openBtn);
+            }
+            if (b.Actions != null)
+            {
+                foreach (var a in b.Actions)
+                {
+                    var ad = a;
+                    var btn = new Button { Content = ad.Label, ToolTip = ad.Description, Margin = new Thickness(6, 0, 0, 0), Padding = new Thickness(10, 3, 10, 3) };
+                    btn.Click += (s, e) =>
+                    {
+                        // No Window inline; pass null. Actions that strictly need a
+                        // Window degrade gracefully (logged, not crashed).
+                        try { ad.Click?.Invoke(null); }
+                        catch (Exception ex) { StingTools.Core.StingLog.Warn($"Inline action '{ad.Label}': {ex.Message}"); }
+                    };
+                    actionBar.Children.Add(btn);
+                }
+            }
+
+            if (actionBar.Children.Count == 0) return scroller;
+
+            var root = new DockPanel { LastChildFill = true };
+            DockPanel.SetDock(actionBar, Dock.Bottom);
+            root.Children.Add(actionBar);
+            root.Children.Add(scroller);
+            return root;
         }
 
         // ══════════════════════════════════════════════════════════════════

--- a/StingTools/UI/StingResultPanel.cs
+++ b/StingTools/UI/StingResultPanel.cs
@@ -166,6 +166,15 @@ namespace StingTools.UI
             /// <summary>Show the result panel and return the index of the clicked action (-1 if closed).</summary>
             public int Show()
             {
+                // Slice 1.5 — when an inline sink is registered (BOQ Cost Manager
+                // Actions pane is hosting), render the result there instead of a
+                // popup window. Falls back to the modal dialog on any failure.
+                var sink = StingResultPanel.InlineSink;
+                if (sink != null)
+                {
+                    try { sink(this); return 1; }
+                    catch (Exception ex) { StingTools.Core.StingLog.Error("StingResultPanel inline sink", ex); }
+                }
                 return StingResultPanel.ShowDialog(this);
             }
 
@@ -217,6 +226,11 @@ namespace StingTools.UI
         // ══════════════════════════════════════════════════════════════════
 
         public static Builder Create(string title) => new Builder { Title = title };
+
+        // Slice 1.5 — inline result routing. When set (by the BOQ Cost Manager
+        // while an Actions command runs), Builder.Show() routes here instead of
+        // popping a window. Cleared by the dispatcher after each command.
+        public static Action<Builder> InlineSink;
 
         // ══════════════════════════════════════════════════════════════════
         //  INLINE CONTENT BUILDER

--- a/StingTools/UI/StingResultPanel.cs
+++ b/StingTools/UI/StingResultPanel.cs
@@ -103,6 +103,23 @@ namespace StingTools.UI
                 return this;
             }
 
+            /// <summary>
+            /// A clickable finding line. Rendered as a hyperlink-styled row that
+            /// fires <paramref name="onClick"/> when clicked — used to select /
+            /// zoom the offending element in the model. Falls back to plain text
+            /// when onClick is null.
+            /// </summary>
+            public Builder Finding(string text, Action onClick, SolidColorBrush brush = null)
+            {
+                EnsureSection();
+                _cur.Items.Add(new ResultItem
+                {
+                    Type = onClick == null ? ItemType.Text : ItemType.Finding,
+                    Label = text, ValueBrush = brush, OnClick = onClick
+                });
+                return this;
+            }
+
             public Builder PassFail(string label, bool passed, string detail = null)
             {
                 EnsureSection();
@@ -198,11 +215,12 @@ namespace StingTools.UI
             public bool? Passed;
             public string[] TableHeaders;
             public List<string[]> TableRows;
+            public Action OnClick;
         }
 
         internal enum ItemType
         {
-            Metric, Text, RAGBar, PassFail, Table, Alert, Separator
+            Metric, Text, RAGBar, PassFail, Table, Alert, Separator, Finding
         }
 
         internal class ActionDef
@@ -514,9 +532,30 @@ namespace StingTools.UI
                         Height = 1, Margin = new Thickness(0, 4, 0, 4),
                         Background = FZ(new SolidColorBrush(Color.FromRgb(0xE0, 0xE0, 0xE0)))
                     };
+                case ItemType.Finding:
+                    return BuildFinding(item);
                 default:
                     return new TextBlock { Text = item.Label ?? "" };
             }
+        }
+
+        private static UIElement BuildFinding(ResultItem item)
+        {
+            var tb = new TextBlock
+            {
+                Text = "▸ " + (item.Label ?? ""),
+                FontSize = 11.5,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 2, 0, 2),
+                Foreground = item.ValueBrush ?? FZ(new SolidColorBrush(Color.FromRgb(0x15, 0x65, 0xC0))),
+                TextDecorations = TextDecorations.Underline,
+                Cursor = System.Windows.Input.Cursors.Hand,
+                ToolTip = "Click to select this element in the model"
+            };
+            var click = item.OnClick;
+            if (click != null)
+                tb.MouseLeftButtonUp += (s, e) => { try { click(); } catch { } };
+            return tb;
         }
 
         private static UIElement BuildMetric(ResultItem item)

--- a/StingTools/UI/StingResultPanel.cs
+++ b/StingTools/UI/StingResultPanel.cs
@@ -231,7 +231,14 @@ namespace StingTools.UI
         // Width is host-driven; the embedded ScrollViewer caps height at
         // 380 px so the panel doesn't dominate the dock.
 
-        public static FrameworkElement BuildInlineContent(Builder b)
+        public static FrameworkElement BuildInlineContent(Builder b) => BuildInlineContent(b, 380);
+
+        /// <summary>
+        /// Inline content with a caller-controlled height cap. Pass
+        /// double.PositiveInfinity when the host (e.g. a docked report column)
+        /// manages height itself and the inner ScrollViewer should simply fill.
+        /// </summary>
+        public static FrameworkElement BuildInlineContent(Builder b, double maxHeight)
         {
             var stack = new StackPanel { Margin = new Thickness(0) };
 
@@ -260,7 +267,7 @@ namespace StingTools.UI
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
                 Content = stack,
-                MaxHeight = 380,
+                MaxHeight = maxHeight,
                 Padding = new Thickness(0)
             };
         }

--- a/deploy.bat
+++ b/deploy.bat
@@ -1,0 +1,15 @@
+@echo off
+:: ──────────────────────────────────────────────────────────────────
+::  Make THIS checkout the live STING plugin in Revit (build + install).
+::
+::  A plain `build.bat` now only COMPILES + STAGES to CompiledPlugin\
+::  (so parallel checkouts / background agents can verify a build without
+::  hijacking the single shared Revit add-in slot). This script is the
+::  explicit, opt-in step that installs THIS checkout's build into Revit.
+::
+::  Run this in whichever checkout you want active, then restart Revit.
+:: ──────────────────────────────────────────────────────────────────
+setlocal
+set "STING_DEPLOY=1"
+call "%~dp0build.bat"
+endlocal

--- a/docs/BOQ_5D_ENHANCEMENTS_PROMPT.md
+++ b/docs/BOQ_5D_ENHANCEMENTS_PROMPT.md
@@ -192,6 +192,31 @@ project → all restored.
 
 ---
 
+### P1.4 — Convert remaining Actions commands to inline (Slice 3) — HIGH PRIORITY
+**Why (found in Revit smoke-test):** the Actions inline pane works only for the
+~9 commands that report via `StingResultPanel.Show()`. The other ~7 (e.g.
+`Cost_RunWorkflow`, `Cost_ClearStale`, `Cost_ToggleStaleMarker`,
+`Cost_MigrateCurrencyParams`, `Cost_MigrateEs*`, the `Meas_*` setters) report via
+`TaskDialog.Show(...)`, so they pop a modal and the pane sat on "Running…".
+A post-review fix (commit on this branch) now **resolves** the placeholder to
+"✓ completed" via `BOQCostManagerPanel.PendingActionResolve` — but the user wants
+the **result itself inline**, not a TaskDialog.
+- **Task:** convert the `TaskDialog.Show(...)` calls in the Actions-dispatched
+  commands (`Commands/Cost/*.cs` — `CostCommands.cs`, `MeasurementStandardCommands.cs`,
+  and any other tag wired into `BuildActionsTab`) to build a
+  `StingResultPanel.Create(title)...` and call `.Show()`. Because `Builder.Show()`
+  already routes to the inline sink when set, **no panel changes are needed** —
+  converted commands render inline automatically and `_inlineResultPosted` flips
+  true (so `ResolveActionPane` no-ops). For genuinely trivial confirmations
+  ("Cleared N stale flags"), a one-section `StingResultPanel` with a single metric
+  is fine.
+- **Do not** change the command's actual work / transactions — only its
+  *reporting surface* (TaskDialog → StingResultPanel). Keep `TaskDialog` only for
+  true blocking confirmations that must interrupt (rare; note any you keep).
+- **Acceptance:** every button in the Actions tab renders its result in the right
+  pane; none leaves the pane on the bare "Running…" placeholder. Multi-step
+  commands (Run Cost Workflow) can stream a final summary panel.
+
 ## P2 — Larger slices (only after P0/P1 land + smoke-test green)
 
 ### P2.1 — 4D / Schedule tab (the real 5D payoff)

--- a/docs/BOQ_5D_ENHANCEMENTS_PROMPT.md
+++ b/docs/BOQ_5D_ENHANCEMENTS_PROMPT.md
@@ -1,0 +1,236 @@
+# BOQ 5D Cost Manager — Enhancement Implementation Prompt
+
+You are a terminal coding agent working on the **StingTools** C# Revit plugin.
+This prompt asks you to harden and extend the **BOQ & Cost Manager** inline
+workspace + linked-models feature that already landed on this branch. Implement
+the tasks in order (P0 → P1 → P2), compile-verifying and committing each, and
+deploying after each so the human can smoke-test in Revit.
+
+---
+
+## 0. Environment, build & deploy protocol (READ FIRST — non-obvious)
+
+- **Work in this worktree:** `C:\Dev\STINGTOOLS-boq-impl`, branch
+  `claude/boq-implementation`. Do **not** build from the main checkout
+  `C:\Dev\STINGTOOLS` — it sits on a different branch and does **not** contain
+  the BOQ work. `git status` / `git branch --show-current` before you touch
+  anything.
+- **The plugin builds headlessly here** via the csproj's Nice3point reference-
+  assembly fallback — the old "can't compile in sandbox" caveat is **obsolete**.
+  You MUST compile-verify every change:
+  ```bash
+  dotnet build StingTools/StingTools.csproj -c Release -t:Rebuild --nologo -v minimal
+  ```
+  A clean forced rebuild is ~30 s and must report `0 Error(s)`. (Incremental
+  builds report `Build succeeded` in ~1.5 s when nothing changed — use
+  `-t:Rebuild` to truly recompile your edits.)
+- **Deploy = a single file copy, but Revit hard-locks it.** The `.addin` loads
+  from the absolute path `C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.dll`
+  (NOT the worktree bin). Deploy with:
+  ```bash
+  cp /c/Dev/STINGTOOLS-boq-impl/StingTools/bin/Release/StingTools.dll \
+     /c/Dev/STINGTOOLS/CompiledPlugin/StingTools.dll
+  ```
+  If this fails with `Device or resource busy`, **Revit is open** — the human
+  must close it first. Confirm the deployed file's timestamp updated after each
+  copy. Source commits alone change nothing in a running Revit; the DLL must be
+  rebuilt + copied + Revit restarted.
+- **Git discipline:** commit per task (imperative subject + the
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer). **Do NOT
+  push or merge** unless explicitly told. Many agents share `C:\Dev\STINGTOOLS`;
+  never `reset --hard` without verifying the branch.
+- Log each task in `docs/CHANGELOG.md` (prepend a `#### Completed (...)` block
+  above the most recent one). Since builds now compile-verify, state
+  `Compile-verified headless (Nice3point): 0 errors` rather than the old
+  no-build caveat. **Behaviour still needs a real Revit run** — say so.
+
+### Current state you are building on (already shipped this branch)
+- **Inline Actions workspace:** `UI/BOQCostManagerPanel.cs` Actions tab is a
+  2-column master-detail (`BuildActionsTab` → `BuildActionReportPane`,
+  `_actionReportHost` / `_actionReportTitle` / `_actionsTab`). `RunActionInline`
+  registers inline sinks then dispatches; `ShowInlineResult(b)` renders into the
+  Actions pane when `_mainTabs.SelectedItem == _actionsTab`.
+- **Inline pickers/results (no popups):**
+  - `UI/StingListPicker.cs` (namespace **`StingTools.Select`**) has statics
+    `InlineHost` (Border) + `InlineTitleSink`, a `_inlineFrame` DispatcherFrame,
+    `ShowInline(string title)`, and `FinishInlineOrClose()`. Both `Show(...)`
+    overloads short-circuit to `ShowInline` when `InlineHost != null`.
+    `PopulateList` honours `ListItem.IsSelected` (pre-check).
+  - `UI/StingResultPanel.cs` has a static `InlineSink`; `Builder.Show()` routes
+    to it instead of `ShowDialog` when set.
+  - `UI/StingCommandHandler.cs` `Execute(...)` `finally` (near
+    `ClearAllExtraParams()`) clears `StingTools.Select.StingListPicker.InlineHost`
+    / `InlineTitleSink` and `StingResultPanel.InlineSink`.
+- **Linked models (per-link, persisted):** `BOQ/BOQCostManager.cs` has
+  `GetIncludedLinkTitles(doc)` / `SetIncludedLinkTitles(doc, titles)` backed by
+  `<project>/_BIM_COORD/boq_links.json` + `_linkInclusionCache`; `BuildBOQDocument`
+  STEP 6c calls `CollectLinkedItems(doc, knownCats, csvRates, cobieCostCodes,
+  grouping, includedTitles)`. Linked rows are neutralised for host write-back
+  (`RevitElementId = -1`, `UniqueId = ""`, `ConstituentElementIds` cleared) and
+  carry `SourceModel = <link Title>` + a `[Linked: <model>]` Note.
+  `BoqGroupingMode.SourceModel` groups host vs each link; header `⛓ Links (N)`
+  button (`_linksBtn` / `UpdateLinksBadge` / `ChooseLinkedModels`).
+
+---
+
+## P0 — Harden the inline message pump (do first; correctness/safety)
+
+**Why:** `StingListPicker.ShowInline` pumps a nested `Dispatcher.PushFrame`
+loop on the Revit API thread. Pumping a WPF message loop **while a Revit
+transaction is open is unsafe** and can corrupt document state. Also the inline
+statics are process-global; a leak would make unrelated pickers render into a
+closed BOQ pane.
+
+### P0.1 — Transaction-state guard (fall back to modal mid-transaction)
+- The panel must tell the picker which `Document` is hosting. Add a static
+  `public static Document InlineHostDoc;` to `StingListPicker` (it already uses
+  `Autodesk.Revit.DB`). In `BOQCostManagerPanel.RunActionInline`, set
+  `StingTools.Select.StingListPicker.InlineHostDoc = Doc;` alongside `InlineHost`,
+  and clear it in `StingCommandHandler.Execute`'s `finally` with the others.
+- In **`ShowInline`** (and at the top of the two `Show` inline gates), before
+  pumping: if `InlineHostDoc != null && InlineHostDoc.IsModifiable` (a
+  transaction is open), **do NOT pump** — fall through to the normal modal
+  `ShowDialog()` path instead. Mirror the precedent in
+  `Core/Drawing/DrawingTypeStamper.StampCrop` which guards on
+  `el.Document.IsModifiable`. Log one `StingLog.Info` when it falls back so the
+  human can see which command needed it.
+- **Audit the Actions commands** under `Commands/Cost/*.cs` +
+  `BOQ/*Commands*.cs` for any `StingListPicker.Show(...)` called **after** a
+  `new Transaction(...).Start()`. List them in the CHANGELOG. (The guard makes
+  them safe regardless, but they should be known.)
+
+### P0.2 — Leak-proof the inline statics
+- At the **top** of `RunActionInline` (before `HighlightActionButton`), defensively
+  clear any stale inline registration from a prior aborted run, then set fresh.
+- Clear the inline statics when the panel/window unloads. Find where the panel is
+  torn down (the `BOQCostManagerWindow` host in `UI/BOQCostManagerWindow.cs`, or a
+  `Unloaded` handler on the `UserControl`) and null out `InlineHost`,
+  `InlineTitleSink`, `InlineHostDoc`, and `StingResultPanel.InlineSink` there.
+
+**Acceptance (P0):** builds clean; with a transaction open the picker shows
+modally (no pump); statics are null whenever no Actions command is mid-flight.
+**Smoke test for the human:** run **Variation from Diff** (it shows 4 sequential
+pickers) and **Issue Cert** from the Actions tab — confirm each picker renders
+inline, OK/Cancel return correctly, and Revit never hangs.
+
+---
+
+## P1 — High value, low risk
+
+### P1.1 — Surface `SourceModel` as a first-class column (grid + exports)
+**Why:** provenance currently rides only the `[Linked: …]` Note string. The
+`BOQLineItem.SourceModel` field already exists — expose it so a QS can
+sort/filter host-vs-link without parsing text.
+- **Grid:** in `BOQCostManagerPanel` where the DataGrid columns are built
+  (around the `DataGridTextColumn` block, ~line 1445; "Ref" column is the
+  anchor), add an optional **"Model"** column bound to `SourceModel` (show
+  `"Host"` when blank). Make it toggle with the existing column-visibility
+  dropdown (the comment near line 86 / 612 lists Level/Location/Source/Confidence/
+  Carbon/Note toggles — add Model there). Add `SourceModel` to the
+  `BOQItemViewModel` if the grid binds to a view-model wrapper.
+- **Exports:** `BOQ/BOQExportCommand.cs` already writes a **Note** column
+  (main sheet col 13 ~line 175/213; audit sheet col 14 ~line 251/271). Add a
+  dedicated **"Source Model"** column next to Note on both sheets (write
+  `item.SourceModel ?? "Host"`). Do the same in
+  `BOQ/BOQProfessionalExportCommand.cs` takeoff/audit sheet if it lists rows.
+- Keep the `[Linked: …]` Note tag too (don't remove — other tooling may read it).
+
+**Acceptance:** Model column visible/toggleable in the grid and present in both
+XLSX exports; host rows read "Host", linked rows read the link Title.
+
+### P1.2 — Don't re-traverse links on every refresh (performance)
+**Why:** `BOQCostManagerPanel.RefreshAsync()` runs `BuildBOQDocument(Doc, …)`
+**synchronously on the UI thread**, and STEP 6c walks **every linked document**
+each rebuild. On a real federated model this freezes Revit on every rate edit /
+filter toggle.
+- **Cache the per-link takeoff** in `BOQCostManager`. Key a cache on the link
+  document's identity (e.g. `linkDoc.PathName` + `linkDoc.GetHashCode()` or a
+  cheap change signal such as the link's `GetWorksharingTooltipInfo`/last-write
+  if available; if no reliable signal exists, key on `PathName` and expose
+  `InvalidateLinkCache()` called from `ChooseLinkedModels` and on document close).
+  Return cloned line items from the cache so callers can mutate freely.
+- Only re-run a link's `CollectCandidateElements` + per-link aggregate when its
+  cache entry is missing/invalidated. Host takeoff stays as-is.
+- Wire `InvalidateLinkCache()` into `StingToolsApp.OnDocumentClosing` next to the
+  other per-doc cache invalidations, and call it from `SetIncludedLinkTitles`
+  (selection changed ⇒ recompute is fine, but a reload of the *same* selection
+  must hit the cache).
+- **Stretch (optional):** if the host takeoff itself is slow on big models, move
+  the whole `BuildBOQDocument` call in `RefreshAsync` onto a background thread
+  with the existing `UI/StingProgressDialog`, marshalling the result back to the
+  UI thread for `RefreshDisplay`. Only do this if profiling shows the host
+  takeoff (not just links) is the bottleneck — Revit API reads must stay on the
+  API thread, so this requires care (read element data into POCOs on the API
+  thread, compute/group off-thread). If unsure, **leave host single-threaded and
+  only cache links** — that alone removes the per-refresh link cost.
+
+**Acceptance:** toggling a filter / editing a rate with links enabled does not
+re-walk link docs (verify via a `StingLog.Info` count that fires only on cache
+miss); first enable still computes once.
+
+### P1.3 — Persist Cost Manager UI state per project
+**Why:** the link selection persists (`boq_links.json`) but grouping mode,
+display currency, column visibility, and the expand/collapse sets reset every
+session — the same sustainability gap, still open.
+- Add `<project>/_BIM_COORD/boq_ui_state.json` (same load/save shape as
+  `BoqPrintProfile` ~line 138 / `ProjectRateCardProvider` ~line 50:
+  `Path.Combine(parent, "_BIM_COORD", ...)` + `JsonConvert`). Persist:
+  `_groupingMode`, `_displayCurrency`, the visible-column set, and optionally
+  `_openSections` / `_openMaterialSections`.
+- Load it when `Doc` is first set / first `RefreshAsync`; save on each change
+  (grouping combo, currency toggle, column toggle, expand/collapse). Keep it
+  best-effort (try/catch + `StingLog.Warn`), never block the UI.
+
+**Acceptance:** set grouping = "Source model", USD, hide a column, reopen the
+project → all restored.
+
+---
+
+## P2 — Larger slices (only after P0/P1 land + smoke-test green)
+
+### P2.1 — 4D / Schedule tab (the real 5D payoff)
+Add a **Schedule** tab to the Cost Manager `_mainTabs`, reusing the existing
+`BIMManager/SchedulingCommands.cs` `Scheduling4DEngine` (32-trade sequences,
+cash-flow forecasting, Gantt). Render **inline** in the same master-detail
+pattern as Actions (no popups): phase-date assignment, a cash-flow S-curve
+(simple WPF polyline/bars — no external chart lib), and EVM (PV/EV/AC/SPI/CPI)
+pulled from `Core/Evm`. Editable grids/combos for phase dates + % complete.
+Scope this as its own multi-commit slice with its own short design note; do not
+fork `Scheduling4DEngine` — call it.
+
+### P2.2 — Inline editable forms for input-heavy actions
+Some actions (Set % Complete, EVM actuals) want an inline editable grid, not a
+pick-then-report list. Build a small reusable inline-form host in the Actions
+pane (combos + numeric fields + a Run button) and route those specific commands
+through it via the ExtraParam contract (command reads values instead of popping
+its own dialog). Convert 2–3 as a proof, then sweep.
+
+### P2.3 — Linked-instance multiplier (correctness option)
+`CollectLinkedItems` dedups by link **Title**, so a model legitimately placed
+**twice** (mirrored wings) is taken off **once** (undercount). Add an optional
+per-link instance count: when a link Title has N loaded `RevitLinkInstance`s,
+offer to multiply its quantities by N (default off — a shared reference model
+placed once is the common case). Surface the instance count in the
+`ChooseLinkedModels` picker `Detail`.
+
+---
+
+## Constraints & definition of done
+- One logical change per commit; compile-verify (`0 Error(s)`) before each commit;
+  deploy after each task and tell the human to restart Revit + smoke-test.
+- Reuse engines/helpers — **no forking** `BOQCostManager`, `Scheduling4DEngine`,
+  `StingListPicker`, `StingResultPanel`. Follow existing conventions
+  (`StingLog`, `_BIM_COORD` JSON overlays, `[Transaction]` attributes,
+  `TaskDialog` for unavoidable messages).
+- Keep linked rows **read-only for host write-back** — never let a linked
+  element's id reach `doc.GetElement` (the `RevitElementId <= 0` guard in
+  `IfcQuantitySetWriter.StampAllElements` + `CostStamp` must keep skipping them).
+- Do **not** push or merge. Log every task in `docs/CHANGELOG.md`.
+- Each task's CHANGELOG entry must list its **Revit smoke test** (the human runs
+  it — you cannot). The inline message pump (P0) MUST be exercised in Revit
+  before P2 begins: run a 4-picker command (Variation from Diff) and confirm no
+  hang and no mid-transaction pump.
+
+## Suggested order
+P0.1 → P0.2 → **(human smoke-test)** → P1.1 → P1.2 → P1.3 → **(human smoke-test)**
+→ P2.1 → P2.2 → P2.3.

--- a/docs/BOQ_5D_ENHANCEMENTS_PROMPT.md
+++ b/docs/BOQ_5D_ENHANCEMENTS_PROMPT.md
@@ -168,6 +168,12 @@ filter toggle.
 re-walk link docs (verify via a `StingLog.Info` count that fires only on cache
 miss); first enable still computes once.
 
+> **DONE (post-review):** P1.2 landed (commit `1e395a471`). A follow-up also
+> wired the header **↻ Refresh** button to call `InvalidateLinkCache()` before
+> rebuilding, so a link **Reloaded** mid-session is picked up on explicit Refresh
+> (the cache otherwise only auto-invalidates on document close). Do **not**
+> re-implement P1.2 — extend it only if profiling still shows a problem.
+
 ### P1.3 — Persist Cost Manager UI state per project
 **Why:** the link selection persists (`boq_links.json`) but grouping mode,
 display currency, column visibility, and the expand/collapse sets reset every

--- a/docs/BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md
+++ b/docs/BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md
@@ -1,0 +1,214 @@
+# BOQ Cost Manager → Unified Inline 5D Workspace — Implementation Prompt
+
+**Branch:** `claude/boq-implementation` (continue here, worktree `C:\Dev\STINGTOOLS-boq-impl`)
+**Owner of this brief:** the implementing agent. Build in **verifiable vertical
+slices**, one logical commit each. **Research further before and during** (see
+§6) — this is not a closed spec; you are expected to find and append enhancement
+gaps, not just execute the slices as written.
+
+---
+
+## 1. Mission
+
+Turn `UI/BOQCostManagerPanel.cs` from a BOQ-only panel into a **single inline 5D
+cost+programme workspace**: BOQ · Materials · **Schedule (4D/5D)** · Cash-flow,
+where every action is performed **inline through editable grids and dropdowns**
+with **zero external reporting popups** (no `TaskDialog`, no `StingResultPanel.Show()`
+windows). Results, warnings, and confirmations render **in the panel**. The user
+should be able to see, edit, and drive cost AND programme from one transparent,
+interactive surface.
+
+This unifies what is today split across the BOQ Cost Manager (cost) and the 13-tab
+BIM Coordination Center / `BIMManager/SchedulingCommands.cs` (4D/5D) — **by
+referencing the existing engine, never forking it.**
+
+---
+
+## 2. Current state (verified anchors — re-read before editing; lines drift)
+
+**The panel already has every mechanism you need — reuse, don't reinvent:**
+
+- **Inline view swap** — `BOQCostManagerPanel.ShowTenderSetupInline()` /
+  `HideTenderSetupInline()` swap `_mainTabs` for a `_contentHost` child built by
+  `BuildTenderSetupView()` (`BOQCostManagerPanel.cs:~2068-2105`). A Schedule view
+  is the same move.
+- **Editable-tabs-from-a-dialog** — `BOQTenderDialog.CreateInlineTabs()`
+  (`:2097`) is the canonical "build a dialog's controls, embed them inline
+  instead of `ShowDialog()`" pattern. The tender setup is already inline,
+  editable grids/dropdowns, **no modal**. Mirror it.
+- **Revit-thread dispatch, no popup** — `DispatchAction("tag")` →
+  `StingBOQActionHandler` ExternalEvent (`:2031`). It sets
+  `StingCommandHandler.SetExtraParam(...)` then dispatches, so the command runs on
+  the Revit API thread and the tag resolves through `StingCommandHandler`'s case
+  map. Action buttons already use it (`:283` Refresh, `:884` Import, `:885`
+  Export, `:1506/1716` per-row edits).
+- **Inline status (the no-popup convention)** — `FlashHint(vm, message)`
+  (`:2039`) flashes an amber message in the coverage strip for 4s then restores.
+  Use/extend this (and an embedded result region) instead of message boxes.
+- **Per-row inline edit + write-back** — `:1715-1720` shows the pattern: set
+  ExtraParams (`BOQEditRateUGX`, `BOQEditNRM2Para`, …) → `DispatchAction(
+  "BOQWriteItemParams", refreshAfter:false)`. Editable grids drive Revit writes
+  through this exact channel.
+
+**The 4D/5D engine to reference (do NOT fork):**
+`BIMManager/SchedulingCommands.cs` — `internal static Scheduling4DEngine` (`:39`)
+plus ~20 commands: `AutoSchedule4DCommand` (`:1211`), `ImportMSProjectCommand`
+(`:1291`), `ExportSchedule4DCommand` (`:1467`), `AutoCost5DCommand` (`:1542`),
+`ImportCostRatesCommand` (`:1629`), `CostReport5DCommand` (`:1678`),
+`CashFlow5DCommand` (`:1745`), `PhaseSummaryCommand` (`:1931`),
+`MilestoneRegisterCommand` (`:2014`), `WorkingCalendarCommand` (`:2090`),
+`NavisworksTimeLinerExportCommand`, `ElementCostTraceCommand`, `ExportFor4DViewerCommand`,
+P6 link (`P6LiveLinkConfigCommand`/`P6WritebackCommand`/`P6SyncNowCommand`).
+
+**Already done on this branch (build on, don't redo):** INT-0 GlobalId
+(gold-standard + canonical encoder, 8/8 tests), INT-2 priced round-trip + P2-8,
+INT-1 `BOQExportIfcQtoCommand` (tag `BOQExportIfcQto`, dispatch case already in
+`StingCommandHandler` at `:3511`).
+
+---
+
+## 3. The one real refactor: engine returns data, panel renders it
+
+"Zero external popups" is impossible while commands call `TaskDialog`/
+`StingResultPanel.Show()` themselves. The structural change:
+
+- **Separate logic from presentation.** Each scheduling/cost action must be able
+  to **return its result as plain data** (task list, phase dates, period costs,
+  cash-flow series, validation messages) instead of popping a window. Most of this
+  already lives in `Scheduling4DEngine` / `BOQCostManager` — surface it.
+- **Render inline.** Bind results to `ObservableCollection`-backed **editable
+  `DataGrid`s** and inline charts in the panel; render status/warnings via the
+  coverage strip / an embedded results region.
+- **`StingResultPanel` as an embedded control.** Where a rich result view is
+  wanted, host `StingResultPanel` as a `FrameworkElement` inside `_contentHost`
+  rather than `.Show()`-ing it as a window. (Small change to how it's hosted; keep
+  the `.Show()` API for non-panel callers.)
+- **Don't break headless callers.** Commands invoked from workflows/ribbon still
+  need a default presentation — gate the inline-vs-popup behaviour on an
+  ExtraParam (e.g. `InlineHost=1`) the panel sets, mirroring the existing
+  `SkipDialog` ExtraParam pattern the tender export already uses.
+
+---
+
+## 4. Hard requirements
+
+1. **No external reporting popups** from any action driven by this panel —
+   replace `TaskDialog.Show` / `StingResultPanel.Show()` with inline rendering.
+   (Genuine *blocking confirmations* — "overwrite N rates?" — may use an inline
+   confirm row, not a modal.)
+2. **Everything editable inline** — grids with editable cells + dropdowns
+   (`ComboBox` cells) for rates, phases, trades, calendars, currency, markups.
+   Edits write through the existing `DispatchAction` + ExtraParam channel on the
+   Revit thread.
+3. **Reference the engine, never duplicate** — call `Scheduling4DEngine` /
+   `BOQCostManager`; do not re-implement 4D/5D math in the panel.
+4. **Revit-thread safety** — all model reads/writes via the panel's ExternalEvent
+   (`DispatchAction`); never touch the Revit API directly from a WPF event.
+5. **Performance** — BOQs/schedules can be thousands of rows. Use
+   `VirtualizingStackPanel`/virtualized `DataGrid`; don't rebuild the whole view
+   on every edit.
+6. **One slice per commit; no-build sandbox** — this is WPF + Revit-API code that
+   **cannot be compile-checked here**. Every Revit/WPF call must use a documented
+   signature; mark uncertainty with `// TODO-VERIFY-API`; note the no-build caveat
+   in the commit + CHANGELOG; **verify each slice in Revit before the next**. Do
+   **not** push or merge.
+
+---
+
+## 5. Phased build
+
+### Slice 1 — QTO button + establish the inline-result convention (small, first)
+- Add a **"⛁ QTO IFC"** (or similar) button to the Cost Manager action row beside
+  Export/Import (`:885` area) → `DispatchAction("BOQExportIfcQto")`. The dispatch
+  case already exists in `StingCommandHandler` (`:3511`) — **verify** the
+  `DispatchAction` path actually reaches it (it routes through `StingCommandHandler`;
+  if the panel's `StingBOQActionHandler` has its own switch, add the case there too).
+- Make `BOQExportIfcQtoCommand` (and ideally the standard Export) **render their
+  result inline** when invoked from the panel (set `InlineHost=1`): output path +
+  "elements stamped" + the LIMITATIONS notes go to an **inline results region /
+  coverage strip**, not `StingResultPanel.Show()`. This proves the no-popup
+  pattern end-to-end on one action and is the template for everything after.
+
+### Slice 2 — Schedule (4D/5D) inline tab
+- Add a **Schedule** tab/inline view (mirror `CreateInlineTabs`/`BuildTenderSetupView`)
+  with editable grids:
+  - **Tasks/phases** — name, trade, predecessor, start/finish, duration, % complete
+    (editable; dropdowns for trade + predecessor). Drives `AutoSchedule4D` /
+    `PhaseSummary` / `WorkingCalendar`.
+  - **Cost-by-period (5D)** — period × cost grid feeding the **cash-flow**; editable
+    rate/calendar inputs. Drives `AutoCost5D` / `CashFlow5D` / `CostReport5D`.
+  - **Cash-flow S-curve** — simple inline bar/line (cumulative cost vs time). No
+    external chart window.
+  - **Import/Export** — MS Project XML (`ImportMSProject`/`ExportSchedule4D`),
+    Navisworks TimeLiner, P6 sync — all results **inline** (status strip), file
+    pickers are the only acceptable OS dialog.
+- All actions via `DispatchAction`; all results inline.
+
+### Slice 3 — Sweep remaining BOQ/scheduling commands to engine-returns-data + inline
+- Convert the remaining cost/scheduling command popups (`CostReport5D`,
+  `PhaseSummary`, `MilestoneRegister`, `ElementCostTrace`, BOQ validate/delta/
+  rate-audit, etc.) to the inline pattern. Retire their `TaskDialog`s when invoked
+  from the panel (keep a popup fallback for ribbon/workflow callers via the
+  `InlineHost` gate).
+
+---
+
+## 6. RESEARCH MANDATE — find more, then append
+
+Before/while building, **research and append enhancement gaps** beyond this brief.
+At minimum:
+
+1. **Industry 5D cost/programme UIs** (RIB iTWO, CostX workbooks, Candy, cove.tool,
+   Power BI cost dashboards): what interactivity do their inline cost+cash-flow
+   grids offer — in-cell editing, grouping/pivot, drill-down to element, undo,
+   live re-cost on edit, variance/EVM colouring — that STING's panel should match?
+   Cite sources; propose the high-value subset.
+2. **WPF interactivity & a11y** patterns for large editable grids: virtualization,
+   in-place validation, keyboard nav, copy/paste from Excel, multi-select edit,
+   theming (the panel already has Navy/Amber theme brushes), undo/redo.
+3. **Cross-check the existing BOQ review** (`docs/BOQ_REVIEW_AND_HARDENING_PROMPT.md`,
+   Part A P0–P3 + Part B INT-0..INT-8) for items that should be **surfaced inline
+   in this panel** rather than hidden, e.g.:
+   - **P0-3** uncosted "value at risk" → an inline **red banner** + a filter to the
+     unpriced rows (not a buried per-row confidence).
+   - **P0-4** rate-confidence gate → inline confidence colouring + an export gate
+     prompt in-panel.
+   - Rate-source heat-map (`BOQRateSourceHeatMapCommand`) → an inline column/legend.
+   - **INT-2** estimator-imported rates → provenance badge inline.
+   - Carbon (P0-7/INT-7) → an inline carbon column + RIBA-stage rollup beside cost.
+4. **STING's own backlog** — scan `docs/ROADMAP.md` and `Planscape.Server/docs/
+   PLANSCAPE_GAPS.md` for cost/5D/UX gaps to fold in.
+5. **EVM** (`Core/Evm/`), **Variations** (`Core/Variation/`), **Payment certs**
+   (`Core/PaymentCert/`) already exist (Phase 191) — propose inline tabs/columns so
+   the workspace covers the full cost-control lifecycle, not just the bill.
+
+For each enhancement you adopt: add it to a slice, justify it in the commit/
+CHANGELOG, and keep it inline + editable + popup-free. **Log what you researched
+and what you deliberately deferred** (no silent scope cuts).
+
+---
+
+## 7. Acceptance criteria
+
+- [ ] BOQ Cost Manager hosts BOQ · Materials · **Schedule (4D/5D)** · Cash-flow
+      inline; no `TaskDialog`/`StingResultPanel.Show()` window appears for any
+      panel-driven action (file pickers excepted).
+- [ ] Cost AND programme are **editable in-grid** (cells + dropdowns); edits write
+      to the model via the ExternalEvent and refresh inline.
+- [ ] Cash-flow S-curve renders inline and updates on edit.
+- [ ] `BOQExportIfcQto` reachable from a panel button, result shown inline.
+- [ ] 4D/5D logic comes from `Scheduling4DEngine` (no forked math).
+- [ ] At least the P0-3/P0-4/heat-map/provenance/carbon items from §6.3 are
+      surfaced inline.
+- [ ] Large-model performance: virtualized grids, no full-rebuild per keystroke.
+- [ ] A short in-Revit smoke-test checklist accompanies each slice.
+- [ ] CHANGELOG entry per slice with the no-build caveat; nothing pushed/merged.
+
+## 8. Guardrails
+
+- Continue on `claude/boq-implementation`; build on its commits; don't regress
+  INT-0/INT-1/INT-2.
+- **Reference, don't fork** the 4D/5D + EVM/Variation/PayCert engines.
+- One logical slice per commit; `// TODO-VERIFY-API` on uncertain Revit/WPF calls;
+  no `dotnet build` here — **verify in Revit before each next slice**.
+- Don't push or merge. Surface decisions; do not silently cut scope.

--- a/docs/BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md
+++ b/docs/BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md
@@ -212,3 +212,105 @@ and what you deliberately deferred** (no silent scope cuts).
 - One logical slice per commit; `// TODO-VERIFY-API` on uncertain Revit/WPF calls;
   no `dotnet build` here — **verify in Revit before each next slice**.
 - Don't push or merge. Surface decisions; do not silently cut scope.
+
+---
+
+## 9. RESEARCH FINDINGS & APPENDED GAPS (per §6 — added by implementing agent)
+
+Researched 2026-06-26 while building Slice 1. Web-citation depth was partially
+constrained by one dropped connection during deep research; the high-value claims
+below are cited, and the rest are from STING's own verified backlog
+(`docs/ROADMAP.md`, `docs/BOQ_REVIEW_AND_HARDENING_PROMPT.md`). Nothing here is a
+silent scope cut — each gap is tagged **[adopt: Slice N]** or **[defer]** with a
+reason.
+
+### 9.1 Industry 5D cost/programme UI — what inline interactivity to match
+
+- **RIB CostX / iTWO** — *live-linked workbooks*: spreadsheet cells live-link to
+  the drawing/model AND to the rate library, so a rate edit re-costs the bill
+  immediately; **double-click drill-down** from a subtotal → cost breakdown and
+  from a quantity cell → quantity breakdown (auto-generated formula). Lesson:
+  (a) **live re-cost on edit**, (b) **drill-down from a cost line to its source**
+  (STING already has `SelectInRevit` per row — surface it as the drill-down).
+  Source: <https://www.rib-software.com/en/rib-costx/bim>,
+  <https://www.rib-software.com/en/blogs/rib-costx-functions>
+- **BuildSoft Candy / cove.tool / Power BI cost dashboards** — pivot/grouping,
+  variance colouring (budget vs actual), and an **S-curve / cash-flow** chart as a
+  first-class view, not a popup. Lesson: grouping is already in STING
+  (`BoqGroupingMode`); add **variance colour** + an **inline S-curve** (Slice 2).
+- **High-value subset adopted:** in-cell editing (have it), live re-cost on edit
+  **[adopt: Slice 2/3]**, drill-down-to-element **[adopt: Slice 3 — promote
+  `SelectInRevit`]**, variance/EVM colouring **[adopt: Slice 2]**, inline S-curve
+  **[adopt: Slice 2]**. Pivot beyond the current grouping modes **[defer]** —
+  current WorkSection/Discipline/Level grouping covers the common case.
+
+### 9.2 WPF large-editable-grid patterns to apply
+
+- `DataGrid.EnableRowVirtualization` is **on by default** (creates/recycles
+  `DataGridRow` only for visible items); `EnableColumnVirtualization` is **off by
+  default** — turn it on for wide cost grids. Add
+  `ScrollViewer.IsDeferredScrollingEnabled="true"` + `VirtualizingPanel.IsVirtualizing`
+  / `VirtualizationMode=Recycling` for thousands of rows.
+  Source: <https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.datagrid.enablerowvirtualization>,
+  <https://docs.telerik.com/devtools/wpf/controls/radgridview/features/ui-virtualization>
+- In-place validation via `IDataErrorInfo` / `ValidationRules`; keyboard nav is
+  native to `DataGrid`; **Excel copy/paste** — `DataGrid` supports Ctrl+C
+  (`ClipboardCopyMode`); paste-from-Excel needs a `CommandBinding` for
+  `ApplicationCommands.Paste` that splits `\t`/`\r\n`. Multi-select bulk-edit via
+  `SelectionMode=Extended` + apply-to-selection. Undo/redo: keep a per-edit
+  command stack (the model edits already round-trip through `BOQWriteItemParams`,
+  so an undo = re-dispatch the prior value).
+  **[adopt: Slice 2 grids use a real `DataGrid` with virtualization; copy/paste +
+  undo adopt: Slice 3]**. NOTE: today's BOQ tab renders **section `StackPanel`s,
+  not a single `DataGrid`** — the Schedule tab (Slice 2) is the first true
+  virtualized `DataGrid`; converting the BOQ bill grid is **[defer]** (large, and
+  the existing per-section rendering already preserves open/closed state).
+
+### 9.3 EVM presentation (Core/Evm already exists — surface it inline)
+
+- Metrics: PV(BCWS), EV(BCWP), AC(ACWP); **CV = EV−AC**, **SV = EV−PV**;
+  **CPI = EV/AC**, **SPI = EV/PV**; **EAC = BAC/CPI** (or `AC+(BAC−EV)`),
+  **ETC = EAC−AC**, **VAC = BAC−EAC**. S-curve = cumulative PV/EV/AC vs time.
+- Conventional RAG on CPI/SPI: **green ≥ 0.95, amber 0.85–0.95, red < 0.85**
+  (some teams: green > 1, amber ≈ 1, red < 0.9).
+  Source: <https://www.planacademy.com/7-earned-value-management-formulas/>,
+  <https://www.gatherinsights.com/en/earned-value/cpi-spi>
+- **[adopt: Slice 2/3]** EVM strip on the Schedule/Cash-flow tab: PV/EV/AC S-curve
+  + CPI/SPI RAG chips, reading from `Core/Evm`. **ROADMAP caveat folded in:** BCWS
+  still comes from a QS-entered planned % (no cost-loaded-schedule wiring) — show
+  that provenance inline rather than implying a real 4D baseline.
+
+### 9.4 BOQ-review items to surface inline (from §6.3 — verified in BOQ_REVIEW)
+
+- **P0-3 (uncosted "value at risk")** — unmatched rate → silent £0 line folded
+  into the total. **[adopt: Slice 1 banner scaffold → Slice 3 full]**: an inline
+  **red banner** with the count + UGX/USD value-at-risk and a one-click filter to
+  the unpriced rows (reuse `_searchBox`/`RebuildSectionsView`).
+- **P0-4 (rate-confidence export gate)** — `RateConfidence` computed but never
+  gates export. **[adopt: Slice 3]**: inline confidence colouring (already partly
+  present per row) + an in-panel acknowledge row before export below
+  `MinRateConfidenceForExport` (default 60).
+- **Rate-source heat-map** (`BOQRateSourceHeatMapCommand`) — **[adopt: Slice 3]**
+  as an inline column + legend, not a separate view.
+- **INT-2 estimator-imported rates** — **[adopt: Slice 3]** provenance badge inline
+  on rows whose rate came from the priced round-trip import.
+- **Carbon (P0-7/INT-7)** — embodied-carbon card already exists; **[adopt: Slice 3]**
+  an inline carbon column + RIBA-stage rollup beside cost. Honour P0-7: do **not**
+  add a new carbon engine — read the existing `CarbonFactorResolver` numbers.
+
+### 9.5 Full cost-control lifecycle (Phase 191 engines already exist)
+
+- `Core/Evm`, `Core/Variation`, `Core/PaymentCert` exist. **[adopt: Slice 3 — thin
+  inline tabs/columns]**: a Variations grid (create/quote/approve, budget impact)
+  and a Payment-cert summary, each **referencing** the existing engines (no forked
+  math), so the workspace covers bill → variation → cert → EVM, all inline +
+  editable + popup-free.
+
+### 9.6 Deliberately deferred (logged, not silently cut)
+
+- Converting the existing per-section BOQ bill `StackPanel` into one virtualized
+  `DataGrid` (large refactor; current rendering preserves section state).
+- Full pivot beyond the existing grouping modes.
+- Cost-loaded 4D baseline for a real EVM BCWS (ROADMAP open item — needs schedule
+  wiring; Slice 2 shows the QS-planned-% provenance instead of faking it).
+- Excel-style copy/paste + a formal undo/redo stack (Slice 3 if budget allows).

--- a/docs/BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md
+++ b/docs/BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md
@@ -314,3 +314,62 @@ reason.
 - Cost-loaded 4D baseline for a real EVM BCWS (ROADMAP open item — needs schedule
   wiring; Slice 2 shows the QS-planned-% provenance instead of faking it).
 - Excel-style copy/paste + a formal undo/redo stack (Slice 3 if budget allows).
+
+---
+
+## 10. Live-test feedback (Slice 1.5) — Actions master-detail + Materials expand fix
+
+From an in-Revit test of Slice 1. Four items; do them as **Slice 1.5** (one
+commit), keeping the zero-popup + inline conventions from Slice 1.
+
+### 10.1 — Actions tab → master-detail (buttons LEFT, report RIGHT) [PRIORITY]
+**Problem:** the Actions tab shows grouped buttons (QS Round-trip, Automation,
+Cost Plan, Payment Certs, Variations, EVM) but clicking them shows nothing inline
+("no functions seen") — results still go to popups or nowhere.
+**Build:** split the Actions tab into a **two-column master-detail** view:
+- **Left rail** — the existing grouped action buttons (P3/P2/P4/P5.1/P5.2/P5.3),
+  vertical, scrollable; the clicked button gets a selected/highlight state.
+- **Right pane** — a single **inline report region** (reuse `BuildInlineContent`
+  + the `BOQInlineResults`/`InlineHost=1` convention from Slice 1) that renders
+  **the result of whichever button was last clicked**. Title = the action name.
+- **Every action routes its result here** — set `InlineHost=1` before each
+  `DispatchAction`, so EVM metrics, VO register, cert register, cost-plan
+  comparison, validation output, etc. all render in the right pane. **No
+  `TaskDialog`/`StingResultPanel.Show()`** for any Actions-tab button.
+- Where the action's output is tabular/editable (EVM metrics, VO register, cert
+  register, cost-plan rows), render an **editable `DataGrid`** in the right pane,
+  not static text — consistent with §4.2.
+- Empty state: right pane shows "Select an action on the left." until first click.
+
+This makes the no-popup convention the default for the whole Actions surface and
+is the template the Schedule tab (§5 Slice 2) will reuse.
+
+### 10.2 — Materials Expand-all / Collapse-all don't work (BOQ does) [BUG]
+**Root cause (verified):** the `⊞ Expand all` / `⊟ Collapse all` toolbar buttons
+(`BOQCostManagerPanel.cs:462-473`) only mutate the BOQ `_openSections` set and
+call `RebuildSectionsView()` — they never touch the Materials tab. The Materials
+expanders (`BuildMaterialsContent` `:1818-1821`) are hardcoded `IsExpanded=false`
+with no state tracking and no `Expanded/Collapsed` handlers.
+**Fix:** give Materials the same treatment as BOQ — an `_openMaterialSections`
+set (or a shared expand-state), `Expanded/Collapsed` handlers that persist it,
+`IsExpanded` seeded from it, and make Expand-all/Collapse-all **apply to the
+active tab** (or both): set the Materials state then `RebuildMaterialsTab()`.
+Also persist per-section state across `Refresh` so a manual chevron toggle
+survives a rebuild (BOQ already does this via `_openSections`).
+
+### 10.3 — Schedule (4D/5D) still absent [= Slice 2, expected]
+Confirmed not built yet — that is **Slice 2** (§5). The Actions tab already
+surfaces P5.x cost-control (certs/variations/EVM); the Schedule tab adds the 4D
+programme + 5D cash-flow grids referencing `Scheduling4DEngine`. Build it after
+1.5 lands, reusing the §10.1 master-detail/inline-report pattern.
+
+### 10.4 — "No functions seen yet"
+Largely a symptom of 10.1 (actions produced no visible inline output). Once the
+right-pane report is wired, every Actions button should visibly do something
+inline. While testing, confirm each P-group button actually reaches its command
+(the `DispatchAction` tag resolves in `StingCommandHandler`); log any tag that
+falls through so it can be wired.
+
+**Guardrails unchanged:** reference engines (don't fork), Revit-thread via
+`DispatchAction`, virtualized grids, `// TODO-VERIFY-API` on uncertain calls, no
+sandbox build → verify each in Revit, one commit for Slice 1.5, don't push/merge.

--- a/docs/BOQ_INLINE_ACTIONS_SLICE3_PROMPT.md
+++ b/docs/BOQ_INLINE_ACTIONS_SLICE3_PROMPT.md
@@ -1,0 +1,169 @@
+# BOQ Cost Manager — Slice 3: convert all Actions to INLINE reporting
+
+You are a terminal coding agent on the **StingTools** C# Revit plugin. The BOQ
+& Cost Manager **Actions** tab is a master-detail surface: buttons on the left, a
+single **report pane on the right**. Inline **input pickers** already work; what
+remains is **inline results** — most Actions commands still report through Revit
+`TaskDialog` popups, so their result never lands in the pane. Your job: convert
+the Actions-dispatched commands to report via `StingResultPanel` so **every
+action renders its result in the right pane, with no popup**.
+
+---
+
+## 0. Environment, build & deploy (READ FIRST)
+
+- **Work in this worktree:** `C:\Dev\STINGTOOLS-boq-impl`, branch
+  `claude/boq-implementation`. Verify with `git branch --show-current` before
+  editing. Do **not** build from `C:\Dev\STINGTOOLS` (different branch).
+- **Compile-verify every change** (Nice3point headless build works here — the old
+  "can't build in sandbox" caveat is dead):
+  ```bash
+  dotnet build StingTools/StingTools.csproj -c Release -t:Rebuild --nologo -v minimal
+  ```
+  Must report `0 Error(s)`. Use `-t:Rebuild` to truly recompile your edits.
+- **Deploy** (the `.addin` loads this absolute path; Revit hard-locks it):
+  ```bash
+  cp /c/Dev/STINGTOOLS-boq-impl/StingTools/bin/Release/StingTools.dll \
+     /c/Dev/STINGTOOLS/CompiledPlugin/StingTools.dll
+  ```
+  `Device or resource busy` ⇒ Revit is open; the human must close it. Confirm the
+  deployed timestamp updated. Source commits alone change nothing in a running
+  Revit.
+- **Commit per file/group**, imperative subject + `Co-Authored-By: Claude Opus
+  4.8 <noreply@anthropic.com>` trailer. **Do NOT push or merge.** Log in
+  `docs/CHANGELOG.md`. Each task's CHANGELOG entry must state its Revit smoke
+  test (the human runs it).
+
+---
+
+## 1. How inline reporting already works (you do NOT touch the panel)
+
+The plumbing is done and shipped on this branch — **do not re-implement it**:
+- `StingResultPanel.InlineSink` (static `Action<Builder>`). When set,
+  `Builder.Show()` routes the result to the sink **instead of** popping a window.
+- `BOQCostManagerPanel.RunActionInline` sets that sink (→ `ShowInlineResult`,
+  which renders into the Actions pane), sets `InlineHost=1`, then dispatches.
+- `StingCommandHandler.Execute`'s `finally` clears the sink and invokes
+  `BOQCostManagerPanel.PendingActionResolve`, which — if the command did NOT post
+  an inline result — resolves the "Running…" placeholder to "✓ completed
+  (reported in a dialog)". **That safety net is why un-converted commands no
+  longer look stuck — but the goal is to make them render inline instead.**
+
+**Therefore: the ONLY change you make is inside each command — swap its terminal
+`TaskDialog.Show(...)` report for a `StingResultPanel.Create(...)…Show()`.** When
+you do, `Builder.Show()` automatically lands it in the pane (and flips
+`_inlineResultPosted` true so the placeholder-resolver no-ops). **No edits to
+`BOQCostManagerPanel`, `StingResultPanel`, `StingListPicker`, or
+`StingCommandHandler` are needed or wanted.**
+
+---
+
+## 2. Scope — the Actions-dispatched commands
+
+The Actions tab (`BuildActionsTab` in `UI/BOQCostManagerPanel.cs`) dispatches
+tags backed by these files (all currently report via `TaskDialog`, none via
+`StingResultPanel`):
+
+| File | TaskDialog calls | Representative tags / actions |
+|---|---|---|
+| `Commands/Cost/CostCommands.cs` | 7 | `Cost_RunWorkflow`, `Cost_ClearStale`, `Cost_ToggleStaleMarker`, `Cost_MigrateCurrencyParams`, `Cost_MigrateEs*`, `Cost_ReloadRules`, `Cost_ValidateAll` |
+| `Commands/Cost/CostPlanCommands.cs` | 6 | `CostPlan_Create`, `CostPlan_Update`, `CostPlan_Export`, `CostPlan_CompareStages`, `CostPlan_SetBudget` |
+| `Commands/Cost/PaymentCertCommands.cs` | 7 | `PayCert_Create`, `PayCert_Export`, `PayCert_Reconcile`, `PayCert_Sign` |
+| `Commands/Cost/VariationAndEvmCommands.cs` | 15 | `Var_Create`, `Var_Approve`, `Evm_Calculate`/`EVM_Dashboard`, `EVM_Export`, `EVM_Forecast` |
+| `Commands/Cost/IfcAndIcmsCommands.cs` | 4 | `ICMS_Export`, `IFC_CostIngest`, `ICMS_Validate`, `IFC_CostBridge` |
+| `Commands/Cost/MeasurementStandardCommands.cs` | 2 | `Meas_SetNRM`, `Meas_SetSMM7`, `Meas_SetCIOS`, `Meas_Audit`, `Meas_RuleReport` |
+| `Commands/Cost/CostControlCommands.cs` | 3 (2 already use SRP) | `Cost_AnticipatedFinalCost`, `Cost_StandardInspect`, `ReconcileProvisionals` |
+
+Plus the `BOQ*` tags already on the Actions tab (`BOQQsExport`, `BOQQsImport`,
+`BOQAddManualRow`) — audit those too; convert any terminal `TaskDialog` report.
+
+**First step:** enumerate the action tags by reading `BuildActionsTab`, map each
+tag → command class (via `StingCommandHandler`'s switch + the `[…]` command
+files), and build a checklist. Work file-by-file.
+
+---
+
+## 3. The conversion pattern
+
+For each command, replace the **terminal result** `TaskDialog.Show(title, body)`
+with a `StingResultPanel`. Keep the command's actual work/transactions identical
+— only the reporting surface changes.
+
+**Before:**
+```csharp
+TaskDialog.Show("STING Cost", $"Cleared {cleared} stale flag(s).");
+return Result.Succeeded;
+```
+**After:**
+```csharp
+var rp = StingResultPanel.Create("Clear stale flags");
+rp.AddSection("RESULT").Metric("Stale flags cleared", cleared.ToString());
+rp.Show();   // routes inline automatically when the Actions pane is hosting
+return Result.Succeeded;
+```
+
+Richer reports use multiple sections / metrics / text rows (see the existing
+inline-capable example `BOQ/BOQExportIfcQtoCommand.cs` and the 2 SRP users in
+`CostControlCommands.cs` for the API shape — `Create` / `SetSubtitle` /
+`AddSection` / `.Metric(k,v)` / `.Text(...)`).
+
+### Rules
+1. **Terminal success/summary dialogs → `StingResultPanel`.** Always.
+2. **Early-return guards** ("No active document", "Select a section first",
+   "Pick a baseline"): prefer a one-line `StingResultPanel.Create(title)
+   .AddSection("…").Text(msg).Show()` so they also land inline. You MAY leave a
+   `TaskDialog` only for a genuine hard block that must interrupt the user (note
+   any you keep, and why, in the CHANGELOG).
+3. **Do NOT** alter command logic, transaction scope, parameter writes, or the
+   `[Transaction]` attribute. Reporting surface only.
+4. **Do NOT** set/clear `StingResultPanel.InlineSink` yourself — the panel owns
+   it. Your command just calls `rp.Show()`.
+5. Commands invoked from BOTH the Actions tab AND the ribbon/workflow still work:
+   when no inline sink is set (ribbon), `Builder.Show()` falls back to the modal
+   dialog automatically. So conversion is safe everywhere.
+6. Long/multi-step commands (e.g. `Cost_RunWorkflow`) may show progress via the
+   existing `StingProgressDialog` during the run, but their **final** report must
+   be a `StingResultPanel` (a summary: steps run, totals, pass/fail).
+
+### Verify each command is actually wired to the Actions tab
+A few of the listed tags may not be on the Actions tab (some are ribbon-only).
+Convert the ones reachable from `BuildActionsTab` first (that's the user-visible
+gap); convert the rest opportunistically for consistency, but they're lower
+priority.
+
+---
+
+## 4. Order of work (smallest blast radius first)
+1. `CostCommands.cs` (7) — incl. `Cost_RunWorkflow`, the action the user tested.
+2. `MeasurementStandardCommands.cs` (2) + `IfcAndIcmsCommands.cs` (4).
+3. `CostPlanCommands.cs` (6).
+4. `PaymentCertCommands.cs` (7).
+5. `VariationAndEvmCommands.cs` (15) — largest; the pickers already render inline,
+   so only the result dialogs remain.
+6. `CostControlCommands.cs` (3 remaining) + `BOQ*` Actions tags.
+
+Build + commit after each file. Deploy after each logical group so the human can
+smoke-test incrementally.
+
+---
+
+## 5. Acceptance & smoke test
+- **Build:** `0 Error(s)` on `-t:Rebuild` before every commit.
+- **Per file:** every converted command's terminal report renders in the Actions
+  right pane; the pane never shows the bare "Running…" placeholder after the
+  command finishes, and **no `TaskDialog` pops** for a normal success path.
+- **Regression:** dispatching the same command from the **ribbon** (no inline
+  sink) still shows its result as a modal dialog (the automatic fallback).
+- **Human smoke test (state it in CHANGELOG):** Actions tab → click **Run Cost
+  Workflow**, **Calculate EVM**, **New Cost Plan**, **Issue Cert**, **Validate
+  Cost** — each result appears in the right pane, no popups; the input pickers
+  for New Cost Plan / Issue Cert / Variation still render inline (they already
+  do — don't regress them).
+
+## 6. Constraints
+- One file (or small group) per commit; compile-verify first; deploy per group.
+- Reporting surface only — **no logic, transaction, or panel changes**. No fork
+  of `StingResultPanel` / `BOQCostManager`.
+- Use `StingLog` for errors; never silent-catch. **Do not push or merge.**
+- Log every file converted in `docs/CHANGELOG.md`, listing any `TaskDialog` you
+  deliberately kept (hard blocks) and why.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,40 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ Review & Hardening — INT-0 encoder hardening)
+
+Follow-up to the INT-0 encoder correction below, closing the one review caveat:
+the canonical *compression* was verified but no *real Revit-export* vector was
+pinned, so equality with what Revit's exporter writes was asserted only at the
+compression layer.
+
+- **Gold-standard path for live elements.** New `IfcGuidEncoder.FromElementGoldStandard(object)`
+  calls `Autodesk.Revit.DB.IFC.ExporterIFCUtils.CreateGUID(Element)` at runtime
+  via reflection — the exact GlobalId Revit's IFC exporter assigns — with no
+  `RevitAPIIFC.dll` compile reference (the codebase deliberately avoids it; mirrors
+  `ClashExportContext.TryGetIfcGuid`). Falls back to the canonical string encoder
+  off-Revit. Parameter typed `object` (reflects `UniqueId`) so the file stays
+  dependency-free and the fallback is unit-testable without a Revit `Element`.
+- **COBie/handover callers repointed** to the gold standard:
+  `BIMManagerCommands` (COBie ExternalIdentifier), `DocAutomationExtCommands`,
+  `HandoverExportCommands`. BOQ snapshot path stays on the string encoder
+  (UniqueId string only). Same element → identical GlobalId across all surfaces.
+- **Docstring accuracy + naming.** Softened the overstated "matches a real Revit
+  export" claim to state the compression is verified canonical, the reconstruction
+  follows the documented episode + XOR-suffix algorithm, and the gold standard is
+  the reflection path; renamed the misleading `elementId` local to `suffix`
+  (the XOR math is unchanged — `origLow4 XOR suffix = elementId`).
+- **Reflection-based logging** (`Type.GetType("StingTools.Core.StingLog, StingTools")`)
+  so the warn fires inside the plugin but the file still links standalone into
+  `StingTools.Boq.Tests`.
+- **Tests:** added a fallback pin (gold standard == string encoder when RevitAPIIFC
+  absent) + null guard. `dotnet test` green — **8/8 IfcGuidEncoder tests pass**,
+  verified locally in the sandbox (pure .NET). (The one unrelated
+  `MaterialLookupPopulate` failure pre-exists on origin/main.)
+- Open: a real Revit-export `UniqueId → GlobalId` vector still can't be pinned
+  without a Revit session — Revit-verify TODO. The reflection gold-standard path
+  closes the gap operationally for live-element callers.
+
 #### Completed (BOQ Review & Hardening — INT-0 encoder correction)
 
 Follow-up from a code review of the INT-0 commit (see

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,31 @@ Schedule/cash-flow tab (Slice 2) and the command sweep (Slice 3).
   IFC lands under `<project>/_BIM_COORD/ifc/`, (d) the ✕ dismisses the region, and
   (e) running `BOQExportIfcQto` from the ribbon still shows the normal popup.
 
+#### Completed (BOQ 5D Workspace — Slice 1.5: Actions master-detail + Materials expand)
+
+In-Revit feedback from Slice 1, two items.
+
+- **Actions tab → master-detail** (`UI/BOQCostManagerPanel.cs`). The Actions tab
+  is now a two-column `Grid`: the grouped action buttons on the **left**, a single
+  inline **report pane on the right** with a draggable `GridSplitter`. Clicking an
+  action highlights it, titles the right pane with the action name, shows a running
+  placeholder, and sets `InlineHost=1` so any inline-capable command renders its
+  result in the pane (via `BOQInlineResults` → `ShowInlineResult`, which now routes
+  to the Actions pane when that tab is active). No popup for the action surface.
+  Commands not yet converted to the inline gate still pop their own dialog — that
+  conversion is the Slice 3 sweep — but the pane always responds per-button so the
+  surface is never dead.
+- **Materials Expand-all / Collapse-all fixed** (BUG). Root cause: the ⊞/⊟ toolbar
+  buttons only drove the BOQ `_openSections`; Materials expanders were hardcoded
+  `IsExpanded=false` and untracked. Added `_openMaterialSections` (+ a
+  `MaterialCategoryKeys` helper), seeded each Materials expander's `IsExpanded` from
+  it, added `Expanded/Collapsed` handlers to persist it, and made Expand/Collapse-all
+  drive both tabs. Manual chevron state now survives a rebuild too.
+
+Built without Revit (WPF/Revit-API panel, no sandbox compile). Encoder tests still
+8/8. Schedule (4D/5D) tab is Slice 2; converting every Actions command's popup to
+inline is Slice 3. Not pushed/merged.
+
 #### Completed (BOQ Review & Hardening — INT-1 QTO IFC + pro-export round-trip key)
 
 Closed the two "known limitations" left after INT-2.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,27 @@ Schedule/cash-flow tab (Slice 2) and the command sweep (Slice 3).
   IFC lands under `<project>/_BIM_COORD/ifc/`, (d) the ✕ dismisses the region, and
   (e) running `BOQExportIfcQto` from the ribbon still shows the normal popup.
 
+#### Completed (BOQ — include-linked-models option)
+
+User request: a toggle to include / exclude linked Revit models in the takeoff.
+
+- **Engine** (`BOQ/BOQCostManager.cs`). New `IncludeLinkedModels` process-wide
+  flag (default off — so every consumer: panel, QTO export, snapshots, stays
+  consistent). New STEP 6c in `BuildBOQDocument` + `CollectLinkedItems` helper:
+  walks every loaded `RevitLinkInstance`, runs the existing
+  `CollectCandidateElements` over each `GetLinkDocument()`, builds + aggregates
+  line items per link. **Safety**: linked rows are neutralised for host
+  write-back — `RevitElementId = -1`, `UniqueId` cleared, constituent ids
+  dropped — because a link element's id can collide with a host id and stamp the
+  wrong element. `IfcQuantitySetWriter` / `CostStamp` / select-in-Revit already
+  skip `RevitElementId <= 0`, so linked rows contribute quantity + cost + carbon
+  only, tagged `[Linked: <model>]` in the Note. Quantities are parameter-derived,
+  so the link transform doesn't affect them. Unloaded links are skipped.
+- **UI** (`UI/BOQCostManagerPanel.cs`). "Incl. links" checkbox in the header
+  action strip; toggling sets the flag and refreshes. Off by default.
+
+Compile-verified headless (Nice3point): 0 errors / 0 warnings. Not pushed/merged.
+
 #### Completed (BOQ 5D Workspace — Slice 2: inline pickers + inline results, zero popups)
 
 In-Revit feedback: the Actions commands still opened external windows for input

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,46 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ 5D — P1.2: cache per-link takeoff)
+
+`RefreshAsync` runs `BuildBOQDocument` synchronously, and STEP 6c
+(`CollectLinkedItems`) re-walked every linked Revit document on every rebuild —
+so a filter toggle / rate edit / grouping change froze Revit on a federated model.
+Now each link's takeoff is cached. Compile-verified headless (Nice3point): 0 errors.
+
+- **Per-link cache** (`BOQCostManager.cs`) — `_linkTakeoffCache` keyed on the linked
+  file's `PathName` (falls back to Title). It stores the **raw** per-link line items
+  (post-`BuildLineItemFromElement`, pre-aggregate / pre-neutralise), so a host-side
+  refresh reuses them without re-reading the link's Revit DB. `AggregateLineItems`
+  + neutralise run on a clone every time, so **grouping changes stay correct without
+  invalidating the cache**. Cache contents are cloned on both store and read, so a
+  caller mutating returned rows can't corrupt the cache.
+- **Cache-hit/miss logging** — `StingLog.Info` distinguishes
+  "cache MISS — walked link" (the only path that re-reads the link DB) from
+  "cache hit — link not re-walked", so the human can confirm via `StingTools.log`
+  that a refresh no longer re-traverses links.
+- **`InvalidateLinkCache()`** — clears all cached link takeoffs; wired into
+  `StingToolsApp.OnDocumentClosing` beside the other per-doc cache invalidations.
+  **Deliberately not called from `SetIncludedLinkTitles`**: the cache is keyed
+  per-link, so changing the included-set just changes which keys are looked up
+  (newly added links miss → compute once; deselected links' entries sit harmlessly).
+  A full clear there would defeat the requirement that *a reload of the same
+  selection hits the cache*.
+- **Stretch (background-threading the host takeoff) deferred** — only links were
+  the per-refresh cost; the prompt says cache links alone when the host walk
+  isn't profiled as the bottleneck. Host takeoff stays on the API thread.
+
+**Known limitation:** with no reliable per-link change signal, reloading a link's
+geometry mid-session (Manage Links → Reload) won't invalidate its cached takeoff —
+close/reopen the document (or wait for a manual rebuild path) to refresh it.
+
+**Revit smoke test (human):** Open BOQ & Cost Manager on a model with ≥1 linked
+model included. Watch `StingTools.log`: (1) first refresh logs "cache MISS — walked
+link" once per link. (2) Toggle a discipline filter / edit a host rate / change the
+grouping mode → the rebuild logs "cache hit — link not re-walked" (no MISS), and
+the UI no longer stalls on the link walk. (3) Close + reopen the project → the next
+refresh logs MISS again (cache cleared on close).
+
 #### Completed (BOQ 5D — P1.1: SourceModel as a first-class column)
 
 Provenance (host vs linked model) was only carried on the `[Linked: …]` Note

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,40 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ Review & Hardening — prerequisite cluster: P0-1, P0-2, INT-0)
+
+First slice of `docs/BOQ_REVIEW_AND_HARDENING_PROMPT.md` on branch
+`claude/boq-implementation`. The prerequisite cluster that most other
+items depend on. **Not compile-verified (Linux sandbox, no Revit API) —
+verify in Revit before merge; do not merge to `main` without it.**
+
+- **P0-1 — IFC Qtos no longer written as zero.** `IfcQuantitySetWriter`
+  compared `item.Unit` against the Unicode glyphs `m²`/`m³`/`m`, but
+  takeoff rules + `cost_rates_5d.csv` use ASCII `m2`/`m3`/`each`, so every
+  comparison was false and `StampQuantity`'s `value <= 0` guard skipped
+  every GrossArea/NetArea/GrossVolume/NetVolume/Length/Weight Qto —
+  external cost tools (CostX, CostOS, Candy) received empty quantity sets.
+  Both sides now canonicalise through `BOQCostManager.NormaliseUnit` (made
+  `internal` as the single unit table); added `Count` stamping for `each`.
+- **P0-2 — deterministic snapshot checksum.** `BoqSnapshotHasher` ordered
+  items by `BOQLineItem.Id` and hashed it, but `Id` is a fresh
+  `Guid.NewGuid()` per build, so an unchanged model produced a different
+  SHA-256 each time and every push looked "new". Now orders by a stable
+  key (UniqueId → RevitElementId → BOQLineRef → Category → ItemName) and
+  drops the random `Id` from the hashed projection.
+- **INT-0 — stable IFC GlobalId spine.** The sync payload field
+  `ifcGlobalId` actually shipped the 45-char Revit UniqueId, and all three
+  COBie Component writers keyed off a volatile/wrong id (`el.Id` or
+  `el.UniqueId`), so BOQ rows + COBie could never join the server's
+  `ExternalElementMapping` (keyed on the real 22-char IFC GlobalId).
+  Added `BOQLineItem.IfcGlobalId` (computed from UniqueId via the one
+  shared encoder `IfcResults.IfcGuidEncoder`); `BuildLinePayload`,
+  `HandoverExportCommands`, `BIMManagerCommands`, and
+  `DocAutomationExtCommands` now all emit the canonical GlobalId. Marked
+  the server's `ElementGlobalIdRegistry` superseded by the authoritative
+  `ExternalElementMapping` (doc note — full table consolidation staged
+  separately as it needs an EF migration + consumer sweep).
+
 #### Completed (BOQ QS Upgrade — integration + Stage-B bug fixes)
 
 Consolidated P1–P4 onto one linear stack (`main→P1→P2→P3→P0fix→P4`) and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,37 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ 5D — P1.1: SourceModel as a first-class column)
+
+Provenance (host vs linked model) was only carried on the `[Linked: …]` Note
+string. The `BOQLineItem.SourceModel` field already existed — now surfaced as a
+real column so a QS can sort/filter host-vs-link without parsing text. The
+`[Linked: …]` Note tag is kept (other tooling may read it). Compile-verified
+headless (Nice3point): 0 errors.
+
+- **Grid** (`BOQCostManagerPanel.cs`) — new `BOQItemViewModel.ModelDisplay`
+  (`SourceModel` or "Host" when blank) + a toggleable **Model** DataGrid column
+  beside Src. Added "Model" to `BoqPrintProfileRegistry.ToggleableColumns` so it
+  appears in the ▦ Columns dropdown (visible by default, like Level/Location).
+  Print profiles that don't list "Model" hide it when applied — expected
+  profile-column behaviour, non-breaking until a profile is edited.
+- **Standard export** (`BOQExportCommand.cs`) — "Source Model" column added after
+  Note on both the main BOQ sheet (now col 14, Ifc GlobalId → 15) and the Item
+  Schedule sheet (col 15, trailing columns shifted). Safe for the INT-2
+  round-trip importer: `ImportBoqRatesCommand` resolves every column by header
+  name (`colIdx`), not fixed index, and scans cols 1–24.
+- **Professional export** (`BOQProfessionalExportCommand.cs`) — "Source Model"
+  column added before Ifc GlobalId on the Schedule of Sizes (takeoff/audit) sheet;
+  banner merge + widths extended to match.
+- Host rows render/write **"Host"**; linked rows the link Title.
+
+**Revit smoke test (human):** Open BOQ & Cost Manager with ≥1 linked model
+included (⛓ Links). (1) Grid shows a **Model** column — host rows "Host", linked
+rows the link Title; toggle it off/on via ▦ Columns. (2) Export ↗ (standard) →
+both the BOQ and Item Schedule sheets carry a "Source Model" column; re-import the
+edited Item Schedule and confirm rates still apply (header-name join intact).
+(3) Run the professional export → Schedule of Sizes sheet carries "Source Model".
+
 #### Completed (BOQ 5D — P0: harden the inline message pump)
 
 Correctness/safety hardening of the BOQ Cost Manager inline pickers + results

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,34 @@ Schedule/cash-flow tab (Slice 2) and the command sweep (Slice 3).
   IFC lands under `<project>/_BIM_COORD/ifc/`, (d) the ✕ dismisses the region, and
   (e) running `BOQExportIfcQto` from the ribbon still shows the normal popup.
 
+#### Completed (BOQ 5D Workspace — Slice 2: inline pickers + inline results, zero popups)
+
+In-Revit feedback: the Actions commands still opened external windows for input
+(building type / contract form / baseline snapshot) and results. Closed it
+centrally — no per-command edits, no engine forking.
+
+- **`StingListPicker` inline-aware** (`UI/StingListPicker.cs`). New static
+  `InlineHost` (+ `InlineTitleSink`). When set, `Show(...)` renders the picker's
+  content INTO the host (the Actions report pane) and pumps a nested
+  `DispatcherFrame` until OK/Cancel — so the synchronous `Show()` still returns
+  the picked value, but the user sees an inline list, not a modal window. The
+  OK/Cancel/Esc paths route through a new `FinishInlineOrClose()` that stops the
+  frame inline (never calls `Close()` on a never-shown window — which would throw
+  and hang the pump). Null host ⇒ legacy modal behaviour everywhere else.
+- **`StingResultPanel` inline-aware** (`UI/StingResultPanel.cs`). New static
+  `InlineSink`; `Builder.Show()` routes to it (→ `ShowInlineResult` → Actions
+  pane) instead of `ShowDialog` when set. Falls back to the popup on any failure.
+- **Wiring** (`BOQCostManagerPanel.RunActionInline` +
+  `StingCommandHandler.Execute`). Clicking an Actions button registers both sinks
+  pointing at the Actions pane, sets `InlineHost=1`, dispatches; the command's
+  pickers + result panel now render inline. The dispatcher's `finally` tears the
+  hooks down after the (synchronous) command runs, so ribbon / other-panel
+  commands keep their normal popups.
+
+Net effect: every Actions command — across all ~25, with zero per-command edits —
+gathers input via an inline list in the right pane and reports inline. Built
+headless via Nice3point: **0 errors / 0 warnings**. Not pushed/merged.
+
 #### Completed (BOQ 5D Workspace — Slice 1.5: Actions master-detail + Materials expand)
 
 In-Revit feedback from Slice 1, two items.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,42 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ Review & Hardening — INT-0 encoder correction)
+
+Follow-up from a code review of the INT-0 commit (see
+`docs/INT0_ENCODER_FIX_PROMPT.md`). P0-1 and P0-2 confirmed correct and
+untouched; this fixes only the GlobalId encoder INT-0 was built on.
+
+- **Encoder was non-canonical.** `IfcResults.IfcGuidEncoder.FromGuid` packed
+  bytes `3/6/7 → 4/8/10` chars and `FromRevitUniqueId` discarded the
+  element-id suffix, so STING's GlobalIds were internally consistent but did
+  **not** equal a real Revit/ArchiCAD IFC export, the server's IFC-parsed
+  mappings, or what an external estimator reads from the exported IFC. Ported
+  the canonical buildingSMART / Autodesk RevitIFC `GUIDUtil` algorithm
+  verbatim (`2/4/4/4/4/4` grouping over the documented `num[0..5]` byteArray
+  mapping) and added the element-id XOR-fold into the GUID's low 4 bytes that
+  Revit's exporter applies.
+- **Pinned with a unit test** (`StingTools.Boq.Tests/IfcGuidEncoderTests.cs`)
+  against the canonical IfcOpenShell reference vector
+  (`f70dd363-bfe3-495d-84a0-2c02dcb7d4d2` → `3t3TDZl_D9NOIWB0BSjzJI`), a
+  hand-derived folded vector, and an element-id-sensitivity check. **6/6 pass
+  under `dotnet test`** (the encoder is pure C#/net8.0, so this path *is*
+  verified here even though the wider plugin is not).
+- **Chose the string algorithm over a RevitAPIIFC reference.** Considered
+  `ExporterIFCUtils.CreateGUID(el)` for the live-element COBie path, but kept
+  one encoder (no csproj risk, sandbox-testable). BOQ snapshot + all three
+  COBie writers already route through `FromRevitUniqueId`, so they now emit
+  identical canonical GlobalIds for the same element.
+- **Server-source audit (staged follow-up, not paper-over).** The
+  server-ingest path (`IFC_PushModelCommand`) keys `ExternalElementMapping`
+  off the stored `IFC_GLOBAL_ID_TXT`, which `StabilizeIfcGuidsCommand` fills
+  from Revit's built-in IfcGUID. That equals the encoder value in the default
+  case, but **diverges under an explicit IFC-GUID override or for
+  never-exported elements**. Documented on `BOQLineItem.IfcGlobalId`: the
+  unification is to have BOQ + COBie prefer a stored `IFC_GLOBAL_ID_TXT` when
+  present (threaded through BOQ build), falling back to the encoder — staged,
+  as it touches the BOQ build path and is an override-only edge.
+
 #### Completed (BOQ Review & Hardening — prerequisite cluster: P0-1, P0-2, INT-0)
 
 First slice of `docs/BOQ_REVIEW_AND_HARDENING_PROMPT.md` on branch

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,66 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ 5D — Slice 3: convert Actions commands to inline StingResultPanel)
+
+Every Actions-tab-dispatched command now reports through `StingResultPanel`
+instead of a terminal `TaskDialog`, so each result renders in the right-hand
+inline pane (no popup) and the placeholder-resolver no longer falls back to
+"✓ completed (reported in a dialog)". `Builder.Show()` auto-routes to the
+inline sink when the pane is hosting and falls back to the modal dialog from
+the ribbon/workflow path — so conversion is safe in both surfaces. Reporting
+surface only — no command logic, transaction scope, or panel changes.
+
+Files converted (one commit each):
+
+- `Commands/Cost/CostCommands.cs` — Cost_ValidateAll (table report + dialog-only
+  "select affected" action), Cost_ClearStale, Cost_RunWorkflow (no-presets
+  guard), Cost_ToggleStaleMarker, Cost_ReloadRules, Cost_MigrateCurrencyParams,
+  Cost_MigrateESEntities.
+- `Commands/Cost/MeasurementStandardCommands.cs` — Cost_SetMeasurementStandard,
+  Cost_StandardInspect (per-standard tables).
+- `Commands/Cost/IfcAndIcmsCommands.cs` — Cost_StampIfcQuantities,
+  Cost_ExportIcms3Report (SetCsvPath → Open Export on dialog path).
+- `Commands/Cost/CostPlanCommands.cs` — CostPlan_Create, CostPlan_Compare
+  (variance table), CostPlan_Export.
+- `Commands/Cost/PaymentCertCommands.cs` — PaymentCert_Issue/Approve/Register.
+- `Commands/Cost/CostControlCommands.cs` — PaymentCert_SetProgress,
+  PaymentCert_ExportDoc (folder-open command-link → SetCsvPath). (Cost_Anticipated
+  FinalCost already used StingResultPanel.)
+- `Commands/Cost/VariationAndEvmCommands.cs` — Variation_FromDiff,
+  Variation_BuildStarRate, Variation_ExportRegister, Variation_ReclassifyLegacy,
+  Evm_Calculate, Evm_ImportActuals, Evm_ExportReport.
+- `BOQ/BOQQsRoundtripCommands.cs` — BOQQsExport (terminal + folder-open →
+  SetCsvPath), BOQQsImport (two guards + two terminals).
+- `BOQ/BOQSupportCommands.cs` — BOQAddManualRow (added an inline success report;
+  it previously reported nothing), BOQReconcileProvisionals (no-match guard +
+  terminal).
+
+TaskDialogs deliberately kept (interactive input / hard confirmation that must
+interrupt — not terminal reports, so out of the inline-result scope):
+
+- `CostPlanCommands.PromptForGifa` — TaskDialog command-links picking the GIFA
+  source (model rooms vs literal). Genuine input prompt.
+- `VariationAndEvmCommands` — PickEotDays / contract-form / kind / reason /
+  liability StingListPicker pickers and the `PromptForReasonDetail` WPF input
+  window (all input).
+- `BOQQsExportCommand` — the priced/unpriced TaskDialog command-link (input).
+- `BOQQsImportCommand` — the `StingDataGridDialog` diff-preview (input).
+- `BOQReconcileProvisionalsCommand` — the Yes/No confirmation before promoting
+  provisional sums to modelled rows (destructive confirm).
+
+Compile-verified headless (Nice3point): 0 errors per file. Deployed to
+CompiledPlugin per group. Not pushed/merged.
+
+**Revit smoke test (human):** Open the BOQ & Cost Manager → Actions tab. Click
+Run Cost Workflow, Validate Cost, New Cost Plan, Compare vs BOQ, Issue Cert,
+Calculate EVM, Variation from Diff, ICMS3 Report, Export QS Bill, Import QS Bill,
+Add Manual Row, Reconcile Provisionals — each result must render in the right
+pane with no popup, and the pane must never stay on "Running…". Confirm the input
+pickers for New Cost Plan / Issue Cert / Variation still render inline (no
+regression). Dispatch any one of the same commands from the ribbon and confirm it
+still shows a modal dialog (automatic fallback).
+
 #### Completed (BOQ 5D — resolve stuck Actions "Running…" placeholder)
 
 In-Revit finding: the Actions inline pane only renders results for the ~9

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,24 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ 5D — resolve stuck Actions "Running…" placeholder)
+
+In-Revit finding: the Actions inline pane only renders results for the ~9
+commands that report via StingResultPanel; the ~7 that use TaskDialog (Run Cost
+Workflow, stale-flag/migration/Meas setters) left the pane stuck on "Running…".
+
+- `BOQCostManagerPanel`: `_inlineResultPosted` flips true when a result lands
+  inline; `RunActionInline` registers `PendingActionResolve = () =>
+  ResolveActionPane(label)`. `StingCommandHandler.Execute`'s finally invokes +
+  clears it once the command returns. If no inline result was posted (TaskDialog
+  command), `ResolveActionPane` replaces the placeholder with "✓ <label>
+  completed" + a note that the action reported in its own dialog — so the pane is
+  never stuck. No-op when a result already rendered inline.
+- Full inline conversion of the TaskDialog actions is the Slice 3 sweep — added
+  to docs/BOQ_5D_ENHANCEMENTS_PROMPT.md as **P1.4 (high priority)**.
+
+Compile-verified headless (Nice3point): 0 errors. Not pushed/merged.
+
 #### Completed (BOQ 5D — P1.3: persist Cost Manager UI state per project)
 
 Link selection already persisted (`boq_links.json`), but grouping mode, display

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,40 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ Review & Hardening — INT-2 priced-BOQ round-trip)
+
+GUID-keyed priced round-trip so an external estimator can fill rates and
+re-import them onto the model. Built on the INT-0 GlobalId key.
+
+- **Export** (`BOQExportCommand`) — new **"Ifc GlobalId"** column (col 14,
+  `BOQLineItem.IfcGlobalId`) as the stable join key alongside the editable
+  Rate UGX cell.
+- **Import** (`BOQImportCommand`) — joins each priced row on the most stable
+  key available: **IFC GlobalId → Revit UniqueId → ASS_BOQ_LINE_REF**
+  (was line-ref only, which churns — P3-1). GlobalId index built with the same
+  `IfcGuidEncoder.FromRevitUniqueId` the export uses, so the join is exact.
+  Header-name column lookup means old line-ref-only sheets still import.
+- **Provenance** — imported rates stamp `CST_RATE_SOURCE = "estimator"` (was
+  the generic "Override") so the rate-source heat-map / at-risk rollup can
+  distinguish a priced import from a hand-typed override.
+- **P2-8 fixed** — import now writes the edited description to
+  `ASS_NRM2_PARA_TXT` (which `ResolveNrm2Paragraph` reads first), not
+  `ASS_DESCRIPTION_TXT` — so an edited description survives the next BOQ
+  refresh instead of being silently dropped.
+- **Precedence — deliberate deviation from the prompt.** The prompt assumed an
+  "estimator below manual ES override" tier; the actual `RateProviderRegistry`
+  has a *single* override surface — `ParameterOverrideRateProvider`
+  (`CST_UNIT_RATE_UGX`, priority **100**) sits *above* `ExtensibleStorageRateProvider`
+  (95). Building a separate sub-tier would have meant a new shared param +
+  provider and would have inverted the documented "param override is the user's
+  top-priority rate." So estimator rides the existing `CST_UNIT_RATE_UGX`
+  override surface (a priced bill IS the authoritative rate), distinguished only
+  by the `CST_RATE_SOURCE` provenance stamp. Documented inline.
+- **Not done this commit:** the branded `BOQProfessionalExportCommand` doesn't
+  yet carry the GlobalId column (round-trip is via the standard `BOQExportCommand`);
+  GAEB DA XML remains scope-only (`IPricedExchange` interface TBD). Built without
+  Revit (main-project files, no sandbox compile) — verify in Revit.
+
 #### Completed (BOQ Review & Hardening — INT-0 encoder hardening)
 
 Follow-up to the INT-0 encoder correction below, closing the one review caveat:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,31 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ Review & Hardening — INT-1 QTO IFC + pro-export round-trip key)
+
+Closed the two "known limitations" left after INT-2.
+
+- **Professional export now carries the join key.** `BOQProfessionalExportCommand`
+  adds an **"Ifc GlobalId"** column to its **audit/takeoff sheet** (next to the
+  existing "Revit ID"), so the priced professional export can reconcile back to
+  the model. The printed *tender* bill is left clean (no machine ids on it) — the
+  primary round-trip remains the standard `BOQExportCommand` schema.
+- **INT-1 — QTO-conformant IFC export** (`BOQ/BOQExportIfcQtoCommand`, tag
+  `BOQExportIfcQto`). Builds the BOQ, stamps `Qto_*.*` + `Pset_StingCost.*`
+  (`IfcQuantitySetWriter.StampAllElements`) in a committed transaction, then
+  exports **IFC4 with `ExportBaseQuantities=true`** + the cost/classification
+  psets — the practical estimator feed CostX/iTWO consume.
+  - **Honest scope (documented in the command):** Revit has **no literal
+    "Quantity Takeoff MVD"** enum — IFC4 + base quantities is the equivalent.
+    NRM2/ICMS rides `Pset_StingCost.NRM2Section`; a true `IfcClassificationReference`
+    needs a Revit classification-mapping file (not settable via headless
+    `IFCExportOptions`) — `TODO-VERIFY-API` / future. The base quantities (core
+    QTO payload) come from `ExportBaseQuantities` and don't depend on the cost-pset
+    emission, which itself needs in-Revit confirmation.
+  - GAEB DA XML remains scope-only (the `IPricedExchange` interface is still TBD).
+- Built without Revit (main-project files; only the encoder is sandbox-compiled).
+  Dock-panel button for `BOQExportIfcQto` is a trivial follow-up. Verify in Revit.
+
 #### Completed (BOQ Review & Hardening — INT-2 priced-BOQ round-trip)
 
 GUID-keyed priced round-trip so an external estimator can fill rates and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,23 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ 5D — inline result action bar: Open-Export + Action buttons)
+
+Slice 3 review found the inline renderer dropped the dialog footer entirely, so
+the ~6 export commands that attach an Open-Export button via `SetCsvPath` (ICMS3,
+cert doc, registers, QS bill, cost plan) rendered their result inline with **no
+way to open the generated file** — a functional regression vs the dialog.
+
+- `StingResultPanel.BuildInlineContent` now renders a compact bottom **action
+  bar**: an "Open file" button when `CsvExportPath` is set (shell-opens the path),
+  plus any `Action(...)` buttons. Wrapped in a `DockPanel` so the bar stays
+  visible while the result scrolls. Action clicks pass a null `Window` (inline has
+  none) inside try/catch — Window-dependent actions degrade gracefully (logged),
+  never crash. No bar rendered when there are no buttons.
+
+Closes the "acceptable degradation" the Slice 3 agent flagged. Compile-verified
+headless (Nice3point): 0 errors. Not pushed/merged.
+
 #### Completed (BOQ 5D — Slice 3: convert Actions commands to inline StingResultPanel)
 
 Every Actions-tab-dispatched command now reports through `StingResultPanel`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,21 @@ Schedule/cash-flow tab (Slice 2) and the command sweep (Slice 3).
   IFC lands under `<project>/_BIM_COORD/ifc/`, (d) the ✕ dismisses the region, and
   (e) running `BOQExportIfcQto` from the ribbon still shows the normal popup.
 
+#### Completed (BOQ — "by Source model" grouping + Links (N) badge)
+
+- **Group → "Source model"** (`BoqGroupingMode.SourceModel`). New grouping mode
+  + dropdown entry: the bill reads as one block per model — "Host model" first,
+  then each included link as its own section. Driven by a new
+  `BOQLineItem.SourceModel` field (copied in `Clone`, set to the link Title in
+  `CollectLinkedItems`); host rows leave it blank ⇒ "Host model". Routes through
+  the existing `GroupBySpatial` grouper; `AggregateLineItems` default branch
+  already handles the new enum.
+- **"⛓ Links (N)" badge.** The header Links button now shows the count of
+  included links — "⛓ Links" when none, "⛓ Links (N)" otherwise. Updated on every
+  `RefreshDisplay` and immediately after the chooser saves, via `UpdateLinksBadge`.
+
+Compile-verified headless (Nice3point): 0 errors / 0 warnings. Not pushed/merged.
+
 #### Completed (BOQ — linked models: persisted, per-link selection)
 
 Upgraded the include-links option from a session-only global bool to the best

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,32 @@ Schedule/cash-flow tab (Slice 2) and the command sweep (Slice 3).
   IFC lands under `<project>/_BIM_COORD/ifc/`, (d) the ✕ dismisses the region, and
   (e) running `BOQExportIfcQto` from the ribbon still shows the normal popup.
 
+#### Completed (BOQ — linked models: persisted, per-link selection)
+
+Upgraded the include-links option from a session-only global bool to the best
+flexible + sustainable design, following the codebase's `_BIM_COORD` project-
+overlay + multi-select-picker conventions.
+
+- **Flexible — per link, not all-or-nothing.** Header **"⛓ Links"** button opens
+  the multi-select `StingListPicker` (checkbox list) of *loaded* links, pre-ticked
+  to the current selection; tick exactly the links to fold into the takeoff. A
+  link placed multiple times is taken off once (dedup by Title).
+- **Sustainable — persisted per project.** Selection saved to
+  `<project>/_BIM_COORD/boq_links.json` (same convention as `rate_card.json` /
+  `boq_print_profiles.json`) and cached per doc path, so it survives reopen and
+  every consumer (panel, QTO export, snapshots) reads the same set —
+  `BOQCostManager.GetIncludedLinkTitles` / `SetIncludedLinkTitles`. Replaces the
+  process-global `IncludeLinkedModels` bool that reset every session.
+- **Safety unchanged.** Linked rows stay read-only for host write-back
+  (`RevitElementId=-1`, `UniqueId` cleared, constituents dropped) — never
+  cost-stamped or selectable in the host; tagged `[Linked: <model>]`.
+  Parameter-derived quantities are transform-independent; unloaded links skipped.
+- **Picker pre-check fix** (`UI/StingListPicker.cs`): `PopulateList` now honours
+  `ListItem.IsSelected`, so the chooser (and any future multi-select caller)
+  opens with current selections ticked.
+
+Compile-verified headless (Nice3point): 0 errors / 0 warnings. Not pushed/merged.
+
 #### Completed (BOQ — include-linked-models option)
 
 User request: a toggle to include / exclude linked Revit models in the takeoff.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,39 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (5D Cost Workspace — Slice 1: QTO IFC button + inline-result convention)
+
+First slice of the unified inline 5D cost+programme workspace
+(`docs/BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md`). Establishes the "zero external
+reporting popups" convention end-to-end on one action, as the template for the
+Schedule/cash-flow tab (Slice 2) and the command sweep (Slice 3).
+
+- **Inline result region** (`BOQCostManagerPanel.cs`) — a collapsed `Border`
+  docked above the footer with a title + ✕ dismiss. Panel-driven commands render
+  their result here via `StingResultPanel.BuildInlineContent` (the same
+  section/metric/table tree the Healthcare tab already hosts inline) instead of a
+  `StingResultPanel.Show()` window.
+- **`BOQInlineResults` static mailbox** — bridges a Revit-thread command to the
+  live panel. The panel registers `Sink` on construction (cleared on `Unloaded`
+  via a stored delegate so a closed panel can't capture a later invocation).
+  `Post(builder)` returns false when no panel is hosting → the command falls back
+  to `.Show()`, so ribbon/workflow callers are unaffected.
+- **`InlineHost=1` ExtraParam gate** — mirrors the existing `SkipDialog` pattern.
+  The panel sets it before dispatch; `BOQExportIfcQtoCommand` reads it and routes
+  the result inline (consuming the flag; `ClearAllExtraParams` in the handler's
+  `finally` also clears it post-execution, so no cross-command leakage).
+- **"⛁ QTO IFC" button** added to the Cost Manager footer beside Export/Import →
+  `DispatchAction("BOQExportIfcQto")` (dispatch case already at
+  `StingCommandHandler:3511`; path verified panel → `DispatchCommand` →
+  ExternalEvent → case). Tooltip explains the estimator feed; result shows inline.
+- **No-build caveat:** WPF + Revit-API code, not compile-checked in this sandbox.
+  Revit/WPF calls use documented signatures. **Verify in Revit before Slice 2.**
+  In-Revit smoke test: open BOQ Cost Manager → click **⛁ QTO IFC** → confirm
+  (a) no popup window appears, (b) the inline region opens below the bill with
+  "IFC4 written: …", elements-stamped count, and the LIMITATIONS notes, (c) the
+  IFC lands under `<project>/_BIM_COORD/ifc/`, (d) the ✕ dismisses the region, and
+  (e) running `BOQExportIfcQto` from the ribbon still shows the normal popup.
+
 #### Completed (BOQ Review & Hardening — INT-1 QTO IFC + pro-export round-trip key)
 
 Closed the two "known limitations" left after INT-2.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,37 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ 5D — P1.3: persist Cost Manager UI state per project)
+
+Link selection already persisted (`boq_links.json`), but grouping mode, display
+currency, column visibility and the expand/collapse sets reset every session.
+Now persisted to `<project>/_BIM_COORD/boq_ui_state.json` (same load/save shape as
+`BoqPrintProfile` / `ProjectRateCardProvider`). Compile-verified headless
+(Nice3point): 0 errors.
+
+- **`BoqUiState` POCO + `LoadUiState` / `SaveUiState`** (`BOQCostManagerPanel.cs`).
+  Persists `GroupingMode`, `DisplayCurrency`, `HiddenColumns`, `OpenSections`,
+  `OpenMaterialSections`. Best-effort: read/write failures `StingLog.Warn` and never
+  block the UI. A `_uiStateLoaded` gate stops a write firing mid-`Build` (which
+  would clobber the file being read).
+- **Load before `Build()`** so the currency toggles, grouping combo and column set
+  open in the user's last configuration. Toggle `IsChecked` + combo `SelectedItem`
+  are set in the initializer *before* their handlers attach, so restoring state
+  doesn't fire a redundant `RefreshDisplay` / `RefreshAsync`.
+- **Save on each change** — currency toggle, grouping change, ▦ Columns toggle,
+  Expand-all / Collapse-all, per-section + per-material expander, and
+  `ApplyPrintProfile` (which sets the hidden-column set).
+- **Collapse-all survives reopen** — `RefreshAsync` auto-opens every section only
+  on a genuine first load; `_suppressAutoOpenOnce` (set when a persisted
+  `OpenSections` set is loaded) stops a deliberately-empty collapse-all state from
+  being re-expanded on the first refresh.
+
+**Revit smoke test (human):** Open BOQ & Cost Manager. Set grouping = "Source
+model", switch to USD, hide a column via ▦ Columns, collapse all sections. Close
+the window and reopen the project (or the BOQ window) → grouping, currency, hidden
+column and collapsed state all restored. Confirm `_BIM_COORD/boq_ui_state.json`
+exists and reflects the choices.
+
 #### Completed (BOQ 5D — P1.2: cache per-link takeoff)
 
 `RefreshAsync` runs `BuildBOQDocument` synchronously, and STEP 6c

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,47 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (BOQ 5D — P0: harden the inline message pump)
+
+Correctness/safety hardening of the BOQ Cost Manager inline pickers + results
+(`docs/BOQ_5D_ENHANCEMENTS_PROMPT.md`). Compile-verified headless (Nice3point):
+0 errors. Behaviour still needs a real Revit run — see smoke test below.
+
+- **P0.1 — transaction-state guard** (`StingListPicker.cs`). Pumping a nested
+  `Dispatcher.PushFrame` loop while a Revit transaction is open on the host
+  document is unsafe (can corrupt document state). New
+  `public static Autodesk.Revit.DB.Document InlineHostDoc;` + a private
+  `InlineSafe(title)` gate: when `InlineHostDoc.IsModifiable` (a transaction is
+  open) the two `Show(...)` overloads fall back to the normal modal `ShowDialog()`
+  path instead of pumping. `ShowInline` carries the same defensive guard for any
+  future direct caller. One `StingLog.Info` fires on fallback so the human can see
+  which command needed it. Mirrors the `IsModifiable` precedent in
+  `DrawingTypeStamper.StampCrop`. `BOQCostManagerPanel.RunActionInline` sets
+  `InlineHostDoc = Doc` alongside `InlineHost`; `StingCommandHandler.Execute`'s
+  `finally` clears it with the other inline statics.
+  - **Audit** (Actions commands under `Commands/Cost/*.cs` + `BOQ/*Commands*.cs`):
+    no `StingListPicker.Show(...)` is called inside an open transaction — every
+    Cost command picks first, then transacts (pick → `using (Transaction) { Start;
+    …; Commit }`). The guard is a forward-safe net, not a fix for an existing leak.
+    Files scanned: `CostCommands.cs`, `CostControlCommands.cs`, `CostPlanCommands.cs`,
+    `MeasurementStandardCommands.cs`, `PaymentCertCommands.cs`,
+    `VariationAndEvmCommands.cs`.
+- **P0.2 — leak-proof the inline statics.** `RunActionInline` now defensively
+  nulls `InlineHost` / `InlineHostDoc` / `InlineTitleSink` /
+  `StingResultPanel.InlineSink` at the top (before re-registering fresh) so a
+  prior aborted run can't leave a stale foreign sink. `BOQCostManagerWindow.Closed`
+  nulls all four when the window tears down, so a later command from another
+  surface can't render into (or pump against) the disposed Actions pane.
+
+**Revit smoke test (human):** (1) Open BOQ & Cost Manager. On the Actions tab run
+**Variation from Diff** — it shows 4 sequential pickers; confirm each renders
+inline, OK/Cancel return correctly, and Revit never hangs. (2) Run **Issue Cert**;
+confirm inline render. (3) If any command opens a transaction before a picker,
+verify `StingTools.log` shows the "falling back to modal" Info line and the picker
+appears as a normal modal dialog (not a freeze). (4) Close the BOQ window, then run
+any ribbon command that uses a list picker — confirm it pops a normal modal, not
+into a dead pane.
+
 #### Completed (5D Cost Workspace — Slice 1: QTO IFC button + inline-result convention)
 
 First slice of the unified inline 5D cost+programme workspace

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,40 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Placement Centre — review follow-up: five minor fixes)
+
+Branch `claude/placement-centre-review-audit`. Closes the five minor items
+raised in the post-implementation review of the Placement Centre hardening
+pass. **Built without `dotnet build` verification — verify in Revit before
+merge.**
+
+1. **Standards gate now effective for `StandardRef`-only rules**
+   (`PlacementRuleLoader.FilterByProfile`). When a rule has no structured
+   `ApplicableStandards` it now falls back to its free-text `StandardRef`,
+   matched case-insensitively contains-either-direction (profile "BS 6465"
+   ↔ rule "BS 6465-1:2006"). Previously such rules bypassed the standards
+   filter entirely (inert). The engine's inert-standards warning was updated
+   to fire only when no rule carries *either* field.
+2. **Idempotency now covers face / work-plane-hosted instances**
+   (`FixturePlacementEngine.BuildPriorPlacedIndex`). Instances with no
+   `LocationPoint` fall back to the family-instance transform origin so they
+   are de-duped on re-run instead of duplicating.
+3. **MEP auto-connect search retuned to a coincidence tolerance**
+   (`PostPlacementHooks`). `Connector.ConnectTo` only joins coincident
+   connectors, so the 600 mm "radius" was misleading and inflated the
+   left-open count with near-but-not-coincident candidates. Replaced with a
+   25 mm `MepCoincidenceTolFt`.
+4. **Routing tooltip matches the dropdown** (`StingPlacementCenter.xaml`) —
+   dropped the stale `WALL_FOLLOWER` entry; tooltip now reads
+   `NONE / AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT`.
+5. **Idempotency scan scoped to active categories**
+   (`FixturePlacementEngine`). `BuildPriorPlacedIndex` now takes the set of
+   `BuiltInCategory` resolved from the (already profile-filtered) active
+   rules via `ResolvePriorPlacedCategories` and uses an
+   `ElementMulticategoryFilter`, instead of walking every `FamilyInstance`
+   in the model each run. Falls back to the full scan when no category
+   resolves or the filter is invalid.
+
 #### Completed (Placement Centre — review, gap-closure & hardening)
 
 Branch `claude/placement-centre-review-audit`. Closes the gaps from the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,125 @@ StructuralAnalysisEngine general — deflection / punching / wind / vibration / 
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Placement Centre — review, gap-closure & hardening)
+
+Branch `claude/placement-centre-review-audit`. Closes the gaps from the
+Placement Centre deep-read review. **Built without `dotnet build`
+verification (no Revit API / .NET in this environment) — verify in Revit
+before merge.** Some review findings were already addressed by the merged
+`claude/placement-center-fixes` (PR #376) on this branch (e.g. the
+building-profile filter was wired in the engine); those were reconciled
+against the live code rather than re-implemented.
+
+**Part A — strip internal tokens from visible UI.** Removed every
+`PC-NN` / `Pack NN` / `Phase NNN` token from user-visible strings:
+GroupBox headers, checkbox content, tooltips, the title-bar build stamp
+(now `[build <date>]`, no phase tag), the run-result subtitle, two
+prerequisite-dialog hints, and a Save-view-preset transaction name.
+`PhaseTag` kept as an internal log constant; `// comments` keep their
+tokens. The `Probe MEP connectors` checkbox was relabelled `Connect MEP
+systems after placement` (see Part C.4).
+
+**Part C — Run-Options checkboxes made honest.**
+- **C.1** Data-tag pipeline: `PostPlacementHooks` used a reflection probe
+  for a non-existent `TagPipelineHelper.RunFullPipeline(Document,Element)`
+  overload, so the checkbox tagged nothing. Now builds the canonical
+  population context once per run (cached, reset by `BeginRun`) and calls
+  the real 11-arg `RunFullPipeline` directly; `TagPipelineMissing` is
+  surfaced as a post-run warning.
+- **C.3** Validators: `SeparationValidator` is a static class with only
+  `ValidateElement(...)`, so the bridge's reflection block silently
+  produced zero findings. Added `SeparationValidator.Validate(Document)`
+  and replaced the whole reflection block with direct typed calls to all
+  eight validators (`Clearance / Maintenance(Clash) / Connectivity / Fill
+  / Spec / Termination / Slope / Separation`).
+- **C.4** MEP connect: `AssignMepSafe` was a logging no-op. It now
+  auto-connects each open HVAC/piping/cable-tray connector to the nearest
+  coincident compatible connector within 600 mm and reports
+  connected/left-open counts.
+- **C.5** Routing modes: the dropdown offered `WALL_FOLLOW /
+  CEILING_FOLLOW / FLOOR_FOLLOW / CONDUIT_RUN / TRAY_RUN` but the engine
+  only acted on `AUTO_CONDUIT` (not even listed). Dropdown trimmed to
+  `NONE / AUTO_CONDUIT / AUTO_PIPE / AUTO_DUCT`; `RouteAfterPlacement`
+  dispatches all three real drop engines; `EffectiveRoutingMode()`
+  normalizes the legacy follow tokens still in shipped packs
+  (`routing.json` / `commissioning.json`) to the matching drop engine by
+  `RouteSegmentCategory` with an honest per-rule warning. Also fixed a
+  latent bug: `RouteAfterPlacement` matched fixtures via the never-written
+  `ASS_PLACEMENT_RULE_TXT` against `RuleId`, so AUTO routing matched zero
+  fixtures — now matches via provenance (`MergeKey`).
+- **C.6** Excel import already refreshes the live `ICollectionView`
+  (PR #376); added a defensive `ApplyFilter()` after import.
+
+**Part B — Building Profile end-to-end.** The engine loaded
+`placement_profile.json` from disk, so the live UI selection only took
+effect after a manual Save. Added `PlaceFixturesOptions.SessionProfile`,
+pushed from the live VM before every Run/Preview and cleared after, so the
+building-type / standards gate works **without a Save first**. Rules carry
+`BuildingType` (Office/Healthcare/Residential/…), so the gate measurably
+changes the run. Wired the three toggles: **wet-zone** →
+`WetZoneExclusionChecker` filters candidates in `ProcessRoomRule`;
+**accessibility** → gates the height-standards validation; **coverage
+guarantee** → gates the coverage-grid expansion (Part D.1). StandardRef-only
+rules are kept (not dropped) and the engine warns when the standards filter
+is inert.
+
+**Part D — engine correctness / accuracy / perf.**
+- **D.1** `CoverageGridGenerator` was fully written but never invoked.
+  `ProcessRoomRule` now routes `GuaranteeCoverage` rules through it (when
+  the profile toggle is on), placing all generated points and surfacing
+  the MinSpacing-cap warning. New `PlacementScorer.ResolveAnchorZForRoom`.
+- **D.2** Re-runs duplicated fixtures (dedup saw only this-run state).
+  `BuildPriorPlacedIndex` scans the doc once per committing run for
+  STING-provenance fixtures and seeds their positions into the per-room
+  dedup; a prominent warning tells the user prior placements were found.
+- **D.3** Dependency cycles (`A→B→A` via DependsOn/RelativeTo/CoPlaceWith)
+  silently deadlocked. `PlacementRuleLoader.DetectDependencyCycles` now
+  reports them via the validation-warning channel.
+- **D.4** `EmitColumnFaceNearest` re-ran full-model column collectors per
+  call → per-run `_columnLocsCache`.
+- **D.5** Verified `ComputeRoomPerimeterMetres` returns metres (no bug).
+- **D.6** `ResolveSymbol == null` was silent; now increments
+  `SkippedNoSymbol`, sets the diag reason, and emits a one-shot
+  per-(rule,category,variant) warning.
+- **D.7** Documented the spacing-as-post-rank-gate contract on
+  `ComputeSpacingScore`.
+- **D.8** Fixed the misleading coverage sample-step comment.
+
+**Part E/G — categories + rule/field reconciliation.** Annotated the
+Auto-place checklist: Conduits/Pipes/Cable Trays are routing outputs (not
+point targets), Specialty Equipment / Nurse Call need a rule pack. Invalid
+rules (already excluded from runs by `ToRules`) now explain why on hover.
+
+**Part F — integrations.** Extracted `LearnPlacementV4Command.RunLearn`
+and added a Centre "Learn from model" button that runs it and imports the
+learned rules into the grid. Verified provenance→History refresh and
+Excel/JSON import live-refresh. BOQ quantity handoff and Drawing-Type
+preset *apply* deferred to ROADMAP (larger unfamiliar API surfaces;
+shipping untested buttons would reintroduce the silent-no-op anti-pattern).
+
+**PlacementRule field decision table** (fields loaded from JSON, audited
+against engine/scorer consumption):
+
+| Field | Status | Note |
+|---|---|---|
+| `WetZoneExclusion` | FIXED | now consumed by `WetZoneExclusionChecker` (Part B) |
+| `GuaranteeCoverage` / `CoverageRadiusMm` / `MaxSpacingMm` / `WallClearanceMm` / `ObstructionClearanceMm` | FIXED | now consumed via the coverage grid (Part D.1) |
+| `MountingContext` | WIRED | drives routing chase detection |
+| `CableBundleAdvisoryCount` | WIRED | advisory in routing |
+| `RoutingMode` / `RouteSegmentCategory` | FIXED | reconciled + normalized (Part C.5) |
+| `Material` / `GlazingSpec` / `InsulationThicknessMm` / `NominalDiameterMm` / `MaintenanceClearance` | DEFERRED | push-to-family-types metadata surfaced in the Clearance/Envelope/Weight card, not placement-engine knobs |
+| `ToughenedGlazingRequired` / `MinSlopePercent` / `MinUniformityRatio` / `ExposureClass` / `EmitSupports` | DEFERRED | spec/advisory metadata, not consumed by placement; kept for schedules/export |
+
+**Category checklist decision table:**
+
+| Category | Status | Note |
+|---|---|---|
+| Electrical/Lighting/Comm/Data/Security/Fire/Plumbing/Air Terminals/Sprinklers/Mechanical/Junction Boxes/Furniture | WIRED | placeable, baseline rules + anchors ship |
+| Conduits / Pipes / Cable Trays | ANNOTATED | routing outputs (obstruction-only as targets); tooltip added |
+| Specialty Equipment | ANNOTATED | no baseline rules — needs project/specialty pack |
+| Nurse Call Devices | ANNOTATED | needs healthcare rule pack |
+
 #### Completed (BOQ QS Upgrade — integration + Stage-B bug fixes)
 
 Consolidated P1–P4 onto one linear stack (`main→P1→P2→P3→P0fix→P4`) and

--- a/docs/PLACEMENT_SEEDS_SWAP_AND_ALGORITHM_DESIGN.md
+++ b/docs/PLACEMENT_SEEDS_SWAP_AND_ALGORITHM_DESIGN.md
@@ -1,0 +1,229 @@
+# Placement: Seed-Family-Per-Rule, Non-Destructive Swap & Algorithm Roadmap
+
+> Design + research deliverable. Grounded in the existing tag-seed, symbol-library, and
+> swap code. The model-modifying parts (auto-build seed, swap parameter-bridge) are
+> **designed and code-sketched but not yet wired** — they create/modify families and must
+> be verified in Revit before merge. The data artifact (`STING_CATEGORY_TO_SEED_MAP.json`)
+> and the rule/scorer fixes already landed.
+
+---
+
+## 1. The core idea (what the user asked for)
+
+> "Like we did for tag family seeds, we should already have a seed-family folder with each
+> rule aligning to a family; at placement, use those default families; then research the
+> most flexible way of swapping families without destruction while maintaining parameter
+> alignment — even when swapping with an old family that has no STING parameters."
+
+Three things, in order:
+
+1. **Every placement rule resolves to a guaranteed default seed family** (mirroring how tags
+   resolve a seed per category) so a run *always* has something to place — no more silent
+   `SkippedNoSymbol` because "no family is loaded."
+2. **Placement uses those seeds by default**, stamped with STING shared parameters by GUID
+   and `STING_SEED_FAMILY_TXT = <seedId>` so they are swap-ready.
+3. **Swap seed → real/manufacturer family non-destructively**, preserving position, host,
+   and *parameter values*, even when the target family was authored without STING params.
+
+The good news from the audit: **the seed specs already exist** — 33 `Data/Seeds/STING_SEED_*.json`
+cover virtually every placement category (Lighting Fixtures, Lighting Devices, Electrical
+Fixtures/Equipment, Air Terminals, Sprinklers, Fire Alarm, Comms/Data/Security, Plumbing,
+Mechanical, Junction Boxes, …). They were just **never wired into the placement resolution
+path**. This design closes that loop.
+
+---
+
+## 2. How tag seeds work today (the model to mirror)
+
+(From `Tags/TagFamilyCreatorCommand.cs` + `Tags/FamilyParamCreatorCommand.cs`.)
+
+```
+BuiltInCategory  --CategoryTemplateMap-->  Revit .rft template
+   --NewFamilyDocument-->  family doc
+   --FamilyParamEngine.InjectSharedParams (MR_PARAMETERS.txt, bound by GUID)-->
+   --InjectTagPosFormulas + InjectPositionTypes (16 variants)-->
+   --save .rfa--> TagFamilies/  --LoadFamily--> project
+```
+
+Key property that makes tags robust: **parameters are bound by GUID, not name** — so once a
+family carries `ASS_TAG_1` (GUID `g`), the value survives type swaps and is readable by every
+consumer keyed on `g`.
+
+The placement seed system already has the equivalent machinery:
+- `Core/Symbols/SymbolLibraryCreator.cs` builds a `.rfa` from a `Data/Seeds/*.json` spec
+  (geometry + connectors + parameters + type variants), stamps every type with
+  `STING_SEED_FAMILY_TXT = def.Id`, and can load it into the project.
+- `Commands/Symbols/BuildSeedFamiliesCommand.cs` builds all seeds into
+  `<project>/_BIM_COORD/Families/Seeds/`, with `MissingOnly | RebuildUnfinalized | RebuildAll`
+  modes and a `.sting-finalized` protection sidecar.
+- `Commands/Symbols/SwapToManufacturerCommand.cs` swaps via `Element.ChangeTypeId`.
+
+What's missing is the **explicit category → seed binding** and the **placement → seed
+resolution tier**.
+
+---
+
+## 3. Seed-family-per-rule — architecture
+
+### 3.1 The binding (DONE — data)
+`StingTools/Data/Placement/STING_CATEGORY_TO_SEED_MAP.json` — a flat
+`CategoryFilter → seedId` map (29 categories; `Conduits/Pipes/Stairs` intentionally
+seedless). This is the single source of truth that ties a rule's category to its default
+seed family. Project override goes at `<project>/_BIM_COORD/category_to_seed_map.json`.
+
+### 3.2 The resolution tier (TO WIRE — `FixturePlacementEngine.ResolveSymbol`)
+Insert a **seed tier** between "loaded-family match" and "skip". New order:
+
+1. Already-loaded family of the category (current behaviour) — honour `VariantHint` /
+   `FamilyTypeRegex`.
+2. `TryAutoLoadFromLibrary` from `Families/<subdir>/` (current).
+3. **NEW — seed tier:** look up the rule's category in `STING_CATEGORY_TO_SEED_MAP`. If a
+   seed is mapped and not yet loaded, **build-or-load the seed** (see 3.3) and use its
+   symbol. Stamp the seed instance with STING params (already done at build) + provenance.
+4. Skip with a *visible* `SkippedNoSymbol` warning naming the missing seed (so the user can
+   build it) — current behaviour, now the last resort.
+
+Resolution stays per-(category, variant) cached, so the build happens at most once per run.
+
+### 3.3 Build-or-load seed (TO WIRE)
+```
+EnsureSeedSymbol(doc, category):
+    seedId = CategoryToSeedMap.Resolve(category)        // null -> caller skips
+    if loaded family stamped STING_SEED_FAMILY_TXT==seedId exists -> return its active symbol
+    path = <project>/_BIM_COORD/Families/Seeds/<seedId>.rfa
+    if !exists(path):  SymbolLibraryCreator.BuildOne(Data/Seeds/<seedId>.json) -> path  // model-modifying
+    LoadFamily(path) ; activate first symbol ; return symbol
+```
+Risk: builds/loads families **inside the placement transaction**. Revit allows
+`LoadFamily`/family creation inside a transaction, but it is slow and must be verified.
+Safer variant: a **pre-pass** (`Placement_EnsureSeeds` button / first step of the run
+workflow) that builds every seed for the ticked categories *before* the placement
+transaction opens — keeps the hot path fast and avoids nested-transaction surprises.
+
+### 3.4 Why this makes runs robust
+- "Tick Lighting Fixtures, run, with no luminaire family loaded" → engine builds/loads
+  `STING_SEED_LightingFixture`, places it (stamped, ISO-tagged), and the result is a real
+  scheduled instance — not a silent skip.
+- Every placed seed is swap-ready (carries `STING_SEED_FAMILY_TXT`), so the designer later
+  swaps the whole project to manufacturer families in one pass (§4).
+
+---
+
+## 4. Non-destructive family swap with parameter alignment (the research)
+
+### 4.1 What `ChangeTypeId` already preserves
+`Element.ChangeTypeId(newTypeId)` (used by `SwapToManufacturerCommand`) is the right
+primitive — **in-place, fast, non-destructive**:
+- **Preserved automatically:** XYZ location, rotation, **host** (wall/ceiling/floor),
+  element id, connector topology (best-effort).
+- **Preserved iff the destination family carries the same parameter by GUID:** all STING
+  shared params (`ASS_TAG_*`, `ELC_*`, `LTG_*`, …). Revit copies the instance value across a
+  type change **by GUID**, not by name.
+- **Audit:** the command stamps `STING_DESIGN_REF_TXT` (original seed id) and appends
+  `STING_SWAP_HISTORY_TXT` (`ts|operator|src|dst`).
+
+### 4.2 The failure the user named
+> "swapping with an old family that has **no** STING parameters."
+
+If the destination family was authored without STING shared params, then after
+`ChangeTypeId` the instance has **no parameter with the STING GUIDs**, so:
+- The values aren't carried (nothing to carry them into) → tags/schedules read empty.
+- Native equivalents (e.g. a manufacturer's own "Mounting Height") are unrelated to
+  `MNT_HGT_MM` and don't line up.
+
+### 4.3 The fix — a swap-time **Parameter Bridge** (stamp → snapshot → swap → restore)
+The flexible, non-destructive answer is to make the destination family STING-aware *as part
+of the swap*, and carry values through a name↔GUID alias table. Per swap group
+`(seedId, sourceType) → destFamily`:
+
+```
+1. ENSURE-STAMP (once per destFamily, not per instance):
+   if destFamily lacks the STING shared params (by GUID):
+       FamilyParamEngine.InjectSharedParams(destFamily, requiredGuids)   // geometry untouched
+       (optionally InjectTagPos formulas/types if it's tag-like)
+       reload destFamily into project
+   -> destFamily now carries ASS_TAG_*, discipline params by GUID. Non-destructive:
+      only ADDS parameters; never alters geometry, existing types, or native params.
+
+2. SNAPSHOT (per instance, before ChangeTypeId):
+   values = { guid -> instance.get_Parameter(guid).Value  for guid in STING set if present }
+   // also capture native-named values for ALIAS carry-over (see 4.4)
+   nativeValues = { nativeName -> value  for nativeName in AliasTable.keys if present }
+
+3. SWAP:
+   instance.ChangeTypeId(destTypeId)      // location/host/rotation preserved
+
+4. RESTORE (per instance, after ChangeTypeId):
+   for guid,value in values:    instance.get_Parameter(guid)?.Set(value)   // now exists on dest
+   for nativeName,value in nativeValues:
+       guid = AliasTable[nativeName]
+       if instance.get_Parameter(guid) is empty: instance.get_Parameter(guid).Set(value)
+```
+
+Result: an *old, STING-naive* family becomes a first-class STING instance after the swap,
+with positions and values intact — fully non-destructive (additive only).
+
+### 4.4 Alias table — carrying legacy values into STING GUIDs
+A small data file `STING_PARAM_ALIAS_MAP.json` maps common native/legacy parameter names to
+the STING shared-parameter GUID they should populate:
+```
+"Mounting Height"      -> MNT_HGT_MM
+"Elevation from Level" -> MNT_HGT_MM    (fallback)
+"Wattage" / "Load"     -> ELC_LOAD_VA
+"Switch Voltage"       -> ELC_VOLT_V
+"IP Rating"            -> ASS_IP_RATING_TXT
+```
+On swap, if the old family carried a value under a legacy name, it lands in the right STING
+GUID. Unknown native params are left untouched (non-destructive). This is the "maintain
+parameter alignment even with an old family" guarantee.
+
+### 4.5 Flexibility + speed
+- **Batch by `(seedId, sourceType)`** (already done) so `EnsureStamp` + `EditFamily/reload`
+  runs **once per destination family**, then `ChangeTypeId` runs per instance (cheap).
+- **No delete+recreate** anywhere — `ChangeTypeId` keeps element ids stable (preserves
+  hosting, view-specific overrides, dimensions referencing the element).
+- **Connector re-stitch** (existing, 600 mm proximity) handles connector count/position
+  differences after swap.
+- **Reversible:** `STING_DESIGN_REF_TXT` retains the original seed id, so a "swap back to
+  seed" is symmetric.
+
+### 4.6 Swap surfaces to add
+- `Placement → Swap to Manufacturer` already exists. Add a **bridge** flag (default on) that
+  runs §4.3 so swapping to non-STING families is safe.
+- Expose **"Stamp this family with STING params"** as a standalone command (it already
+  exists for tags via `FamilyParamCreator`; generalize to any placeable category) so users
+  can pre-bless a manufacturer library once.
+
+---
+
+## 5. Algorithm gaps & roadmap (from the deep review)
+
+Ordered by value. Items marked ✅ are already fixed on this branch.
+
+| # | Area | Gap | Severity | Status / fix |
+|---|---|---|---|---|
+| A1 | Candidate gen | `CEILING_CENTRE` emitted **1 point** → fire alarms / sprinklers / emergency lights / area-lights placed one device per room | CRITICAL | ✅ Fixed — `EmitCeilingGrid` (density/spacing aware, backward-compatible) |
+| A2 | Symbol res | Light-switch rules picked a "Circuit Breaker" type (no `FamilyTypeRegex`) | HIGH | ✅ Fixed — gang-aware `FamilyTypeRegex` on mk switch rules |
+| A3 | Resolution | No category→seed wiring → "no family loaded" silently skips | HIGH | ▶ §3 (map landed; engine tier to wire) |
+| A4 | Swap | Values lost swapping to families without STING params | HIGH | ▶ §4 parameter-bridge (designed) |
+| A5 | Candidate gen | **Linear** rules (`PerLinearMetre`) don't densify along the perimeter — `WALL_MIDPOINT` emits 1 pt/segment → ~40% of intended count | HIGH | New `LINEAR_WALL` densifier OR post-emit re-spacing keyed on `ComputeCap` |
+| A6 | Flexibility | No "≥X m from door/window" clearance for sockets | HIGH | Add `DoorClearanceMm`/`WindowClearanceMm` + collision penalty |
+| A7 | Flexibility | No "one per wall segment > X m" | HIGH | Add `MinSegmentLengthMm`; filter in `EmitWallMidpoints` |
+| A8 | Selection | `SelectWithSpacing` is greedy nearest-first → clusters / bare corners in L-shaped/tight rooms | MEDIUM | Poisson-disk seed or Lloyd-relaxation pass for density/coverage rules; expose `SelectionMethod` |
+| A9 | Scoring | Score weights are global constants, not sensitive to `RuleKind` (density rules under-weight spacing/coverage) | MEDIUM | Per-`RuleKind` weight profiles; allow per-rule override |
+| A10 | Candidate gen | Single-point structural anchors (`BEAM_SOFFIT`, `COLUMN_FACE_NEAREST`) can't satisfy density rules | MEDIUM | Emit a local grid / N-nearest for density |
+| A11 | Diagnostics | Anchor generators silently fall back to `ROOM_CENTRE` (no door/window/ceiling) with no warning | MEDIUM | `StingLog.Warn` + per-rule "anchor-miss" count surfaced in the run report |
+| A12 | Perf | Obstruction + wall-inside checks are O(candidates × obstacles); CSG per candidate when `RejectInsideWall` on | MEDIUM | 2D grid/quadtree of exclusion rects when >10–20; pre-computed boundary derivatives |
+| A13 | Flexibility | No `LONGEST_WALL_MIDPOINT`, no structural-grid-aligned anchor, no adjacent-room stagger | MEDIUM | New anchors (each ~20–40 lines) |
+| A14 | Density math | `room.Area` ft²→m² uses `0.3048*0.3048` (numerically right, semantically confusing); under-fill is silent | LOW | Named constant + "cap N but only M candidates" warning |
+
+### 5.1 Recommended next implementation slice (when a stable run is available)
+1. **Seed tier + EnsureSeeds pre-pass** (§3) — biggest UX win: runs never silently skip.
+2. **Swap parameter-bridge** (§4) — makes manufacturer adoption non-destructive.
+3. **A5 (linear densify) + A6 (door/window clearance)** — the two highest-value placement-
+   quality fixes for real MEP layouts.
+4. **A11 (anchor-miss diagnostics)** — cheap, makes every other gap self-reporting in the run
+   report so users (and we) can see *why* a rule under-placed.
+
+All of #1–#2 are model-modifying and need in-Revit verification; #3–#4 are candidate-
+generation/scoring and can be unit-reasoned but should still be eyeballed on a real plan.

--- a/docs/PLACEMENT_SEEDS_SWAP_IMPLEMENTATION_PROMPT.md
+++ b/docs/PLACEMENT_SEEDS_SWAP_IMPLEMENTATION_PROMPT.md
@@ -1,0 +1,195 @@
+# Implementation Prompt — Seed Tier, Swap Bridge, Placement-Quality Fixes & Diagnostics
+
+> **For the implementing agent.** Self-contained brief to implement four placement
+> improvements. The full rationale + design is in
+> [`PLACEMENT_SEEDS_SWAP_AND_ALGORITHM_DESIGN.md`](PLACEMENT_SEEDS_SWAP_AND_ALGORITHM_DESIGN.md) —
+> read it first. Work on the **current branch** (`claude/placement-centre-review-audit`); do
+> not branch or merge. The repo builds only on Windows with the Revit API — verify call
+> signatures against the documented Revit 2025/2026/2027 API. `build.bat` now only
+> compiles + stages (no Revit install); use it to compile-check. Note the
+> "built without in-Revit verification" caveat in commits + a CHANGELOG entry.
+> **Items 1 and 2 create/modify families — they MUST be verified in Revit before merge.**
+
+---
+
+## Where things live
+
+| Concern | File |
+|---|---|
+| Engine run loop + `ResolveSymbol` + `TryAutoLoadFromLibrary` + `ComputeCap` + `ComputeRoomPerimeterMetres` | `StingTools/Core/Placement/FixturePlacementEngine.cs` |
+| Anchor emitters (`EmitWallMidpoints`, `EmitDoorAnchor`, `GetBoundary`, `Fallback`) + scoring | `StingTools/Core/Placement/PlacementScorer.cs`, `PlacementScorer.AnchorTypes.cs` |
+| Rule POCO (add new fields here) | `StingTools/Core/Placement/PlacementRule.cs` |
+| Seed build from JSON | `StingTools/Core/Symbols/SymbolLibraryCreator.cs` (`CreateAllFromFile`, `BuildOne`) |
+| Seed build command (output folder, modes) | `StingTools/Commands/Symbols/BuildSeedFamiliesCommand.cs` |
+| Swap command (batch, `ChangeTypeId`, audit) | `StingTools/Commands/Symbols/SwapToManufacturerCommand.cs` |
+| Stamp shared params into a family by GUID | `StingTools/Tags/FamilyParamCreatorCommand.cs` → `FamilyParamEngine.InjectSharedParams` |
+| Category → seed map (already landed) | `StingTools/Data/Placement/STING_CATEGORY_TO_SEED_MAP.json` |
+| Run report surface (per-rule counts/warnings) | `StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs` (`OnRunCompleted`, the inline Report panel) |
+
+Re-`grep`/re-read before editing — line numbers drift.
+
+---
+
+## Item 1 — Seed tier + `EnsureSeeds` pre-pass (model-modifying)
+
+**Goal:** a placement run must *never* silently skip a ticked category for "no family
+loaded." When no manufacturer family is loaded, build/load the mapped **seed** family and
+place it (stamped, swap-ready).
+
+1. **`CategoryToSeedRegistry`** (new, `Core/Placement/`): loads
+   `STING_CATEGORY_TO_SEED_MAP.json` (corporate) + `<project>/_BIM_COORD/category_to_seed_map.json`
+   (project override, merged by `category`). `Resolve(categoryName) → seedId|null`. Cache per
+   document like the other registries.
+2. **`EnsureSeeds` pre-pass** — the safe path (do this, not in-transaction building):
+   - New command `Placement_EnsureSeeds` (`Commands/Placement/`) + a step at the **start** of
+     the Centre run (before the engine transaction opens, in `OnRunPlacement_Click` /
+     `ExecuteRun`). For each ticked category with no loaded family of that category:
+     resolve the seed id, and if the seed `.rfa` isn't already at
+     `<project>/_BIM_COORD/Families/Seeds/<seedId>.rfa`, build it via
+     `SymbolLibraryCreator` (reuse `BuildSeedFamiliesCommand`'s build path in `MissingOnly`
+     mode for just those seeds), then `LoadFamily` it. Idempotent.
+   - Report what was built/loaded in the run report.
+3. **Seed tier in `ResolveSymbol`** (`FixturePlacementEngine.cs`, ~the `ResolveSymbol`
+   method ending with the "using first available symbol" warning ~line 1516): after the
+   loaded-family + `TryAutoLoadFromLibrary` tiers and before returning null, consult
+   `CategoryToSeedRegistry`. If a seed is mapped and now loaded (from the pre-pass), return
+   its active symbol. Honour `FamilyTypeRegex`/`VariantHint` against the seed's type
+   variants. Keep the per-(category,variant) `perCategorySymbol` cache.
+4. **Guarantee the seed instance is STING-stamped + swap-ready.** Seeds built by
+   `SymbolLibraryCreator` already inject STING params + stamp `STING_SEED_FAMILY_TXT`. Verify
+   the placed instance carries `STING_SEED_FAMILY_TXT = <seedId>` so §Item-2 swap can find it.
+5. **Caveats to honour:** building/loading families inside the engine's transaction is slow
+   and risky — keep it in the **pre-pass** (own transaction) so the hot placement loop only
+   resolves already-loaded symbols. If a seed build fails, warn and fall through to the
+   existing visible `SkippedNoSymbol` path (never abort the run).
+
+**Acceptance:** with no luminaire/switch/etc. family loaded, ticking those categories and
+running places the seed families (real scheduled instances), and the run report lists
+"built/loaded seed X for category Y." No silent skips for mapped categories.
+
+---
+
+## Item 2 — Swap parameter-bridge (model-modifying)
+
+**Goal:** swapping a seed (or any) instance to a real/manufacturer family must preserve
+**parameter values even when the destination family has no STING shared parameters** — fully
+non-destructive. Implement the bridge from design §4.3 in `SwapToManufacturerCommand` (and/or
+a shared helper so a future Placement-Centre "Swap" button reuses it).
+
+Per swap group `(seedId, sourceType) → destFamily` (the command already batches like this):
+
+1. **Ensure-stamp (once per destFamily):** if `destFamily` lacks the required STING shared
+   params (check by GUID via `FamilyManager`/`get_Parameter`), open it (`Document.EditFamily`),
+   inject them by GUID via `FamilyParamEngine.InjectSharedParams` (geometry/types untouched —
+   additive only), reload into the project. Skip if already stamped.
+2. **Snapshot (per instance, before `ChangeTypeId`):** capture `{ guid → value }` for every
+   STING shared param present on the instance, **and** `{ nativeName → value }` for any name
+   in the alias map (Item 2c).
+3. **Swap:** `instance.ChangeTypeId(destTypeId)` (already in the command; preserves
+   location/host/rotation/element-id).
+4. **Restore (per instance, after `ChangeTypeId`):** write each snapshotted `guid → value`
+   back (the param now exists on the dest). For each `nativeName → value`, write it to the
+   mapped STING GUID **only if that GUID is currently empty** (don't clobber a real value).
+5. **Alias map (Item 2c) — new data file** `StingTools/Data/STING_PARAM_ALIAS_MAP.json`:
+   `{ "Mounting Height": "MNT_HGT_MM", "Elevation from Level": "MNT_HGT_MM", "Wattage":
+   "ELC_LOAD_VA", "IP Rating": "ASS_IP_RATING_TXT", ... }` — native/legacy parameter name →
+   STING shared-param name (resolve to GUID via `ParamRegistry`). Project override at
+   `_BIM_COORD/param_alias_map.json`. Keep it small + documented; only well-known aliases.
+6. **Keep existing behaviour:** `STING_DESIGN_REF_TXT` + `STING_SWAP_HISTORY_TXT` stamping,
+   connector re-stitch, UL-system match. Add a `bridge` toggle (default **on**); when off,
+   legacy swap behaviour.
+
+**Acceptance:** swap a seed instance to a manufacturer family that has **no** STING params →
+after swap the instance carries the STING params (added by stamp) with the original values
+(restored), positions/hosts intact, and a legacy "Mounting Height" value shows up under
+`MNT_HGT_MM`. Re-running the swap is idempotent (stamp skipped).
+
+---
+
+## Item 3 — Placement-quality: linear densify + door/window clearance (candidate gen + scoring)
+
+### 3a — Linear-rule perimeter densify (gap A5)
+**Problem:** a `RuleKind = Linear` rule with `PerLinearMetre` on a `WALL_MIDPOINT` anchor
+emits ~1 point per wall segment, so it places ~40% of the intended count. **Fix:** in
+`PlacementScorer.GenerateAnchorPoints` (or a post-emit pass), when `rule.RuleKind == Linear`
+and `rule.PerLinearMetre > 0`, **densify along the perimeter** to the target count: walk the
+room boundary segments (already cached in `GetBoundary`), step along each segment at
+`PerLinearMetre` spacing (inset by `WallClearanceMm`), and emit candidates. Respect
+`MinSpacingMm`. Prefer this over relying on `WALL_MIDPOINT`'s one-per-segment output.
+Consider a dedicated `LINEAR_WALL` anchor token so authors can opt in explicitly, while also
+auto-densifying existing `WALL_MIDPOINT`+Linear rules.
+
+**Acceptance:** "outlet every 2 m" in a 20 m-perimeter room places ~10, evenly along the
+walls, not 4 at segment midpoints.
+
+### 3b — Door/window clearance (gap A6)
+**Problem:** no way to keep sockets/devices clear of door/window openings. **Fix:** add
+`DoorClearanceMm` + `WindowClearanceMm` to `PlacementRule.cs` (default 0 = off). In the
+candidate scoring (`PlacementScorer` collision/`BuildCandidate` path), compute the distance
+from each candidate to the nearest door/window (the door/window sets are already collected in
+`GetBoundary`); when within the clearance, **reject or heavily penalise** the candidate
+(mirror the obstruction-buffer logic). Add the two fields to the rule-editor UI cards in the
+Placement Centre so they're authorable.
+
+**Acceptance:** a socket rule with `DoorClearanceMm: 300` never places a socket within 300 mm
+of a door opening.
+
+These are candidate-generation/scoring changes — unit-reasonable, but still eyeball on a real
+plan. Keep both **default-off / no-op** so existing rules are unchanged unless they opt in.
+
+---
+
+## Item 4 — Anchor-miss diagnostics (cheap, high signal)
+
+**Problem (gap A11):** anchor generators silently fall back to `ROOM_CENTRE` when the room
+has no doors/windows/ceiling/grid, so devices land at the centroid with no warning — the user
+can't tell *why* a rule mis-placed.
+
+**Fix:**
+1. In every `Fallback(...)` / default-case ROOM_CENTRE path in `PlacementScorer.cs` +
+   `PlacementScorer.AnchorTypes.cs` (`EmitWallMidpoints`, `EmitDoorAnchor`, `EmitWindowSills`,
+   the door/window/ceiling/grid/column emitters), emit a one-shot
+   `StingLog.Warn` AND increment a per-rule diagnostic counter (the `RuleDiagnostic` object
+   already exists on `PlacementResult` — add an `AnchorMisses` / `FellBackToRoomCentre`
+   count if not present).
+2. Also warn when `ComputeCap` derives a cap greater than the candidate count (silent
+   under-fill): `"rule X cap=N but only M candidates generated — placed M"`.
+3. Surface both in the **run report** (per-rule section already lists counts): show
+   "anchor fell back to room centre: K room(s)" and "under-filled: cap N vs M" per rule, so
+   every other algorithm gap becomes self-reporting.
+
+**Acceptance:** running a door-anchored rule in a doorless room shows a clear per-rule warning
+in the report ("DOOR_HINGE found no doors in 3 room(s) — used room centre"), not a silent
+mis-placement.
+
+---
+
+## Constraints & house rules
+- One branch (`claude/placement-centre-review-audit`); no merge to `main`.
+- Read before edit; targeted `Edit`s; one logical change per commit (suggest one commit per
+  Item).
+- Revit transactions wrapped + named `STING …`; `[Transaction(Manual)]` for state-changers;
+  `TaskDialog`/inline report for user messages; all error paths via `StingLog`; never abort a
+  run on a single rule/seed failure.
+- **Keep the working path byte-identical when a feature is off**: Item 3 fields default to 0
+  (no-op); Item 1 seed tier only fires when no family is otherwise resolved; Item 2 bridge is
+  additive-only and toggleable.
+- Reuse existing engines (`SymbolLibraryCreator`, `FamilyParamEngine`, `GetBoundary`,
+  `ParamRegistry`) — don't re-implement.
+- Compile with `build.bat` (stages only, no Revit install). Log work in `docs/CHANGELOG.md`;
+  note the "no in-Revit verification" caveat. **Items 1 & 2 need an in-Revit smoke test before
+  merge** (build a seed for an empty category and place it; swap to a non-STING family and
+  confirm values survive).
+
+## Suggested order
+1. **Item 4** (diagnostics) — cheap, and it makes Items 1/3 self-verifying in the report.
+2. **Item 1** (seed tier + EnsureSeeds) — the headline UX fix.
+3. **Item 3** (linear densify + clearance) — placement quality.
+4. **Item 2** (swap bridge) — manufacturer adoption.
+
+## Definition of done
+- A run with no families loaded for ticked categories places seed families and reports it.
+- Swapping to a STING-naive family preserves positions + values (via stamp+restore+alias).
+- Linear rules hit their target count along walls; clearance rules respect door/window gaps.
+- Every anchor fallback / under-fill is visible in the run report.
+- CHANGELOG entry; the model-modifying items flagged for in-Revit verification.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,38 @@
 
 Open automation gaps, future-enhancement tables, and deep-review findings for the StingTools plugin. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`CHANGELOG.md`](CHANGELOG.md) for the history of closed items.
 
+## Placement Centre — residual gaps (post review/hardening)
+
+- **BOQ quantity handoff.** Placed-element counts (`PlacementResult.PlacedIds`,
+  keyed by provenance) still don't feed `StingTools/BOQ/`. A "Send placed
+  quantities to BOQ" action keyed off the provenance stamp would close the
+  loop. Deferred from the review (large BOQ API surface; unverifiable here).
+- **Drawing-Type preset *apply* during placement.** "Save view preset" writes
+  `StingViewPresetSchema` (works), but nothing applies a preset during a run
+  and it bypasses `DrawingTypePresentation.Apply`. Either route through the
+  Drawing Template Manager or drop the half-feature. Deferred.
+- **Wall/ceiling/floor-follow router.** The legacy `WALL_FOLLOW` /
+  `CEILING_FOLLOW` / `FLOOR_FOLLOW` rule tokens are normalized to the nearest
+  drop engine with an honest warning (Part C.5). A genuine follower router
+  (route along wall/ceiling faces, not a drop) is net-new work.
+- **Data-driven Auto-place category checklist.** The 19 category checkboxes
+  are hardcoded; non-placeable ones (Conduits/Pipes/Cable Trays routing
+  outputs; Specialty/Nurse Call needing rule packs) are annotated via tooltips
+  rather than driven from the engine's supported-category set. A registry-driven
+  checklist would prevent UI↔engine drift.
+- **PlacementRule push-to-family-types fields.** `Material` / `GlazingSpec` /
+  `InsulationThicknessMm` / `NominalDiameterMm` / `MaintenanceClearance` and
+  the advisory fields (`ToughenedGlazingRequired` / `MinSlopePercent` /
+  `MinUniformityRatio` / `ExposureClass` / `EmitSupports`) are loaded + edited
+  but not consumed by the placement engine (DEFERRED in the CHANGELOG table).
+  Either wire them into the push-to-family-types pass / a post-validator, or
+  retire the editor cards.
+- **StandardRef ↔ ApplicableStandards.** The profile standards gate keys off
+  the structured `ApplicableStandards`; rules citing standards only via
+  free-text `StandardRef` are kept (not dropped) and the engine warns when the
+  filter is inert. Backfilling `ApplicableStandards` across the rule packs (or
+  a normalized StandardRef token match) would make the standards filter active.
+
 ## BOQ / Cost — residual gaps (post Stage-B integration)
 
 - **Currency conversion (not just labels).** Stage-B B.1 made currency labels

--- a/extract_plugin.sh
+++ b/extract_plugin.sh
@@ -108,32 +108,40 @@ cat > "$DEPLOY_DIR/StingTools.addin" <<ADDIN_EOF
 </RevitAddIns>
 ADDIN_EOF
 
-# ── Auto-deploy to Revit Addins folder (Phase 188 follow-up) ──────
-# Manifest now points at CompiledPlugin/StingTools.dll, so the only
-# manual step remaining is "copy StingTools.addin into Revit Addins
-# folder once." This block does that automatically for Revit 2025/26/27
-# common locations so every rebuild reaches Revit without manual copy.
-if [ -n "$APPDATA" ]; then
-    # APPDATA on Git Bash / MSYS may arrive in Windows form (C:\Users\...).
-    # Try the value directly first; if that's not a directory, translate
-    # backslashes to forward slashes and the drive letter to /c/ form.
-    REVIT_ADDINS_BASE="$APPDATA/Autodesk/Revit/Addins"
-    if [ ! -d "$REVIT_ADDINS_BASE" ]; then
-        REVIT_ADDINS_BASE="$(echo "$APPDATA" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')/Autodesk/Revit/Addins"
-    fi
-    deployed=0
-    for ver in 2025 2026 2027; do
-        target_dir="$REVIT_ADDINS_BASE/$ver"
-        if [ -d "$target_dir" ]; then
-            if cp -f "$DEPLOY_DIR/StingTools.addin" "$target_dir/StingTools.addin" 2>/dev/null; then
-                echo "  Auto-deployed manifest to: $target_dir"
-                deployed=$((deployed + 1))
-            fi
+# ── Install into Revit — OPT-IN ONLY (STING_DEPLOY=1) ────────────
+# Installing the manifest into Revit's single shared Addins folder is
+# what makes a build "the live plugin". With multiple parallel checkouts
+# (agents building to verify), auto-installing on every build means the
+# last build silently wins and clobbers whatever you were testing.
+#
+# So this is now opt-in: a plain build stages to CompiledPlugin/ (for
+# verification) and does NOT touch Revit. To make THIS checkout the live
+# plugin, run `deploy.bat` (or `STING_DEPLOY=1 bash extract_plugin.sh`).
+if [ "${STING_DEPLOY:-0}" = "1" ]; then
+    if [ -n "$APPDATA" ]; then
+        REVIT_ADDINS_BASE="$APPDATA/Autodesk/Revit/Addins"
+        if [ ! -d "$REVIT_ADDINS_BASE" ]; then
+            REVIT_ADDINS_BASE="$(echo "$APPDATA" | sed 's|\\|/|g; s|^\([A-Za-z]\):|/\L\1|')/Autodesk/Revit/Addins"
         fi
-    done
-    if [ "$deployed" = "0" ]; then
-        echo "  (No Revit Addins folder found under \$APPDATA — manual copy still needed.)"
+        deployed=0
+        for ver in 2025 2026 2027; do
+            target_dir="$REVIT_ADDINS_BASE/$ver"
+            if [ -d "$target_dir" ]; then
+                # Clear any read-only lock a previous isolated deploy set.
+                chmod u+w "$target_dir/StingTools.addin" 2>/dev/null || true
+                if cp -f "$DEPLOY_DIR/StingTools.addin" "$target_dir/StingTools.addin" 2>/dev/null; then
+                    echo "  Installed manifest into Revit: $target_dir"
+                    deployed=$((deployed + 1))
+                fi
+            fi
+        done
+        if [ "$deployed" = "0" ]; then
+            echo "  (No Revit Addins folder found under \$APPDATA — manual copy still needed.)"
+        fi
     fi
+else
+    echo "  Revit install SKIPPED (staged to CompiledPlugin only)."
+    echo "  -> Run deploy.bat (or STING_DEPLOY=1 bash extract_plugin.sh) to make THIS checkout the live plugin."
 fi
 
 # ── Report ────────────────────────────────────────────────────────


### PR DESCRIPTION
Deep review of the STING Placement Centre (UI window + `FixturePlacementEngine` + rules + integrations), the implementation that closed the findings, and a five-item review follow-up.

## What changed

**UI honesty (Part A/C)**
- Stripped internal work-tracking tokens (`PC-NN` / `Pack NN` / `Phase NNN`) from all user-visible headers, checkboxes, tooltips, and the title/version stamp.
- Run-Options checkboxes are now honest: data-tag pipeline calls `TagPipelineHelper.RunFullPipeline` directly (was a dead reflection probe); MEP "probe" now actually connects coincident connectors; routing dropdown reconciled to `NONE/AUTO_CONDUIT/AUTO_PIPE/AUTO_DUCT` (no dead modes); import refreshes the grid.
- Validator checklist: all 8 run real validators — `SeparationValidator` gained a `Validate(Document)` entry point and the fragile reflection block was replaced with direct typed calls.

**Building Profile, now live (Part B)**
- The building type + active standards + wet-zone/accessibility/coverage toggles now flow into the actual run (previously `FilterByProfile` was never called at run-time — it only filtered the grid display). No Save-first required.

**Engine correctness (Part D)**
- Coverage grid wired so `GuaranteeCoverage` actually guarantees coverage.
- Re-runs are idempotent via a prior-placed provenance index (no duplicate fixtures).
- Rule-dependency cycle detection; `COLUMN_FACE_NEAREST` per-room column cache; missing-symbol skips are now visible in diagnostics.

**Category/rule reconciliation + integration notes (Part E/F/G)**
- Non-placeable categories annotated; invalid rules explain why on hover; in-Centre "Learn from model" button; BOQ handoff + preset-apply documented as deferred.

## Review follow-up — five minor fixes (commit `2a765eddc`)
1. Standards gate falls back to free-text `StandardRef` when `ApplicableStandards` is empty (contains-either-direction), so `StandardRef`-only rules are actually gated.
2. Idempotency indexes face/work-plane-hosted instances via the transform origin (no `LocationPoint`).
3. MEP auto-connect retuned from a misleading 600 mm "radius" to a 25 mm coincidence tolerance (`ConnectTo` only joins coincident connectors).
4. Routing tooltip drops the stale `WALL_FOLLOWER` entry.
5. Idempotency scan scoped to the active rules' `BuiltInCategory` set via `ElementMulticategoryFilter` instead of walking every `FamilyInstance` each run.

## Verification
- **Compiles clean** against the Revit 2025 API (`build.bat`, Release): 0 compile errors. This is the first real compile of the whole hardening pass.
- Deployed locally to Revit 2025/2026 Addins.
- Runtime behaviour (placement runs, MEP connect, profile gating) still needs exercising inside Revit.

Full per-part decision tables (field/category WIRED/FIXED/DEFERRED) are in `docs/CHANGELOG.md`; the original review brief is `docs/PLACEMENT_CENTRE_REVIEW_AND_FIX_PROMPT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)