### PR TITLE
Wire the planscape.build funnel to the shipped D1 auth + billing backend (Phase 1 + 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1940,7 +1940,7 @@ databases:
 ### Production Domain
 
 - **API**: `api.planscape.build` → Render planscape-api service
-- **Web app**: `app.planscape.build` → Planscape React/Expo web build
+- **Web app**: `app.planscape.build` → `planscape-web` (Next.js) — see `render.yaml` + `docs/DEPLOY_RUNBOOK.md`
 - **Marketing**: `planscape.build` → `marketing-site/`
 - **Platform owner**: `davis@planscape.build`
 

--- a/marketing-site/BILLING_SETUP.md
+++ b/marketing-site/BILLING_SETUP.md
@@ -434,3 +434,68 @@ When 1–4 behave as annotated, **B3b is done**.
 | `_lib/billing/tax.ts` | Country tax table (inclusive VAT / reverse charge) |
 | `_lib/billing/discounts.ts` | Validate / apply / record-redemption |
 | `marketing-site-cron/` | Standalone cron Worker (separate `wrangler.toml`, same D1) |
+
+---
+
+# The web funnel (Phase 1 + 2) — setup notes
+
+The pages that actually call all of the above. Until these landed, nothing on
+planscape.build touched the billing API: `/signup` posted to `/api/waitlist` and
+there was no login or account page.
+
+## Required environment variables — the gaps that bite
+
+Set per environment in **Pages → planscape-marketing → Settings → Environment
+variables**. Production and **Preview are separate** — a secret set only on
+Production leaves every preview deployment 500ing on any auth call, because
+`JWT_SECRET` is undefined and token minting throws. Preview's `JWT_SECRET` does
+**not** need to match production's: refresh tokens are opaque D1 rows, only the
+short-lived access token is a JWT.
+
+| Variable | Without it |
+|---|---|
+| `JWT_SECRET` | Signup/login 500 — no token can be minted |
+| `RESEND_API_KEY` | **Verification + reset email is silently skipped** (`email.ts` logs and returns). Users sign up and never receive the link |
+| `STRIPE_SECRET_KEY` | USD/EUR/GBP checkout returns `500 "Billing is not configured."` — only the Pesapal rail can take money |
+| `PESAPAL_CONSUMER_KEY` / `PESAPAL_IPN_ID` | UGX/KES/TZS/RWF checkout returns `500 "Mobile-money billing is not configured."` |
+
+## One-time data migration — tenant currency backfill
+
+`createTenant()` used to hardcode `currency = "USD"`, ignoring the country it
+already stored, so **no tenant could ever route to Pesapal**. It now derives the
+currency via `currencyForCountry()`. That fix only applies to *new* tenants —
+rows created earlier keep the wrong currency and must be backfilled **once**:
+
+```bash
+wrangler d1 execute planscape-waitlist --remote --command="
+UPDATE tenants
+   SET currency = CASE country WHEN 'UG' THEN 'UGX' WHEN 'KE' THEN 'KES'
+                               WHEN 'TZ' THEN 'TZS' WHEN 'RW' THEN 'RWF' END,
+       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+ WHERE country IN ('UG','KE','TZ','RW')
+   AND currency <> CASE country WHEN 'UG' THEN 'UGX' WHEN 'KE' THEN 'KES'
+                                WHEN 'TZ' THEN 'TZS' WHEN 'RW' THEN 'RWF' END
+   AND id NOT IN (SELECT tenant_id FROM subscriptions WHERE status <> 'cancelled');"
+```
+
+Idempotent (re-running changes 0 rows) and guarded: it never touches a tenant
+with a live subscription, since changing the currency under an open Stripe or
+Pesapal subscription would desync it from the provider. Applied to production on
+2026-07-17 — 11 rows.
+
+## Local development gotcha
+
+`wrangler pages dev` and `wrangler d1 execute --local` key their local SQLite
+files differently (two files under
+`.wrangler/state/v3/d1/miniflare-D1DatabaseObject/`), so a schema applied with
+`--local` is **invisible** to `pages dev` — signup fails with `no such table:
+users`. Workaround: copy the seeded `.sqlite` over the empty one, or seed
+through the dev server. Also put `JWT_SECRET` in `.dev.vars` (gitignored).
+
+## Why curl is not enough
+
+`isAllowedOrigin()` rejects any browser origin not in `ALLOWED_ORIGINS`, but
+**curl sends no `Origin` header and is always allowed**. Four phases of
+curl-verified backend therefore never revealed that the Functions rejected their
+own pages on every host except the two hardcoded production hostnames. Test the
+funnel in a real browser, on a preview URL, before trusting it.

--- a/marketing-site/_redirects
+++ b/marketing-site/_redirects
@@ -10,12 +10,9 @@
 # Never add /signup → /signup.html or /pricing → /pricing.html — they create a redirect loop.
 # Cloudflare automatically serves /signup.html when someone requests /signup.
 
-# Pre-launch: /login and /app/* land on the waitlist page (/signup).
-# Don't write /signup.html as the target — write the canonical /signup so CF doesn't loop.
-# When the real API is live, change these to point at api.planscape.build/auth/*.
-/login          /signup                          302
-/app            /signup                          302
-/app/*          /signup                          302
+# Note: /login and /account are real pages now (login.html / account.html).
+# Cloudflare auto-canonicalises .html → clean URL, so they need no rule here —
+# adding one for /login or /account would create a redirect loop (see d75f094a0).
 
 # Old WordPress-style paths (just in case)
 /?p=*           /blog/                          301

--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Your account — Planscape</title>
+<meta name="theme-color" content="#E8912D">
+<meta name="robots" content="noindex,nofollow">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/account">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.acct-wrap { max-width: 640px; margin: 40px auto; padding: 0 16px; }
+.acct-card { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 32px; }
+.acct-card h1 { margin: 0 0 4px; font-size: 26px; }
+.acct-card .sub { color: var(--muted); margin: 0 0 24px; }
+.state { display: none; }
+.state.shown { display: block; }
+.spinner { font-size: 28px; text-align: center; }
+.dl { display: grid; grid-template-columns: 180px 1fr; gap: 0; border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+.dl > div { padding: 14px 16px; border-bottom: 1px solid var(--line); }
+.dl > div:nth-last-child(-n+2) { border-bottom: 0; }
+.dl dt { font-weight: 600; color: var(--muted); font-size: 14px; background: #faf8f5; margin: 0; }
+.dl dd { margin: 0; font-size: 15px; }
+@media (max-width: 480px) { .dl { grid-template-columns: 1fr; } .dl dt { border-bottom: 0; } }
+.pill { display: inline-block; padding: 3px 12px; border-radius: 999px; font-size: 13px; font-weight: 600; }
+.pill.trial { background: rgba(232,145,45,.14); color: #b5670f; }
+.pill.active { background: rgba(40,167,69,.12); color: #1e7e34; }
+.pill.read_only, .pill.past_due, .pill.cancelled { background: rgba(204,51,34,.12); color: #8b2018; }
+.acct-actions { margin-top: 24px; display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+.btn-primary { display: inline-block; background: var(--accent); color: #fff; border: 0; padding: 11px 20px; font-size: 15px; font-weight: 600; border-radius: 8px; cursor: pointer; text-decoration: none; }
+.btn-primary:hover { background: #d57f1f; }
+.link-btn { background: none; border: 0; color: var(--accent); font-weight: 600; font-size: 14px; cursor: pointer; }
+.phase2-note { margin-top: 24px; font-size: 13px; color: var(--muted); padding: 12px 14px; background: #faf8f5; border: 1px solid var(--line); border-radius: 8px; }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <div class="links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+</nav>
+
+<div class="acct-wrap">
+  <div class="acct-card">
+    <div class="state shown" id="loading">
+      <div class="spinner">⏳</div>
+      <p class="sub" style="text-align:center;margin-top:12px">Loading your account…</p>
+    </div>
+
+    <div class="state" id="ready">
+      <h1 id="greeting">Your account</h1>
+      <p class="sub" id="firm-line"></p>
+
+      <dl class="dl">
+        <div><dt>Firm</dt></div>
+        <div><dd id="v-firm">—</dd></div>
+        <div><dt>Subscription</dt></div>
+        <div><dd><span class="pill" id="v-status">—</span></dd></div>
+        <div><dt>Trial</dt></div>
+        <div><dd id="v-trial">—</dd></div>
+        <div><dt>Plan</dt></div>
+        <div><dd id="v-plan">—</dd></div>
+        <div><dt>Seats</dt></div>
+        <div><dd id="v-seats">—</dd></div>
+        <div><dt>Billing currency</dt></div>
+        <div><dd id="v-currency">—</dd></div>
+      </dl>
+
+      <div class="acct-actions">
+        <a class="btn-primary" href="/pricing.html">View plans</a>
+        <button type="button" class="link-btn" id="logout-btn">Log out</button>
+      </div>
+
+      <p class="phase2-note">Billing controls — choosing a plan and paying — are coming here soon. For now, browse the <a href="/pricing.html">plans</a>; your trial gives you full access in the meantime.</p>
+    </div>
+  </div>
+</div>
+
+<footer class="site">
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+<script>
+(function(){
+  var loading = document.getElementById('loading');
+  var ready = document.getElementById('ready');
+
+  function toLogin() { window.location.href = '/login'; }
+
+  function titleCase(s) {
+    return String(s || '').replace(/[-_]+/g, ' ').replace(/\b\w/g, function(c){ return c.toUpperCase(); });
+  }
+
+  function trialDaysLeft(iso) {
+    if (!iso) return null;
+    var end = new Date(iso).getTime();
+    if (isNaN(end)) return null;
+    return Math.max(0, Math.ceil((end - Date.now()) / 86400000));
+  }
+
+  function render(data) {
+    var t = data.tenant || {};
+    document.getElementById('v-firm').textContent = t.name || '—';
+
+    var status = t.subscriptionStatus || 'unknown';
+    var statusEl = document.getElementById('v-status');
+    statusEl.textContent = titleCase(status);
+    statusEl.className = 'pill ' + status;
+
+    // Trial days remaining (only meaningful while on trial).
+    var days = trialDaysLeft(t.trialEndsAt);
+    if (status === 'trial' && days !== null) {
+      document.getElementById('v-trial').textContent =
+        days === 0 ? 'Ends today' : (days + ' day' + (days === 1 ? '' : 's') + ' remaining');
+    } else if (days !== null) {
+      document.getElementById('v-trial').textContent = 'Trial ended';
+    } else {
+      document.getElementById('v-trial').textContent = '—';
+    }
+
+    // Plan: null tier means the trial hasn't converted to a paid plan yet.
+    if (t.planTier) {
+      var prod = t.planProduct ? titleCase(t.planProduct) + ' · ' : '';
+      document.getElementById('v-plan').textContent = prod + titleCase(t.planTier);
+    } else {
+      document.getElementById('v-plan').textContent = 'Trial — no plan yet';
+    }
+
+    // Seats: seatsUsed / cap (cap null = unlimited).
+    var used = (data.seatsUsed != null) ? data.seatsUsed : data.memberCount;
+    if (used != null) {
+      document.getElementById('v-seats').textContent =
+        used + (data.cap != null ? ' of ' + data.cap : ' (unlimited)');
+    }
+
+    document.getElementById('v-currency').textContent = t.currency || 'USD';
+
+    document.getElementById('firm-line').textContent =
+      t.name ? ('Signed in — ' + t.name) : '';
+
+    loading.classList.remove('shown');
+    ready.classList.add('shown');
+  }
+
+  // Session convention (see billing-success.html): mint an access token from the
+  // HttpOnly ps_refresh cookie, hold it in memory only, use it as a Bearer token.
+  // NEVER persist tokens to localStorage/sessionStorage.
+  var accessToken = null;
+
+  document.getElementById('logout-btn').addEventListener('click', function(){
+    fetch('/api/auth/logout', { method: 'POST', credentials: 'include',
+      headers: { 'Content-Type': 'application/json' }, body: '{}' })
+      .then(toLogin, toLogin);
+  });
+
+  fetch('/api/auth/refresh', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}'
+  }).then(function(res){
+    if (!res.ok) throw new Error('refresh');
+    return res.json();
+  }).then(function(j){
+    accessToken = j && j.token;
+    if (!accessToken) throw new Error('no token');
+    // /api/tenants/me carries the tenant (with currency + plan) plus live seat usage.
+    return fetch('/api/tenants/me', { headers: { 'Authorization': 'Bearer ' + accessToken } });
+  }).then(function(res){
+    if (!res.ok) throw new Error('me');
+    return res.json();
+  }).then(function(j){
+    render(j);
+  }).catch(function(){
+    // No valid session → send them to log in.
+    toLogin();
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -10,9 +10,10 @@
 <link rel="canonical" href="https://planscape.build/account">
 <link rel="stylesheet" href="/assets/site.css">
 <style>
-.acct-wrap { max-width: 640px; margin: 40px auto; padding: 0 16px; }
-.acct-card { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 32px; }
+.acct-wrap { max-width: 720px; margin: 40px auto; padding: 0 16px; }
+.acct-card { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 32px; margin-bottom: 20px; }
 .acct-card h1 { margin: 0 0 4px; font-size: 26px; }
+.acct-card h2 { margin: 0 0 4px; font-size: 19px; }
 .acct-card .sub { color: var(--muted); margin: 0 0 24px; }
 .state { display: none; }
 .state.shown { display: block; }
@@ -30,8 +31,35 @@
 .acct-actions { margin-top: 24px; display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
 .btn-primary { display: inline-block; background: var(--accent); color: #fff; border: 0; padding: 11px 20px; font-size: 15px; font-weight: 600; border-radius: 8px; cursor: pointer; text-decoration: none; }
 .btn-primary:hover { background: #d57f1f; }
+.btn-primary:disabled { opacity: .55; cursor: default; }
+.btn-secondary { display: inline-block; background: none; color: var(--ink); border: 1px solid var(--line); padding: 10px 18px; font-size: 14px; font-weight: 600; border-radius: 8px; cursor: pointer; text-decoration: none; }
+.btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
 .link-btn { background: none; border: 0; color: var(--accent); font-weight: 600; font-size: 14px; cursor: pointer; }
-.phase2-note { margin-top: 24px; font-size: 13px; color: var(--muted); padding: 12px 14px; background: #faf8f5; border: 1px solid var(--line); border-radius: 8px; }
+.note { margin-top: 20px; font-size: 13px; color: var(--muted); padding: 12px 14px; background: #faf8f5; border: 1px solid var(--line); border-radius: 8px; }
+.note.warn { background: rgba(204,51,34,.06); border-color: rgba(204,51,34,.25); color: #8b2018; }
+.err { display: none; margin-top: 16px; padding: 11px 14px; border-radius: 8px; background: rgba(204,51,34,.08); border: 1px solid rgba(204,51,34,.3); color: #8b2018; font-size: 14px; }
+.err.shown { display: block; }
+.field { margin-bottom: 16px; }
+.field label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 6px; }
+.field select, .field input { width: 100%; padding: 10px 12px; border: 1px solid var(--line); border-radius: 8px; font-size: 15px; font-family: inherit; background: #fff; }
+.field select:focus, .field input:focus { outline: 0; border-color: var(--accent); }
+.radio-row { display: flex; gap: 10px; flex-wrap: wrap; }
+.radio-row label { flex: 1; min-width: 130px; display: flex; align-items: center; gap: 8px; padding: 11px 14px; border: 1px solid var(--line); border-radius: 8px; cursor: pointer; font-size: 14px; font-weight: 500; background: #fff; }
+.radio-row label:has(input:checked) { border-color: var(--accent); background: rgba(232,145,45,.06); }
+.radio-row input { margin: 0; }
+.price-box { margin: 20px 0 4px; padding: 16px; border: 1px solid var(--line); border-radius: 10px; background: #faf8f5; }
+.price-box .amount { font-size: 26px; font-weight: 700; }
+.price-box .per { color: var(--muted); font-size: 14px; }
+.price-box .meta { color: var(--muted); font-size: 13px; margin-top: 4px; }
+table.inv { width: 100%; border-collapse: collapse; font-size: 14px; }
+table.inv th { text-align: left; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); padding: 8px 10px; border-bottom: 1px solid var(--line); }
+table.inv td { padding: 10px; border-bottom: 1px solid var(--line); }
+table.inv tr:last-child td { border-bottom: 0; }
+.inv-wrap { overflow-x: auto; }
+.tag { font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 999px; }
+.tag.paid { background: rgba(40,167,69,.12); color: #1e7e34; }
+.tag.open, .tag.pending { background: rgba(232,145,45,.14); color: #b5670f; }
+.tag.void, .tag.failed { background: rgba(204,51,34,.12); color: #8b2018; }
 </style>
 </head>
 <body>
@@ -46,6 +74,7 @@
 </nav>
 
 <div class="acct-wrap">
+
   <div class="acct-card">
     <div class="state shown" id="loading">
       <div class="spinner">⏳</div>
@@ -72,13 +101,71 @@
       </dl>
 
       <div class="acct-actions">
-        <a class="btn-primary" href="/pricing.html">View plans</a>
         <button type="button" class="link-btn" id="logout-btn">Log out</button>
       </div>
-
-      <p class="phase2-note">Billing controls — choosing a plan and paying — are coming here soon. For now, browse the <a href="/pricing.html">plans</a>; your trial gives you full access in the meantime.</p>
     </div>
   </div>
+
+  <!-- Current subscription — only once one exists. -->
+  <div class="acct-card state" id="sub-card">
+    <h2>Your subscription</h2>
+    <p class="sub" id="sub-line">—</p>
+    <div class="acct-actions" id="sub-actions"></div>
+    <div class="err" id="sub-err"></div>
+    <p class="note" id="sub-note" style="display:none"></p>
+  </div>
+
+  <!-- Plan picker — owner only, when there's no paid plan yet. -->
+  <div class="acct-card state" id="plan-card">
+    <h2 id="plan-heading">Choose a plan</h2>
+    <p class="sub" id="plan-sub">Your trial gives you full access. Pick a plan to keep it after the trial ends.</p>
+
+    <div class="field">
+      <label>Product</label>
+      <div class="radio-row" id="product-row"></div>
+    </div>
+
+    <div class="field">
+      <label for="tier-select">Plan</label>
+      <select id="tier-select"></select>
+    </div>
+
+    <div class="field">
+      <label>Billing cycle</label>
+      <div class="radio-row">
+        <label><input type="radio" name="cycle" value="monthly" checked> Monthly</label>
+        <label><input type="radio" name="cycle" value="annual"> Annual <span class="per" id="annual-off"></span></label>
+      </div>
+    </div>
+
+    <div class="field">
+      <label for="discount">Discount code <span class="per">(optional)</span></label>
+      <input type="text" id="discount" autocomplete="off" placeholder="e.g. LAUNCH20">
+    </div>
+
+    <div class="price-box">
+      <div><span class="amount" id="price-amount">—</span> <span class="per" id="price-per"></span></div>
+      <div class="meta" id="price-meta"></div>
+    </div>
+
+    <div class="acct-actions">
+      <button type="button" class="btn-primary" id="subscribe-btn">Continue to payment</button>
+    </div>
+    <div class="err" id="plan-err"></div>
+    <p class="note" id="pay-route"></p>
+  </div>
+
+  <!-- Invoices — admin+ only. -->
+  <div class="acct-card state" id="inv-card">
+    <h2>Invoices</h2>
+    <p class="sub">Your most recent invoices.</p>
+    <div class="inv-wrap"><table class="inv" id="inv-table">
+      <thead><tr><th>Number</th><th>Date</th><th>Amount</th><th>Status</th><th></th></tr></thead>
+      <tbody id="inv-body"></tbody>
+    </table></div>
+    <p class="note" id="inv-empty" style="display:none">No invoices yet — they appear here after your first payment.</p>
+  </div>
+
 </div>
 
 <footer class="site">
@@ -91,9 +178,35 @@
   var ready = document.getElementById('ready');
 
   function toLogin() { window.location.href = '/login'; }
+  function $(id) { return document.getElementById(id); }
+  function show(el) { el.classList.add('shown'); }
 
   function titleCase(s) {
     return String(s || '').replace(/[-_]+/g, ' ').replace(/\b\w/g, function(c){ return c.toUpperCase(); });
+  }
+
+  // Mirrors CURRENCY_MINOR_EXP in functions/api/_lib/billing/catalog.ts. Display
+  // only — the server is the source of truth for what's actually charged.
+  function minorExp(cur) { return (cur === 'UGX' || cur === 'RWF') ? 0 : 2; }
+
+  function fmtMoney(minor, cur) {
+    if (minor == null || isNaN(minor)) return '—';
+    var v = minor / Math.pow(10, minorExp(cur));
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency', currency: cur,
+        minimumFractionDigits: minorExp(cur), maximumFractionDigits: minorExp(cur)
+      }).format(v);
+    } catch (e) {
+      return cur + ' ' + v.toLocaleString();
+    }
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return '—';
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
   }
 
   function trialDaysLeft(iso) {
@@ -103,56 +216,335 @@
     return Math.max(0, Math.ceil((end - Date.now()) / 86400000));
   }
 
-  function render(data) {
-    var t = data.tenant || {};
-    document.getElementById('v-firm').textContent = t.name || '—';
-
-    var status = t.subscriptionStatus || 'unknown';
-    var statusEl = document.getElementById('v-status');
-    statusEl.textContent = titleCase(status);
-    statusEl.className = 'pill ' + status;
-
-    // Trial days remaining (only meaningful while on trial).
-    var days = trialDaysLeft(t.trialEndsAt);
-    if (status === 'trial' && days !== null) {
-      document.getElementById('v-trial').textContent =
-        days === 0 ? 'Ends today' : (days + ' day' + (days === 1 ? '' : 's') + ' remaining');
-    } else if (days !== null) {
-      document.getElementById('v-trial').textContent = 'Trial ended';
-    } else {
-      document.getElementById('v-trial').textContent = '—';
-    }
-
-    // Plan: null tier means the trial hasn't converted to a paid plan yet.
-    if (t.planTier) {
-      var prod = t.planProduct ? titleCase(t.planProduct) + ' · ' : '';
-      document.getElementById('v-plan').textContent = prod + titleCase(t.planTier);
-    } else {
-      document.getElementById('v-plan').textContent = 'Trial — no plan yet';
-    }
-
-    // Seats: seatsUsed / cap (cap null = unlimited).
-    var used = (data.seatsUsed != null) ? data.seatsUsed : data.memberCount;
-    if (used != null) {
-      document.getElementById('v-seats').textContent =
-        used + (data.cap != null ? ' of ' + data.cap : ' (unlimited)');
-    }
-
-    document.getElementById('v-currency').textContent = t.currency || 'USD';
-
-    document.getElementById('firm-line').textContent =
-      t.name ? ('Signed in — ' + t.name) : '';
-
-    loading.classList.remove('shown');
-    ready.classList.add('shown');
-  }
+  function showErr(el, msg) { el.textContent = msg; el.classList.add('shown'); }
+  function clearErr(el) { el.textContent = ''; el.classList.remove('shown'); }
 
   // Session convention (see billing-success.html): mint an access token from the
   // HttpOnly ps_refresh cookie, hold it in memory only, use it as a Bearer token.
   // NEVER persist tokens to localStorage/sessionStorage.
   var accessToken = null;
+  var state = { user: null, tenant: null, sub: null, plans: null, currency: 'USD', role: 'member' };
 
-  document.getElementById('logout-btn').addEventListener('click', function(){
+  // One nonce per page load. The checkout Idempotency-Key is derived from it plus
+  // the chosen plan, so a double-click on the same selection replays the same
+  // Checkout Session instead of opening a second one, while changing the
+  // selection legitimately starts a new one.
+  var pageNonce = (window.crypto && crypto.randomUUID) ? crypto.randomUUID()
+                  : String(Date.now()) + Math.random().toString(16).slice(2);
+
+  function api(path, opts) {
+    opts = opts || {};
+    opts.headers = opts.headers || {};
+    opts.headers['Authorization'] = 'Bearer ' + accessToken;
+    return fetch(path, opts).then(function(res){
+      return res.json().catch(function(){ return {}; }).then(function(body){
+        if (!res.ok) throw new Error((body && body.error) || ('Request failed (' + res.status + ')'));
+        return body;
+      });
+    });
+  }
+
+  function isAtLeast(role, min) {
+    var order = { member: 0, admin: 1, owner: 2 };
+    return (order[role] != null ? order[role] : 0) >= order[min];
+  }
+
+  // ---- render: account details ---------------------------------------------
+
+  function renderAccount(data) {
+    var t = data.tenant || {};
+    $('v-firm').textContent = t.name || '—';
+
+    var status = t.subscriptionStatus || 'unknown';
+    var statusEl = $('v-status');
+    statusEl.textContent = titleCase(status);
+    statusEl.className = 'pill ' + status;
+
+    var days = trialDaysLeft(t.trialEndsAt);
+    if (status === 'trial' && days !== null) {
+      $('v-trial').textContent = days === 0 ? 'Ends today' : (days + ' day' + (days === 1 ? '' : 's') + ' remaining');
+    } else if (days !== null) {
+      $('v-trial').textContent = 'Trial ended';
+    } else {
+      $('v-trial').textContent = '—';
+    }
+
+    if (t.planTier) {
+      var prod = t.planProduct ? titleCase(t.planProduct) + ' · ' : '';
+      $('v-plan').textContent = prod + titleCase(t.planTier);
+    } else {
+      $('v-plan').textContent = 'Trial — no plan yet';
+    }
+
+    var used = (data.seatsUsed != null) ? data.seatsUsed : data.memberCount;
+    if (used != null) {
+      $('v-seats').textContent = used + (data.cap != null ? ' of ' + data.cap : ' (unlimited)');
+    }
+
+    $('v-currency').textContent = t.currency || 'USD';
+    $('firm-line').textContent = t.name ? ('Signed in — ' + t.name) : '';
+
+    loading.classList.remove('shown');
+    show(ready);
+  }
+
+  // ---- render: current subscription ----------------------------------------
+
+  function renderSubscription() {
+    var s = state.sub;
+    if (!s) return;
+    show($('sub-card'));
+
+    $('sub-line').textContent =
+      titleCase(s.product) + ' · ' + titleCase(s.tier) + ' — ' +
+      fmtMoney(s.amountCents, s.currency) + ' / ' + (s.billingCycle === 'annual' ? 'year' : 'month');
+
+    var actions = $('sub-actions');
+    actions.innerHTML = '';
+
+    // Self-serve cancel / resume / portal drive the Stripe API, so they only
+    // exist for Stripe subscriptions (see getActiveSubscription in state.ts,
+    // which is deliberately Stripe-only).
+    if (s.provider !== 'stripe') {
+      $('sub-note').style.display = 'block';
+      $('sub-note').textContent =
+        'This subscription is billed by mobile money (Pesapal), which charges one period at a time — ' +
+        'it does not auto-renew, so there is nothing to cancel. To change or stop it, contact us and ' +
+        'we will sort it out.';
+      return;
+    }
+
+    if (s.cancelAtPeriodEnd) {
+      $('sub-note').style.display = 'block';
+      $('sub-note').className = 'note warn';
+      $('sub-note').textContent = 'Cancellation scheduled — you keep access until ' + fmtDate(s.currentPeriodEnd) + '.';
+      if (isAtLeast(state.role, 'owner')) actions.appendChild(mkBtn('Resume subscription', 'btn-primary', doResume));
+    } else {
+      $('sub-note').style.display = 'block';
+      $('sub-note').className = 'note';
+      $('sub-note').textContent = 'Renews on ' + fmtDate(s.currentPeriodEnd) + '.';
+      if (isAtLeast(state.role, 'owner')) actions.appendChild(mkBtn('Cancel subscription', 'btn-secondary', doCancel));
+    }
+
+    if (isAtLeast(state.role, 'owner')) {
+      actions.appendChild(mkBtn('Manage payment method', 'btn-secondary', doPortal));
+    }
+  }
+
+  function mkBtn(label, cls, fn) {
+    var b = document.createElement('button');
+    b.type = 'button'; b.className = cls; b.textContent = label;
+    b.addEventListener('click', function(){ fn(b); });
+    return b;
+  }
+
+  // ---- billing actions ------------------------------------------------------
+
+  function doCancel(btn) {
+    if (!window.confirm('Cancel your subscription? You keep access until the end of the current period.')) return;
+    clearErr($('sub-err')); btn.disabled = true;
+    api('/api/billing/subscription/cancel', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+      .then(function(){ window.location.reload(); })
+      .catch(function(e){ btn.disabled = false; showErr($('sub-err'), e.message); });
+  }
+
+  function doResume(btn) {
+    clearErr($('sub-err')); btn.disabled = true;
+    api('/api/billing/subscription/resume', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+      .then(function(){ window.location.reload(); })
+      .catch(function(e){ btn.disabled = false; showErr($('sub-err'), e.message); });
+  }
+
+  function doPortal(btn) {
+    clearErr($('sub-err')); btn.disabled = true;
+    api('/api/billing/portal', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+      .then(function(j){
+        if (j && j.portalUrl) { window.location.href = j.portalUrl; return; }
+        throw new Error('Could not open the billing portal.');
+      })
+      .catch(function(e){ btn.disabled = false; showErr($('sub-err'), e.message); });
+  }
+
+  // ---- plan picker ----------------------------------------------------------
+
+  function productsFromPlans() { return (state.plans && state.plans.products) || []; }
+
+  function selectedProduct() {
+    var el = document.querySelector('input[name=product]:checked');
+    return el ? el.value : null;
+  }
+  function selectedCycle() {
+    var el = document.querySelector('input[name=cycle]:checked');
+    return el ? el.value : 'monthly';
+  }
+
+  function buildProductRow() {
+    var row = $('product-row');
+    row.innerHTML = '';
+    productsFromPlans().forEach(function(p, i){
+      var id = 'prod-' + p.product;
+      var label = document.createElement('label');
+      label.innerHTML = '<input type="radio" name="product" value="' + p.product + '" id="' + id + '"' +
+        (i === 0 ? ' checked' : '') + '> ' + titleCase(p.product);
+      row.appendChild(label);
+    });
+    row.addEventListener('change', function(){ buildTierSelect(); renderPrice(); });
+  }
+
+  function buildTierSelect() {
+    var sel = $('tier-select');
+    sel.innerHTML = '';
+    var prod = productsFromPlans().filter(function(p){ return p.product === selectedProduct(); })[0];
+    if (!prod) return;
+    prod.tiers.forEach(function(t){
+      var o = document.createElement('option');
+      o.value = t.tier;
+      var price = t.prices && t.prices[state.currency];
+      o.textContent = titleCase(t.tier) +
+        (t.contactSales ? ' — contact sales'
+                        : (price ? ' — ' + fmtMoney(price.monthly, state.currency) + '/mo' : '')) +
+        (t.cap != null ? ' · up to ' + t.cap + ' seat' + (t.cap === 1 ? '' : 's') : '');
+      sel.appendChild(o);
+    });
+    sel.addEventListener('change', renderPrice);
+  }
+
+  function currentTier() {
+    var prod = productsFromPlans().filter(function(p){ return p.product === selectedProduct(); })[0];
+    if (!prod) return null;
+    var tier = $('tier-select').value;
+    return prod.tiers.filter(function(t){ return t.tier === tier; })[0] || null;
+  }
+
+  function renderPrice() {
+    var t = currentTier();
+    var btn = $('subscribe-btn');
+    if (!t) return;
+
+    if (t.contactSales) {
+      $('price-amount').textContent = 'Contact sales';
+      $('price-per').textContent = '';
+      $('price-meta').textContent = 'Enterprise plans are quoted individually.';
+      btn.disabled = true;
+      btn.textContent = 'Contact sales';
+      return;
+    }
+
+    var cycle = selectedCycle();
+    var price = t.prices && t.prices[state.currency];
+    if (!price) {
+      $('price-amount').textContent = '—';
+      $('price-meta').textContent = 'Pricing unavailable for ' + state.currency + '.';
+      btn.disabled = true;
+      return;
+    }
+
+    var minor = cycle === 'annual' ? price.annual : price.monthly;
+    $('price-amount').textContent = fmtMoney(minor, state.currency);
+    $('price-per').textContent = cycle === 'annual' ? '/ year' : '/ month';
+    $('price-meta').textContent = cycle === 'annual'
+      ? 'Billed yearly · equivalent to ' + fmtMoney(Math.round(minor / 12), state.currency) + '/month'
+      : 'Billed monthly';
+    btn.disabled = false;
+    btn.textContent = 'Continue to payment';
+  }
+
+  function doSubscribe() {
+    var btn = $('subscribe-btn');
+    var t = currentTier();
+    if (!t || t.contactSales) { window.location.href = '/contact.html#enterprise'; return; }
+
+    clearErr($('plan-err'));
+    btn.disabled = true;
+    btn.textContent = 'Starting checkout…';
+
+    var product = selectedProduct();
+    var cycle = selectedCycle();
+    var body = { product: product, tier: t.tier, cycle: cycle, currency: state.currency };
+    var code = $('discount').value.trim();
+    if (code) body.discount = code;
+
+    api('/api/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // Stable per (selection, page load) — see pageNonce above.
+        'Idempotency-Key': 'co-' + product + '-' + t.tier + '-' + cycle + '-' + pageNonce
+      },
+      body: JSON.stringify(body)
+    }).then(function(j){
+      // Both rails return { provider, checkoutUrl } — Stripe Checkout or the
+      // Pesapal mobile-money redirect. Same handling either way.
+      if (j && j.checkoutUrl) { window.location.href = j.checkoutUrl; return; }
+      throw new Error('Checkout did not return a payment link.');
+    }).catch(function(e){
+      btn.disabled = false;
+      btn.textContent = 'Continue to payment';
+      showErr($('plan-err'), e.message);
+    });
+  }
+
+  function renderPlanPicker() {
+    var t = state.tenant || {};
+    // Owner-only: /api/billing/checkout requires the owner role.
+    if (!isAtLeast(state.role, 'owner')) return;
+    // Already on a live paid plan that isn't ending — nothing to choose.
+    if (state.sub && state.sub.status === 'active' && !state.sub.cancelAtPeriodEnd) return;
+
+    if (t.subscriptionStatus === 'read_only' || t.subscriptionStatus === 'cancelled') {
+      $('plan-heading').textContent = 'Reactivate your account';
+      $('plan-sub').textContent = 'Your access is paused. Choose a plan to switch it back on.';
+    } else if (t.subscriptionStatus === 'past_due') {
+      $('plan-heading').textContent = 'Payment needed';
+      $('plan-sub').textContent = 'Your last payment did not go through. Choose a plan or update your card to continue.';
+    }
+
+    var provider = (state.plans && state.plans.providers && state.plans.providers[state.currency]) || null;
+    $('pay-route').textContent = provider === 'pesapal'
+      ? 'You will pay in ' + state.currency + ' by mobile money or card via Pesapal. Your currency is set from your firm\'s country.'
+      : 'You will pay in ' + state.currency + ' by card via Stripe. Your currency is set from your firm\'s country.';
+
+    var off = state.plans && state.plans.annualDiscount;
+    if (off) $('annual-off').textContent = '(save ' + Math.round(off * 100) + '%)';
+
+    buildProductRow();
+    buildTierSelect();
+    renderPrice();
+    $('subscribe-btn').addEventListener('click', doSubscribe);
+    document.querySelectorAll('input[name=cycle]').forEach(function(el){
+      el.addEventListener('change', renderPrice);
+    });
+    show($('plan-card'));
+  }
+
+  // ---- invoices -------------------------------------------------------------
+
+  function renderInvoices(list) {
+    if (!isAtLeast(state.role, 'admin')) return;
+    show($('inv-card'));
+    var body = $('inv-body');
+    if (!list || !list.length) {
+      $('inv-table').style.display = 'none';
+      $('inv-empty').style.display = 'block';
+      return;
+    }
+    list.forEach(function(inv){
+      var tr = document.createElement('tr');
+      var link = inv.hostedUrl || inv.pdfUrl;
+      tr.innerHTML =
+        '<td>' + (inv.number || inv.id.slice(0, 8)) + '</td>' +
+        '<td>' + fmtDate(inv.paidAt || inv.createdAt) + '</td>' +
+        '<td>' + fmtMoney(inv.totalCents, inv.currency) +
+          (inv.taxLabel ? ' <span class="per">incl. ' + inv.taxLabel + '</span>' : '') + '</td>' +
+        '<td><span class="tag ' + (inv.status || '') + '">' + titleCase(inv.status) + '</span></td>' +
+        '<td>' + (link ? '<a href="' + link + '" target="_blank" rel="noopener">View</a>' : '') + '</td>';
+      body.appendChild(tr);
+    });
+  }
+
+  // ---- boot -----------------------------------------------------------------
+
+  $('logout-btn').addEventListener('click', function(){
     fetch('/api/auth/logout', { method: 'POST', credentials: 'include',
       headers: { 'Content-Type': 'application/json' }, body: '{}' })
       .then(toLogin, toLogin);
@@ -169,15 +561,40 @@
   }).then(function(j){
     accessToken = j && j.token;
     if (!accessToken) throw new Error('no token');
-    // /api/tenants/me carries the tenant (with currency + plan) plus live seat usage.
-    return fetch('/api/tenants/me', { headers: { 'Authorization': 'Bearer ' + accessToken } });
-  }).then(function(res){
-    if (!res.ok) throw new Error('me');
-    return res.json();
-  }).then(function(j){
-    render(j);
+    // /api/tenants/me carries the tenant + seat usage but NOT the caller's role,
+    // so /api/auth/me is needed too — billing controls are owner-only and
+    // invoices are admin+.
+    return Promise.all([
+      api('/api/auth/me'),
+      api('/api/tenants/me')
+    ]);
+  }).then(function(r){
+    state.user = r[0] && r[0].user;
+    state.role = (state.user && state.user.role) || 'member';
+    state.tenant = r[1] && r[1].tenant;
+    state.currency = (state.tenant && state.tenant.currency) || 'USD';
+    renderAccount(r[1]);
+
+    // Plans are public. Subscription + invoices are admin+, so skip them for
+    // plain members rather than firing calls that will 403.
+    var jobs = [
+      fetch('/api/billing/plans?currency=' + encodeURIComponent(state.currency))
+        .then(function(res){ return res.ok ? res.json() : null; })
+        .catch(function(){ return null; })
+    ];
+    if (isAtLeast(state.role, 'admin')) {
+      jobs.push(api('/api/billing/subscription').catch(function(){ return null; }));
+      jobs.push(api('/api/billing/invoices?limit=10').catch(function(){ return null; }));
+    }
+    return Promise.all(jobs);
+  }).then(function(r){
+    state.plans = r[0];
+    state.sub = (r[1] && r[1].subscription) || null;
+
+    if (state.sub) renderSubscription();
+    if (state.plans) renderPlanPicker();
+    if (r[2]) renderInvoices(r[2].invoices);
   }).catch(function(){
-    // No valid session → send them to log in.
     toLogin();
   });
 })();

--- a/marketing-site/billing-success.html
+++ b/marketing-site/billing-success.html
@@ -45,7 +45,7 @@
       <h1>Subscription active</h1>
       <span class="status-pill" id="status-pill" hidden></span>
       <p class="lead" id="ok-msg">Your subscription is active.</p>
-      <p><a class="btn-primary" href="/app/">Go to dashboard</a></p>
+      <p><a class="btn-primary" href="/account">Go to your account</a></p>
     </div>
   </div>
 </div>

--- a/marketing-site/functions/api/_lib/billing/catalog.ts
+++ b/marketing-site/functions/api/_lib/billing/catalog.ts
@@ -90,6 +90,39 @@ export function isBillingCycle(c: string): c is BillingCycle {
   return c === "monthly" || c === "annual";
 }
 
+// EU-27 member states (ISO 3166-1 alpha-2). Used only by currencyForCountry to
+// route eurozone + non-eurozone EU members to EUR billing on the Stripe rail.
+const EU_27 = new Set([
+  "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR",
+  "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK",
+  "SI", "ES", "SE",
+]);
+
+// Map an ISO 3166-1 alpha-2 country code to the billing currency a new tenant
+// from that country should transact in. This is the single source that turns a
+// signup's `country` into a payable currency, so its result MUST always route
+// to a provider (Stripe or Pesapal) — an unpayable currency would strand the
+// tenant. NG/ZA are intentionally billed in USD until NGN/ZAR are launched
+// (see the deferred note above); anything unknown falls back to USD.
+export function currencyForCountry(country: string | null | undefined): string {
+  const c = (country ?? "").toUpperCase();
+  let currency = "USD";
+  switch (c) {
+    case "UG": currency = "UGX"; break; // Pesapal
+    case "KE": currency = "KES"; break; // Pesapal
+    case "TZ": currency = "TZS"; break; // Pesapal
+    case "RW": currency = "RWF"; break; // Pesapal
+    case "GB": currency = "GBP"; break; // Stripe
+    default:
+      if (EU_27.has(c)) currency = "EUR"; // Stripe
+      // US / CA / AU / NG / ZA / unknown / null all fall through to USD.
+  }
+  // Invariant: never hand back a currency with no payment provider. If a future
+  // edit maps a country to an unsupported currency, degrade to USD rather than
+  // create a tenant that can never check out.
+  return providerForCurrency(currency) ? currency : "USD";
+}
+
 // Resolve a plan entry, or null if the product/tier pair is unknown.
 export function getPlan(product: string, tier: string): PlanEntry | null {
   if (!isProduct(product)) return null;

--- a/marketing-site/functions/api/_lib/billing/state.ts
+++ b/marketing-site/functions/api/_lib/billing/state.ts
@@ -229,6 +229,33 @@ export async function getActiveSubscription(
     .first<SubscriptionRow>();
 }
 
+// The tenant's current subscription on ANY provider (most recent non-cancelled,
+// else most recent). Unlike getActiveSubscription above — which is deliberately
+// Stripe-only because cancel/resume/change-plan drive the Stripe API — this is
+// read-only and provider-agnostic, so the account page can render a Pesapal
+// subscription too.
+export async function getCurrentSubscription(
+  db: D1Database,
+  tenantId: string
+): Promise<SubscriptionRow | null> {
+  const live = await db
+    .prepare(
+      `SELECT * FROM subscriptions
+         WHERE tenant_id = ? AND status != 'cancelled'
+       ORDER BY created_at DESC LIMIT 1`
+    )
+    .bind(tenantId)
+    .first<SubscriptionRow>();
+  if (live) return live;
+  return db
+    .prepare(
+      `SELECT * FROM subscriptions WHERE tenant_id = ?
+       ORDER BY created_at DESC LIMIT 1`
+    )
+    .bind(tenantId)
+    .first<SubscriptionRow>();
+}
+
 export async function setSubscriptionCancelAtPeriodEnd(
   db: D1Database,
   id: string,
@@ -473,6 +500,26 @@ export async function upsertInvoice(
     due_at: null,
     paid_at: input.paidAt,
     created_at: input.createdAt,
+  };
+}
+
+// cancelAtPeriodEnd + currentPeriodEnd are the two fields the account page can't
+// get from toPublicTenant — they decide whether it offers Cancel or Resume, and
+// what date it quotes. provider is exposed because self-serve cancel/resume are
+// Stripe-only (see getActiveSubscription).
+export function toPublicSubscription(s: SubscriptionRow) {
+  return {
+    id: s.id,
+    provider: s.provider,
+    product: s.product,
+    tier: s.tier,
+    billingCycle: s.billing_cycle,
+    currency: s.currency,
+    amountCents: s.amount_cents,
+    currentPeriodEnd: s.current_period_end,
+    cancelAtPeriodEnd: s.cancel_at_period_end === 1,
+    status: s.status,
+    createdAt: s.created_at,
   };
 }
 

--- a/marketing-site/functions/api/auth/_lib/cors.ts
+++ b/marketing-site/functions/api/auth/_lib/cors.ts
@@ -7,11 +7,26 @@ const ALLOWED_ORIGINS = new Set([
   "https://app.planscape.build",
 ]);
 
+// True when the caller is the very deployment serving this request — the page
+// and the Function share an origin. Covers local dev (http://localhost:8788) and
+// Cloudflare Pages preview URLs (https://<hash>.planscape-marketing.pages.dev)
+// without wildcarding *.pages.dev, which would let any Pages site call us.
+// Cross-origin callers still have to be in ALLOWED_ORIGINS above.
+function isSameOrigin(request: Request): boolean {
+  const origin = request.headers.get("Origin");
+  if (!origin) return false;
+  try {
+    return origin === new URL(request.url).origin;
+  } catch {
+    return false;
+  }
+}
+
 // Echo back the request origin only if it is allow-listed; otherwise fall back
 // to the canonical site so the browser blocks the disallowed origin.
 export function corsHeaders(request: Request): Record<string, string> {
   const origin = request.headers.get("Origin") || "";
-  const allowed = ALLOWED_ORIGINS.has(origin);
+  const allowed = ALLOWED_ORIGINS.has(origin) || isSameOrigin(request);
   return {
     "Access-Control-Allow-Origin": allowed ? origin : "https://planscape.build",
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
@@ -26,7 +41,7 @@ export function isAllowedOrigin(request: Request): boolean {
   const origin = request.headers.get("Origin");
   // Non-browser callers (curl, server-to-server) send no Origin — allow them.
   if (!origin) return true;
-  return ALLOWED_ORIGINS.has(origin);
+  return ALLOWED_ORIGINS.has(origin) || isSameOrigin(request);
 }
 
 // Shared preflight responder. Wire as `onRequestOptions` in each Function.

--- a/marketing-site/functions/api/auth/_lib/db.ts
+++ b/marketing-site/functions/api/auth/_lib/db.ts
@@ -10,6 +10,7 @@ import type {
   PublicUser,
   PublicTenant,
 } from "./types";
+import { currencyForCountry } from "../../_lib/billing/catalog";
 
 const TRIAL_DAYS = 14;
 const REFRESH_TTL_DAYS = 30;
@@ -34,6 +35,9 @@ export function toPublicTenant(t: TenantRow): PublicTenant {
     slug: t.slug,
     trialEndsAt: t.trial_ends_at,
     subscriptionStatus: t.subscription_status,
+    currency: t.currency,
+    planProduct: t.plan_product,
+    planTier: t.plan_tier,
   };
 }
 
@@ -65,7 +69,10 @@ export async function createTenant(
       input.name,
       input.slug,
       input.country,
-      "USD",
+      // Derive the billing currency from the tenant's country so UG/KE/TZ/RW
+      // tenants land on their local (Pesapal) currency instead of USD — the one
+      // line that makes the Pesapal rail reachable. Null country → USD fallback.
+      currencyForCountry(input.country),
       "trial",
       nowIso,
       trialEnds.toISOString(),

--- a/marketing-site/functions/api/auth/_lib/types.ts
+++ b/marketing-site/functions/api/auth/_lib/types.ts
@@ -121,4 +121,7 @@ export interface PublicTenant {
   slug: string;
   trialEndsAt: string;
   subscriptionStatus: string;
+  currency: string;
+  planProduct: string | null;
+  planTier: string | null;
 }

--- a/marketing-site/functions/api/billing/plans.ts
+++ b/marketing-site/functions/api/billing/plans.ts
@@ -1,6 +1,8 @@
 // GET /api/billing/plans — public-ish plan catalog with computed prices.
 // No auth: the pricing page and signup flow read this. Optional query
-// ?currency=USD|EUR|GBP narrows the price matrix to one currency (default: all).
+// ?currency=<one of the 7 supported> narrows the price matrix to one currency
+// (default: all). Every advertised currency routes to a provider (Stripe or
+// Pesapal); NGN/ZAR are deliberately NOT advertised (deferred).
 
 import { withHandler } from "../auth/_lib/handler";
 import { handlePreflight } from "../auth/_lib/cors";
@@ -8,12 +10,11 @@ import { bad } from "../auth/_lib/errors";
 import {
   PLAN_CATALOG,
   ANNUAL_DISCOUNT,
-  FX_FROM_USD,
-  isStripeCurrency,
+  FX_FROM_USD_ALL,
+  providerForCurrency,
   type PlanProduct,
-  type StripeCurrency,
 } from "../_lib/billing/catalog";
-import { unitAmountMinor } from "../_lib/billing/pricing";
+import { unitAmountMinorFor } from "../_lib/billing/pricing";
 
 export const onRequestOptions: PagesFunction = async ({ request }) =>
   handlePreflight(request);
@@ -21,13 +22,23 @@ export const onRequestOptions: PagesFunction = async ({ request }) =>
 export const onRequestGet = withHandler(async ({ request }) => {
   const url = new URL(request.url);
   const cur = url.searchParams.get("currency");
-  let currencies: StripeCurrency[];
+  let currencies: string[];
   if (cur) {
     const upper = cur.toUpperCase();
-    if (!isStripeCurrency(upper)) throw bad("Unsupported currency.");
+    // providerForCurrency covers exactly the 7 payable currencies; unsupported
+    // (incl. deferred NGN/ZAR) → 400.
+    if (!providerForCurrency(upper)) throw bad("Unsupported currency.");
     currencies = [upper];
   } else {
-    currencies = Object.keys(FX_FROM_USD) as StripeCurrency[];
+    currencies = Object.keys(FX_FROM_USD_ALL);
+  }
+
+  // Payment provider per advertised currency, so the front-end can branch on
+  // Stripe (redirect to Checkout) vs Pesapal (redirect to the mobile-money URL).
+  const providers: Record<string, string> = {};
+  for (const c of currencies) {
+    const p = providerForCurrency(c);
+    if (p) providers[c] = p;
   }
 
   const products = (Object.keys(PLAN_CATALOG) as PlanProduct[]).map((product) => {
@@ -46,8 +57,11 @@ export const onRequestGet = withHandler(async ({ request }) => {
             entry.usdMonthly === null
               ? null // enterprise — contact sales
               : {
-                  monthly: unitAmountMinor(entry.usdMonthly, c, "monthly"),
-                  annual: unitAmountMinor(entry.usdMonthly, c, "annual"),
+                  // unitAmountMinorFor honours zero-decimal currencies (UGX/RWF)
+                  // and every FX rate — unlike the Stripe-only pricing helper,
+                  // which returns NaN for Pesapal currencies.
+                  monthly: unitAmountMinorFor(entry.usdMonthly, c, "monthly"),
+                  annual: unitAmountMinorFor(entry.usdMonthly, c, "annual"),
                 };
         }
         return {
@@ -64,7 +78,8 @@ export const onRequestGet = withHandler(async ({ request }) => {
   return {
     products,
     currencies,
+    providers,
     annualDiscount: ANNUAL_DISCOUNT,
-    fxFromUsd: FX_FROM_USD,
+    fxFromUsd: FX_FROM_USD_ALL,
   };
 });

--- a/marketing-site/functions/api/billing/portal.ts
+++ b/marketing-site/functions/api/billing/portal.ts
@@ -36,7 +36,7 @@ export const onRequestPost = withHandler(async ({ request, env }) => {
       "/billing_portal/sessions",
       {
         customer: tenant.stripe_customer_id,
-        return_url: `${appOrigin(env)}/account/billing`,
+        return_url: `${appOrigin(env)}/account`,
       },
       { secretKey: env.STRIPE_SECRET_KEY }
     );

--- a/marketing-site/functions/api/billing/subscription/index.ts
+++ b/marketing-site/functions/api/billing/subscription/index.ts
@@ -1,0 +1,21 @@
+// GET /api/billing/subscription — admin+. The tenant's current subscription, or
+// null while they're still on trial. Read-only, provider-agnostic: the account
+// page needs cancelAtPeriodEnd + currentPeriodEnd to decide between Cancel and
+// Resume, and neither is exposed by toPublicTenant.
+
+import { withHandler } from "../../auth/_lib/handler";
+import { handlePreflight } from "../../auth/_lib/cors";
+import { requireRole } from "../../auth/_lib/auth";
+import {
+  getCurrentSubscription,
+  toPublicSubscription,
+} from "../../_lib/billing/state";
+
+export const onRequestOptions: PagesFunction = async ({ request }) =>
+  handlePreflight(request);
+
+export const onRequestGet = withHandler(async ({ request, env }) => {
+  const auth = await requireRole(request, env, "admin");
+  const sub = await getCurrentSubscription(env.WAITLIST_DB, auth.tenantId);
+  return { subscription: sub ? toPublicSubscription(sub) : null };
+});

--- a/marketing-site/login.html
+++ b/marketing-site/login.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Log in — Planscape</title>
+<meta name="description" content="Log in to your Planscape account.">
+<meta name="theme-color" content="#E8912D">
+<meta name="robots" content="noindex,nofollow">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/login">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.auth-wrap { max-width: 440px; margin: 48px auto; padding: 0 16px; }
+.auth-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 32px;
+}
+.auth-card h1 { margin: 0 0 8px; font-size: 26px; }
+.auth-card .sub { color: var(--muted); margin: 0 0 24px; }
+.field { margin-bottom: 16px; }
+.field label { display: block; font-weight: 600; font-size: 14px; margin-bottom: 6px; }
+.field input {
+  width: 100%;
+  padding: 11px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-size: 15px;
+  background: #fff;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+.field input:focus { outline: 0; border-color: var(--accent); box-shadow: 0 0 0 3px rgba(232, 145, 45, 0.15); }
+.pw-wrap { position: relative; }
+.pw-toggle {
+  position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+  background: none; border: 0; cursor: pointer; font-size: 12px;
+  color: var(--accent); font-weight: 600; padding: 4px;
+}
+.btn-primary {
+  width: 100%; background: var(--accent); color: #fff; border: 0;
+  padding: 14px; font-size: 16px; font-weight: 600; border-radius: 8px;
+  cursor: pointer; margin-top: 8px;
+}
+.btn-primary:hover { background: #d57f1f; }
+.btn-primary:disabled { background: var(--muted); cursor: not-allowed; }
+.error-state, .success-state {
+  border-radius: 10px; padding: 16px; margin-bottom: 16px; display: none; font-size: 14px;
+}
+.error-state { background: #fdebea; border: 1px solid #cc3322; color: #8b2018; }
+.success-state { background: #e8f7ed; border: 1px solid #2e9b59; color: #1e6b3c; }
+.error-state.shown, .success-state.shown { display: block; }
+.error-state a, .success-state a { color: inherit; font-weight: 600; }
+.row-between { display: flex; justify-content: space-between; align-items: baseline; }
+.link-btn { background: none; border: 0; padding: 0; color: var(--accent); font-weight: 600; font-size: 13px; cursor: pointer; }
+.alt-link { text-align: center; margin-top: 20px; font-size: 14px; color: var(--muted); }
+.alt-link a { color: var(--accent); font-weight: 600; }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+</nav>
+
+<div class="auth-wrap">
+  <!-- Login panel -->
+  <div class="auth-card" id="login-panel">
+    <div class="error-state" id="login-error"></div>
+    <h1>Log in</h1>
+    <p class="sub">Welcome back. Log in to reach your account.</p>
+
+    <form id="login-form" novalidate>
+      <div class="field">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required autocomplete="email" placeholder="you@firm.com">
+      </div>
+      <div class="field">
+        <div class="row-between">
+          <label for="password">Password</label>
+          <button type="button" class="link-btn" id="show-forgot">Forgot password?</button>
+        </div>
+        <div class="pw-wrap">
+          <input type="password" id="password" name="password" required autocomplete="current-password">
+          <button type="button" class="pw-toggle" id="pw-toggle" aria-label="Show password">Show</button>
+        </div>
+      </div>
+      <button type="submit" class="btn-primary" id="login-btn">Log in</button>
+    </form>
+
+    <p class="alt-link">No account yet? <a href="/signup">Create one</a></p>
+  </div>
+
+  <!-- Forgot-password panel (inline, revealed on demand or via #forgot) -->
+  <div class="auth-card" id="forgot-panel" style="display:none">
+    <div class="success-state" id="forgot-success"></div>
+    <div class="error-state" id="forgot-error"></div>
+    <h1>Reset your password</h1>
+    <p class="sub">Enter your email and we'll send a reset link if an account exists.</p>
+
+    <form id="forgot-form" novalidate>
+      <div class="field">
+        <label for="forgot-email">Email</label>
+        <input type="email" id="forgot-email" name="email" required autocomplete="email" placeholder="you@firm.com">
+      </div>
+      <button type="submit" class="btn-primary" id="forgot-btn">Send reset link</button>
+    </form>
+
+    <p class="alt-link"><button type="button" class="link-btn" id="back-to-login">← Back to log in</button></p>
+  </div>
+</div>
+
+<footer class="site">
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+<script>
+(function(){
+  var loginPanel = document.getElementById('login-panel');
+  var forgotPanel = document.getElementById('forgot-panel');
+  var loginForm = document.getElementById('login-form');
+  var loginBtn = document.getElementById('login-btn');
+  var loginError = document.getElementById('login-error');
+  var pwToggle = document.getElementById('pw-toggle');
+  var pw = document.getElementById('password');
+
+  var forgotForm = document.getElementById('forgot-form');
+  var forgotBtn = document.getElementById('forgot-btn');
+  var forgotSuccess = document.getElementById('forgot-success');
+  var forgotError = document.getElementById('forgot-error');
+
+  function showPanel(which) {
+    loginPanel.style.display = which === 'forgot' ? 'none' : 'block';
+    forgotPanel.style.display = which === 'forgot' ? 'block' : 'none';
+  }
+  if (location.hash === '#forgot') showPanel('forgot');
+
+  document.getElementById('show-forgot').addEventListener('click', function(){
+    history.replaceState(null, '', '#forgot');
+    showPanel('forgot');
+  });
+  document.getElementById('back-to-login').addEventListener('click', function(){
+    history.replaceState(null, '', location.pathname);
+    showPanel('login');
+  });
+
+  pwToggle.addEventListener('click', function(){
+    var showing = pw.type === 'text';
+    pw.type = showing ? 'password' : 'text';
+    pwToggle.textContent = showing ? 'Show' : 'Hide';
+  });
+
+  function setErr(box, html) {
+    box.innerHTML = html;
+    box.classList.add('shown');
+  }
+
+  // ---- Login ----
+  loginForm.addEventListener('submit', function(e){
+    e.preventDefault();
+    loginError.classList.remove('shown');
+    loginBtn.disabled = true;
+    loginBtn.textContent = 'Logging in…';
+
+    fetch('/api/auth/login', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: loginForm.email.value.trim(),
+        password: loginForm.password.value
+      })
+    }).then(function(res){
+      if (res.ok) return res.json();
+      return res.json().then(function(j){ throw new Error((j && j.error) || 'Invalid email or password.'); },
+        function(){ throw new Error('Invalid email or password.'); });
+    }).then(function(){
+      // ps_refresh cookie is set; /account mints the access token from it.
+      window.location.href = '/account';
+    }).catch(function(err){
+      setErr(loginError, (err && err.message) || 'Something went wrong. Please try again.');
+      loginBtn.disabled = false;
+      loginBtn.textContent = 'Log in';
+    });
+  });
+
+  // ---- Forgot password ----
+  forgotForm.addEventListener('submit', function(e){
+    e.preventDefault();
+    forgotError.classList.remove('shown');
+    forgotSuccess.classList.remove('shown');
+    forgotBtn.disabled = true;
+    forgotBtn.textContent = 'Sending…';
+
+    fetch('/api/auth/password/forgot', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: forgotForm.email.value.trim() })
+    }).then(function(res){
+      // The endpoint always 200s (anti-enumeration).
+      if (!res.ok) throw new Error('Please enter a valid email address.');
+      return res.json();
+    }).then(function(j){
+      setErr(forgotSuccess, (j && j.message) || 'If an account exists for that email, a reset link is on its way.');
+      forgotBtn.disabled = false;
+      forgotBtn.textContent = 'Send reset link';
+    }).catch(function(err){
+      setErr(forgotError, (err && err.message) || 'Something went wrong. Please try again.');
+      forgotBtn.disabled = false;
+      forgotBtn.textContent = 'Send reset link';
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/marketing-site/pricing.html
+++ b/marketing-site/pricing.html
@@ -312,18 +312,18 @@
 
 <section style="background:var(--card)">
   <h2 class="text-center">Pay in your local currency</h2>
-  <p class="lead text-center" style="margin:0 auto 24px">9 currencies supported. Choose at signup; change in your billing settings.</p>
+  <p class="lead text-center" style="margin:0 auto 24px">7 currencies supported. Your billing currency is set automatically from the country you choose at signup.</p>
   <div class="grid-4">
     <div class="card text-center"><div style="font-size:22px;font-weight:700">🇺🇬 UGX</div><p>Ugandan Shilling · MTN Mobile Money · Airtel Money</p></div>
     <div class="card text-center"><div style="font-size:22px;font-weight:700">🇰🇪 KES</div><p>Kenyan Shilling · M-Pesa · Airtel Money</p></div>
     <div class="card text-center"><div style="font-size:22px;font-weight:700">🇹🇿 TZS</div><p>Tanzanian Shilling · M-Pesa · Tigo Pesa · Airtel Money</p></div>
     <div class="card text-center"><div style="font-size:22px;font-weight:700">🇷🇼 RWF</div><p>Rwandan Franc · MTN MoMo</p></div>
-    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇳🇬 NGN</div><p>Nigerian Naira · Bank transfer · Card</p></div>
-    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇿🇦 ZAR</div><p>South African Rand · EFT · Card</p></div>
     <div class="card text-center"><div style="font-size:22px;font-weight:700">🇺🇸 USD</div><p>US Dollar · Stripe card</p></div>
     <div class="card text-center"><div style="font-size:22px;font-weight:700">🇪🇺 EUR</div><p>Euro · Stripe SEPA + card</p></div>
+    <div class="card text-center"><div style="font-size:22px;font-weight:700">🇬🇧 GBP</div><p>Pound Sterling · Stripe card</p></div>
+    <div class="card text-center" style="opacity:.6"><div style="font-size:22px;font-weight:700">🇳🇬 NGN · 🇿🇦 ZAR</div><p>Naira &amp; Rand — <strong>coming soon</strong>. Nigerian &amp; South African firms bill in USD for now.</p></div>
   </div>
-  <p class="text-center muted" style="font-size:13px;margin-top:16px">GBP also supported via Stripe. Bitcoin / USDC on request for international donor-funded work.</p>
+  <p class="text-center muted" style="font-size:13px;margin-top:16px">Bitcoin / USDC on request for international donor-funded work.</p>
 </section>
 
 <section>

--- a/marketing-site/signup.html
+++ b/marketing-site/signup.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Join the waitlist — Planscape</title>
-<meta name="description" content="Planscape is launching in private beta in 2026. Join the waitlist for early access to STING Tools and the Planscape cloud bundle.">
+<title>Create your account — Planscape</title>
+<meta name="description" content="Start your 14-day Planscape trial. No card required. Full access to STING Tools and the Planscape cloud bundle.">
 <meta name="theme-color" content="#E8912D">
 <meta name="robots" content="noindex,follow">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
@@ -40,6 +40,12 @@
 .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
 @media (max-width: 540px) { .field-row { grid-template-columns: 1fr; } }
 .field .hint { font-size: 12px; color: var(--muted); margin-top: 4px; }
+.pw-wrap { position: relative; }
+.pw-toggle {
+  position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+  background: none; border: 0; cursor: pointer; font-size: 12px;
+  color: var(--accent); font-weight: 600; padding: 4px;
+}
 .btn-primary {
   width: 100%;
   background: var(--accent);
@@ -63,26 +69,11 @@
 .success-state { background: #e8f7ed; border: 1px solid #2e9b59; color: #1e6b3c; }
 .error-state { background: #fdebea; border: 1px solid #cc3322; color: #8b2018; }
 .success-state.shown, .error-state.shown { display: block; }
+.error-state a { color: inherit; font-weight: 600; }
 .fineprint { font-size: 12px; color: var(--muted); margin-top: 16px; text-align: center; }
-.product-choice { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
-@media (max-width: 540px) { .product-choice { grid-template-columns: 1fr; } }
-.product-choice label {
-  display: block;
-  padding: 14px 12px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: #fff;
-  cursor: pointer;
-  text-align: center;
-  font-size: 14px;
-  font-weight: 600;
-}
-.product-choice input[type=radio] { display: none; }
-.product-choice input[type=radio]:checked + span { color: var(--accent); }
-.product-choice label:has(input:checked) {
-  border-color: var(--accent);
-  background: #fff5eb;
-}
+.alt-link { text-align: center; margin-top: 20px; font-size: 14px; color: var(--muted); }
+.alt-link a { color: var(--accent); font-weight: 600; }
+.trial-note { font-size: 13px; color: var(--muted); margin: 0 0 20px; padding: 10px 14px; background: #fff5eb; border: 1px solid #f0d5b3; border-radius: 8px; }
 </style>
 </head>
 <body>
@@ -103,29 +94,17 @@
 
 <div class="signup-wrap">
   <div class="signup-card">
-    <div class="success-state" id="success">
-      <h2 style="margin:0 0 8px;font-size:20px">You're on the list 🎉</h2>
-      <p style="margin:0">We'll email you as soon as your trial slot is ready. In the meantime, browse the <a href="/guides/">guides</a> or <a href="/contact.html#demo">book a demo</a>.</p>
-    </div>
     <div class="error-state" id="error">
       <h2 style="margin:0 0 8px;font-size:20px">Something went wrong</h2>
       <p style="margin:0" id="error-msg">Please try again, or email <a href="mailto:hello@planscape.build">hello@planscape.build</a>.</p>
     </div>
 
     <div id="form-block">
-      <h1>Join the waitlist</h1>
-      <p class="sub">Planscape is launching in private beta in 2026. Tell us about your firm and we'll roll out a trial slot as capacity opens up.</p>
+      <h1>Create your account</h1>
+      <p class="sub">Start your 14-day trial — full access to STING Tools and the Planscape cloud bundle.</p>
+      <p class="trial-note">No payment card required. Your trial runs for 14 days; pick a plan whenever you're ready.</p>
 
-      <form id="waitlist-form" novalidate>
-        <div class="field">
-          <label>Which product are you interested in?</label>
-          <div class="product-choice">
-            <label><input type="radio" name="product" value="sting-tools"><span>STING Tools<br><small style="font-weight:400">Plugin only</small></span></label>
-            <label><input type="radio" name="product" value="planscape" checked><span>Planscape<br><small style="font-weight:400">Plugin + cloud</small></span></label>
-            <label><input type="radio" name="product" value="both"><span>Not sure<br><small style="font-weight:400">Tell me both</small></span></label>
-          </div>
-        </div>
-
+      <form id="signup-form" novalidate>
         <div class="field-row">
           <div class="field">
             <label for="firstName">First name</label>
@@ -140,73 +119,62 @@
         <div class="field">
           <label for="email">Work email</label>
           <input type="email" id="email" name="email" required autocomplete="email" placeholder="you@firm.com">
-          <div class="hint">We'll use this to send you your trial invite.</div>
+          <div class="hint">This is your login — we'll also send a verification link here.</div>
         </div>
 
         <div class="field">
-          <label for="firm">Firm name</label>
-          <input type="text" id="firm" name="firm" required autocomplete="organization">
-        </div>
-
-        <div class="field-row">
-          <div class="field">
-            <label for="country">Country</label>
-            <select id="country" name="country" required>
-              <option value="">Choose…</option>
-              <option value="UG">Uganda</option>
-              <option value="KE">Kenya</option>
-              <option value="TZ">Tanzania</option>
-              <option value="RW">Rwanda</option>
-              <option value="NG">Nigeria</option>
-              <option value="ZA">South Africa</option>
-              <option value="GH">Ghana</option>
-              <option value="ET">Ethiopia</option>
-              <option value="SN">Senegal</option>
-              <option value="CI">Côte d'Ivoire</option>
-              <option value="EG">Egypt</option>
-              <option value="MA">Morocco</option>
-              <option value="GB">United Kingdom</option>
-              <option value="US">United States</option>
-              <option value="EU">Other (EU)</option>
-              <option value="OTHER">Other</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="teamSize">Coordinators</label>
-            <select id="teamSize" name="teamSize" required>
-              <option value="">Choose…</option>
-              <option value="1-3">1–3</option>
-              <option value="4-10">4–10</option>
-              <option value="11-25">11–25</option>
-              <option value="26-50">26–50</option>
-              <option value="51-100">51–100</option>
-              <option value="100+">100+</option>
-            </select>
-          </div>
+          <label for="firmName">Firm name</label>
+          <input type="text" id="firmName" name="firmName" required autocomplete="organization">
         </div>
 
         <div class="field">
-          <label for="role">Your role</label>
-          <select id="role" name="role" required>
+          <label for="country">Country</label>
+          <select id="country" name="country" required>
             <option value="">Choose…</option>
-            <option value="bim-manager">BIM Manager</option>
-            <option value="bim-coordinator">BIM Coordinator</option>
-            <option value="project-lead">Project Lead</option>
-            <option value="principal">Principal / Partner</option>
-            <option value="it">IT / Operations</option>
-            <option value="other">Other</option>
+            <option value="UG">Uganda</option>
+            <option value="KE">Kenya</option>
+            <option value="TZ">Tanzania</option>
+            <option value="RW">Rwanda</option>
+            <option value="NG">Nigeria</option>
+            <option value="ZA">South Africa</option>
+            <option value="GH">Ghana</option>
+            <option value="ET">Ethiopia</option>
+            <option value="SN">Senegal</option>
+            <option value="CI">Côte d'Ivoire</option>
+            <option value="EG">Egypt</option>
+            <option value="MA">Morocco</option>
+            <option value="GB">United Kingdom</option>
+            <option value="IE">Ireland</option>
+            <option value="DE">Germany</option>
+            <option value="FR">France</option>
+            <option value="NL">Netherlands</option>
+            <option value="US">United States</option>
+            <option value="CA">Canada</option>
+            <option value="AU">Australia</option>
           </select>
+          <div class="hint">Sets your billing currency — East African countries bill in local currency via mobile money.</div>
         </div>
 
         <div class="field">
-          <label for="notes">Anything we should know? <span style="font-weight:400;color:var(--muted)">(optional)</span></label>
-          <textarea id="notes" name="notes" rows="3" placeholder="e.g. We're starting an ISO 19650 pilot in Q3 / We use Revit + Navisworks today / We deliver hospital projects"></textarea>
+          <label for="password">Password</label>
+          <div class="pw-wrap">
+            <input type="password" id="password" name="password" required autocomplete="new-password" minlength="12">
+            <button type="button" class="pw-toggle" id="pw-toggle" aria-label="Show password">Show</button>
+          </div>
+          <div class="hint">At least 12 characters. Avoid common passwords.</div>
         </div>
 
-        <button type="submit" class="btn-primary" id="submit-btn">Join the waitlist</button>
+        <div class="field">
+          <label for="confirm">Confirm password</label>
+          <input type="password" id="confirm" name="confirm" required autocomplete="new-password" minlength="12">
+        </div>
 
-        <p class="fineprint">By submitting you agree to our <a href="/privacy.html">privacy policy</a>. We'll only email you about your trial — no marketing list.</p>
+        <button type="submit" class="btn-primary" id="submit-btn">Create account &amp; start trial</button>
+
+        <p class="fineprint">By creating an account you agree to our <a href="/terms.html">terms</a> and <a href="/privacy.html">privacy policy</a>.</p>
       </form>
+
+      <p class="alt-link">Already have an account? <a href="/login">Log in</a></p>
     </div>
   </div>
 </div>
@@ -244,74 +212,84 @@
 
 <script>
 (function(){
-  // Pre-select product based on ?plan= query parameter
-  var params = new URLSearchParams(location.search);
-  var plan = params.get('plan') || '';
-  if (plan.indexOf('sting') === 0) {
-    document.querySelector('input[name=product][value=sting-tools]').checked = true;
-  } else if (plan.indexOf('planscape') === 0) {
-    document.querySelector('input[name=product][value=planscape]').checked = true;
-  }
-  // Pre-select team size from plan name
-  var sizeMap = {
-    'solo': '1-3', 'studio': '4-10', 'practice': '11-25',
-    'firm': '26-50', 'large': '51-100'
-  };
-  for (var k in sizeMap) {
-    if (plan.indexOf(k) !== -1) {
-      // delay to ensure DOM is ready
-      var sel = document.getElementById('teamSize');
-      for (var i = 0; i < sel.options.length; i++) {
-        if (sel.options[i].value === sizeMap[k]) { sel.selectedIndex = i; break; }
-      }
-      break;
-    }
-  }
-
-  var form = document.getElementById('waitlist-form');
+  var form = document.getElementById('signup-form');
   var btn = document.getElementById('submit-btn');
-  var formBlock = document.getElementById('form-block');
-  var success = document.getElementById('success');
   var errorBox = document.getElementById('error');
   var errorMsg = document.getElementById('error-msg');
+  var pwToggle = document.getElementById('pw-toggle');
+  var pw = document.getElementById('password');
+
+  pwToggle.addEventListener('click', function(){
+    var showing = pw.type === 'text';
+    pw.type = showing ? 'password' : 'text';
+    pwToggle.textContent = showing ? 'Show' : 'Hide';
+  });
+
+  function showError(msgHtml) {
+    errorMsg.innerHTML = msgHtml;
+    errorBox.classList.add('shown');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    btn.disabled = false;
+    btn.textContent = 'Create account & start trial';
+  }
 
   form.addEventListener('submit', function(e){
     e.preventDefault();
     errorBox.classList.remove('shown');
-    btn.disabled = true;
-    btn.textContent = 'Submitting…';
 
+    var password = form.password.value;
+    var confirm = form.confirm.value;
+
+    // Mirror the server rules in functions/api/auth/_lib/validate.ts so the user
+    // sees a fast, honest hint before the round-trip (server remains the truth).
+    if (password.length < 12) {
+      showError('Password must be at least 12 characters.');
+      return;
+    }
+    if (password !== confirm) {
+      showError('Passwords do not match.');
+      return;
+    }
+    if (!form.country.value) {
+      showError('Please choose your country.');
+      return;
+    }
+
+    btn.disabled = true;
+    btn.textContent = 'Creating your account…';
+
+    // Only the fields the signup API accepts. `firm` is intentionally sent as
+    // `firmName`, and no teamSize/role/product are collected (the trial covers
+    // the whole bundle).
     var data = {
-      product: form.product.value,
       firstName: form.firstName.value.trim(),
       lastName: form.lastName.value.trim(),
       email: form.email.value.trim(),
-      firm: form.firm.value.trim(),
+      firmName: form.firmName.value.trim(),
       country: form.country.value,
-      teamSize: form.teamSize.value,
-      role: form.role.value,
-      notes: form.notes.value.trim(),
-      submittedAt: new Date().toISOString(),
-      referrer: document.referrer || '',
-      utm: location.search || ''
+      password: password
     };
 
-    fetch('/api/waitlist', {
+    fetch('/api/auth/signup', {
       method: 'POST',
+      credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
     }).then(function(res){
-      if (!res.ok) return res.json().then(function(j){ throw new Error(j.error || 'Request failed'); });
+      if (res.status === 409) {
+        throw { handled: true, msg: 'An account with this email already exists. <a href="/login">Log in instead</a> or <a href="/login#forgot">reset your password</a>.' };
+      }
+      if (!res.ok) {
+        return res.json().then(function(j){ throw { handled: true, msg: (j && j.error) || 'Request failed. Please try again.' }; },
+          function(){ throw { handled: true, msg: 'Request failed. Please try again.' }; });
+      }
       return res.json();
     }).then(function(){
-      formBlock.style.display = 'none';
-      success.classList.add('shown');
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      // The signup response set the ps_refresh cookie; the account page mints an
+      // access token from it. Head straight there.
+      window.location.href = '/account';
     }).catch(function(err){
-      errorMsg.textContent = err.message || 'Network error — please try again, or email hello@planscape.build.';
-      errorBox.classList.add('shown');
-      btn.disabled = false;
-      btn.textContent = 'Join the waitlist';
+      showError((err && err.msg) || 'Network error — please try again, or email hello@planscape.build.');
     });
   });
 })();


### PR DESCRIPTION
## Why

planscape.build had **four phases of deployed auth + billing backend that no page called**. `/signup` still POSTed to `/api/waitlist` — the endpoint from day one — and there was no login or account page. `/api/auth/*`, `/api/billing/*` and all eight `/api/tenants/*` endpoints had **zero callers**. The only auth-touching pages were terminal landing pages (`verify-email`, `reset-password`, `accept-invite`, `billing-success`) — the *ends* of flows whose *beginnings did not exist*.

Nobody could sign up, log in, or pay through the site. This connects it.

## What

**Phase 1 — reach** (`015861d04`): signup → `/api/auth/signup`; new `login.html` + `account.html`; `currencyForCountry()`; `plans.ts` advertises all 7 payable currencies; `_redirects` pre-launch block removed; `pricing.html` made honest.

**Phase 2 — revenue** (`5e903b5a6`): plan picker → checkout on both rails, Stripe portal, invoices, cancel/resume, new `GET /api/billing/subscription`.

**Docs** (`be2157ea0`): setup gaps, the one-time backfill, and the curl blind spot.

## Four bugs this fixes

1. **`createTenant` hardcoded `currency = "USD"`**, ignoring the country it already stored — so **no tenant could ever route to Pesapal**. One line; it's why B3b's entire mobile-money rail was unreachable.
2. **`plans.ts` used the Stripe-only `unitAmountMinor`**, which reads `FX_FROM_USD[currency]` and hardcodes `x100` → **`NaN` prices for UGX/RWF, silently**. Now uses the zero-decimal-safe `unitAmountMinorFor`.
3. **`cors.ts` rejected its own pages.** `ALLOWED_ORIGINS` was hardcoded to two production hostnames, so the Functions returned "Origin not allowed" on **every Pages preview deployment and all local dev**. **curl never caught this — it sends no `Origin` header**, which is how four curl-verified phases hid it. Fixed by allowing same-origin, without wildcarding `*.pages.dev`.
4. **`portal.ts` `return_url` pointed at `/account/billing`**, which doesn't exist — exiting the Stripe portal landed on a 404.

## Verified

Locally (`wrangler pages dev` + D1) and **in a real browser**, plus on a live Pages preview:

- signup with country `UG` → tenant `currency=UGX`, 14-day trial, `plan_tier` null
- account page renders "Billing currency UGX"; Solo **UGX 92,500/mo** (= $25 x 3700), annual **888,000** (20% off) — integers, no NaN, no decimals on a zero-decimal currency
- picker reports the **Pesapal** rail; logout → `/login` → log back in round-trips
- preview: 7 currencies, `?currency=UGX` → 200 (400 on main), `/login` → 200 no redirect, same-origin allowed, **hostile origin still 403s**
- both typechecks clean (`marketing-site`, `marketing-site-cron`)

## Not verified

**No real payment has been taken.** Local checkout only reached the provider call — with no keys set, UGX returns "Mobile-money billing is not configured" and USD "Billing is not configured". Different messages, which is what proves the currency router picks the right rail, but it is not a payment. Production now has both Stripe and Pesapal keys, so the **B3b smoke test becomes runnable once this merges**.

## Known gaps (not introduced here)

- **Self-serve Pesapal cancellation doesn't exist** — `getActiveSubscription` is deliberately Stripe-only, so cancel/resume/portal are hidden for Pesapal subscriptions and the panel explains why rather than offering a button that fails.
- **Email failures are silent by design** (`email.ts` logs, never throws). If the `From:` sender isn't verified in Resend, signup succeeds and the verification link silently vanishes. The code reads **`EMAIL_FROM`** — note a `RESEND_FROM` secret is set in production and **nothing reads it**.

## Ops notes

- One-time tenant currency backfill (idempotent, refuses to touch a tenant with a live subscription) — **already applied to production, 11 rows**. Documented in `BILLING_SETUP.md`.
- **Preview and Production env vars are separate.** Preview currently has no secrets, so auth 500s there.
- `npm run deploy` hardcodes `--branch=main` — it is a **production** deploy regardless of the git branch checked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)