### PR TITLE
fix(billing): a failed Pesapal payment must not block a successful retry

### DIFF
--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -150,9 +150,21 @@ table.inv tr:last-child td { border-bottom: 0; }
 
     <div class="acct-actions">
       <button type="button" class="btn-primary" id="subscribe-btn">Continue to payment</button>
+      <button type="button" class="btn-secondary" id="keep-trial-btn">Not now — keep evaluating</button>
     </div>
     <div class="err" id="plan-err"></div>
+    <p class="note" id="cancel-note"></p>
     <p class="note" id="pay-route"></p>
+  </div>
+
+  <!-- Shown when the user dismisses the plan picker. Nothing is charged for
+       choosing this — the trial is already running. -->
+  <div class="acct-card state" id="trial-card">
+    <h2>You're on the free trial</h2>
+    <p class="sub" id="trial-line">No card on file. Nothing will be charged.</p>
+    <div class="acct-actions">
+      <button type="button" class="btn-primary" id="show-plans-btn">See plans</button>
+    </div>
   </div>
 
   <!-- Invoices — admin+ only. -->
@@ -504,6 +516,14 @@ table.inv tr:last-child td { border-bottom: 0; }
       ? 'You will pay in ' + state.currency + ' by mobile money or card via Pesapal. Your currency is set from your firm\'s country.'
       : 'You will pay in ' + state.currency + ' by card via Stripe. Your currency is set from your firm\'s country.';
 
+    // Cancellation terms, worded per rail so it stays true. Stripe subscriptions
+    // renew and can be cancelled here; Pesapal charges one period at a time and
+    // never auto-renews, so there is literally nothing to cancel (self-serve
+    // cancel is Stripe-only — see getActiveSubscription in state.ts).
+    $('cancel-note').textContent = provider === 'pesapal'
+      ? 'No lock-in. Mobile-money plans are charged one period at a time and never auto-renew — if you do nothing at the end of a period, it simply stops. Your trial is unaffected until you pay.'
+      : 'No lock-in. Cancel any time from this page and you keep full access until the end of the period you have paid for — no partial-period charges after that.';
+
     var off = state.plans && state.plans.annualDiscount;
     if (off) $('annual-off').textContent = '(save ' + Math.round(off * 100) + '%)';
 
@@ -514,6 +534,26 @@ table.inv tr:last-child td { border-bottom: 0; }
     document.querySelectorAll('input[name=cycle]').forEach(function(el){
       el.addEventListener('change', renderPrice);
     });
+
+    // "Not now" is a pure UI toggle — it charges nothing and changes no state.
+    // The trial is already running from signup; this just stops the page
+    // reading as a paywall for someone who only wants to evaluate.
+    var days = trialDaysLeft(t.trialEndsAt);
+    $('trial-line').textContent =
+      (t.subscriptionStatus === 'trial' && days !== null
+        ? (days === 0 ? 'Your trial ends today.' : 'You have ' + days + ' day' + (days === 1 ? '' : 's') + ' left.')
+        : '') +
+      ' No card on file and nothing will be charged. Pick a plan whenever you are ready — or not at all.';
+
+    $('keep-trial-btn').addEventListener('click', function(){
+      $('plan-card').classList.remove('shown');
+      show($('trial-card'));
+    });
+    $('show-plans-btn').addEventListener('click', function(){
+      $('trial-card').classList.remove('shown');
+      show($('plan-card'));
+    });
+
     show($('plan-card'));
   }
 

