### PR TITLE
Copilot: Create stage (ModelEngine tools) + panel controls (clear/save/screenshot/settings) — integrated

### DIFF
--- a/StingTools/Core/StingLlmService.cs
+++ b/StingTools/Core/StingLlmService.cs
@@ -45,6 +45,14 @@ namespace StingTools.Core
         private string _claudeKey;
         private string _claudeModel;
         private bool   _enabled;
+        private string _provider;          // "claude" | "azure" — which provider to prefer
+        private int    _timeoutSeconds = 10;
+
+        /// <summary>The Claude model id currently configured (for transcripts / display). Never a secret.</summary>
+        public string ActiveModel => string.IsNullOrWhiteSpace(_claudeModel) ? "claude-haiku-4-5-20251001" : _claudeModel;
+
+        /// <summary>The preferred provider ("claude" | "azure"). Never a secret.</summary>
+        public string ActiveProvider => string.IsNullOrWhiteSpace(_provider) ? "claude" : _provider;
 
         // Valid command tags — LLM output is rejected unless it is in this whitelist
         private static readonly HashSet<string> _commandWhitelist = BuildWhitelist();
@@ -69,11 +77,37 @@ namespace StingTools.Core
                 _azureKey       = cfg["azure_api_key"]?.Value<string>();
                 _claudeKey      = cfg["claude_api_key"]?.Value<string>();
                 _claudeModel    = cfg["claude_model"]?.Value<string>()        ?? "claude-haiku-4-5-20251001";
