### PR TITLE
fix(billing): surface the real Pesapal auth error instead of "unknown"

### DIFF
--- a/marketing-site/functions/api/_lib/billing/pesapal.ts
+++ b/marketing-site/functions/api/_lib/billing/pesapal.ts
@@ -88,7 +88,16 @@ export async function getAccessToken(env: PesapalEnv): Promise<string> {
     }
   );
   if (!r.token) {
-    console.error(`Pesapal RequestToken returned no token: ${r.message ?? "unknown"}`);
+    // Pesapal reports credential failures as HTTP 200 with an error body, so
+    // pesapalFetch's !res.ok check never fires. The detail lives at
+    // error.message ("Invalid Access Credentials provided"), NOT at a top-level
+    // `message` — reading the wrong field logged a useless "unknown" and made
+    // every auth failure undiagnosable.
+    const err = r.error as { code?: string; message?: string } | undefined;
+    const detail = err?.message || err?.code || r.message || "unknown";
+    console.error(
+      `Pesapal RequestToken returned no token from ${pesapalBase(env)}: ${detail}`
+    );
     throw new PesapalError(502, "Pesapal authentication failed");
   }
   return r.token;


### PR DESCRIPTION
A UGX checkout on production failed with "Could not start mobile-money checkout", and the log said only:

```
Pesapal RequestToken returned no token: unknown
```

Undiagnosable. Two reasons the cause was invisible:

1. **Pesapal reports credential failures as HTTP 200** with an error body, so `pesapalFetch`'s `!res.ok` guard never fires and the failure sails through as a success:
   ```json
   {"error":{"error_type":"api_error","code":"invalid_consumer_key_or_secret_provided",
             "message":"Invalid Access Credentials provided"},"status":"500"}
   ```
2. `getAccessToken` then logged `r.message` — a **top-level** field Pesapal does not send. The detail is nested at `error.message`. Hence "unknown".

Now reads `error.message` / `error.code` and includes the base URL in the log, so a sandbox-credentials-against-live-URL mismatch is obvious from one line.

**Diagnostics only — no behaviour change.** Checkout still fails until valid credentials are configured; this just makes the next failure readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)