### PR TITLE
Cancel-anytime terms + "keep evaluating" exit on the account page

### DIFF
--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -150,9 +150,21 @@ table.inv tr:last-child td { border-bottom: 0; }
 
     <div class="acct-actions">
       <button type="button" class="btn-primary" id="subscribe-btn">Continue to payment</button>
+      <button type="button" class="btn-secondary" id="keep-trial-btn">Not now — keep evaluating</button>
     </div>
     <div class="err" id="plan-err"></div>
+    <p class="note" id="cancel-note"></p>
     <p class="note" id="pay-route"></p>
+  </div>
+
+  <!-- Shown when the user dismisses the plan picker. Nothing is charged for
+       choosing this — the trial is already running. -->
+  <div class="acct-card state" id="trial-card">
+    <h2>You're on the free trial</h2>
+    <p class="sub" id="trial-line">No card on file. Nothing will be charged.</p>
+    <div class="acct-actions">
+      <button type="button" class="btn-primary" id="show-plans-btn">See plans</button>
+    </div>
   </div>
 
   <!-- Invoices — admin+ only. -->
@@ -504,6 +516,14 @@ table.inv tr:last-child td { border-bottom: 0; }
       ? 'You will pay in ' + state.currency + ' by mobile money or card via Pesapal. Your currency is set from your firm\'s country.'
       : 'You will pay in ' + state.currency + ' by card via Stripe. Your currency is set from your firm\'s country.';
 
+    // Cancellation terms, worded per rail so it stays true. Stripe subscriptions
+    // renew and can be cancelled here; Pesapal charges one period at a time and
+    // never auto-renews, so there is literally nothing to cancel (self-serve
+    // cancel is Stripe-only — see getActiveSubscription in state.ts).
+    $('cancel-note').textContent = provider === 'pesapal'
+      ? 'No lock-in. Mobile-money plans are charged one period at a time and never auto-renew — if you do nothing at the end of a period, it simply stops. Your trial is unaffected until you pay.'
+      : 'No lock-in. Cancel any time from this page and you keep full access until the end of the period you have paid for — no partial-period charges after that.';
+
     var off = state.plans && state.plans.annualDiscount;
     if (off) $('annual-off').textContent = '(save ' + Math.round(off * 100) + '%)';
 
@@ -514,6 +534,26 @@ table.inv tr:last-child td { border-bottom: 0; }
     document.querySelectorAll('input[name=cycle]').forEach(function(el){
       el.addEventListener('change', renderPrice);
     });
+
+    // "Not now" is a pure UI toggle — it charges nothing and changes no state.
+    // The trial is already running from signup; this just stops the page
+    // reading as a paywall for someone who only wants to evaluate.
+    var days = trialDaysLeft(t.trialEndsAt);
+    $('trial-line').textContent =
+      (t.subscriptionStatus === 'trial' && days !== null
+        ? (days === 0 ? 'Your trial ends today.' : 'You have ' + days + ' day' + (days === 1 ? '' : 's') + ' left.')
+        : '') +
+      ' No card on file and nothing will be charged. Pick a plan whenever you are ready — or not at all.';
+
+    $('keep-trial-btn').addEventListener('click', function(){
+      $('plan-card').classList.remove('shown');
+      show($('trial-card'));
+    });
+    $('show-plans-btn').addEventListener('click', function(){
+      $('trial-card').classList.remove('shown');
+      show($('plan-card'));
+    });
+
     show($('plan-card'));
   }
 

--- a/marketing-site/functions/api/auth/_lib/email.ts
+++ b/marketing-site/functions/api/auth/_lib/email.ts
@@ -36,7 +36,14 @@ async function send(
       }),
     });
     if (!res.ok) {
-      console.error(`Resend send failed (${res.status}) for "${subject}"`);
+      // Log Resend's own message, not just the status. The status alone is not
+      // actionable: 401 means a bad API key, 422 usually means the From: domain
+      // is unverified — and since a failed send never surfaces to the user
+      // (see the catch below), this log is the ONLY evidence anything is wrong.
+      const detail = await res.text().catch(() => "");
+      console.error(
+        `Resend send failed (${res.status}) for "${subject}" from "${env.EMAIL_FROM || DEFAULT_FROM}": ${detail.slice(0, 300)}`
+      );
     }
   } catch (e) {
     // Never let an email failure break the request.

--- a/marketing-site/pricing.html
+++ b/marketing-site/pricing.html
@@ -65,6 +65,7 @@
     <button onclick="setBilling('year')" id="btn-year">Annual <span class="save-badge">Save 20%</span></button>
   </div>
   <p class="text-center muted" style="font-size:13px;margin-bottom:0">14-day free trial · trial both products · no credit card required</p>
+  <p class="text-center muted" style="font-size:13px;margin-top:6px;margin-bottom:0">Cancel any time — you keep access to the end of the period you have paid for. Mobile-money plans are charged one period at a time and never auto-renew.</p>
 </section>
 
 <section class="product-section" style="padding-top:24px">


### PR DESCRIPTION
## What

**1. Cancellation terms, worded per rail.** The account page never said what happens if you stop paying. Now stated under the payment CTA:

- **Stripe** — "Cancel any time from this page and you keep full access until the end of the period you have paid for."
- **Pesapal** — "charged one period at a time and never auto-renew — if you do nothing at the end of a period, it simply stops."

The split is deliberate, not cosmetic: self-serve cancel/resume is **Stripe-only** (`getActiveSubscription` filters `provider='stripe'`), so telling a mobile-money subscriber to "cancel any time from this page" would promise a button that isn't there. Same terms added to `pricing.html`.

**2. "Not now — keep evaluating".** "Continue to payment" was the only action, so the page read as a paywall — even though the trial is already running, with no card, from signup. The new secondary button swaps the picker for a panel showing days remaining and stating plainly that no card is on file and nothing will be charged. Pure UI toggle: charges nothing, changes no state, reversible via "See plans".

**3. Cherry-picks `aac20e1dc`** (Resend error logging), which was deployed to production but never merged. The next deploy from `main` would have silently regressed it.

## Verified

- `npm run typecheck` clean (exit 0)
- All five new element IDs defined and referenced

Not yet clicked through in a browser — deploying next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)