+
+                // Provider preference (explicit key wins; otherwise inferred from which
+                // credentials are present) — keeps the settings-dialog radio meaningful
+                // without deleting the other provider's saved credentials.
+                _provider = cfg["provider"]?.Value<string>()?.Trim().ToLowerInvariant();
+                if (string.IsNullOrWhiteSpace(_provider))
+                    _provider = !string.IsNullOrWhiteSpace(_claudeKey) ? "claude"
+                              : (!string.IsNullOrWhiteSpace(_azureEndpoint) && !string.IsNullOrWhiteSpace(_azureKey)) ? "azure"
+                              : "claude";
+
+                int t = cfg["timeout_seconds"]?.Value<int?>() ?? 10;
+                _timeoutSeconds = t > 0 ? t : 10;
+                // HttpClient.Timeout can only be set before the first request; on a live
+                // reload it may throw — swallow it (the message carries no secret).
+                try { _http.Timeout = TimeSpan.FromSeconds(_timeoutSeconds); }
+                catch (Exception tex) { StingLog.Warn($"LLM timeout not applied (request already in flight): {tex.Message}"); }
             }
             catch (Exception ex)
             {
                 StingLog.Warn($"LLM config load failed (offline mode): {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Re-read STING_LLM_CONFIG.json so a save from the settings dialog takes effect
+        /// without restarting Revit. Never logs credential values.
+        /// </summary>
+        public void ReloadConfig()
+        {
+            LoadConfig();
+            StingLog.Info($"LLM config reloaded (enabled={_enabled}, provider={_provider}, model={_claudeModel}).");
         }
 
         // ── 1. Design brief parser ────────────────────────────────────────────
@@ -147,33 +181,98 @@ namespace StingTools.Core
         {
             if (!_enabled) return null; // LLM disabled in config — rule-based fallback handles this
 
-            // Try Azure OpenAI first
-            if (!string.IsNullOrEmpty(_azureEndpoint) && !string.IsNullOrEmpty(_azureKey))
-            {
-                try
-                {
-                    return await CallAzureOpenAiAsync(userPrompt, systemPrompt);
-                }
-                catch (Exception ex)
-                {
-                    StingLog.Warn($"Azure OpenAI failed, trying Claude fallback: {ex.Message}");
-                }
-            }
+            bool azureReady  = !string.IsNullOrEmpty(_azureEndpoint) && !string.IsNullOrEmpty(_azureKey);
+            bool claudeReady = !string.IsNullOrEmpty(_claudeKey);
+            bool preferAzure = string.Equals(_provider, "azure", StringComparison.OrdinalIgnoreCase);
 
-            // Try Claude API
-            if (!string.IsNullOrEmpty(_claudeKey))
+            // Try the preferred provider first, then fall back to the other.
+            foreach (bool tryAzure in preferAzure ? new[] { true, false } : new[] { false, true })
             {
-                try
+                if (tryAzure && azureReady)
                 {
-                    return await CallClaudeAsync(userPrompt, systemPrompt);
+                    try { return await CallAzureOpenAiAsync(userPrompt, systemPrompt); }
+                    catch (Exception ex) { StingLog.Warn($"Azure OpenAI failed: {ex.Message}"); }
                 }
-                catch (Exception ex)
+                else if (!tryAzure && claudeReady)
                 {
-                    StingLog.Warn($"Claude API failed: {ex.Message}");
+                    try { return await CallClaudeAsync(userPrompt, systemPrompt); }
+                    catch (Exception ex) { StingLog.Warn($"Claude API failed: {ex.Message}"); }
                 }
             }
 
             return null; // Both unavailable — caller uses offline fallback
+        }
+
+        // ── Test connection (settings dialog) ─────────────────────────────────
+        //
+        // Sends a trivial prompt using the values PASSED IN (the dialog's current
+        // fields, not the saved config) so the user can verify before saving. Never
+        // logs the key — only the exception type + message (which carry no secret).
+
+        public async Task<(bool ok, string message)> TestConnectionAsync(
+            bool useClaude, string claudeKey, string claudeModel,
+            string azureEndpoint, string azureKey, string azureDeployment)
+        {
+            try
+            {
+                if (useClaude)
+                {
+                    if (string.IsNullOrWhiteSpace(claudeKey))
+                        return (false, "No Claude API key entered.");
+
+                    string model = string.IsNullOrWhiteSpace(claudeModel) ? "claude-haiku-4-5-20251001" : claudeModel;
+                    var body = new
+                    {
+                        model,
+                        max_tokens = 16,
+                        messages = new[] { new { role = "user", content = "Reply with the single word OK." } }
+                    };
+                    var req = new HttpRequestMessage(HttpMethod.Post, "https://api.anthropic.com/v1/messages");
+                    req.Headers.Add("x-api-key", claudeKey);
+                    req.Headers.Add("anthropic-version", "2023-06-01");
+                    req.Content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
+                    var resp = await _http.SendAsync(req);
+                    string json = await resp.Content.ReadAsStringAsync();
+                    if (!resp.IsSuccessStatusCode)
+                        return (false, $"Claude API {(int)resp.StatusCode}: {ExtractApiError(json) ?? "request failed"}");
+                    string text = JObject.Parse(json)["content"]?[0]?["text"]?.Value<string>();
+                    return (true, $"Claude ({model}) responded: {(text ?? "OK").Trim()}");
+                }
+                else
+                {
+                    if (string.IsNullOrWhiteSpace(azureEndpoint) || string.IsNullOrWhiteSpace(azureKey))
+                        return (false, "Azure endpoint and API key are required.");
+
+                    string dep = string.IsNullOrWhiteSpace(azureDeployment) ? "gpt-4o-mini" : azureDeployment;
+                    string url = $"{azureEndpoint.TrimEnd('/')}/openai/deployments/{dep}/chat/completions?api-version=2024-02-01";
+                    var body = new
+                    {
+                        messages = new[] { new { role = "user", content = "Reply with the single word OK." } },
+                        max_tokens = 16,
+                        temperature = 0.0
+                    };
+                    var req = new HttpRequestMessage(HttpMethod.Post, url);
+                    req.Headers.Add("api-key", azureKey);
+                    req.Content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
+                    var resp = await _http.SendAsync(req);
+                    string json = await resp.Content.ReadAsStringAsync();
+                    if (!resp.IsSuccessStatusCode)
+                        return (false, $"Azure OpenAI {(int)resp.StatusCode}: {ExtractApiError(json) ?? "request failed"}");
+                    string text = JObject.Parse(json)["choices"]?[0]?["message"]?["content"]?.Value<string>();
+                    return (true, $"Azure ({dep}) responded: {(text ?? "OK").Trim()}");
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"LLM test connection failed: {ex.GetType().Name}: {ex.Message}");
+                return (false, $"Connection failed: {ex.Message}");
+            }
+        }
+
+        private static string ExtractApiError(string json)
+        {
+            try { return JObject.Parse(json)["error"]?["message"]?.Value<string>(); }
+            catch { return null; }
         }
 
         private async Task<string> CallAzureOpenAiAsync(string userPrompt, string systemPrompt)

--- a/StingTools/Core/StingLlmService.cs
+++ b/StingTools/Core/StingLlmService.cs
@@ -232,10 +232,16 @@ namespace StingTools.Core
         private const string CopilotSystemPrompt =
             "You are the StingTools assistant inside Revit. You control a Revit BIM model through " +
             "tools. Use search_capabilities to discover commands and describe_capability to understand " +
-            "them. Prefer the Tier-1 read tools (query_elements, get_element, get_compliance, " +
-            "run_validator, get_model_info) to answer questions. For ANY write/mutation, ALWAYS call " +
-            "the tool with dryRun:true first, show the user the projected plan, and run for real only " +
-            "after the user confirms. NEVER claim a write happened unless the read-back confirms it — " +
+            "them. Prefer the Tier-1 read tools (query_elements, get_element, get_rooms, get_levels, " +
+            "get_grids, get_warnings, get_compliance, run_validator, get_model_info) to answer questions. " +
+            "You can also CREATE model geometry: create_wall, create_floor, create_floor_in_room, " +
+            "create_roof, create_duct, create_pipe, create_room, place_family, and building_shell. " +
+            "ALL coordinates and dimensions passed to create tools are in MILLIMETRES. " +
+            "For ANY write, mutation, or creation, ALWAYS call the tool with dryRun:true first, show the " +
+            "user the projected plan, and run for real only after the user confirms. building_shell (and " +
+            "any multi-element create) additionally requires confirm:true on the real run. When a create " +
+            "tool reports an unknown type/level/family (bad_args), read the listed options and pick a valid " +
+            "one or ask the user. NEVER claim a write/create happened unless the read-back confirms it — " +
             "watch for noWritesPersisted and typeScopeWrites in results and report them honestly. " +
             "Be concise; answer in plain English.";
 
@@ -254,11 +260,13 @@ namespace StingTools.Core
         /// write that returned needs_confirmation; returns true to proceed. May be null.
         /// </param>
         /// <param name="onToolStart">Optional progress callback fired with each tool name before it runs.</param>
+        /// <param name="onToolResult">Optional callback fired with (toolName, compactResultSummary) after each tool runs — for chat activity transparency.</param>
         public async Task<CopilotTurn> RunCopilotTurnAsync(
             List<CopilotMessage> conversation,
             CancellationToken ct,
             Func<string, bool> confirmCallback = null,
-            Action<string> onToolStart = null)
+            Action<string> onToolStart = null,
+            Action<string, string> onToolResult = null)
         {
             var turn = new CopilotTurn { ToolsUsed = new List<string>() };
 
@@ -284,7 +292,7 @@ namespace StingTools.Core
 
             try
             {
-                return await RunClaudeToolLoopAsync(conversation, ct, confirmCallback, onToolStart);
+                return await RunClaudeToolLoopAsync(conversation, ct, confirmCallback, onToolStart, onToolResult);
             }
             catch (OperationCanceledException)
             {
@@ -305,9 +313,18 @@ namespace StingTools.Core
             List<CopilotMessage> conversation,
             CancellationToken ct,
             Func<string, bool> confirmCallback,
-            Action<string> onToolStart)
+            Action<string> onToolStart,
+            Action<string, string> onToolResult)
         {
             var turn = new CopilotTurn { ToolsUsed = new List<string>() };
+
+            // Context auto-include: read the active view + current selection once so the
+            // model can resolve "this view" / "these" / "here" without the user restating them.
+            string contextPreamble = BuildContextPreamble();
+            string systemPrompt = string.IsNullOrEmpty(contextPreamble)
+                ? CopilotSystemPrompt
+                : CopilotSystemPrompt + "\n\nCurrent Revit context — " + contextPreamble +
+                  " Use these when the user says 'this view', 'these', 'the selection', or 'here'.";
 
             // Build the Anthropic tools array ONCE from the shared registry. Note the
             // registry serialises the schema under "inputSchema"; the Anthropic Messages
@@ -343,7 +360,7 @@ namespace StingTools.Core
                 {
                     ["model"]      = _claudeModel ?? "claude-haiku-4-5-20251001",
                     ["max_tokens"] = 1024,
-                    ["system"]     = CopilotSystemPrompt,
+                    ["system"]     = systemPrompt,
                     ["tools"]      = toolsArr,
                     ["messages"]   = messages,
                 };
@@ -403,6 +420,7 @@ namespace StingTools.Core
                     try { onToolStart?.Invoke(name); } catch { /* progress is best-effort */ }
 
                     var (text, isError) = ExecuteToolWithConfirm(name, input, confirmCallback);
+                    try { onToolResult?.Invoke(name, CompactSummary(text)); } catch { /* transparency is best-effort */ }
 
                     toolResults.Add(new JObject
                     {
@@ -460,6 +478,47 @@ namespace StingTools.Core
         {
             if (result?.Content == null || result.Content.Count == 0) return string.Empty;
             return string.Join("\n", result.Content.Select(c => c?.Text ?? string.Empty));
+        }
+
+        /// <summary>First meaningful line of a tool result (the Summary above the JSON fence), for the chat activity line.</summary>
+        private static string CompactSummary(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return "(no result)";
+            int fence = text.IndexOf("```", StringComparison.Ordinal);
+            string head = (fence > 0 ? text.Substring(0, fence) : text).Trim();
+            string line = head.Split('\n').FirstOrDefault(l => !string.IsNullOrWhiteSpace(l))?.Trim() ?? "";
+            if (line.Length > 140) line = line.Substring(0, 137) + "…";
+            return string.IsNullOrEmpty(line) ? "(done)" : line;
+        }
+
+        /// <summary>
+        /// Read the active view name + current selection on the Revit API thread (short timeout,
+        /// no mutation) so the Copilot can resolve deictic references. Returns null on any failure.
+        /// </summary>
+        private static string BuildContextPreamble()
+        {
+            try
+            {
+                var r = McpJobBridge.Run(uiApp =>
+                {
+                    var uidoc = uiApp?.ActiveUIDocument;
+                    if (uidoc?.Document == null) return McpJobResult.Success("", null);
+                    string view = uidoc.ActiveView?.Name ?? "(none)";
+                    var sel = uidoc.Selection.GetElementIds();
+                    string selStr = sel.Count == 0
+                        ? "none"
+                        : (sel.Count <= 15
+                            ? string.Join(",", sel.Select(i => i.Value))
+                            : $"{sel.Count} elements (ids: {string.Join(",", sel.Take(15).Select(i => i.Value))}…)");
+                    return McpJobResult.Success($"active view: '{view}'; selection: {selStr}.", null);
+                }, 5000);
+                return (r != null && r.Ok && !string.IsNullOrEmpty(r.Summary)) ? r.Summary : null;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Copilot context preamble failed: {ex.Message}");
+                return null;
+            }
         }
 
         /// <summary>

--- a/StingTools/Mcp/McpCreateTools.cs
+++ b/StingTools/Mcp/McpCreateTools.cs
@@ -1,0 +1,541 @@
+// ════════════════════════════════════════════════════════════════════════════
+// McpCreateTools — Create-stage WRITE verbs that build model geometry
+//
+// Thin adapters over the dialog-free StingTools.Model.ModelEngine. Each tool:
+//   • runs on the Revit API thread via McpJobBridge.Run (60s, no modal UI),
+//   • Guard()s the licence + open document (McpSafety),
+//   • resolves type/level/family NAMES against the live doc — an explicitly named
+//     type/level/family that does not resolve returns bad_args listing the options
+//     (never a silent wrong-type create); an omitted name uses the project default,
+//     reported back as typeUsed,
+//   • dryRun:true VALIDATES only (resolution + coord/dimension sanity) and returns
+//     the plan — it creates NOTHING,
+//   • building_shell (and any >5-element create) requires confirm:true,
+//   • returns read-back {created:[ids], count, typeUsed, warnings}.
+//
+// IMPORTANT — transactions: unlike the parameter/tag write verbs, the ModelEngine
+// methods open (and commit/roll back) their OWN Transaction/TransactionGroup
+// internally. These tools therefore do NOT wrap a second transaction — they reuse
+// the engine's, and report created ids from ModelResult only on Success (== commit).
+// All coordinates and dimensions are MILLIMETRES.
+// ════════════════════════════════════════════════════════════════════════════
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.DB.Mechanical;
+using Autodesk.Revit.DB.Plumbing;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+using StingTools.Model;
+
+namespace StingTools.Mcp
+{
+    internal static class McpCreateTools
+    {
+        // Coordinates beyond ±10 km (mm) are almost certainly a units mistake.
+        private const double MaxCoordMm = 10_000_000.0;
+
+        // ── create_wall ──────────────────────────────────────────────────────────
+
+        public static McpCallResult CreateWall(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                if (!TryNum(args, "startX", out double sx, out var e1)) return e1;
+                if (!TryNum(args, "startY", out double sy, out var e2)) return e2;
+                if (!TryNum(args, "endX", out double ex, out var e3)) return e3;
+                if (!TryNum(args, "endY", out double ey, out var e4)) return e4;
+                double heightMm = args["heightMm"]?.Value<double?>() ?? 0;
+
+                var sane = CheckFinite(sx, sy, ex, ey, heightMm);
+                if (sane != null) return sane;
+                if (heightMm <= 0) return Bad("heightMm must be greater than 0.");
+                double lenMm = Math.Sqrt((ex - sx) * (ex - sx) + (ey - sy) * (ey - sy));
+                if (lenMm < 3.0) return Bad("Start and end points are too close to form a wall (< 3 mm).");
+
+                if (!ResolveType<WallType>(doc, args["typeName"]?.Value<string>(), "wall type", out string wt, out var te)) return te;
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("wall", wt, lv, new Dictionary<string, object>
+                    {
+                        ["lengthMm"] = Math.Round(lenMm, 1),
+                        ["heightMm"] = heightMm,
+                    });
+
+                var res = new ModelEngine(doc).CreateWall(sx, sy, ex, ey, wt, lv, heightMm);
+                return ReadBack(doc, res, wt);
+            }, 60000).ToCallResult();
+        }
+
+        // ── create_floor ─────────────────────────────────────────────────────────
+
+        public static McpCallResult CreateFloor(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                if (!TryProfile(args, out var profile, out var pe)) return pe;
+                if (!ResolveType<FloorType>(doc, args["typeName"]?.Value<string>(), "floor type", out string ft, out var te)) return te;
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("floor", ft, lv, new Dictionary<string, object> { ["points"] = profile.Count });
+
+                var res = new ModelEngine(doc).CreateFloorFromProfile(profile, ft, lv);
+                return ReadBack(doc, res, ft);
+            }, 60000).ToCallResult();
+        }
+
+        // ── create_floor_in_room ─────────────────────────────────────────────────
+
+        public static McpCallResult CreateFloorInRoom(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                if (!TryId(args, "roomId", out long roomId, out var re)) return re;
+                if (!(doc.GetElement(new ElementId(roomId)) is Room room))
+                    return McpJobResult.Error("bad_args", $"Element {roomId} is not a Room.");
+
+                if (!ResolveType<FloorType>(doc, args["typeName"]?.Value<string>(), "floor type", out string ft, out var te)) return te;
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("floor-in-room", ft, lv, new Dictionary<string, object> { ["roomId"] = roomId, ["room"] = SafeRoomName(room) });
+
+                var res = new ModelEngine(doc).CreateFloorInRoom(room, ft, lv);
+                return ReadBack(doc, res, ft);
+            }, 60000).ToCallResult();
+        }
+
+        // ── create_roof ──────────────────────────────────────────────────────────
+
+        public static McpCallResult CreateRoof(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                if (!TryProfile(args, out var profile, out var pe)) return pe;
+                double slope = args["slopeDeg"]?.Value<double?>() ?? 25;
+                if (slope < 0 || slope > 85) return Bad("slopeDeg must be between 0 and 85.");
+                if (!ResolveType<RoofType>(doc, args["typeName"]?.Value<string>(), "roof type", out string rt, out var te)) return te;
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("roof", rt, lv, new Dictionary<string, object> { ["points"] = profile.Count, ["slopeDeg"] = slope });
+
+                var res = new ModelEngine(doc).CreateRoofFromProfile(profile, rt, lv, slope);
+                return ReadBack(doc, res, rt);
+            }, 60000).ToCallResult();
+        }
+
+        // ── create_duct ──────────────────────────────────────────────────────────
+
+        public static McpCallResult CreateDuct(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                if (!TryRun3D(args, out double sx, out double sy, out double sz,
+                              out double ex, out double ey, out double ez, out var re)) return re;
+
+                double dia = args["diameterMm"]?.Value<double?>() ?? args["sizeMm"]?.Value<double?>() ?? 0;
+                double w = args["widthMm"]?.Value<double?>() ?? 0;
+                double h = args["heightMm"]?.Value<double?>() ?? 0;
+                if (dia < 0 || w < 0 || h < 0) return Bad("Sizes must be non-negative.");
+
+                if (!ResolveType<DuctType>(doc, args["ductTypeName"]?.Value<string>() ?? args["typeName"]?.Value<string>(),
+                        "duct type", out string dt, out var te)) return te;
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("duct", dt, lv, new Dictionary<string, object>
+                    {
+                        ["diameterMm"] = dia, ["widthMm"] = w, ["heightMm"] = h,
+                        ["note"] = "duct system defaults to Supply Air",
+                    });
+
+                var res = new ModelEngine(doc).CreateDuct(sx, sy, sz, ex, ey, ez, dt, lv, dia, w, h);
+                return ReadBack(doc, res, dt);
+            }, 60000).ToCallResult();
+        }
+
+        // ── create_pipe ──────────────────────────────────────────────────────────
+
+        public static McpCallResult CreatePipe(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                if (!TryRun3D(args, out double sx, out double sy, out double sz,
+                              out double ex, out double ey, out double ez, out var re)) return re;
+
+                double dia = args["diameterMm"]?.Value<double?>() ?? args["sizeMm"]?.Value<double?>() ?? 0;
+                if (dia < 0) return Bad("diameterMm must be non-negative.");
+                string sysType = args["systemType"]?.Value<string>() ?? "DomesticColdWater";
+
+                if (!ResolveType<PipeType>(doc, args["pipeTypeName"]?.Value<string>() ?? args["typeName"]?.Value<string>(),
+                        "pipe type", out string pt, out var te)) return te;
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("pipe", pt, lv, new Dictionary<string, object>
+                    {
+                        ["diameterMm"] = dia, ["systemType"] = sysType,
+                    });
+
+                var res = new ModelEngine(doc).CreatePipe(sx, sy, sz, ex, ey, ez, pt, lv, sysType, dia);
+                return ReadBack(doc, res, pt);
+            }, 60000).ToCallResult();
+        }
+
+        // ── create_room ──────────────────────────────────────────────────────────
+
+        public static McpCallResult CreateRoom(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                if (!TryNum(args, "x", out double x, out var e1)) return e1;
+                if (!TryNum(args, "y", out double y, out var e2)) return e2;
+                var sane = CheckFinite(x, y);
+                if (sane != null) return sane;
+
+                string name = args["name"]?.Value<string>();
+                string number = args["number"]?.Value<string>();
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("room", null, lv, new Dictionary<string, object>
+                    {
+                        ["x"] = x, ["y"] = y, ["name"] = name ?? "", ["number"] = number ?? "",
+                    });
+
+                var res = new ModelEngine(doc).PlaceRoom(x, y, name, number, lv);
+                return ReadBack(doc, res, name ?? "Room");
+            }, 60000).ToCallResult();
+        }
+
+        // ── place_family ─────────────────────────────────────────────────────────
+
+        public static McpCallResult PlaceFamily(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                string familyName = args["familyName"]?.Value<string>()?.Trim();
+                string typeName = args["typeName"]?.Value<string>()?.Trim();
+                if (string.IsNullOrEmpty(familyName)) return Bad("Missing required argument: familyName.");
+
+                if (!TryNum(args, "x", out double x, out var e1)) return e1;
+                if (!TryNum(args, "y", out double y, out var e2)) return e2;
+                double z = args["z"]?.Value<double?>() ?? 0;
+                var sane = CheckFinite(x, y, z);
+                if (sane != null) return sane;
+
+                // Resolve the exact symbol (validation + bad_args with options).
+                var symbols = new FilteredElementCollector(doc)
+                    .OfClass(typeof(FamilySymbol)).Cast<FamilySymbol>().ToList();
+                if (symbols.Count == 0) return Bad("No loadable families in the project. Load one first.");
+
+                var famPool = symbols
+                    .Where(s => s.FamilyName.Equals(familyName, StringComparison.OrdinalIgnoreCase)).ToList();
+                if (famPool.Count == 0)
+                    famPool = symbols.Where(s => s.FamilyName.IndexOf(familyName, StringComparison.OrdinalIgnoreCase) >= 0).ToList();
+                if (famPool.Count == 0)
+                {
+                    var fams = symbols.Select(s => s.FamilyName).Distinct().OrderBy(n => n).Take(20).ToList();
+                    return McpJobResult.Error("bad_args",
+                        $"No family matching '{familyName}'. Loaded families include: {string.Join(", ", fams)}" +
+                        (symbols.Select(s => s.FamilyName).Distinct().Count() > 20 ? "…" : "") + ".");
+                }
+
+                FamilySymbol symbol;
+                if (!string.IsNullOrEmpty(typeName))
+                {
+                    symbol = famPool.FirstOrDefault(s => s.Name.Equals(typeName, StringComparison.OrdinalIgnoreCase))
+                          ?? famPool.FirstOrDefault(s => s.Name.IndexOf(typeName, StringComparison.OrdinalIgnoreCase) >= 0);
+                    if (symbol == null)
+                    {
+                        var types = famPool.Select(s => s.Name).Distinct().OrderBy(n => n).Take(20).ToList();
+                        return McpJobResult.Error("bad_args",
+                            $"Family '{famPool[0].FamilyName}' has no type '{typeName}'. Available types: {string.Join(", ", types)}.");
+                    }
+                }
+                else symbol = famPool[0];
+
+                long? hostId = args["hostId"]?.Value<long?>();
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("family", $"{symbol.FamilyName}: {symbol.Name}", lv, new Dictionary<string, object>
+                    {
+                        ["x"] = x, ["y"] = y, ["z"] = z, ["hostId"] = hostId ?? -1,
+                    });
+
+                var res = new ModelEngine(doc).PlaceFamilyByName(symbol.FamilyName, symbol.Name, x, y, z, lv, hostId);
+                return ReadBack(doc, res, $"{symbol.FamilyName}: {symbol.Name}");
+            }, 60000).ToCallResult();
+        }
+
+        // ── building_shell (multi-element → confirm required) ────────────────────
+
+        public static McpCallResult BuildingShell(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out Document doc);
+                if (g != null) return g;
+
+                double w = args["widthMm"]?.Value<double?>() ?? 0;
+                double d = args["depthMm"]?.Value<double?>() ?? 0;
+                double h = args["heightMm"]?.Value<double?>() ?? 3000;
+                double ox = args["originX"]?.Value<double?>() ?? 0;
+                double oy = args["originY"]?.Value<double?>() ?? 0;
+
+                var sane = CheckFinite(w, d, h, ox, oy);
+                if (sane != null) return sane;
+                if (w <= 0 || d <= 0) return Bad("widthMm and depthMm must be greater than 0.");
+                if (h <= 0) return Bad("heightMm must be greater than 0.");
+
+                if (!ResolveLevel(doc, args["levelName"]?.Value<string>(), out string lv, out var le)) return le;
+
+                if (McpSafety.IsDryRun(args))
+                    return Plan("building-shell", null, lv, new Dictionary<string, object>
+                    {
+                        ["widthMm"] = w, ["depthMm"] = d, ["heightMm"] = h,
+                        ["elements"] = "4 walls + floor + roof (~6)",
+                    });
+
+                // Multi-element create → always requires confirm:true.
+                var confirmErr = McpSafety.RequireConfirmation(6, isProjectScope: false, confirmed: McpSafety.IsConfirmed(args));
+                if (confirmErr != null) return confirmErr;
+
+                var res = new ModelEngine(doc).CreateBuildingShell(
+                    w, d, h, roofSlopeDeg: 25, overhangMm: 600,
+                    levelName: lv, wallTypeName: null, floorTypeName: null, roofTypeName: null,
+                    originXMm: ox, originYMm: oy);
+                return ReadBack(doc, res, lv ?? "(default)");
+            }, 60000).ToCallResult();
+        }
+
+        // ── shared helpers ────────────────────────────────────────────────────────
+
+        private static McpJobResult Guard(UIApplication uiApp, out Document doc)
+        {
+            doc = null;
+            var lic = McpSafety.RequireLicense();
+            if (lic != null) return lic;
+            var de = McpSafety.RequireDocument(uiApp);
+            if (de != null) return de;
+            doc = uiApp.ActiveUIDocument.Document;
+            return null;
+        }
+
+        private static McpJobResult Bad(string msg) => McpJobResult.Error("bad_args", msg);
+
+        private static bool TryNum(JObject args, string key, out double val, out McpJobResult err)
+        {
+            val = 0; err = null;
+            var tok = args[key];
+            if (tok == null) { err = Bad($"Missing required argument: {key}."); return false; }
+            double? v = tok.Type == JTokenType.String
+                ? (double.TryParse(tok.Value<string>(), out double pv) ? pv : (double?)null)
+                : tok.Value<double?>();
+            if (v == null) { err = Bad($"Argument '{key}' must be a number (millimetres)."); return false; }
+            val = v.Value;
+            return true;
+        }
+
+        private static bool TryId(JObject args, string key, out long id, out McpJobResult err)
+        {
+            id = 0; err = null;
+            var tok = args[key];
+            if (tok == null) { err = Bad($"Missing required argument: {key}."); return false; }
+            long? v = tok.Type == JTokenType.String
+                ? (long.TryParse(tok.Value<string>(), out long pv) ? pv : (long?)null)
+                : tok.Value<long?>();
+            if (v == null) { err = Bad($"Argument '{key}' must be an element id."); return false; }
+            id = v.Value;
+            return true;
+        }
+
+        private static bool TryRun3D(JObject args,
+            out double sx, out double sy, out double sz, out double ex, out double ey, out double ez,
+            out McpJobResult err)
+        {
+            sx = sy = sz = ex = ey = ez = 0;
+            if (!TryNum(args, "startX", out sx, out err)) return false;
+            if (!TryNum(args, "startY", out sy, out err)) return false;
+            sz = args["startZ"]?.Value<double?>() ?? 0;
+            if (!TryNum(args, "endX", out ex, out err)) return false;
+            if (!TryNum(args, "endY", out ey, out err)) return false;
+            ez = args["endZ"]?.Value<double?>() ?? 0;
+            err = CheckFinite(sx, sy, sz, ex, ey, ez);
+            if (err != null) return false;
+            double len = Math.Sqrt((ex - sx) * (ex - sx) + (ey - sy) * (ey - sy) + (ez - sz) * (ez - sz));
+            if (len < 3.0) { err = Bad("Start and end points are too close (< 3 mm)."); return false; }
+            return true;
+        }
+
+        private static bool TryProfile(JObject args, out List<(double xMm, double yMm)> profile, out McpJobResult err)
+        {
+            profile = new List<(double, double)>();
+            err = null;
+            if (!(args["profile"] is JArray arr) || arr.Count < 3)
+            { err = Bad("profile must be an array of at least 3 [x, y] point pairs (mm)."); return false; }
+
+            foreach (var item in arr)
+            {
+                if (!(item is JArray p) || p.Count < 2)
+                { err = Bad("Each profile point must be a [x, y] pair."); return false; }
+                double? x = p[0]?.Value<double?>();
+                double? y = p[1]?.Value<double?>();
+                if (x == null || y == null || !IsFinite(x.Value) || !IsFinite(y.Value) ||
+                    Math.Abs(x.Value) > MaxCoordMm || Math.Abs(y.Value) > MaxCoordMm)
+                { err = Bad("Profile point coordinates must be finite numbers within ±10 km (mm)."); return false; }
+                profile.Add((x.Value, y.Value));
+            }
+            return true;
+        }
+
+        private static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
+
+        private static McpJobResult CheckFinite(params double[] vals)
+        {
+            foreach (double v in vals)
+            {
+                if (!IsFinite(v)) return Bad("Coordinates/dimensions must be finite numbers.");
+                if (Math.Abs(v) > MaxCoordMm) return Bad("Coordinate/dimension out of range (> ±10 km in mm — check units).");
+            }
+            return null;
+        }
+
+        /// <summary>Resolve a system-family type by name. Omitted → engine default (resolved=null,
+        /// reported as project default). Named but absent → bad_args listing the options.</summary>
+        private static bool ResolveType<T>(Document doc, string requested, string label,
+            out string resolved, out McpJobResult err) where T : ElementType
+        {
+            resolved = null; err = null;
+            var names = new FilteredElementCollector(doc).OfClass(typeof(T)).Cast<T>()
+                .Select(t => t.Name).Distinct().OrderBy(n => n).ToList();
+            if (names.Count == 0) { err = Bad($"No {label}s loaded in the project. Load one first."); return false; }
+            if (string.IsNullOrWhiteSpace(requested)) return true;   // engine default
+
+            var exact = names.FirstOrDefault(n => n.Equals(requested, StringComparison.OrdinalIgnoreCase));
+            if (exact != null) { resolved = exact; return true; }
+            var part = names.FirstOrDefault(n => n.IndexOf(requested, StringComparison.OrdinalIgnoreCase) >= 0);
+            if (part != null) { resolved = part; return true; }
+
+            err = McpJobResult.Error("bad_args",
+                $"No {label} named '{requested}'. Available: {string.Join(", ", names.Take(20))}" +
+                (names.Count > 20 ? "…" : "") + ".");
+            return false;
+        }
+
+        private static bool ResolveLevel(Document doc, string requested, out string resolved, out McpJobResult err)
+        {
+            resolved = null; err = null;
+            var levels = new FilteredElementCollector(doc).OfClass(typeof(Level)).Cast<Level>()
+                .OrderBy(l => l.Elevation).ToList();
+            if (levels.Count == 0) { err = Bad("No levels in the project. Create a level first."); return false; }
+            if (string.IsNullOrWhiteSpace(requested)) return true;   // engine default (lowest level)
+
+            var exact = levels.FirstOrDefault(l => l.Name.Equals(requested, StringComparison.OrdinalIgnoreCase));
+            if (exact != null) { resolved = exact.Name; return true; }
+            var part = levels.FirstOrDefault(l => l.Name.IndexOf(requested, StringComparison.OrdinalIgnoreCase) >= 0);
+            if (part != null) { resolved = part.Name; return true; }
+
+            err = McpJobResult.Error("bad_args",
+                $"No level named '{requested}'. Available: {string.Join(", ", levels.Select(l => l.Name).Take(20))}" +
+                (levels.Count > 20 ? "…" : "") + ".");
+            return false;
+        }
+
+        private static McpJobResult Plan(string kind, string typeUsed, string levelUsed, Dictionary<string, object> details)
+        {
+            details ??= new Dictionary<string, object>();
+            details["status"] = "dry_run";
+            details["kind"] = kind;
+            details["typeUsed"] = typeUsed ?? "(project default)";
+            if (levelUsed != null || kind != "family") details["levelUsed"] = levelUsed ?? "(lowest level)";
+            details["wouldCreate"] = kind == "building-shell" ? "~6 elements" : "1 element";
+            return McpJobResult.Success(
+                $"Dry run: would create {kind} [{typeUsed ?? "project default"}]; nothing created.", details);
+        }
+
+        private static McpJobResult ReadBack(Document doc, ModelResult res, string typeLabel)
+        {
+            if (res == null) return McpJobResult.Error("exception", "The model engine returned no result.");
+            if (!res.Success)
+                return McpJobResult.Error("exception", res.Error ?? res.Message ?? "Creation failed.");
+
+            var ids = CollectIds(res);
+            string typeUsed = typeLabel;
+            if (ids.Count > 0)
+            {
+                string t = TypeNameOf(doc, new ElementId(ids[0]));
+                if (!string.IsNullOrEmpty(t)) typeUsed = t;
+            }
+
+            var data = new Dictionary<string, object>
+            {
+                ["created"]  = ids,
+                ["count"]    = ids.Count,
+                ["typeUsed"] = typeUsed ?? "(default)",
+                ["warnings"] = res.Warnings ?? new List<string>(),
+            };
+            return McpJobResult.Success(res.Message ?? $"Created {ids.Count} element(s).", data);
+        }
+
+        private static List<long> CollectIds(ModelResult res)
+        {
+            var ids = new List<long>();
+            if (res.CreatedElementId != null && res.CreatedElementId != ElementId.InvalidElementId)
+                ids.Add(res.CreatedElementId.Value);
+            foreach (var id in res.CreatedElementIds)
+                if (id != null && id != ElementId.InvalidElementId && !ids.Contains(id.Value))
+                    ids.Add(id.Value);
+            return ids;
+        }
+
+        private static string TypeNameOf(Document doc, ElementId id)
+        {
+            try
+            {
+                Element el = doc.GetElement(id);
+                if (el == null) return null;
+                Element t = doc.GetElement(el.GetTypeId());
+                return t?.Name ?? el.Name;
+            }
+            catch { return null; }
+        }
+
+        private static string SafeRoomName(Room room)
+        {
+            try { return room.Name ?? ""; } catch { return ""; }
+        }
+    }
+}

