### PR TITLE
Remove a fabricated testimonial and correct false pricing claims

### DIFF
--- a/marketing-site/about.html
+++ b/marketing-site/about.html
@@ -55,7 +55,7 @@
   <p>We're not VC-funded and we're not trying to be. The product earns its keep — flat per-firm pricing, modest cloud bills, no growth-at-all-costs runway pressure. We answer support tickets in the same timezone you read them.</p>
 
   <h2>Where we're going</h2>
-  <p>The pilot cohort runs through 2026. By end of 2026 we expect to support 40+ practices across East and West Africa across a mixed portfolio of healthcare, transport, education, and commercial work. Our 2027 roadmap focuses on:</p>
+  <p>Our pilot programme is open through 2026 — we are onboarding our first practices now. By the end of 2026 we aim to support 40+ practices across East and West Africa, spanning healthcare, transport, education, and commercial work. Our 2027 roadmap focuses on:</p>
   <ul>
     <li>Nairobi edge replica for sub-100ms latency across East Africa</li>
     <li>ArchiCAD + Tekla plugins (Revit is shipping, the IFC substrate is host-agnostic)</li>

--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Planscape — BIM coordination for East African firms</title>
-<meta name="description" content="ISO 19650 BIM coordination · Revit plugin from $15/mo · cloud platform from $35/mo · invoiced in UGX/KES/TZS.">
+<meta name="description" content="ISO 19650 BIM coordination · Revit plugin from $25/mo · cloud platform from $60/mo · invoiced in UGX/KES/TZS.">
 <meta property="og:title" content="Planscape — BIM coordination for East African firms">
-<meta property="og:description" content="Revit plugin from $15/firm/month. Add cloud sync + mobile from $35/firm/month. ISO 19650 templates pre-built. Invoiced in your local currency.">
+<meta property="og:description" content="Revit plugin from $25/firm/month. Add cloud sync + mobile from $60/firm/month. ISO 19650 templates pre-built. Invoiced in your local currency.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://planscape.build/">
 <meta property="og:image" content="https://planscape.build/images/og-card.png">
@@ -14,7 +14,7 @@
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Planscape — BIM coordination for East African firms">
-<meta name="twitter:description" content="Revit plugin from $15/mo · cloud platform from $35/mo · ISO 19650 templates · invoiced in UGX/KES/TZS.">
+<meta name="twitter:description" content="Revit plugin from $25/mo · cloud platform from $60/mo · ISO 19650 templates · invoiced in UGX/KES/TZS.">
 <meta name="twitter:image" content="https://planscape.build/images/og-card.png">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
@@ -193,7 +193,8 @@
   <table class="tbl">
     <thead><tr><th>Tool</th><th>Pricing model</th><th>Offline mobile</th><th>Local invoicing</th></tr></thead>
     <tbody>
-      <tr><td class="us">Planscape Large (20 users)</td><td class="us">$90/firm — $4.50/user</td><td class="us">Yes</td><td class="us">Yes (UGX/KES/TZS/…)</td></tr>
+      <tr><td class="us">Planscape Practice (25 coordinators)</td><td class="us">$280/firm — $11.20/user</td><td class="us">Yes</td><td class="us">Yes (UGX/KES/TZS/…)</td></tr>
+      <tr><td class="us">Planscape Large (100 coordinators)</td><td class="us">$1,000/firm — $10/user</td><td class="us">Yes</td><td class="us">Yes (UGX/KES/TZS/…)</td></tr>
       <tr><td>Autodesk Construction Cloud</td><td>$40–80/seat/mo</td><td>No</td><td>USD only</td></tr>
       <tr><td>Procore</td><td>$375–549+/firm/mo</td><td>Partial</td><td>USD only</td></tr>
       <tr><td>Trimble Connect</td><td>$20–40/seat/mo</td><td>Partial</td><td>USD only</td></tr>
@@ -202,15 +203,8 @@
     </tbody>
   </table>
   <p style="font-size:12px;color:var(--muted);margin-top:10px">
