### PR TITLE
docs(electrical): conduit auto-routing, sleeve method + rough-in workflow

### DIFF
--- a/docs/STING_ELECTRICAL_LAYMANS_GUIDE.md
+++ b/docs/STING_ELECTRICAL_LAYMANS_GUIDE.md
@@ -241,7 +241,9 @@ Walks every cable in the manifest with no `RouteTrayIds`, computes a Manhattan L
 For each unrouted cable:
 
 1. Resolve ElectricalSystem by CircuitId (BuiltInParameter.RBS_ELEC_CIRCUIT_NUMBER)
-2. Resolve start (load location) + end (panel location) from LocationPoint
+2. Resolve start (load) + end (panel) via RoutingOriginResolver:
+   free conduit connector → any free connector → LocationPoint (fallback)
+   (one origin contract shared with AutoConduitDrop's fixture drops)
 3. Resolve level from loadEl.LevelId or active view
 4. SelectConduitDiameterMm — ≤40% fill (BS EN 61386)
 5. ComputeRoute(start, end, diameter, label) — 3-segment L/Z
@@ -319,6 +321,49 @@ After all cables are routed:
 - **"No conduit type found"** → Load a `ConduitType` family before running.
 - **All cables skip with "no panel"** → Run `Circuit_AssignAuto` first so cables have `BaseEquipment` set.
 - **Junction boxes show "NEEDED:..." instead of placing** → `STING_SEED_JunctionBox` family not loaded. Run `Build Seed Families`, finish per `Families/Seeds/README.md`.
+
+---
+
+## Sleeve connectors (the "sleeve method")
+
+### What it does
+Authors a short conduit **stub** carrying a real `Domain.DomainCableTrayConduit` connector on electrical fixtures that have **no free conduit connector** — chiefly manufacturer families after `Symbols_SwapToManufacturer`, which drop the seed's authored connector. Gives `RoutingOriginResolver` / `AutoConduitDrop` a genuine terminal to start from instead of the family `LocationPoint`. This is the connector-authorship gap no third-party conduit tool (EasyConduit, ConduiTool, Automatic Conduit, EVOLVE) fills — they all *require* a connector and none author one.
+
+### Command
+- **Tag**: `Routing_PlaceSleeveConnectors` (interactive — previews, then places) / `Routing_PlaceSleeveConnectorsAuto` (headless, workflow step)
+- **Class**: `PlaceSleeveConnectorsCommand` / `PlaceSleeveConnectorsAutoCommand`
+- **Engine**: `SleeveConnectorEngine` (`Core/Mep/`)
+
+### Pipeline
+
+```
+Target set: selection (electrical fixtures) else active-view electrical fixtures
+For each fixture:
+
+1. HasFreeConduitConnector? → AlreadyRoutable, skip
+2. terminal = LocationPoint (+ FIXTURE_DROP_OFFSET_Z_MM hint; Double=feet, String=mm)
+3. AlreadySleeved(fixtureId, terminal)? → skip (idempotent)
+   ├── primary: a conduit stub stamped
+   │            ELC_CDT_INSTALL_METHOD_TXT = "STING_SLEEVE_STUB:<fixtureId>"
+   └── fallback: a conduit End connector ≤ 10 mm from the terminal
+4. dirZ = -1 for floor boxes (ELE_FIX_MOUNT_HEIGHT_MM≈0 / "FLOOR" / Floor host), else +1
+5. Conduit.Create(doc, conduitType, from, from + dirZ*StubLength, level)
+   ├── RBS_CONDUIT_DIAMETER_PARAM = StubSizeMm (default 20 mm)
+   └── ELC_CDT_INSTALL_METHOD_TXT  = "STING_SLEEVE_STUB:<fixtureId>"
+```
+
+### Inputs
+- Loaded `ConduitType` (first available)
+- `MepSizingRegistry`: `conduit.sleeveStubSizeMm` (20) / `sleeveStubLengthMm` (150); project override at `<project>/_BIM_COORD/mep_sizing_rules.json`
+
+### Outputs
+- One `Conduit` stub per connector-less fixture; the free (outward) end is the routable terminal `Routing_AutoDrop` extends to containment
+- Dry-run mode plans + reports counts/positions without opening a transaction or creating geometry
+
+### Notes
+- **Idempotent** — the per-fixture ElementId stamp means re-runs are no-ops, and two connector-less fixtures ~30 mm apart each get their **own** stub (not merged).
+- **Not bonded to the fixture** — a connector-less fixture has nothing to bond to; the stub floats at the face and *provides* the terminal. Bonding is stub ↔ drop ↔ containment.
+- **Pre-flight**: `RoutingPreflightValidator` (in `Run All Validators` and inside Auto Drop) flags `CONN.DOMAIN.NOCONDUIT` (a sleeve target) and `SIZE.MISMATCH` (a connector Ø not in the project Conduit Standards size list — the "no auto-route solution" cause).
 
 ---
 
@@ -760,7 +805,7 @@ Because every STING parameter has a stable shared-param GUID:
 - ✅ `LTG_*` lighting params — UF/MF/lumens carry over
 - ✅ `ELC_PHOTO_*` photometric params — Dialux references survive
 - ✅ `STING_DESIGN_REF_TXT` — original seed identity audit-trail preserved
-- ⚠️ Connectors — Revit re-creates them on `ChangeTypeId`; mismatches drop. RestitchSwappedConnectors rejoins what it can.
+- ⚠️ Connectors — Revit re-creates them on `ChangeTypeId`; mismatches drop. RestitchSwappedConnectors rejoins what it can; for fixtures the swap leaves with **no conduit connector**, the **sleeve method** (`Routing_PlaceSleeveConnectors`, see above) authors a stub terminal so auto-drop can still route them.
 
 ---
 
@@ -792,6 +837,20 @@ End-to-end panel-schedule pipeline:
 5. Panel_Audit              (re-audit to confirm convergence)
 ```
 
+### `WORKFLOW_ElectricalRoughIn.json`
+Place → sleeve → drop → validate, from selected rooms to routed conduit in one run.
+Each step hands the next its selection (`PlaceFixturesCommand` calls `Selection.SetElementIds`).
+
+```
+1. Seeds_Build                       (build STING_SEED_ElectricalFixture, incl. conduit terminal)
+2. Placement_PlaceFixtures           (place per room rules; leaves them selected)
+3. Routing_PlaceSleeveConnectorsAuto (sleeve connector-less fixtures; no-op if already routable)
+4. Routing_AutoDrop                  (AutoConduitDrop → nearest containment)
+5. Validation_RunAll                 (CONN.OPEN + SIZE.MISMATCH + penetration coverage)
+```
+
+Field names are `commandTag`/`label` per the `WorkflowStep` POCO; every tag resolves in `WorkflowEngine.ResolveCommand`.
+
 ### Conditions implemented in `WorkflowEngine.EvaluateSingleCondition`
 | Condition | Returns true when |
 |---|---|
@@ -820,7 +879,7 @@ End-to-end panel-schedule pipeline:
 | `ELC_CDT_CABLE_COUNT_NR` | Conduits | `ConsolidatorApply`, manual | `ElectricalStandardsValidator` (fill table row) |
 | `ELC_CDT_BREAKPOINT_TXT` | Conduits, Conduit Fittings | `JBAutoPlacer` | `SlabPenetrationDetector` (Wave J3 inheritance) |
 | `ELC_CDT_PENETRATION_COUNT_NR` | Conduits, Pipes, Ducts | `SlabPenetrationDetector` | schedule, JBAutoPlacer (avoid-collision) |
-| `ELC_CDT_INSTALL_METHOD_TXT` | Conduits, Conduit Fittings | `AutoConduitDrop` | takeoff, schedule |
+| `ELC_CDT_INSTALL_METHOD_TXT` | Conduits, Conduit Fittings | `AutoConduitDrop`, `SleeveConnectorEngine` (`STING_SLEEVE_STUB:<fixtureId>`) | takeoff, schedule, sleeve idempotency |
 | `ELC_CDT_FAB_METHOD_TXT` | Conduits | `AutoConduitDrop` | fabrication |
 | `ELC_CDT_CBL_FILL_PCT` | Conduits | `ConduitFillValidate` | `ElectricalStandardsValidator` |
 | `ELC_CONDUIT_ROUTE` | Conduits | `ConduitAutoRouteCommand`, `Consolidator` | route grouping |

--- a/docs/guides/ELECTRICAL_WORKFLOW_GUIDE.md
+++ b/docs/guides/ELECTRICAL_WORKFLOW_GUIDE.md
@@ -1,8 +1,9 @@
 # STING Electrical Workflow Guide
 
-> **Version note:** This guide reflects the STING Tools plugin as shipped on branch
-> `claude/merge-branches-update-docs-SvA31` (Phase 176 + v4 MVP). All button names,
-> dialog labels, and parameter names are written exactly as they appear in STING.
+> **Version note:** This guide reflects the STING Tools plugin as shipped on `main`
+> (Phase 176 + v4 MVP, plus the Phase 196–198 conduit auto-routing / sleeve method /
+> Electrical Rough-In workflow — see Chapter 6). All button names, dialog labels, and
+> parameter names are written exactly as they appear in STING.
 
 ---
 
@@ -967,6 +968,86 @@ flagged in red.
 > in the result), the `STING_SEED_JunctionBox` family is not loaded. Go to
 > **TEMP → Build Seed Families** to create and load it.
 
+### How routing knows where to start: conduit connectors
+
+A conduit run has to begin somewhere on the device. STING routing starts at a **conduit
+connector** on the fixture rather than the family's insertion point, so the run lands
+exactly where the conduit physically enters the back box.
+
+- **Placed fixtures already carry a connector.** `STING_SEED_ElectricalFixture` authors one
+  `Domain = Conduit` terminal connector (facing +Z, 20 mm) on **every** variant — sockets,
+  switches, FCUs, isolators, EV chargers, data outlets, floor boxes. Auto Drop finds it
+  automatically.
+- **Junction boxes and panels are routing anchors.** `STING_SEED_JunctionBox` (four faces)
+  and `STING_SEED_ElectricalEquipment` (panels/DBs) also carry `Domain = Conduit` terminals,
+  so Auto Drop can bond a rising or branching conduit to them — a JB is a real conduit
+  junction, not a dead end.
+- **One start-point contract.** Both routers — Auto Drop (device → containment) and the
+  cable-manifest router (device → panel) — pick the start point the same way: *free conduit
+  connector → any free connector → the insertion point*, in that order.
+
+> **Why this matters:** before this, a side-mounted socket routed from its insertion point,
+> which could sit 100 mm off the real terminal. Now the run starts on the connector.
+
+### The sleeve method — routing manufacturer families that have no conduit connector
+
+Vendor families (the `.rfa` you swap to with **Seeds → Swap to Manufacturer**) almost never
+ship with a conduit connector. Every off-the-shelf conduit plugin (EasyConduit, ConduiTool,
+Automatic Conduit, EVOLVE) simply *requires* the family to have one and cannot route these
+fixtures. STING authors the connector for you with the **sleeve method**.
+
+For each electrical fixture with **no free conduit connector**, `SleeveConnectorEngine`
+places a short conduit **stub** (20 mm × 150 mm by default) at the fixture face — rising +Z
+for wall/ceiling devices, dropping −Z for floor boxes. A conduit always exposes real
+`Domain = Conduit` connectors, so the stub's free end becomes the routable terminal that
+Auto Drop then extends to containment.
+
+| Command | Where | Behaviour |
+|---------|-------|-----------|
+| **Place Sleeve Connectors** (`Routing_PlaceSleeveConnectors`) | TAGS → Routing | Interactive: previews *"N fixtures would get a conduit terminal"*, then places on confirm. |
+| **Place Sleeve Connectors (Auto)** (`Routing_PlaceSleeveConnectorsAuto`) | Workflow / dispatch | Non-interactive, no dialog — used inside the rough-in workflow. |
+
+- **Target set:** the current selection when it holds electrical fixtures, otherwise every
+  electrical fixture in the active view.
+- **Idempotent.** Each stub is stamped `ELC_CDT_INSTALL_METHOD_TXT = STING_SLEEVE_STUB:<id>`
+  with the fixture's ElementId, so a re-run places nothing new, and two connector-less
+  fixtures 30 mm apart each get their **own** stub (they are not merged onto one).
+- **Skips fixtures that don't need it** — anything that already has a free conduit connector
+  (a seed fixture, or a manufacturer family that does carry one) is left alone.
+- **Tunable** via `conduit.sleeveStubSizeMm` / `sleeveStubLengthMm` in the project's
+  `_BIM_COORD/mep_sizing_rules.json` override.
+
+> **Stuck?** If the sleeve pass reports `placed=0 alreadyRoutable=N`, your fixtures already
+> have conduit connectors — nothing to do; go straight to Auto Drop.
+
+### One-click rough-in: the Electrical Rough-In workflow
+
+`WORKFLOW_ElectricalRoughIn.json` chains the whole sequence so you can take a set of rooms to
+fully-routed conduit in one run. Open the **Workflow Preset** picker (BIM → Workflows) and
+choose **"Electrical Rough-In Pipeline"**:
+
+| Step | Command | What happens |
+|------|---------|--------------|
+| 1 | `Seeds_Build` | Builds `STING_SEED_ElectricalFixture` (with its conduit terminal). Safe to re-run. |
+| 2 | `Placement_PlaceFixtures` | Places fixtures per room rules; leaves them selected. |
+| 3 | `Routing_PlaceSleeveConnectorsAuto` | Authors sleeve terminals on any connector-less fixtures (no-op for seed fixtures). |
+| 4 | `Routing_AutoDrop` | Routes conduit from each fixture/stub connector to the nearest containment. |
+| 5 | `Validation_RunAll` | Flags any conduit connector left open + firestop coverage. |
+
+**Select the target rooms before you launch** — step 2 needs them, and each step hands the
+next its selection automatically.
+
+### Routing pre-flight checks
+
+`RoutingPreflightValidator` runs automatically inside Auto Drop (electrical group) and as part
+of **Run All Validators**. It surfaces two things before a drop goes wrong:
+
+- **`SIZE.MISMATCH`** — a conduit connector whose diameter is not in the project's Conduit
+  Standards size list. Off-list sizes are what make Revit throw *"No auto-route solution
+  found"* or silently insert a junction-box reducer.
+- **`CONN.DOMAIN.NOCONDUIT`** (Info) — an electrical device that has MEP connectors but no
+  conduit connector: a **sleeve target**. Run the sleeve pass before Auto Drop to clear these.
+
 ### Creating conduit runs manually (and tagging them)
 
 When you draw conduits using Revit's native `Systems → Electrical → Conduit` tool, STING
@@ -1554,8 +1635,10 @@ separately, then run the workflow again from step 1 to re-audit and confirm conv
 | Fill All Spares (Project-Wide) | BIM | Panel Schedules | Fills all empty slots in every schedule as SPARE | Before export and issue |
 | Convert Spaces to Spares | BIM | Panel Schedules | Changes SPACE declarations to SPARE | When breakers have been retrofitted to previously empty slots |
 | Clear Spares and Spaces | BIM | Panel Schedules | Removes all spare/space declarations from active schedule | When resetting a schedule |
-| Workflow Preset | BIM | Workflows | Runs a named workflow chain | Run PanelScheduleProduction for panel schedule batch processing |
-| Auto Drop | TAGS | Routing | Routes conduits from panels to all connected devices | After circuit assignment |
+| Workflow Preset | BIM | Workflows | Runs a named workflow chain | Run **Electrical Rough-In Pipeline** for place → sleeve → drop → validate, or PanelScheduleProduction for panel schedules |
+| Auto Drop | TAGS | Routing | Routes conduits from fixture/stub connectors to the nearest containment | After circuit assignment (or after the sleeve pass) |
+| Place Sleeve Connectors | TAGS | Routing | Authors a conduit terminal stub on connector-less fixtures (interactive, previews first) | After swapping fixtures to manufacturer families, before Auto Drop |
+| Place Sleeve Connectors (Auto) | (workflow) | Routing | Non-interactive sleeve pass used inside the Electrical Rough-In workflow | Runs headless as a workflow step |
 | Validate Fills | TAGS | Routing | Checks conduit fill percentages against BS EN 61386 | Before issuing drawings |
 | Consolidate Conduits | TAGS | Routing | Merges multiple per-cable conduits sharing a route into one | After initial routing to rationalise the model |
 | Run All Validators | TAGS | Routing | Runs full validation chain (BS 7671 + all STING validators) | Final QA before drawing issue |

--- a/docs/guides/STING_ELECTRICAL_LAYMANS_GUIDE.md
+++ b/docs/guides/STING_ELECTRICAL_LAYMANS_GUIDE.md
@@ -737,6 +737,48 @@ For each circuit, STING:
 4. Sets the conduit's `CPC_SZ_MM` (circuit protective conductor size) and
    fill capacity per BS 7671 Table 4D5.
 
+### 8.1a Where the conduit starts — connectors and the "sleeve" trick
+
+Auto-drop has to know *where* on the fixture the conduit should begin. Every
+fixture STING places carries a tiny **conduit connector** — think of it as the
+hole in the back box where the conduit screws in. Auto-drop starts the run
+there, so the conduit lands exactly where it should, not at some arbitrary
+middle-of-the-symbol point.
+
+- STING's own sockets, switches, isolators, data outlets and floor boxes all
+  have this connector built in.
+- Junction boxes and panels have them too, on each face — so a conduit can
+  branch into a junction box the way it does in real life.
+
+**The catch:** when you swap a STING fixture for a real **manufacturer's
+family** (`Symbols_SwapToManufacturer`), the vendor's model usually has *no*
+conduit connector. Every rival tool (EasyConduit, ConduiTool, EVOLVE) just
+gives up on those fixtures. STING fixes it with the **sleeve method** —
+**TAGS → Routing → Place Sleeve Connectors** (`Routing_PlaceSleeveConnectors`).
+For each fixture that's missing a connector, STING pushes a short conduit
+"sleeve" out of the box face (up for wall/ceiling devices, down for floor
+boxes). That sleeve *has* a connector, so auto-drop can grab it and carry on.
+It previews first, it's safe to run again (it won't double up), and two
+fixtures side-by-side each get their own sleeve.
+
+### 8.1b One button for the whole job — the Electrical Rough-In workflow
+
+You don't have to run those steps one at a time. **BIM → Workflows → Workflow
+Preset → "Electrical Rough-In Pipeline"** does the lot, in order:
+
+1. Build the STING fixture family.
+2. Place fixtures in the rooms you selected.
+3. Add sleeve connectors to anything that's missing one (skips fixtures that
+   already have one).
+4. Auto-drop the conduit to the nearest tray / basket.
+5. Run the full validator check.
+
+Select your rooms first, press go, and STING hands each step's result to the
+next. If a fixture ends up with no conduit, the validator's **CONN.OPEN** line
+tells you which one; a **SIZE.MISMATCH** line means a connector size isn't in
+your project's conduit size list (the usual cause of *"no auto-route solution
+found"*).
+
 ### 8.2 Cable tray sizing
 
 Once auto-dropped, **Routing → Validate Fills** checks each tray against
@@ -1610,6 +1652,8 @@ concepts but they remove pain points first-timers hit constantly.
 | `Symbols_BuildSeeds`                | TAGS      | Builds all 16 seed families from JSON. Includes `STING_SEED_ElectricalEquipment` (MDB / DB / SDB / MCB / MCCB / ACB / RCD), `STING_SEED_LightingFixture` (5 variants), `STING_SEED_ElectricalFixture` (4 variants), `STING_SEED_FireAlarmDevice` (5 variants), `STING_SEED_JunctionBox` (4 variants), `STING_SEED_CommunicationDevice` (5 variants). |
 | `Symbols_SwapToManufacturer`        | TAGS      | Swaps a seed family for a manufacturer family via `STING_FAMILY_SWAP_REGISTRY.json`; stamps `PEN_CERTIFICATION_TXT` with the UL system. |
 | `Symbols_DriftDetect`               | TAGS      | Detects symbols whose geometry / parameters have drifted from the JSON spec — catches the "manufacturer family lost a connector" failure mode. |
+| `Routing_PlaceSleeveConnectors`     | TAGS Routing | The **sleeve method** — authors a short conduit stub carrying a real conduit terminal on fixtures that have no conduit connector (chiefly manufacturer families after swap). Previews first; idempotent; up for wall/ceiling, down for floor boxes. Run before Auto Drop. See §8.1a. |
+| `Routing_PlaceSleeveConnectorsAuto` | (workflow) | Non-interactive sleeve pass used inside the **Electrical Rough-In Pipeline** workflow (§8.1b) — no dialog, safe to run headless. |
 | `DesignOptions_Audit`                | DOCS      | Read-only audit of cost/carbon implications per design option. Use when the architect provides "option A vs option B" — STING reports the electrical containment delta. |
 | `DesignOptions_ClashView`            | DOCS      | Creates a view isolating the primary option only so your clash detection doesn't false-flag option-B containment against option-A architecture. |
 | `Hvac_EnvelopeStaleToggle`           | HVAC LOADS| Subscribes the envelope-stale IUpdater. After it's on, any wall / window geometry change marks affected Spaces with `HVC_LOAD_STALE_BOOL = 1`. Run `Hvac_BlockLoad` to re-stamp and the flag clears. Coordinate with your panel schedule re-run. |


### PR DESCRIPTION
Documents the Phase 196-198 conduit functions (now merged to main via #386) in the Electrical Workflow Guide.

**Chapter 6 additions:**
- Routing now starts at fixture **conduit connectors** (seed terminal + JB/panel anchors + shared origin-resolution contract).
- The **sleeve method** — `Routing_PlaceSleeveConnectors` / `...Auto` author a conduit stub on connector-less manufacturer families (idempotent, floor-box -Z, tunable).
- The **Electrical Rough-In Pipeline** workflow.
- **RoutingPreflightValidator** (SIZE.MISMATCH / CONN.DOMAIN.NOCONDUIT).

Plus command-table rows for the sleeve commands and a refreshed version note. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)