--- a/StingTools/Mcp/McpQueryTools.cs
+++ b/StingTools/Mcp/McpQueryTools.cs
@@ -677,6 +677,186 @@ namespace StingTools.Mcp
             public readonly List<long> IncompleteIds = new List<long>();
         }
 
+        // ── get_rooms ────────────────────────────────────────────────────────────
+
+        public static McpCallResult GetRooms(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out UIDocument _, out Document doc);
+                if (g != null) return g;
+
+                string filter = args["filter"]?.Value<string>()?.Trim();
+                int    limit  = args["limit"]?.Value<int?>() ?? 50;
+                string cursor = args["cursor"]?.Value<string>();
+
+                var rooms = new FilteredElementCollector(doc)
+                    .OfCategory(BuiltInCategory.OST_Rooms).WhereElementIsNotElementType()
+                    .Cast<Autodesk.Revit.DB.Architecture.Room>()
+                    .Where(r => string.IsNullOrEmpty(filter) ||
+                                (r.Name?.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0) ||
+                                (SafeRoomNumber(r).IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0))
+                    .OrderBy(SafeRoomNumber)
+                    .ToList();
+
+                int placed = rooms.Count(r => { try { return r.Area > 1e-6; } catch { return false; } });
+                var (total, page, nextCursor, offset) = Paginate(rooms, limit, cursor);
+
+                var list = page.Select(r => (object)new Dictionary<string, object>
+                {
+                    ["id"]     = r.Id.Value,
+                    ["name"]   = SafeName(r),
+                    ["number"] = SafeRoomNumber(r),
+                    ["areaM2"] = RoomAreaM2(r),
+                    ["level"]  = SafeLevel(doc, r),
+                }).ToList();
+
+                var data = new Dictionary<string, object>
+                {
+                    ["total"]      = total,
+                    ["placed"]     = placed,
+                    ["returned"]   = page.Count,
+                    ["offset"]     = offset,
+                    ["nextCursor"] = nextCursor,
+                    ["rooms"]      = list,
+                };
+                return McpJobResult.Success(
+                    $"{total} room(s) ({placed} placed); showing {page.Count} from offset {offset}" +
+                    (nextCursor != null ? $" (more — cursor '{nextCursor}')" : "") + ".", data);
+            }).ToCallResult();
+        }
+
+        // ── get_levels ───────────────────────────────────────────────────────────
+
+        public static McpCallResult GetLevels()
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out UIDocument _, out Document doc);
+                if (g != null) return g;
+
+                var levels = new FilteredElementCollector(doc).OfClass(typeof(Level)).Cast<Level>()
+                    .OrderBy(l => l.Elevation).ToList();
+
+                double Mm(double ft) => Math.Round(UnitUtils.ConvertFromInternalUnits(ft, UnitTypeId.Millimeters), 1);
+                var list = levels.Select(l => (object)new Dictionary<string, object>
+                {
+                    ["id"]          = l.Id.Value,
+                    ["name"]        = l.Name,
+                    ["elevationMm"] = Mm(l.Elevation),
+                }).ToList();
+
+                var data = new Dictionary<string, object> { ["total"] = levels.Count, ["levels"] = list };
+                return McpJobResult.Success($"{levels.Count} level(s).", data);
+            }).ToCallResult();
+        }
+
+        // ── get_grids ────────────────────────────────────────────────────────────
+
+        public static McpCallResult GetGrids()
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out UIDocument _, out Document doc);
+                if (g != null) return g;
+
+                var grids = new FilteredElementCollector(doc).OfClass(typeof(Grid)).Cast<Grid>()
+                    .OrderBy(gr => gr.Name).ToList();
+
+                var list = grids.Select(gr =>
+                {
+                    var d = new Dictionary<string, object> { ["id"] = gr.Id.Value, ["name"] = gr.Name };
+                    try
+                    {
+                        Curve c = gr.Curve;
+                        if (c != null && c.IsBound)
+                        {
+                            d["start"] = XyzMm(c.GetEndPoint(0));
+                            d["end"]   = XyzMm(c.GetEndPoint(1));
+                            d["shape"] = c is Arc ? "arc" : "line";
+                        }
+                    }
+                    catch (Exception ex) { StingLog.Warn($"get_grids curve: {ex.Message}"); }
+                    return (object)d;
+                }).ToList();
+
+                var data = new Dictionary<string, object> { ["total"] = grids.Count, ["grids"] = list };
+                return McpJobResult.Success($"{grids.Count} grid(s).", data);
+            }).ToCallResult();
+        }
+
+        // ── get_warnings ─────────────────────────────────────────────────────────
+
+        public static McpCallResult GetWarnings(JObject args)
+        {
+            return McpJobBridge.Run(uiApp =>
+            {
+                var g = Guard(uiApp, out UIDocument _, out Document doc);
+                if (g != null) return g;
+
+                int limit = args["limit"]?.Value<int?>() ?? 100;
+                if (limit <= 0) limit = 100;
+                if (limit > 500) limit = 500;
+
+                IList<FailureMessage> warnings;
+                try { warnings = doc.GetWarnings(); }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"get_warnings: {ex.Message}");
+                    return McpJobResult.Error("exception", $"Could not read warnings: {ex.Message}");
+                }
+
+                int total = warnings.Count;
+                var byDesc = new Dictionary<string, int>();
+                foreach (var w in warnings)
+                {
+                    string d = SafeDesc(w);
+                    byDesc[d] = byDesc.TryGetValue(d, out int c) ? c + 1 : 1;
+                }
+
+                var list = warnings.Take(limit).Select(w => (object)new Dictionary<string, object>
+                {
+                    ["description"] = SafeDesc(w),
+                    ["severity"]    = SafeSeverity(w),
+                    ["elementIds"]  = SafeFailingIds(w),
+                }).ToList();
+
+                var data = new Dictionary<string, object>
+                {
+                    ["total"]     = total,
+                    ["returned"]  = list.Count,
+                    ["truncated"] = total > limit,
+                    ["topTypes"]  = byDesc.OrderByDescending(k => k.Value).Take(15).ToDictionary(k => k.Key, k => k.Value),
+                    ["warnings"]  = list,
+                };
+                return McpJobResult.Success(
+                    $"{total} model warning(s)" + (total > limit ? $" (showing first {limit})" : "") + ".", data);
+            }).ToCallResult();
+        }
+
+        private static string SafeRoomNumber(Autodesk.Revit.DB.Architecture.Room r)
+        {
+            try { return r.Number ?? ""; } catch { return ""; }
+        }
+        private static double RoomAreaM2(Autodesk.Revit.DB.Architecture.Room r)
+        {
+            try { return Math.Round(UnitUtils.ConvertFromInternalUnits(r.Area, UnitTypeId.SquareMeters), 2); }
+            catch { return 0; }
+        }
+        private static string SafeDesc(FailureMessage w)
+        {
+            try { return w.GetDescriptionText() ?? ""; } catch { return ""; }
+        }
+        private static string SafeSeverity(FailureMessage w)
+        {
+            try { return w.GetSeverity().ToString(); } catch { return ""; }
+        }
+        private static List<long> SafeFailingIds(FailureMessage w)
+        {
+            try { return w.GetFailingElements().Select(i => i.Value).Take(25).ToList(); }
+            catch { return new List<long>(); }
+        }
+
         // ── shared guard + readers ───────────────────────────────────────────────
 
         /// <summary>License + document guard used by every job. Returns a typed error