-    Competitor pricing sourced from public rate cards, May 2026. Actual pricing varies by contract. Planscape per-user figure based on Large plan ($90/mo ÷ 20 users).
+    Competitor pricing sourced from public rate cards, May 2026 — check their current pricing before relying on it. Actual pricing varies by contract. Planscape per-user figures are the plan price divided by its coordinator cap ($280 ÷ 25, $1,000 ÷ 100); see <a href="/pricing">pricing</a> for all tiers.
   </p>
-</section>
-
-<section>
-  <div class="testimonial">
-    <div class="quote">"We were paying for ACC seats we never used. Switched 18 coordinators to Planscape and stopped sweating the monthly USD bill — local invoicing was the unlock."</div>
-    <div class="who">— Practice Owner, Kampala, Uganda · Pilot cohort, early 2026</div>
-  </div>
 </section>
 
 <section id="demo">
@@ -230,10 +224,10 @@
       <div class="eyebrow">Made for Africa's AEC sector</div>
       <h2>Global standards. Built for East &amp; West Africa.</h2>
       <p>From hospital wings in Kampala to port infrastructure in Lagos, Planscape is built by AEC practitioners who understand the realities of delivery across the continent — mixed teams, variable connectivity, and projects that must satisfy both local standards and international donor requirements.</p>
-      <p>The map shows six representative project types from our pilot cohort — hospital, airport, port, mixed-use, commercial, and utilities — illustrating the range of sectors and geographies we're designed for.</p>
+      <p>The map shows six representative project types — hospital, airport, port, mixed-use, commercial, and utilities — illustrating the range of sectors and geographies Planscape is designed for.</p>
       <div class="africa-stats">
-        <span class="stat-chip">🌍 Pilot projects across East &amp; West Africa</span>
-        <span class="stat-chip">🗂 Demo data — real client data on request</span>
+        <span class="stat-chip">🌍 Built for East &amp; West Africa</span>
+        <span class="stat-chip">🗂 Illustrative project types, not client data</span>
       </div>
     </div>
     <div>


### PR DESCRIPTION
Found while auditing the guides. Three factual problems on the **live** site, two of which carry real risk.

## 1. Fabricated testimonial

`index.html` carried:

> *"We were paying for ACC seats we never used. Switched 18 coordinators to Planscape and stopped sweating the monthly USD bill."*
> — Practice Owner, Kampala, Uganda · **Pilot cohort, early 2026**

**No such customer exists.** The production database holds **three tenants — all the owner's own test accounts** — and zero subscriptions have ever been created. Removed, together with the surrounding claims that implied real customers ("from our pilot cohort", "Pilot projects across East & West Africa", "real client data on request"). `about.html`'s "The pilot cohort runs through 2026" is reworded as the forward-looking statement it actually is.

## 2. Prices understated by more than half — in four places

| Homepage said | Catalog actually charges |
|---|---|
| "Revit plugin from **$15**/mo" | **$25**/mo |
| "cloud platform from **$35**/mo" | **$60**/mo |

Verified against a live checkout: UGX 92,500 = $25 × 3,700. It appeared in the hero, `description`, `og:description` and `twitter:description`. `pricing.html` already said $25/$60 — **the two pages contradicted each other**, and a prospect arriving on $15 would be charged $25.

## 3. Comparison table wrong by 11×

> "Planscape Large (20 users) — **$90/firm** — $4.50/user"

against `large: { usdMonthly: 1000, capCoordinators: 100 }`. Replaced with real figures for Practice ($280 ÷ 25 = $11.20) and Large ($1,000 ÷ 100 = $10) — which **still undercut every per-seat competitor in the table**, so the argument survives on honest numbers. Footnote now shows the arithmetic and flags that the competitor rate cards are unverified May-2026 figures.

(1) and (3) look like leftovers from the older flat per-firm pricing model (`fba697305`) that were never updated when the catalog changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)