--- a/marketing-site/functions/api/auth/_lib/email.ts
+++ b/marketing-site/functions/api/auth/_lib/email.ts
@@ -36,7 +36,14 @@ async function send(
       }),
     });
     if (!res.ok) {
-      console.error(`Resend send failed (${res.status}) for "${subject}"`);
+      // Log Resend's own message, not just the status. The status alone is not
+      // actionable: 401 means a bad API key, 422 usually means the From: domain
+      // is unverified — and since a failed send never surfaces to the user
+      // (see the catch below), this log is the ONLY evidence anything is wrong.
+      const detail = await res.text().catch(() => "");
+      console.error(
+        `Resend send failed (${res.status}) for "${subject}" from "${env.EMAIL_FROM || DEFAULT_FROM}": ${detail.slice(0, 300)}`
+      );
     }
   } catch (e) {
     // Never let an email failure break the request.

--- a/marketing-site/functions/api/webhooks/pesapal.ts
+++ b/marketing-site/functions/api/webhooks/pesapal.ts
@@ -163,10 +163,21 @@ async function handle(request: Request, env: Env): Promise<Response> {
     return ack(p, 200);
   }
 
-  // Dedupe on the tracking id (Pesapal can fire the IPN more than once).
+  // Dedupe on the tracking id — but ONLY once the order has actually been
+  // applied. Unlike Stripe (fresh Event.id per event), Pesapal reuses the same
+  // OrderTrackingId across payment retries on one order: a customer whose MTN
+  // prompt fails can retry on the same checkout page and succeed. Skipping on
+  // "we've seen this id" would drop that second, successful IPN and leave a
+  // paying customer with no subscription. Re-processing is safe because
+  // processCompleted() returns early when order.status is already 'completed'.
   const prior = await getWebhookByEventId(env.WAITLIST_DB, "pesapal", p.orderTrackingId);
   if (prior && (prior.status === "processed" || prior.status === "ignored")) {
-    return ack(p, 200);
+    const applied = await getPesapalOrderByTracking(env.WAITLIST_DB, p.orderTrackingId);
+    if (!applied || applied.status === "completed") {
+      return ack(p, 200);
+    }
+    // Order exists but is not completed (e.g. a failed first attempt) — fall
+    // through and re-query Pesapal in case this IPN reports a successful retry.
   }
 
   const logId =

--- a/marketing-site/pricing.html
+++ b/marketing-site/pricing.html
@@ -65,6 +65,7 @@
     <button onclick="setBilling('year')" id="btn-year">Annual <span class="save-badge">Save 20%</span></button>
   </div>
   <p class="text-center muted" style="font-size:13px;margin-bottom:0">14-day free trial · trial both products · no credit card required</p>
+  <p class="text-center muted" style="font-size:13px;margin-top:6px;margin-bottom:0">Cancel any time — you keep access to the end of the period you have paid for. Mobile-money plans are charged one period at a time and never auto-renew.</p>
 </section>
 
 <section class="product-section" style="padding-top:24px">


### PR DESCRIPTION
## The bug

Pesapal reuses the same `OrderTrackingId` across payment retries on a single order — unlike Stripe, which issues a fresh `Event.id` per event. The IPN handler deduped on that tracking id and skipped anything already marked `processed`:

1. Customer checks out → order `pending`, tracking id `T`
2. MTN prompt **fails** → IPN(`T`) processed, order = `failed`, webhook log = `processed`
3. Customer retries on the **same** checkout page and **succeeds**
4. Pesapal fires IPN(`T`) again → **short-circuited before any processing**

**The customer pays and gets nothing** — no subscription, no invoice, tenant left on trial.

Retrying after a failed prompt is completely ordinary on mobile money; the Pesapal page has a **RESEND PAYMENT PROMPT** button for exactly that. This was likely to hit the first real customer whose first attempt failed.

## The fix

Short-circuit only when the order has actually reached `completed`. Anything else falls through and re-queries `GetTransactionStatus`, which is authoritative. Re-processing is safe — `processCompleted()` already returns early on a `completed` order — so the cost of a genuine duplicate is one extra status query.

## How it was found

By reviewing the success path, which **had never executed**. The sandbox payments available for testing all fail at the MTN step, so no test would have caught this: it needs a fail-then-succeed sequence on one order.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)