--- a/StingTools/Mcp/McpToolDispatcher.cs
+++ b/StingTools/Mcp/McpToolDispatcher.cs
@@ -80,6 +80,23 @@ namespace StingTools.Mcp
                 case "size_pipes":            return McpWriteTools.SizePipes(args);
                 case "build_panel_schedules": return McpWriteTools.BuildPanelSchedules(args);
 
+                // ── Create stage — read tools ──────────────────────────────────
+                case "get_rooms":    return McpQueryTools.GetRooms(args);
+                case "get_levels":   return McpQueryTools.GetLevels();
+                case "get_grids":    return McpQueryTools.GetGrids();
+                case "get_warnings": return McpQueryTools.GetWarnings(args);
+
+                // ── Create stage — ModelEngine creation tools (WRITE) ───────────
+                case "create_wall":         return McpCreateTools.CreateWall(args);
+                case "create_floor":        return McpCreateTools.CreateFloor(args);
+                case "create_floor_in_room": return McpCreateTools.CreateFloorInRoom(args);
+                case "create_roof":         return McpCreateTools.CreateRoof(args);
+                case "create_duct":         return McpCreateTools.CreateDuct(args);
+                case "create_pipe":         return McpCreateTools.CreatePipe(args);
+                case "create_room":         return McpCreateTools.CreateRoom(args);
+                case "place_family":        return McpCreateTools.PlaceFamily(args);
+                case "building_shell":      return McpCreateTools.BuildingShell(args);
+
                 default:
                     return Err($"Unknown tool: {toolName}. Call tools/list to see available tools.");
             }

--- a/StingTools/Mcp/McpToolRegistry.cs
+++ b/StingTools/Mcp/McpToolRegistry.cs
@@ -575,6 +575,250 @@ namespace StingTools.Mcp
                     }
                 }"),
             },
+
+            // ── Create stage — high-value read tools ────────────────────────────
+            new McpTool
+            {
+                Name = "get_rooms",
+                Description =
+                    "List Revit rooms with id, name, number, area (m²), and level. Summarized + " +
+                    "paginated (total + placed count + nextCursor). Optional filter matches name or " +
+                    "number. Example: {filter: 'Ward', limit: 50}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""filter"": { ""type"": ""string"",  ""description"": ""Name/number contains filter"" },
+                        ""limit"":  { ""type"": ""integer"", ""description"": ""Page size (default 50, max 200)"" },
+                        ""cursor"": { ""type"": ""string"",  ""description"": ""nextCursor from a previous call"" }
+                    }
+                }"),
+            },
+            new McpTool
+            {
+                Name = "get_levels",
+                Description =
+                    "List project levels sorted by elevation, with id, name, and elevation (mm). Use to " +
+                    "discover valid levelName values before a create_* tool. Takes no arguments.",
+                InputSchema = JObject.Parse(@"{""type"": ""object"", ""properties"": {}}"),
+            },
+            new McpTool
+            {
+                Name = "get_grids",
+                Description =
+                    "List structural grids with id, name, and endpoints (mm) — line grids report start/end, " +
+                    "arc grids are flagged. Use to place elements relative to gridlines. Takes no arguments.",
+                InputSchema = JObject.Parse(@"{""type"": ""object"", ""properties"": {}}"),
+            },
+            new McpTool
+            {
+                Name = "get_warnings",
+                Description =
+                    "List the document's active Revit warnings (doc.GetWarnings): description, severity, and " +
+                    "the failing element ids (capped). Returns a total + a topTypes histogram + a capped page. " +
+                    "Use to triage model health. Example: {limit: 100}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": { ""limit"": { ""type"": ""integer"", ""description"": ""Max warnings returned (default 100, max 500)"" } }
+                }"),
+            },
+
+            // ── Create stage — ModelEngine creation tools (WRITE / build geometry) ──
+            // ALL coordinates and dimensions are in MILLIMETRES. dryRun:true validates
+            // and returns a plan, creating NOTHING. Unknown type/level/family → bad_args
+            // listing the available options. Read-back: {created:[ids], count, typeUsed, warnings}.
+            new McpTool
+            {
+                Name = "create_wall",
+                Description =
+                    "CREATE (build geometry). Create a straight wall between two plan points. All coordinates " +
+                    "and dimensions are in MILLIMETRES. typeName/levelName are resolved by name (omit for the " +
+                    "project default; an unknown name returns bad_args with the available options). dryRun:true " +
+                    "validates and returns a plan, creating nothing. Read-back {created,count,typeUsed,warnings}. " +
+                    "Example: {startX:0, startY:0, endX:5000, endY:0, heightMm:3000, dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""startX"":    { ""type"": ""number"" }, ""startY"": { ""type"": ""number"" },
+                        ""endX"":      { ""type"": ""number"" }, ""endY"":   { ""type"": ""number"" },
+                        ""heightMm"":  { ""type"": ""number"",  ""description"": ""Wall height (mm)"" },
+                        ""typeName"":  { ""type"": ""string"",  ""description"": ""Wall type name (optional)"" },
+                        ""levelName"": { ""type"": ""string"",  ""description"": ""Level name (optional)"" },
+                        ""dryRun"":    { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""startX"", ""startY"", ""endX"", ""endY"", ""heightMm""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "create_floor",
+                Description =
+                    "CREATE (build geometry). Create a floor from a closed polygon. profile is an array of " +
+                    "[x, y] point pairs in MILLIMETRES (auto-closed). typeName/levelName resolved by name " +
+                    "(omit for default; unknown → bad_args with options). dryRun:true plans only. " +
+                    "Example: {profile:[[0,0],[5000,0],[5000,4000],[0,4000]], dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""profile"":   { ""type"": ""array"", ""description"": ""Array of [x,y] point pairs (mm)"",
+                                          ""items"": { ""type"": ""array"", ""items"": { ""type"": ""number"" } } },
+                        ""typeName"":  { ""type"": ""string"",  ""description"": ""Floor type name (optional)"" },
+                        ""levelName"": { ""type"": ""string"",  ""description"": ""Level name (optional)"" },
+                        ""dryRun"":    { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""profile""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "create_floor_in_room",
+                Description =
+                    "CREATE (build geometry). Create a floor that fills an existing room's boundary. roomId is " +
+                    "the Room element id (see get_rooms). typeName/levelName resolved by name (omit for default). " +
+                    "dryRun:true plans only. Example: {roomId: 348122, dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""roomId"":    { ""type"": ""integer"", ""description"": ""Room element id"" },
+                        ""typeName"":  { ""type"": ""string"",  ""description"": ""Floor type name (optional)"" },
+                        ""levelName"": { ""type"": ""string"",  ""description"": ""Level name (optional)"" },
+                        ""dryRun"":    { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""roomId""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "create_roof",
+                Description =
+                    "CREATE (build geometry). Create a footprint roof from a closed polygon with a uniform edge " +
+                    "slope. profile is an array of [x, y] pairs in MILLIMETRES. slopeDeg default 25. " +
+                    "typeName/levelName resolved by name. dryRun:true plans only. " +
+                    "Example: {profile:[[0,0],[6000,0],[6000,8000],[0,8000]], slopeDeg:30, dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""profile"":   { ""type"": ""array"", ""description"": ""Array of [x,y] point pairs (mm)"",
+                                          ""items"": { ""type"": ""array"", ""items"": { ""type"": ""number"" } } },
+                        ""slopeDeg"":  { ""type"": ""number"",  ""description"": ""Edge slope in degrees (default 25)"" },
+                        ""typeName"":  { ""type"": ""string"",  ""description"": ""Roof type name (optional)"" },
+                        ""levelName"": { ""type"": ""string"",  ""description"": ""Level name (optional)"" },
+                        ""dryRun"":    { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""profile""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "create_duct",
+                Description =
+                    "CREATE (build geometry). Create a duct segment between two 3D points. All coordinates and " +
+                    "sizes are in MILLIMETRES. Provide diameterMm for round, or widthMm + heightMm for " +
+                    "rectangular (omit for the duct type's default size). The duct system defaults to Supply Air. " +
+                    "ductTypeName/levelName resolved by name. dryRun:true plans only. " +
+                    "Example: {startX:0,startY:0,startZ:2700, endX:4000,endY:0,endZ:2700, diameterMm:250, dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""startX"": { ""type"": ""number"" }, ""startY"": { ""type"": ""number"" }, ""startZ"": { ""type"": ""number"" },
+                        ""endX"":   { ""type"": ""number"" }, ""endY"":   { ""type"": ""number"" }, ""endZ"":   { ""type"": ""number"" },
+                        ""diameterMm"":   { ""type"": ""number"", ""description"": ""Round diameter (mm)"" },
+                        ""widthMm"":      { ""type"": ""number"", ""description"": ""Rectangular width (mm)"" },
+                        ""heightMm"":     { ""type"": ""number"", ""description"": ""Rectangular height (mm)"" },
+                        ""ductTypeName"": { ""type"": ""string"", ""description"": ""Duct type name (optional)"" },
+                        ""levelName"":    { ""type"": ""string"", ""description"": ""Level name (optional)"" },
+                        ""dryRun"":       { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""startX"", ""startY"", ""endX"", ""endY""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "create_pipe",
+                Description =
+                    "CREATE (build geometry). Create a pipe segment between two 3D points. All coordinates and " +
+                    "diameterMm are in MILLIMETRES. systemType chooses the piping system classification: " +
+                    "DomesticColdWater (default) | DomesticHotWater | Sanitary. pipeTypeName/levelName resolved " +
+                    "by name. dryRun:true plans only. " +
+                    "Example: {startX:0,startY:0,startZ:0, endX:3000,endY:0,endZ:0, diameterMm:32, systemType:'DomesticColdWater', dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""startX"": { ""type"": ""number"" }, ""startY"": { ""type"": ""number"" }, ""startZ"": { ""type"": ""number"" },
+                        ""endX"":   { ""type"": ""number"" }, ""endY"":   { ""type"": ""number"" }, ""endZ"":   { ""type"": ""number"" },
+                        ""diameterMm"":   { ""type"": ""number"", ""description"": ""Pipe bore diameter (mm)"" },
+                        ""systemType"":   { ""type"": ""string"", ""description"": ""DomesticColdWater | DomesticHotWater | Sanitary"" },
+                        ""pipeTypeName"": { ""type"": ""string"", ""description"": ""Pipe type name (optional)"" },
+                        ""levelName"":    { ""type"": ""string"", ""description"": ""Level name (optional)"" },
+                        ""dryRun"":       { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""startX"", ""startY"", ""endX"", ""endY""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "create_room",
+                Description =
+                    "CREATE (build geometry). Place a Room element at a plan point (MILLIMETRES). The point should " +
+                    "be inside a wall-enclosed region to bound the room; an unbounded room is still created and " +
+                    "reported. levelName resolved by name. dryRun:true plans only. " +
+                    "Example: {x:2500, y:2000, name:'Office', number:'G01', dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""x"":         { ""type"": ""number"" }, ""y"": { ""type"": ""number"" },
+                        ""name"":      { ""type"": ""string"",  ""description"": ""Room name (optional)"" },
+                        ""number"":    { ""type"": ""string"",  ""description"": ""Room number (optional)"" },
+                        ""levelName"": { ""type"": ""string"",  ""description"": ""Level name (optional)"" },
+                        ""dryRun"":    { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""x"", ""y""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "place_family",
+                Description =
+                    "CREATE (build geometry). Place a loadable family instance at a point (MILLIMETRES). " +
+                    "familyName is required and typeName optional — both are resolved by name against the loaded " +
+                    "families; an unknown family/type returns bad_args listing the options. Pass hostId to host " +
+                    "the instance on an element (e.g. a wall). levelName resolved by name. dryRun:true plans only. " +
+                    "Example: {familyName:'Single-Flush', typeName:'0915 x 2134mm', x:2500, y:0, z:0, dryRun:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""familyName"": { ""type"": ""string"", ""description"": ""Family name (required)"" },
+                        ""typeName"":   { ""type"": ""string"", ""description"": ""Type/symbol name (optional)"" },
+                        ""x"": { ""type"": ""number"" }, ""y"": { ""type"": ""number"" }, ""z"": { ""type"": ""number"" },
+                        ""levelName"":  { ""type"": ""string"",  ""description"": ""Level name (optional)"" },
+                        ""hostId"":     { ""type"": ""integer"", ""description"": ""Host element id (optional)"" },
+                        ""dryRun"":     { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" }
+                    },
+                    ""required"": [""familyName"", ""x"", ""y""]
+                }"),
+            },
+            new McpTool
+            {
+                Name = "building_shell",
+                Description =
+                    "CREATE (build geometry — MULTIPLE elements). Build a complete rectangular building shell " +
+                    "(4 walls + floor + roof) in one atomic operation. widthMm/depthMm/heightMm are in " +
+                    "MILLIMETRES. Because it creates ~6 elements, confirm:true is REQUIRED for a real run; " +
+                    "dryRun:true returns the plan without creating anything. levelName resolved by name. " +
+                    "Example: {widthMm:8000, depthMm:6000, heightMm:3000, dryRun:true} then {…, confirm:true}.",
+                InputSchema = JObject.Parse(@"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""widthMm"":   { ""type"": ""number"" }, ""depthMm"": { ""type"": ""number"" },
+                        ""heightMm"":  { ""type"": ""number"" },
+                        ""originX"":   { ""type"": ""number"",  ""description"": ""Origin X (mm, default 0)"" },
+                        ""originY"":   { ""type"": ""number"",  ""description"": ""Origin Y (mm, default 0)"" },
+                        ""levelName"": { ""type"": ""string"",  ""description"": ""Level name (optional)"" },
+                        ""dryRun"":    { ""type"": ""boolean"", ""description"": ""Validate + plan only; create nothing"" },
+                        ""confirm"":   { ""type"": ""boolean"", ""description"": ""REQUIRED for a real run (multi-element)"" }
+                    },
+                    ""required"": [""widthMm"", ""depthMm"", ""heightMm""]
+                }"),
+            },
         };
     }
 }

--- a/StingTools/Model/ModelEngine.cs
+++ b/StingTools/Model/ModelEngine.cs
@@ -1144,7 +1144,10 @@ namespace StingTools.Model
             double startXMm, double startYMm, double startZMm,
             double endXMm, double endYMm, double endZMm,
             string ductTypeName = null,
-            string levelName = null)
+            string levelName = null,
+            double diameterMm = 0,
+            double widthMm = 0,
+            double heightMm = 0)
         {
             try
             {
@@ -1181,11 +1184,23 @@ namespace StingTools.Model
                     duct = Duct.Create(_doc, sysType.Id, ductType.Id, level.Id,
                         new XYZ(Units.Mm(startXMm), Units.Mm(startYMm), Units.Mm(startZMm)),
                         new XYZ(Units.Mm(endXMm), Units.Mm(endYMm), Units.Mm(endZMm)));
+                    // Apply requested size to native geometry params (best-effort; skipped if read-only)
+                    if (widthMm > 0 && heightMm > 0)
+                    {
+                        TrySetParam(duct, BuiltInParameter.RBS_CURVE_WIDTH_PARAM, Units.Mm(widthMm));
+                        TrySetParam(duct, BuiltInParameter.RBS_CURVE_HEIGHT_PARAM, Units.Mm(heightMm));
+                    }
+                    else if (diameterMm > 0)
+                    {
+                        TrySetParam(duct, BuiltInParameter.RBS_CURVE_DIAMETER_PARAM, Units.Mm(diameterMm));
+                    }
                     ModelWorksetAssigner.Assign(_doc, duct);
                     tx.Commit();
                 }
 
-                return ModelResult.Ok($"Created duct on {level.Name}", duct.Id);
+                string sizeNote = (widthMm > 0 && heightMm > 0) ? $" {widthMm:F0}×{heightMm:F0}mm"
+                    : diameterMm > 0 ? $" Ø{diameterMm:F0}mm" : "";
+                return ModelResult.Ok($"Created{sizeNote} {ductType.Name} duct on {level.Name}", duct.Id);
             }
             catch (Exception ex)
             {
@@ -1202,7 +1217,8 @@ namespace StingTools.Model
             double endXMm, double endYMm, double endZMm,
             string pipeTypeName = null,
             string levelName = null,
-            string systemClassification = "DomesticColdWater")
+            string systemClassification = "DomesticColdWater",
+            double diameterMm = 0)
         {
             try
             {
@@ -1240,11 +1256,14 @@ namespace StingTools.Model
                     pipe = Pipe.Create(_doc, sysType.Id, pipeType.Id, level.Id,
                         new XYZ(Units.Mm(startXMm), Units.Mm(startYMm), Units.Mm(startZMm)),
                         new XYZ(Units.Mm(endXMm), Units.Mm(endYMm), Units.Mm(endZMm)));
+                    if (diameterMm > 0)
+                        TrySetParam(pipe, BuiltInParameter.RBS_PIPE_DIAMETER_PARAM, Units.Mm(diameterMm));
                     ModelWorksetAssigner.Assign(_doc, pipe);
                     tx.Commit();
                 }
 
-                return ModelResult.Ok($"Created pipe on {level.Name}", pipe.Id);
+                string sizeNote = diameterMm > 0 ? $" Ø{diameterMm:F0}mm" : "";
+                return ModelResult.Ok($"Created{sizeNote} {pipeType.Name} pipe on {level.Name}", pipe.Id);
             }
             catch (Exception ex)
             {
@@ -1291,6 +1310,304 @@ namespace StingTools.Model
                 StingLog.Error("ModelEngine.PlaceMEPFixture", ex);
                 return ModelResult.Fail($"Fixture placement failed: {ex.Message}");
             }
+        }
+
+        // ── Floor / Roof from arbitrary profile ───────────────────────
+
+        /// <summary>
+        /// Creates a floor from an arbitrary closed polygon (mm x,y point pairs).
+        /// Points are auto-closed if the last point does not equal the first.
+        /// </summary>
+        public ModelResult CreateFloorFromProfile(
+            IList<(double xMm, double yMm)> profileMm,
+            string floorTypeName = null,
+            string levelName = null)
+        {
+            try
+            {
+                if (profileMm == null || profileMm.Count < 3)
+                    return ModelResult.Fail("A floor profile needs at least 3 points.");
+
+                var level = _resolver.ResolveLevel(levelName);
+                if (level == null) return ModelResult.Fail("No levels found.");
+
+                var typeResult = _resolver.ResolveFloorType(floorTypeName);
+                if (!typeResult.Success) return ModelResult.Fail(typeResult.Message);
+
+                CurveLoop loop = BuildCurveLoop(profileMm, out string loopErr);
+                if (loop == null) return ModelResult.Fail(loopErr);
+
+                Floor floor = null;
+                var fh = new ModelFailureHandler();
+                using (var tx = new Transaction(_doc, "STING MODEL: Create Floor (profile)"))
+                {
+                    AttachFailureHandler(tx, fh);
+                    tx.Start();
+                    try
+                    {
+                        floor = Floor.Create(_doc, new List<CurveLoop> { loop }, typeResult.TypeId, level.Id);
+                        ModelWorksetAssigner.Assign(_doc, floor);
+                        tx.Commit();
+                    }
+                    catch (Exception ex)
+                    {
+                        tx.RollBack();
+                        return ModelResult.Fail($"Floor creation failed: {ex.Message}");
+                    }
+                }
+
+                var result = ModelResult.Ok(
+                    $"Created {profileMm.Count}-point {typeResult.TypeName} floor on {level.Name}", floor.Id);
+                result.Warnings = fh.CapturedWarnings;
+                return result;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("ModelEngine.CreateFloorFromProfile", ex);
+                return ModelResult.Fail($"Floor creation failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Creates a footprint roof from an arbitrary closed polygon (mm x,y point pairs)
+        /// with a uniform slope on every edge.
+        /// </summary>
+        public ModelResult CreateRoofFromProfile(
+            IList<(double xMm, double yMm)> profileMm,
+            string roofTypeName = null,
+            string levelName = null,
+            double slopeDegrees = 25)
+        {
+            try
+            {
+                if (profileMm == null || profileMm.Count < 3)
+                    return ModelResult.Fail("A roof profile needs at least 3 points.");
+
+                var level = _resolver.ResolveLevel(levelName);
+                if (level == null) return ModelResult.Fail("No levels found.");
+
+                var typeResult = _resolver.ResolveRoofType(roofTypeName);
+                if (!typeResult.Success) return ModelResult.Fail(typeResult.Message);
+                var roofType = _doc.GetElement(typeResult.TypeId) as RoofType;
+
+                var pts = ClosePolygon(profileMm);
+                var footprint = new CurveArray();
+                for (int i = 0; i < pts.Count - 1; i++)
+                {
+                    var a = new XYZ(Units.Mm(pts[i].xMm), Units.Mm(pts[i].yMm), 0);
+                    var b = new XYZ(Units.Mm(pts[i + 1].xMm), Units.Mm(pts[i + 1].yMm), 0);
+                    if (a.DistanceTo(b) < 0.01) return ModelResult.Fail("Roof profile has a zero-length edge.");
+                    footprint.Append(Line.CreateBound(a, b));
+                }
+
+                FootPrintRoof roof = null;
+                using (var tx = new Transaction(_doc, "STING MODEL: Create Roof (profile)"))
+                {
+                    tx.Start();
+                    try
+                    {
+                        ModelCurveArray modelCurves;
+                        roof = _doc.Create.NewFootPrintRoof(footprint, level, roofType, out modelCurves);
+                        double slopeRad = slopeDegrees * Math.PI / 180.0;
+                        foreach (ModelCurve mc in modelCurves)
+                        {
+                            roof.set_DefinesSlope(mc, true);
+                            roof.set_SlopeAngle(mc, Math.Tan(slopeRad));
+                        }
+                        ModelWorksetAssigner.Assign(_doc, roof);
+                        tx.Commit();
+                    }
+                    catch (Exception ex)
+                    {
+                        tx.RollBack();
+                        return ModelResult.Fail($"Roof creation failed: {ex.Message}");
+                    }
+                }
+
+                return ModelResult.Ok(
+                    $"Created {profileMm.Count}-point {roofType.Name} roof ({slopeDegrees}° slope) on {level.Name}",
+                    roof.Id);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("ModelEngine.CreateRoofFromProfile", ex);
+                return ModelResult.Fail($"Roof creation failed: {ex.Message}");
+            }
+        }
+
+        // ── Room element at a point ───────────────────────────────────
+
+        /// <summary>
+        /// Places a Room element at a plan point (mm). The point must fall inside an
+        /// enclosed region for the room to bound; an unbounded room is still created
+        /// and reported. Optionally sets name + number.
+        /// </summary>
+        public ModelResult PlaceRoom(
+            double xMm, double yMm,
+            string roomName = null,
+            string roomNumber = null,
+            string levelName = null)
+        {
+            try
+            {
+                var level = _resolver.ResolveLevel(levelName);
+                if (level == null) return ModelResult.Fail("No levels found.");
+
+                Room room = null;
+                using (var tx = new Transaction(_doc, "STING MODEL: Place Room"))
+                {
+                    tx.Start();
+                    try
+                    {
+                        room = _doc.Create.NewRoom(level, new UV(Units.Mm(xMm), Units.Mm(yMm)));
+                        if (room == null) { tx.RollBack(); return ModelResult.Fail("Revit could not place a room at that point."); }
+                        if (!string.IsNullOrEmpty(roomName)) room.Name = roomName;
+                        if (!string.IsNullOrEmpty(roomNumber))
+                            room.get_Parameter(BuiltInParameter.ROOM_NUMBER)?.Set(roomNumber);
+                        ModelWorksetAssigner.Assign(_doc, room);
+                        tx.Commit();
+                    }
+                    catch (Exception ex)
+                    {
+                        tx.RollBack();
+                        return ModelResult.Fail($"Room placement failed: {ex.Message}");
+                    }
+                }
+
+                bool bounded = false;
+                try { bounded = room.Area > 1e-6; } catch { }
+                return ModelResult.Ok(
+                    $"Placed room '{room.Name}' on {level.Name}" + (bounded ? "" : " (unbounded — not enclosed by walls)"),
+                    room.Id);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("ModelEngine.PlaceRoom", ex);
+                return ModelResult.Fail($"Room placement failed: {ex.Message}");
+            }
+        }
+
+        // ── Generic family placement by name ──────────────────────────
+
+        /// <summary>
+        /// Places a loadable family instance identified by family + type name at a point (mm).
+        /// When hostId refers to a valid host element the instance is hosted on it.
+        /// </summary>
+        public ModelResult PlaceFamilyByName(
+            string familyName, string typeName,
+            double xMm, double yMm, double zMm,
+            string levelName = null,
+            long? hostId = null)
+        {
+            try
+            {
+                FamilySymbol symbol = FindSymbol(familyName, typeName);
+                if (symbol == null)
+                    return ModelResult.Fail(
+                        $"No family symbol matching family '{familyName}' / type '{typeName}'. Load the family first.");
+
+                _resolver.EnsureActive(symbol);
+                var level = _resolver.ResolveLevel(levelName);
+                var pt = new XYZ(Units.Mm(xMm), Units.Mm(yMm), Units.Mm(zMm));
+
+                Element host = null;
+                if (hostId.HasValue && hostId.Value >= 0)
+                    host = _doc.GetElement(new ElementId(hostId.Value));
+
+                FamilyInstance inst = null;
+                using (var tx = new Transaction(_doc, "STING MODEL: Place Family"))
+                {
+                    tx.Start();
+                    try
+                    {
+                        if (host != null)
+                            inst = _doc.Create.NewFamilyInstance(pt, symbol, host, StructuralType.NonStructural);
+                        else if (level != null)
+                            inst = _doc.Create.NewFamilyInstance(pt, symbol, level, StructuralType.NonStructural);
+                        else
+                            inst = _doc.Create.NewFamilyInstance(pt, symbol, StructuralType.NonStructural);
+                        ModelWorksetAssigner.Assign(_doc, inst);
+                        tx.Commit();
+                    }
+                    catch (Exception ex)
+                    {
+                        tx.RollBack();
+                        return ModelResult.Fail($"Family placement failed: {ex.Message}");
+                    }
+                }
+
+                return ModelResult.Ok(
+                    $"Placed {symbol.FamilyName}: {symbol.Name}" + (host != null ? $" hosted on {host.Id.Value}" : ""),
+                    inst.Id);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("ModelEngine.PlaceFamilyByName", ex);
+                return ModelResult.Fail($"Family placement failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>Resolve a FamilySymbol by family name (+ optional type name) across all categories.</summary>
+        private FamilySymbol FindSymbol(string familyName, string typeName)
+        {
+            var symbols = new FilteredElementCollector(_doc)
+                .OfClass(typeof(FamilySymbol)).Cast<FamilySymbol>().ToList();
+            if (symbols.Count == 0) return null;
+
+            IEnumerable<FamilySymbol> pool = symbols;
+            if (!string.IsNullOrEmpty(familyName))
+            {
+                var famExact = symbols.Where(s => s.FamilyName.Equals(familyName, StringComparison.OrdinalIgnoreCase)).ToList();
+                var fam = famExact.Count > 0 ? famExact
+                    : symbols.Where(s => s.FamilyName.IndexOf(familyName, StringComparison.OrdinalIgnoreCase) >= 0).ToList();
+                if (fam.Count > 0) pool = fam;
+            }
+            if (!string.IsNullOrEmpty(typeName))
+            {
+                var tExact = pool.FirstOrDefault(s => s.Name.Equals(typeName, StringComparison.OrdinalIgnoreCase));
+                if (tExact != null) return tExact;
+                var tPart = pool.FirstOrDefault(s => s.Name.IndexOf(typeName, StringComparison.OrdinalIgnoreCase) >= 0);
+                if (tPart != null) return tPart;
+            }
+            return pool.FirstOrDefault();
+        }
+
+        /// <summary>Build a closed CurveLoop from mm point pairs; null + reason on failure.</summary>
+        private CurveLoop BuildCurveLoop(IList<(double xMm, double yMm)> profileMm, out string err)
+        {
+            err = null;
+            var pts = ClosePolygon(profileMm);
+            var loop = new CurveLoop();
+            for (int i = 0; i < pts.Count - 1; i++)
+            {
+                var a = new XYZ(Units.Mm(pts[i].xMm), Units.Mm(pts[i].yMm), 0);
+                var b = new XYZ(Units.Mm(pts[i + 1].xMm), Units.Mm(pts[i + 1].yMm), 0);
+                if (a.DistanceTo(b) < 0.01) { err = "Profile has a zero-length edge (duplicate consecutive points)."; return null; }
+                loop.Append(Line.CreateBound(a, b));
+            }
+            return loop;
+        }
+
+        /// <summary>Return the polygon with an explicit closing point appended when open.</summary>
+        private static List<(double xMm, double yMm)> ClosePolygon(IList<(double xMm, double yMm)> profileMm)
+        {
+            var pts = new List<(double xMm, double yMm)>(profileMm);
+            var first = pts[0];
+            var last = pts[pts.Count - 1];
+            if (Math.Abs(first.xMm - last.xMm) > 1e-6 || Math.Abs(first.yMm - last.yMm) > 1e-6)
+                pts.Add(first);
+            return pts;
+        }
+
+        /// <summary>Set a Double built-in param (internal units) if present and writable.</summary>
+        private static void TrySetParam(Element el, BuiltInParameter bip, double internalValue)
+        {
+            try
+            {
+                var p = el?.get_Parameter(bip);
+                if (p != null && !p.IsReadOnly) p.Set(internalValue);
+            }
+            catch (Exception ex) { StingLog.Warn($"TrySetParam {bip}: {ex.Message}"); }
         }
 
         // ── Batch Operations ──────────────────────────────────────────

--- a/StingTools/UI/StingCopilotPanel.xaml
+++ b/StingTools/UI/StingCopilotPanel.xaml
@@ -10,6 +10,7 @@
             <RowDefinition Height="*"/>      <!-- chat history -->
             <RowDefinition Height="Auto"/>   <!-- running-tool status -->
             <RowDefinition Height="Auto"/>   <!-- usage / credit note -->
+            <RowDefinition Height="Auto"/>   <!-- suggestion chips -->
             <RowDefinition Height="Auto"/>   <!-- input -->
             <RowDefinition Height="Auto"/>   <!-- buttons -->
         </Grid.RowDefinitions>
@@ -19,7 +20,7 @@
             <TextBlock Text="STING Copilot"
                        FontSize="14" FontWeight="Bold"
                        Foreground="{DynamicResource PrimaryText}"/>
-            <TextBlock Text="Ask in plain English. The AI drives StingTools through the MCP tools."
+            <TextBlock Text="Ask in plain English. The AI drives StingTools through the MCP tools — read, tag, size, and now BUILD."
                        FontSize="10" TextWrapping="Wrap" Opacity="0.8"
                        Foreground="{DynamicResource PrimaryText}"/>
         </StackPanel>
@@ -43,15 +44,18 @@
                    Foreground="{DynamicResource PrimaryText}" Opacity="0.7"
                    Text="Each turn calls the LLM API and consumes credits."/>
 
+        <!-- Suggestion chips + undo -->
+        <WrapPanel x:Name="ChipPanel" Grid.Row="4" Orientation="Horizontal" Margin="0,0,0,4"/>
+
         <!-- Input -->
-        <TextBox x:Name="InputBox" Grid.Row="4"
+        <TextBox x:Name="InputBox" Grid.Row="5"
                  MinHeight="52" MaxHeight="120"
                  AcceptsReturn="True" TextWrapping="Wrap"
                  VerticalScrollBarVisibility="Auto"
                  FontSize="11"/>
 
         <!-- Buttons -->
-        <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
+        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
             <Button x:Name="CancelBtn" Content="Cancel" Width="80" Height="26"
                     Margin="0,0,6,0" IsEnabled="False" Click="CancelBtn_Click"/>
             <Button x:Name="SendBtn" Content="Send" Width="90" Height="26"

--- a/StingTools/UI/StingCopilotPanel.xaml
+++ b/StingTools/UI/StingCopilotPanel.xaml
@@ -14,15 +14,35 @@
             <RowDefinition Height="Auto"/>   <!-- buttons -->
         </Grid.RowDefinitions>
 
-        <!-- Header -->
-        <StackPanel Grid.Row="0" Margin="0,0,0,6">
-            <TextBlock Text="STING Copilot"
-                       FontSize="14" FontWeight="Bold"
-                       Foreground="{DynamicResource PrimaryText}"/>
-            <TextBlock Text="Ask in plain English. The AI drives StingTools through the MCP tools."
-                       FontSize="10" TextWrapping="Wrap" Opacity="0.8"
-                       Foreground="{DynamicResource PrimaryText}"/>
-        </StackPanel>
+        <!-- Header + toolbar -->
+        <Grid Grid.Row="0" Margin="0,0,0,6">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <TextBlock Text="STING Copilot"
+                           FontSize="14" FontWeight="Bold"
+                           Foreground="{DynamicResource PrimaryText}"/>
+                <TextBlock Text="Ask in plain English. The AI drives StingTools through the MCP tools."
+                           FontSize="10" TextWrapping="Wrap" Opacity="0.8"
+                           Foreground="{DynamicResource PrimaryText}"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Top">
+                <Button x:Name="ClearBtn" Content="🗑" Width="26" Height="26" FontSize="12"
+                        Margin="0,0,3,0" ToolTip="Clear chat (resets the conversation)"
+                        Click="ClearBtn_Click"/>
+                <Button x:Name="SaveBtn2" Content="💾" Width="26" Height="26" FontSize="12"
+                        Margin="0,0,3,0" ToolTip="Save chat transcript to Markdown (.md)"
+                        Click="SaveChatBtn_Click"/>
+                <Button x:Name="ShotBtn" Content="📷" Width="26" Height="26" FontSize="12"
+                        Margin="0,0,3,0" ToolTip="Screenshot the chat (PNG / clipboard)"
+                        Click="ScreenshotBtn_Click"/>
+                <Button x:Name="SettingsBtn" Content="⚙" Width="26" Height="26" FontSize="13"
+                        ToolTip="Copilot Settings (AI provider, API key, model)"
+                        Click="SettingsBtn_Click"/>
+            </StackPanel>
+        </Grid>
 
         <!-- Chat history -->
         <Border Grid.Row="1" BorderBrush="#55808080" BorderThickness="1" CornerRadius="3">

--- a/StingTools/UI/StingCopilotPanel.xaml.cs
+++ b/StingTools/UI/StingCopilotPanel.xaml.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using Autodesk.Revit.UI;
 using StingTools.Core;
@@ -33,6 +35,26 @@ namespace StingTools.UI
         private CancellationTokenSource _cts;
         private bool _busy;
 
+        // One-click prompt starters (label → text placed in the input box).
+        private static readonly (string label, string prompt)[] Suggestions =
+        {
+            ("Tag compliance",     "What is the current tag compliance?"),
+            ("Untagged elements",  "Which elements are untagged, by discipline?"),
+            ("Ducts under 100mm",  "How many ducts are under 100mm?"),
+            ("Create a 5m wall",   "Create a 5 metre wall from 0,0 to 5000,0 that is 3000mm high. Dry-run it first."),
+            ("Build a shell",      "Build an 8m x 6m building shell 3m high. Dry-run it first, then ask me to confirm."),
+            ("What can you do?",   "What can you do? List your tool categories: read, tag, size, create, and discover."),
+        };
+
+        // Tools that mutate the model — used to decide whether to offer an Undo chip.
+        private static readonly HashSet<string> MutatingTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "create_wall", "create_floor", "create_floor_in_room", "create_roof", "create_duct",
+            "create_pipe", "create_room", "place_family", "building_shell",
+            "set_parameter", "auto_tag", "tag_scheme_render", "size_ducts", "size_pipes",
+            "size_cables", "build_panel_schedules", "invoke_capability",
+        };
+
         public StingCopilotPanel()
         {
             InitializeComponent();
@@ -42,8 +64,11 @@ namespace StingTools.UI
 
             AppendBubble("assistant",
                 "Hi — I'm the STING Copilot. Ask me about the model or tell me what to do " +
-                "(e.g. \"how many ducts are under 100mm?\" or \"tag the mechanical elements in this view\"). " +
-                "I preview any change before running it.");
+                "(e.g. \"how many ducts are under 100mm?\" or \"create a 5m wall in this view\"). " +
+                "I preview any change before running it, and I can build walls, floors, ducts, pipes, " +
+                "rooms, families and whole shells.");
+
+            RefreshChips(showUndo: false);
         }
 
         // ── Send ─────────────────────────────────────────────────────────────────
@@ -69,6 +94,7 @@ namespace StingTools.UI
 
             Func<string, bool> confirmCallback = ConfirmOnUiThread;
             Action<string> onToolStart = ToolStartOnUiThread;
+            Action<string, string> onToolResult = ToolResultOnUiThread;
 
             Task.Run(async () =>
             {
@@ -76,7 +102,7 @@ namespace StingTools.UI
                 try
                 {
                     turn = await StingLlmService.Instance
-                        .RunCopilotTurnAsync(convo, ct, confirmCallback, onToolStart);
+                        .RunCopilotTurnAsync(convo, ct, confirmCallback, onToolStart, onToolResult);
                 }
                 catch (OperationCanceledException)
                 {
@@ -108,6 +134,10 @@ namespace StingTools.UI
                     else
                         UsageText.Text = "Each turn calls the LLM API and consumes credits.";
 
+                    // Offer an Undo affordance when this turn mutated the model.
+                    bool mutated = turn.ToolsUsed != null && turn.ToolsUsed.Any(MutatingTools.Contains);
+                    RefreshChips(showUndo: mutated);
+
                     SetBusy(false);
                 });
             });
@@ -134,6 +164,18 @@ namespace StingTools.UI
                 });
             }
             catch { /* best-effort progress */ }
+        }
+
+        /// <summary>Transparency: append a compact activity line to the chat as each tool completes.</summary>
+        private void ToolResultOnUiThread(string toolName, string compactSummary)
+        {
+            try
+            {
+                Dispatcher.Invoke(() =>
+                    AppendActivity($"🔧 {toolName}" +
+                        (string.IsNullOrEmpty(compactSummary) ? "" : $" — {compactSummary}")));
+            }
+            catch { /* best-effort transparency */ }
         }
 
         /// <summary>
@@ -195,6 +237,70 @@ namespace StingTools.UI
             };
             ChatStack.Children.Add(bubble);
             try { ChatScroll.ScrollToEnd(); } catch { }
+        }
+
+        /// <summary>Append a small, dim activity line (tool call) — visually distinct from chat bubbles.</summary>
+        private void AppendActivity(string text)
+        {
+            var line = new TextBlock
+            {
+                Text = text,
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 10,
+                FontStyle = FontStyles.Italic,
+                Opacity = 0.75,
+                Margin = new Thickness(2, 1, 40, 1),
+                Foreground = new SolidColorBrush(Color.FromRgb(0xB0, 0xC4, 0xDE)),
+            };
+            ChatStack.Children.Add(line);
+            try { ChatScroll.ScrollToEnd(); } catch { }
+        }
+
+        // ── Suggestion chips + undo ──────────────────────────────────────────────
+
+        /// <summary>Rebuild the chip row: an optional Undo chip, then the prompt-starter chips.</summary>
+        private void RefreshChips(bool showUndo)
+        {
+            ChipPanel.Children.Clear();
+
+            if (showUndo)
+                ChipPanel.Children.Add(MakeChip("↶ Undo last", isAccent: true, onClick: (_, __) =>
+                {
+                    AppendBubble("assistant",
+                        "Press Ctrl+Z in Revit to undo the last change. Every write is transaction-wrapped, " +
+                        "so undo reverts it cleanly.");
+                }));
+
+            foreach (var (label, prompt) in Suggestions)
+            {
+                string p = prompt;   // capture
+                ChipPanel.Children.Add(MakeChip(label, isAccent: false, onClick: (_, __) =>
+                {
+                    InputBox.Text = p;
+                    try { InputBox.Focus(); InputBox.CaretIndex = InputBox.Text.Length; } catch { }
+                }));
+            }
+        }
+
+        /// <summary>Build one clickable chip (rounded, theme-neutral).</summary>
+        private static Button MakeChip(string label, bool isAccent, RoutedEventHandler onClick)
+        {
+            var btn = new Button
+            {
+                Content = label,
+                FontSize = 10,
+                Margin = new Thickness(0, 0, 4, 4),
+                Padding = new Thickness(8, 3, 8, 3),
+                Cursor = Cursors.Hand,
+                BorderThickness = new Thickness(1),
+                BorderBrush = new SolidColorBrush(Color.FromArgb(0x88, 0x80, 0x80, 0x80)),
+                Foreground = Brushes.White,
+                Background = new SolidColorBrush(isAccent
+                    ? Color.FromRgb(0x6E, 0x4A, 0x2A)   // warm accent for Undo
+                    : Color.FromRgb(0x3A, 0x3A, 0x3A)),
+            };
+            btn.Click += onClick;
+            return btn;
         }
     }
 }

--- a/StingTools/UI/StingCopilotPanel.xaml.cs
+++ b/StingTools/UI/StingCopilotPanel.xaml.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using Autodesk.Revit.UI;
 using StingTools.Core;
 
@@ -27,8 +30,18 @@ namespace StingTools.UI
         private static StingCopilotPanel _instance;
         public static StingCopilotPanel Instance => _instance;
 
-        // Full text history for the current session (both roles).
+        // Full text history for the current session (both roles) — this IS the LLM
+        // conversation context passed to each turn. Clearing it resets the context.
         private readonly List<CopilotMessage> _history = new List<CopilotMessage>();
+
+        // Rendered transcript (greeting + user + assistant + tool activity) for save /
+        // screenshot. role is "user" | "assistant" | "activity".
+        private readonly List<(string role, string text)> _transcript = new List<(string, string)>();
+
+        private const string GreetingText =
+            "Hi — I'm the STING Copilot. Ask me about the model or tell me what to do " +
+            "(e.g. \"how many ducts are under 100mm?\" or \"tag the mechanical elements in this view\"). " +
+            "I preview any change before running it.";
 
         private CancellationTokenSource _cts;
         private bool _busy;
@@ -40,11 +53,10 @@ namespace StingTools.UI
             catch { /* theme is non-fatal */ }
             _instance = this;
 
-            AppendBubble("assistant",
-                "Hi — I'm the STING Copilot. Ask me about the model or tell me what to do " +
-                "(e.g. \"how many ducts are under 100mm?\" or \"tag the mechanical elements in this view\"). " +
-                "I preview any change before running it.");
+            ShowGreeting();
         }
+
+        private void ShowGreeting() => AppendBubble("assistant", GreetingText);
 
         // ── Send ─────────────────────────────────────────────────────────────────
 
@@ -131,6 +143,8 @@ namespace StingTools.UI
                 {
                     StatusText.Text = string.IsNullOrEmpty(toolName)
                         ? "running tool…" : $"running tool: {toolName}";
+                    if (!string.IsNullOrEmpty(toolName))
+                        AppendActivity($"🔧 {toolName}");
                 });
             }
             catch { /* best-effort progress */ }
@@ -194,7 +208,214 @@ namespace StingTools.UI
                 },
             };
             ChatStack.Children.Add(bubble);
+            _transcript.Add((isUser ? "user" : "assistant", text));
             try { ChatScroll.ScrollToEnd(); } catch { }
         }
+
+        /// <summary>Append a dim tool-activity line to the chat (and the transcript).</summary>
+        private void AppendActivity(string text)
+        {
+            var line = new TextBlock
+            {
+                Text = text,
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 10,
+                FontStyle = FontStyles.Italic,
+                Opacity = 0.75,
+                Margin = new Thickness(2, 1, 40, 1),
+                Foreground = new SolidColorBrush(Color.FromRgb(0xB0, 0xC4, 0xDE)),
+            };
+            ChatStack.Children.Add(line);
+            _transcript.Add(("activity", text));
+            try { ChatScroll.ScrollToEnd(); } catch { }
+        }
+
+        // ── Header toolbar: clear / save / screenshot / settings ────────────────────
+
+        /// <summary>Clear chat: reset messages AND the LLM conversation context, re-show greeting.</summary>
+        private void ClearBtn_Click(object sender, RoutedEventArgs e)
+        {
+            if (_busy)
+            {
+                TaskDialog.Show("STING Copilot", "A turn is still running — cancel or wait for it to finish first.");
+                return;
+            }
+            if (_history.Count > 0)
+            {
+                var td = new TaskDialog("STING Copilot — clear chat")
+                {
+                    MainInstruction = "Clear the chat and reset the conversation?",
+                    MainContent = "This removes the current messages and the AI's memory of this session. It cannot be undone.",
+                    CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                    DefaultButton = TaskDialogResult.No,
+                };
+                if (td.Show() != TaskDialogResult.Yes) return;
+            }
+
+            _history.Clear();          // resets the LLM conversation context (each turn passes a snapshot of this)
+            _transcript.Clear();
+            ChatStack.Children.Clear();
+            StatusText.Text = string.Empty;
+            UsageText.Text = "Each turn calls the LLM API and consumes credits.";
+            ShowGreeting();
+        }
+
+        /// <summary>Save chat: write the transcript to a Markdown (.md) file.</summary>
+        private void SaveChatBtn_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_transcript.Count == 0)
+                {
+                    TaskDialog.Show("STING Copilot", "Nothing to save yet.");
+                    return;
+                }
+
+                var dlg = new Microsoft.Win32.SaveFileDialog
+                {
+                    Title = "Save Copilot chat",
+                    Filter = "Markdown (*.md)|*.md|Text (*.txt)|*.txt",
+                    DefaultExt = ".md",
+                    FileName = $"Copilot_Chat_{DateStamp()}.md",
+                };
+                if (dlg.ShowDialog() != true) return;
+
+                File.WriteAllText(dlg.FileName, BuildMarkdown(), Encoding.UTF8);
+                StingLog.Info($"Copilot chat saved: {Path.GetFileName(dlg.FileName)} ({_transcript.Count} line(s)).");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("Copilot chat save failed", ex);
+                TaskDialog.Show("STING Copilot", "Could not save the chat: " + ex.Message);
+            }
+        }
+
+        private string BuildMarkdown()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("# STING Copilot — Chat Transcript");
+            sb.AppendLine();
+            sb.AppendLine($"- Date: {DateTime.Now:yyyy-MM-dd HH:mm}");
+            try
+            {
+                sb.AppendLine($"- Model: {StingLlmService.Instance.ActiveModel} " +
+                              $"(provider: {StingLlmService.Instance.ActiveProvider})");
+            }
+            catch { /* model line is best-effort */ }
+            sb.AppendLine();
+            sb.AppendLine("---");
+            sb.AppendLine();
+            foreach (var (role, text) in _transcript)
+            {
+                switch (role)
+                {
+                    case "user":      sb.AppendLine($"**You:** {text}"); break;
+                    case "assistant": sb.AppendLine($"**Copilot:** {text}"); break;
+                    case "activity":  sb.AppendLine($"> {text}"); break;
+                    default:          sb.AppendLine(text); break;
+                }
+                sb.AppendLine();
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>Screenshot the full chat to PNG (file or clipboard).</summary>
+        private void ScreenshotBtn_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var bmp = RenderChatToBitmap();
+                if (bmp == null)
+                {
+                    TaskDialog.Show("STING Copilot", "Nothing to capture yet.");
+                    return;
+                }
+
+                var td = new TaskDialog("STING Copilot — Screenshot")
+                {
+                    MainInstruction = "Chat screenshot ready.",
+                    MainContent = "Save the full chat as a PNG, or copy it to the clipboard to paste elsewhere.",
+                    CommonButtons = TaskDialogCommonButtons.Cancel,
+                    DefaultButton = TaskDialogResult.Cancel,
+                };
+                td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Save as PNG…");
+                td.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Copy to clipboard");
+                var r = td.Show();
+
+                if (r == TaskDialogResult.CommandLink1)
+                {
+                    var dlg = new Microsoft.Win32.SaveFileDialog
+                    {
+                        Title = "Save Copilot screenshot",
+                        Filter = "PNG image (*.png)|*.png",
+                        DefaultExt = ".png",
+                        FileName = $"Copilot_Chat_{DateStamp()}.png",
+                    };
+                    if (dlg.ShowDialog() != true) return;
+                    using (var fs = File.Create(dlg.FileName))
+                    {
+                        var enc = new PngBitmapEncoder();
+                        enc.Frames.Add(BitmapFrame.Create(bmp));
+                        enc.Save(fs);
+                    }
+                    StingLog.Info($"Copilot screenshot saved: {Path.GetFileName(dlg.FileName)}.");
+                }
+                else if (r == TaskDialogResult.CommandLink2)
+                {
+                    System.Windows.Clipboard.SetImage(bmp);
+                    StatusText.Text = "screenshot copied to clipboard";
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("Copilot screenshot failed", ex);
+                TaskDialog.Show("STING Copilot", "Could not capture the chat: " + ex.Message);
+            }
+        }
+
+        /// <summary>Render the FULL chat content (not just the visible viewport) to a bitmap.</summary>
+        private RenderTargetBitmap RenderChatToBitmap()
+        {
+            double w = ChatStack.ActualWidth;
+            double h = ChatStack.ActualHeight;
+            if (w < 1 || h < 1) return null;
+
+            // Solid dark canvas so white bubble text stays legible (chat bg is transparent).
+            var bg = new SolidColorBrush(Color.FromRgb(0x2B, 0x2B, 0x2B));
+            var dv = new DrawingVisual();
+            using (var dc = dv.RenderOpen())
+            {
+                dc.DrawRectangle(bg, null, new Rect(0, 0, w, h));
+                var vb = new VisualBrush(ChatStack)
+                {
+                    Stretch = Stretch.None,
+                    AlignmentX = AlignmentX.Left,
+                    AlignmentY = AlignmentY.Top,
+                };
+                dc.DrawRectangle(vb, null, new Rect(0, 0, w, h));
+            }
+
+            var rtb = new RenderTargetBitmap(
+                (int)Math.Ceiling(w), (int)Math.Ceiling(h), 96, 96, PixelFormats.Pbgra32);
+            rtb.Render(dv);
+            rtb.Freeze();
+            return rtb;
+        }
+
+        /// <summary>Gear affordance — open the Copilot Settings (LLM config) dialog.</summary>
+        private void SettingsBtn_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (StingLlmConfigDialog.Show())
+                    AppendActivity("⚙ Settings saved — the new provider/model is active now.");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("Open Copilot Settings from panel failed", ex);
+            }
+        }
+
+        private static string DateStamp() => DateTime.Now.ToString("yyyyMMdd_HHmm");
     }
 }

--- a/StingTools/UI/StingLlmConfigDialog.cs
+++ b/StingTools/UI/StingLlmConfigDialog.cs
@@ -1,0 +1,351 @@
+using System;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.UI
+{
+    /// <summary>
+    /// Copilot Settings — a WPF dialog for editing STING_LLM_CONFIG.json without hand-
+    /// editing JSON. Mirrors the MCP Server toggle's clobber-safe persistence: it loads
+    /// the whole JObject, sets ONLY the LLM fields (enabled / provider / claude_* /
+    /// azure_*), and writes it back indented so mcp_* keys and notes are preserved.
+    ///
+    /// Security: the API key lives in a masked PasswordBox and is NEVER written to the log.
+    /// Test connection uses the dialog's CURRENT field values (not the saved config) so the
+    /// user can verify before saving. On Save, StingLlmService.ReloadConfig() picks up the
+    /// change live — no Revit restart required.
+    /// </summary>
+    public class StingLlmConfigDialog : Window
+    {
+        private static readonly Color BrandPurple = Color.FromRgb(88, 44, 131);
+        private static readonly Color BrandPurpleLight = Color.FromRgb(206, 147, 216);
+        private static readonly Color TextPrimary = Color.FromRgb(40, 40, 50);
+        private static readonly Color TextSecondary = Color.FromRgb(120, 120, 140);
+        private static readonly Color FieldBorder = Color.FromRgb(200, 200, 210);
+
+        private static readonly string[] ClaudeModels =
+            { "claude-haiku-4-5-20251001", "claude-sonnet-5", "claude-opus-4-8" };
+
+        private readonly CheckBox _enabled;
+        private readonly RadioButton _providerClaude;
+        private readonly RadioButton _providerAzure;
+        private readonly PasswordBox _claudeKey;
+        private readonly ComboBox _claudeModel;
+        private readonly TextBox _azureEndpoint;
+        private readonly PasswordBox _azureKey;
+        private readonly TextBox _azureDeployment;
+        private readonly Border _claudeGroup;
+        private readonly Border _azureGroup;
+        private readonly TextBlock _status;
+        private readonly Button _testBtn;
+
+        private StingLlmConfigDialog()
+        {
+            Title = "Copilot Settings";
+            Width = 480;
+            SizeToContent = SizeToContent.Height;
+            MaxHeight = 720;
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            ResizeMode = ResizeMode.NoResize;
+            Background = new SolidColorBrush(Color.FromRgb(250, 250, 252));
+            FontFamily = new FontFamily("Segoe UI");
+
+            var root = new Grid();
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // header
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // body
+            root.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto }); // footer
+
+            // ── Header ──
+            var header = new Border { Background = new SolidColorBrush(BrandPurple), Padding = new Thickness(16, 12, 16, 12) };
+            var headerStack = new StackPanel();
+            headerStack.Children.Add(new TextBlock
+            {
+                Text = "Copilot Settings",
+                FontSize = 15, FontWeight = FontWeights.SemiBold, Foreground = Brushes.White
+            });
+            headerStack.Children.Add(new TextBlock
+            {
+                Text = "Configure the STING Copilot's AI provider. Stored in STING_LLM_CONFIG.json.",
+                FontSize = 11, Foreground = new SolidColorBrush(BrandPurpleLight),
+                Margin = new Thickness(0, 2, 0, 0), TextWrapping = TextWrapping.Wrap
+            });
+            header.Child = headerStack;
+            Grid.SetRow(header, 0);
+            root.Children.Add(header);
+
+            // ── Body ──
+            var body = new StackPanel { Margin = new Thickness(16, 14, 16, 8) };
+
+            _enabled = new CheckBox
+            {
+                Content = "Enable the Copilot (calls the LLM API — consumes credits)",
+                FontSize = 12, Foreground = new SolidColorBrush(TextPrimary),
+                Margin = new Thickness(0, 0, 0, 12)
+            };
+            body.Children.Add(_enabled);
+
+            body.Children.Add(SectionLabel("Provider"));
+            var providerRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 2, 0, 10) };
+            _providerClaude = new RadioButton { Content = "Claude (Anthropic)", FontSize = 12, GroupName = "prov", Margin = new Thickness(0, 0, 18, 0), Foreground = new SolidColorBrush(TextPrimary) };
+            _providerAzure = new RadioButton { Content = "Azure OpenAI", FontSize = 12, GroupName = "prov", Foreground = new SolidColorBrush(TextPrimary) };
+            providerRow.Children.Add(_providerClaude);
+            providerRow.Children.Add(_providerAzure);
+            body.Children.Add(providerRow);
+
+            // ── Claude group ──
+            var claudeStack = new StackPanel();
+            claudeStack.Children.Add(SectionLabel("Claude API key"));
+            _claudeKey = new PasswordBox { FontSize = 12, Height = 26, Margin = new Thickness(0, 2, 0, 8), Padding = new Thickness(4, 2, 4, 2) };
+            claudeStack.Children.Add(_claudeKey);
+            claudeStack.Children.Add(SectionLabel("Model"));
+            _claudeModel = new ComboBox { FontSize = 12, Height = 26, IsEditable = true, Margin = new Thickness(0, 2, 0, 2) };
+            foreach (var m in ClaudeModels) _claudeModel.Items.Add(m);
+            claudeStack.Children.Add(_claudeModel);
+            _claudeGroup = GroupBox("Claude", claudeStack);
+            body.Children.Add(_claudeGroup);
+
+            // ── Azure group ──
+            var azureStack = new StackPanel();
+            azureStack.Children.Add(SectionLabel("Azure endpoint"));
+            _azureEndpoint = MakeTextBox();
+            azureStack.Children.Add(_azureEndpoint);
+            azureStack.Children.Add(SectionLabel("Azure API key"));
+            _azureKey = new PasswordBox { FontSize = 12, Height = 26, Margin = new Thickness(0, 2, 0, 8), Padding = new Thickness(4, 2, 4, 2) };
+            azureStack.Children.Add(_azureKey);
+            azureStack.Children.Add(SectionLabel("Deployment name"));
+            _azureDeployment = MakeTextBox();
+            azureStack.Children.Add(_azureDeployment);
+            _azureGroup = GroupBox("Azure OpenAI", azureStack);
+            body.Children.Add(_azureGroup);
+
+            // ── Test connection ──
+            var testRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 6, 0, 2) };
+            _testBtn = new Button
+            {
+                Content = "Test connection", MinWidth = 120, Height = 28, FontSize = 12,
+                Padding = new Thickness(10, 3, 10, 3), Cursor = Cursors.Hand,
+                Background = Brushes.White, BorderBrush = new SolidColorBrush(FieldBorder)
+            };
+            _testBtn.Click += TestBtn_Click;
+            testRow.Children.Add(_testBtn);
+            body.Children.Add(testRow);
+
+            _status = new TextBlock
+            {
+                FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(2, 6, 2, 0),
+                Foreground = new SolidColorBrush(TextSecondary), Text = ""
+            };
+            body.Children.Add(_status);
+
+            Grid.SetRow(body, 1);
+            root.Children.Add(body);
+
+            // ── Footer ──
+            var footer = new Border
+            {
+                Background = new SolidColorBrush(Color.FromRgb(245, 245, 248)),
+                BorderBrush = new SolidColorBrush(FieldBorder), BorderThickness = new Thickness(0, 1, 0, 0),
+                Padding = new Thickness(12, 8, 12, 8)
+            };
+            var footerStack = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
+            var cancelBtn = new Button
+            {
+                Content = "Cancel", MinWidth = 80, Height = 30, FontSize = 12, Margin = new Thickness(0, 0, 8, 0),
+                Padding = new Thickness(12, 4, 12, 4), Cursor = Cursors.Hand, Background = Brushes.White,
+                BorderBrush = new SolidColorBrush(FieldBorder)
+            };
+            cancelBtn.Click += (s, e) => { DialogResult = false; Close(); };
+            var saveBtn = new Button
+            {
+                Content = "Save", MinWidth = 90, Height = 30, FontSize = 12, FontWeight = FontWeights.SemiBold,
+                Padding = new Thickness(12, 4, 12, 4), Cursor = Cursors.Hand,
+                Background = new SolidColorBrush(BrandPurple), Foreground = Brushes.White,
+                BorderBrush = new SolidColorBrush(BrandPurple)
+            };
+            saveBtn.Click += SaveBtn_Click;
+            footerStack.Children.Add(cancelBtn);
+            footerStack.Children.Add(saveBtn);
+            footer.Child = footerStack;
+            Grid.SetRow(footer, 2);
+            root.Children.Add(footer);
+
+            Content = root;
+            KeyDown += (s, e) => { if (e.Key == Key.Escape) { DialogResult = false; Close(); } };
+
+            _providerClaude.Checked += (s, e) => UpdateProviderVisibility();
+            _providerAzure.Checked += (s, e) => UpdateProviderVisibility();
+
+            LoadFromConfig();
+            UpdateProviderVisibility();
+        }
+
+        // ── Load ─────────────────────────────────────────────────────────────
+
+        private void LoadFromConfig()
+        {
+            try
+            {
+                string path = ConfigPath();
+                if (!File.Exists(path))
+                {
+                    _providerClaude.IsChecked = true;
+                    _claudeModel.SelectedItem = ClaudeModels[0];
+                    return;
+                }
+
+                var cfg = JObject.Parse(File.ReadAllText(path));
+                _enabled.IsChecked = cfg["enabled"]?.Value<bool>() ?? false;
+
+                string ck = cfg["claude_api_key"]?.Value<string>() ?? "";
+                _claudeKey.Password = ck;
+                string model = cfg["claude_model"]?.Value<string>();
+                if (!string.IsNullOrWhiteSpace(model))
+                {
+                    if (!_claudeModel.Items.Contains(model)) _claudeModel.Items.Add(model);
+                    _claudeModel.SelectedItem = model;
+                }
+                else _claudeModel.SelectedItem = ClaudeModels[0];
+
+                _azureEndpoint.Text = cfg["azure_endpoint"]?.Value<string>() ?? "";
+                _azureKey.Password = cfg["azure_api_key"]?.Value<string>() ?? "";
+                _azureDeployment.Text = cfg["azure_deployment"]?.Value<string>() ?? "";
+
+                string provider = cfg["provider"]?.Value<string>()?.Trim().ToLowerInvariant();
+                if (string.IsNullOrWhiteSpace(provider))
+                    provider = !string.IsNullOrWhiteSpace(ck) ? "claude"
+                             : (!string.IsNullOrWhiteSpace(_azureEndpoint.Text) && !string.IsNullOrWhiteSpace(_azureKey.Password)) ? "azure"
+                             : "claude";
+                if (provider == "azure") _providerAzure.IsChecked = true; else _providerClaude.IsChecked = true;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Copilot Settings load failed: {ex.Message}");
+                _providerClaude.IsChecked = true;
+                _claudeModel.SelectedItem = ClaudeModels[0];
+            }
+        }
+
+        // ── Save (clobber-safe) ────────────────────────────────────────────────
+
+        private void SaveBtn_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                string path = ConfigPath();
+                JObject cfg = File.Exists(path) ? JObject.Parse(File.ReadAllText(path)) : new JObject();
+
+                // Set ONLY the LLM fields — every other key (mcp_*, notes, timeout_seconds…) is preserved.
+                cfg["enabled"]          = _enabled.IsChecked == true;
+                cfg["provider"]         = _providerAzure.IsChecked == true ? "azure" : "claude";
+                cfg["claude_api_key"]   = _claudeKey.Password ?? "";
+                cfg["claude_model"]     = CurrentModel();
+                cfg["azure_endpoint"]   = _azureEndpoint.Text?.Trim() ?? "";
+                cfg["azure_api_key"]    = _azureKey.Password ?? "";
+                cfg["azure_deployment"] = _azureDeployment.Text?.Trim() ?? "";
+
+                File.WriteAllText(path, cfg.ToString(Formatting.Indented));
+                StingLog.Info($"Copilot Settings saved (enabled={cfg["enabled"]}, provider={cfg["provider"]}, model={cfg["claude_model"]}).");
+
+                // Live pick-up — no Revit restart needed.
+                try { StingLlmService.Instance.ReloadConfig(); }
+                catch (Exception rex) { StingLog.Warn($"Copilot Settings reload after save failed: {rex.Message}"); }
+
+                DialogResult = true;
+                Close();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("Copilot Settings save failed", ex);
+                _status.Foreground = new SolidColorBrush(Color.FromRgb(180, 40, 40));
+                _status.Text = "Save failed: " + ex.Message;
+            }
+        }
+
+        // ── Test connection ────────────────────────────────────────────────────
+
+        private async void TestBtn_Click(object sender, RoutedEventArgs e)
+        {
+            _testBtn.IsEnabled = false;
+            _status.Foreground = new SolidColorBrush(TextSecondary);
+            _status.Text = "Testing…";
+            try
+            {
+                bool useClaude = _providerClaude.IsChecked == true;
+                var (ok, msg) = await StingLlmService.Instance.TestConnectionAsync(
+                    useClaude,
+                    _claudeKey.Password, CurrentModel(),
+                    _azureEndpoint.Text?.Trim(), _azureKey.Password, _azureDeployment.Text?.Trim());
+
+                _status.Foreground = new SolidColorBrush(ok ? Color.FromRgb(30, 130, 60) : Color.FromRgb(180, 40, 40));
+                _status.Text = (ok ? "✓ " : "✗ ") + msg;
+            }
+            catch (Exception ex)
+            {
+                _status.Foreground = new SolidColorBrush(Color.FromRgb(180, 40, 40));
+                _status.Text = "✗ " + ex.Message;
+                StingLog.Warn($"Copilot Settings test failed: {ex.Message}");
+            }
+            finally { _testBtn.IsEnabled = true; }
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────────────────
+
+        private void UpdateProviderVisibility()
+        {
+            bool azure = _providerAzure.IsChecked == true;
+            _azureGroup.Visibility = azure ? Visibility.Visible : Visibility.Collapsed;
+            _claudeGroup.Visibility = azure ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private string CurrentModel()
+        {
+            string m = (_claudeModel.SelectedItem as string) ?? _claudeModel.Text;
+            return string.IsNullOrWhiteSpace(m) ? ClaudeModels[0] : m.Trim();
+        }
+
+        private static string ConfigPath() =>
+            Path.Combine(StingToolsApp.DataPath, "STING_LLM_CONFIG.json");
+
+        private static TextBlock SectionLabel(string text) => new TextBlock
+        {
+            Text = text, FontSize = 11, FontWeight = FontWeights.SemiBold,
+            Foreground = new SolidColorBrush(TextSecondary), Margin = new Thickness(0, 4, 0, 0)
+        };
+
+        private static TextBox MakeTextBox() => new TextBox
+        {
+            FontSize = 12, Height = 26, Margin = new Thickness(0, 2, 0, 8), Padding = new Thickness(4, 2, 4, 2)
+        };
+
+        private static Border GroupBox(string title, UIElement content)
+        {
+            var stack = new StackPanel();
+            stack.Children.Add(new TextBlock
+            {
+                Text = title, FontSize = 11, FontWeight = FontWeights.Bold,
+                Foreground = new SolidColorBrush(BrandPurple), Margin = new Thickness(0, 0, 0, 4)
+            });
+            stack.Children.Add(content);
+            return new Border
+            {
+                BorderBrush = new SolidColorBrush(FieldBorder), BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(5), Padding = new Thickness(10, 8, 10, 8),
+                Margin = new Thickness(0, 4, 0, 8), Child = stack
+            };
+        }
+
+        /// <summary>Open the Copilot Settings dialog modally. Returns true when saved.</summary>
+        public static bool Show()
+        {
+            var dlg = new StingLlmConfigDialog();
+            try { StingWindowHelper.ApplyOwner(dlg); } catch { /* owner is best-effort */ }
+            return dlg.ShowDialog() == true;
+        }
+    }
+}


### PR DESCRIPTION
Integrates two Copilot branches into `main`, panel conflict resolved to keep BOTH feature sets.

## Create stage (from claude/create-stage)
- 9 `ModelEngine`-backed creation tools: create_wall/floor/floor_in_room/roof/duct/pipe/room, place_family, building_shell
  (building_shell confirm-gated). Dialog-free, self-transacting engine; dryRun validates without creating; created-id read-back.
- 4 read tools: get_rooms / get_levels / get_grids / get_warnings.
- Copilot UX: suggestion chips, tool-call transparency, active-view/selection context, undo chip, "…read, tag, size, and now BUILD" greeting.
- Tool count → ~43.

## Panel controls (from claude/copilot-polish)
- Header toolbar: Clear chat (resets messages + LLM context) · Save chat (Markdown transcript) · Screenshot (full-chat PNG + clipboard) · Settings (gear).
- `StingLlmConfigDialog`: enter API key (masked) + pick provider/model in-Revit, "Test connection", clobber-safe save (preserves mcp_* keys), `ReloadConfig()` — no JSON editing, no restart.

## Conflict resolution
Only `StingCopilotPanel.xaml`/`.xaml.cs` conflicted (both edited the panel). Resolved to keep both: polish's toolbar Grid with create-stage's BUILD subtitle; `AppendActivity` records to the transcript; `GreetingText` carries the build-capable greeting; chips + toolbar methods coexist. `StingLlmService.cs` auto-merged.

## Verification
Build green (Release, Revit 2025). Unverified in Revit: real element creation + a live Copilot LLM turn (needs an API key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)