### PR TITLE
feat(downloads): gated download area, and stop discarding the chosen plan

### DIFF
--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -101,6 +101,7 @@ table.inv tr:last-child td { border-bottom: 0; }
       </dl>
 
       <div class="acct-actions">
+        <a class="btn-primary" href="/downloads">Downloads</a>
         <button type="button" class="link-btn" id="logout-btn">Log out</button>
       </div>
     </div>
@@ -496,6 +497,17 @@ table.inv tr:last-child td { border-bottom: 0; }
     });
   }
 
+  // A plan chosen on the pricing page arrives as ?plan=planscape-studio. Split
+  // it into product + tier so the picker opens on what the visitor actually
+  // asked for instead of making them choose twice.
+  function preselectFromQuery() {
+    var raw = new URLSearchParams(window.location.search).get('plan');
+    if (!raw) return null;
+    var i = raw.lastIndexOf('-');
+    if (i < 1) return null;
+    return { product: raw.slice(0, i), tier: raw.slice(i + 1) };
+  }
+
   function renderPlanPicker() {
     var t = state.tenant || {};
     // Owner-only: /api/billing/checkout requires the owner role.
@@ -528,7 +540,18 @@ table.inv tr:last-child td { border-bottom: 0; }
     if (off) $('annual-off').textContent = '(save ' + Math.round(off * 100) + '%)';
 
     buildProductRow();
+    var pre = preselectFromQuery();
+    if (pre) {
+      var pr = document.querySelector('input[name=product][value="' + pre.product + '"]');
+      if (pr) pr.checked = true;
+    }
     buildTierSelect();
+    if (pre) {
+      var sel = $('tier-select');
+      for (var i = 0; i < sel.options.length; i++) {
+        if (sel.options[i].value === pre.tier) { sel.selectedIndex = i; break; }
+      }
+    }
     renderPrice();
     $('subscribe-btn').addEventListener('click', doSubscribe);
     document.querySelectorAll('input[name=cycle]').forEach(function(el){

--- a/marketing-site/downloads.html
+++ b/marketing-site/downloads.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Downloads — Planscape</title>
+<meta name="theme-color" content="#E8912D">
+<meta name="robots" content="noindex,nofollow">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/downloads">
+<link rel="stylesheet" href="/assets/site.css">
+<style>
+.dl-wrap { max-width: 780px; margin: 40px auto; padding: 0 16px; }
+.dl-head { margin-bottom: 8px; }
+.dl-head h1 { margin: 0 0 4px; font-size: 26px; }
+.dl-head .sub { color: var(--muted); margin: 0 0 20px; }
+.state { display: none; }
+.state.shown { display: block; }
+.spinner { font-size: 28px; text-align: center; padding: 40px 0; }
+.banner { padding: 13px 16px; border-radius: 10px; font-size: 14px; margin-bottom: 22px; border: 1px solid var(--line); background: #faf8f5; }
+.banner.warn { background: rgba(232,145,45,.08); border-color: rgba(232,145,45,.35); color: #8a5210; }
+.banner.stop { background: rgba(204,51,34,.07); border-color: rgba(204,51,34,.3); color: #8b2018; }
+.tool { border: 1px solid var(--line); border-radius: 12px; background: var(--card); padding: 20px 22px; margin-bottom: 16px; }
+.tool h2 { margin: 0 0 2px; font-size: 19px; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.tool .tagline { color: var(--muted); font-size: 14px; margin: 0 0 12px; }
+.tool .plat { font-size: 13px; color: var(--muted); margin: 0 0 14px; }
+.pill { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 11px; font-weight: 700; letter-spacing: .02em; }
+.pill.available { background: rgba(40,167,69,.12); color: #1e7e34; }
+.pill.beta { background: rgba(232,145,45,.16); color: #b5670f; }
+.pill.in-development { background: rgba(90,100,120,.12); color: #56607a; }
+.ver { border-top: 1px solid var(--line); padding-top: 13px; margin-top: 13px; }
+.ver:first-of-type { border-top: 0; }
+.ver .meta { font-size: 13px; color: var(--muted); margin: 0 0 9px; }
+.btn-primary { display: inline-block; background: var(--accent); color: #fff; border: 0; padding: 10px 18px; font-size: 14px; font-weight: 600; border-radius: 8px; cursor: pointer; text-decoration: none; }
+.btn-primary:hover { background: #d57f1f; }
+.btn-secondary { display: inline-block; background: none; color: var(--ink); border: 1px solid var(--line); padding: 9px 16px; font-size: 14px; font-weight: 600; border-radius: 8px; text-decoration: none; }
+.btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+.locked-note { font-size: 13px; color: var(--muted); margin: 10px 0 0; }
+.req { font-size: 13px; color: var(--muted); margin: 10px 0 0; }
+.acts { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+</style>
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <div class="links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/">Guides</a>
+    <a href="/account">Account</a>
+  </div>
+</nav>
+
+<div class="dl-wrap">
+  <div class="state shown" id="loading">
+    <div class="spinner">⏳</div>
+    <p class="sub" style="text-align:center">Checking your account…</p>
+  </div>
+
+  <div class="state" id="ready">
+    <div class="dl-head">
+      <h1>Downloads</h1>
+      <p class="sub" id="head-sub">Everything your plan includes.</p>
+    </div>
+    <div id="banner-slot"></div>
+    <div id="tools"></div>
+    <p class="req">Need something that isn't here, or a build for an older Revit version? Email <a href="mailto:hello@planscape.build">hello@planscape.build</a>.</p>
+  </div>
+</div>
+
+<footer class="site">
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+<script>
+(function(){
+  function $(id){ return document.getElementById(id); }
+  function toLogin(){ window.location.href = '/login'; }
+  function esc(s){ return String(s == null ? '' : s).replace(/[&<>"]/g, function(c){
+    return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]; }); }
+
+  // Session convention (see billing-success.html): mint an access token from the
+  // HttpOnly ps_refresh cookie and keep it in memory only. Never persisted.
+  var accessToken = null;
+
+  function daysLeft(iso){
+    if (!iso) return null;
+    var end = new Date(iso).getTime();
+    if (isNaN(end)) return null;
+    return Math.max(0, Math.ceil((end - Date.now()) / 86400000));
+  }
+
+  function banner(data){
+    var s = data.subscriptionStatus, d = daysLeft(data.trialEndsAt), el = $('banner-slot');
+    if (s === 'trial') {
+      el.innerHTML = '<div class="banner">You are on the free trial' +
+        (d !== null ? ' — <strong>' + d + ' day' + (d === 1 ? '' : 's') + ' left</strong>' : '') +
+        '. Everything below is yours to use meanwhile. No card is on file.</div>';
+    } else if (s === 'past_due') {
+      el.innerHTML = '<div class="banner warn">Your last payment did not go through. Downloads still work, but please ' +
+        '<a href="/account">update your payment method</a> to keep them.</div>';
+    } else if (s === 'read_only' || s === 'cancelled') {
+      el.innerHTML = '<div class="banner stop">Your access has ended, so downloads are locked. ' +
+        '<a href="/account">Choose a plan</a> to switch them back on.</div>';
+    }
+  }
+
+  function versionBlock(t, v){
+    var bits = [];
+    if (v.version && v.version !== 'current') bits.push('Version ' + esc(v.version));
+    if (v.hosts && v.hosts.length) bits.push(esc(v.hosts.join(' · ')));
+    if (v.sizeMb) bits.push(v.sizeMb + ' MB');
+    var meta = bits.length ? '<p class="meta">' + bits.join(' &middot; ') + '</p>' : '';
+    var note = v.notes ? '<p class="meta">' + esc(v.notes) + '</p>' : '';
+
+    // A version with no URL is not an error — it means we do not have a
+    // self-serve link for it yet. Say so plainly and give the way that works,
+    // rather than showing a button that goes nowhere.
+    var action = v.url
+      ? '<a class="btn-primary" href="' + esc(v.url) + '">Download</a>'
+      : '<a class="btn-secondary" href="mailto:hello@planscape.build?subject=' +
+        encodeURIComponent('Download request: ' + t.name) +
+        '">Request by email</a><span class="meta" style="margin:0">Self-serve download coming soon</span>';
+
+    return '<div class="ver">' + meta + note + '<div class="acts">' + action + '</div></div>';
+  }
+
+  function render(data){
+    banner(data);
+    var html = data.tools.map(function(t){
+      var head = '<h2>' + esc(t.name) +
+        '<span class="pill ' + esc(t.status) + '">' +
+        (t.status === 'in-development' ? 'IN DEVELOPMENT' : t.status.toUpperCase()) +
+        '</span></h2>';
+      var body = '<p class="tagline">' + esc(t.tagline) + '</p>' +
+        (t.platform ? '<p class="plat">' + esc(t.platform) + '</p>' : '');
+
+      var inner;
+      if (t.entitlement === 'allowed' && t.versions.length) {
+        inner = t.versions.map(function(v){ return versionBlock(t, v); }).join('');
+      } else if (t.entitlement === 'locked') {
+        inner = '<p class="locked-note">🔒 ' + esc(t.entitlementReason) +
+          ' <a href="/account">See plans</a></p>';
+      } else {
+        inner = '<p class="locked-note">' + esc(t.entitlementReason) + '</p>';
+      }
+
+      var docs = t.docsUrl
+        ? '<p class="req" style="margin-top:12px">Setup guide: <a href="' + esc(t.docsUrl) + '">' + esc(t.name) + '</a></p>'
+        : '';
+
+      return '<div class="tool">' + head + body + inner + docs + '</div>';
+    }).join('');
+
+    $('tools').innerHTML = html;
+    $('loading').classList.remove('shown');
+    $('ready').classList.add('shown');
+  }
+
+  fetch('/api/auth/refresh', {
+    method: 'POST', credentials: 'include',
+    headers: { 'Content-Type': 'application/json' }, body: '{}'
+  }).then(function(r){
+    if (!r.ok) throw new Error('refresh');
+    return r.json();
+  }).then(function(j){
+    accessToken = j && j.token;
+    if (!accessToken) throw new Error('no token');
+    return fetch('/api/downloads', { headers: { 'Authorization': 'Bearer ' + accessToken } });
+  }).then(function(r){
+    if (!r.ok) throw new Error('downloads');
+    return r.json();
+  }).then(render)
+    .catch(toLogin);
+})();
+</script>
+
+</body>
+</html>

--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -1,0 +1,148 @@
+// The download catalogue — one entry per distributable tool.
+//
+// This is deliberately data, not code: adding a tool (or a new version of an
+// existing one) means adding an object here, and the API and the downloads page
+// pick it up with no other changes. The same applies to tools that do not exist
+// yet — declare them with status "in-development" and they appear on the page as
+// "coming soon" rather than being invisible until launch day.
+//
+// Entitlement is by tenant subscription status, resolved in entitlementFor()
+// below. It is intentionally coarse: trial and active tenants get everything.
+// Per-product entitlement (STING Tools subscribers get only the plugin) would go
+// here too, via requiresProduct, once the plans justify it.
+
+export type ToolStatus = "available" | "beta" | "in-development";
+
+export interface ToolVersion {
+  version: string;
+  // Which Revit releases this build targets. Empty for tools that aren't
+  // Revit add-ins.
+  hosts?: string[];
+  sizeMb?: number;
+  releasedAt?: string; // ISO date
+  notes?: string;
+  // Where the file actually lives. Null means "we don't have a self-serve URL
+  // yet" — the page then tells the user to request it by email rather than
+  // showing a button that 404s. Set this and the button lights up; no code
+  // change needed.
+  url?: string | null;
+  sha256?: string | null;
+}
+
+export interface Tool {
+  id: string;
+  name: string;
+  tagline: string;
+  // What kind of thing this is, so the page can group and label sensibly.
+  kind: "revit-plugin" | "connector" | "desktop" | "cloud" | "cli";
+  status: ToolStatus;
+  platform?: string;
+  // Product a tenant must be subscribed to in order to download. null = any
+  // entitled tenant. Reserved for when plans diverge.
+  requiresProduct?: "sting-tools" | "planscape" | null;
+  docsUrl?: string;
+  versions: ToolVersion[];
+}
+
+export const DOWNLOAD_CATALOG: Tool[] = [
+  {
+    id: "sting-tools",
+    name: "STING Tools",
+    tagline:
+      "The Revit plugin — tagging, drawing production, MEP sizing and coordination. Runs on your workstation; no internet connection needed.",
+    kind: "revit-plugin",
+    status: "available",
+    platform: "Windows · Revit 2025, 2026, 2027",
+    requiresProduct: null,
+    docsUrl: "/guides/revit-plugin-setup.html",
+    versions: [
+      {
+        version: "current",
+        hosts: ["Revit 2025", "Revit 2026", "Revit 2027"],
+        notes:
+          "Tell us which Revit version you run and we will send the matching build with your licence.",
+        url: null,
+        sha256: null,
+      },
+    ],
+  },
+  {
+    id: "sting-bridge",
+    name: "StingBridge",
+    tagline:
+      "Connects ArchiCAD models to Planscape, and watches a folder for IFC files to bring in automatically.",
+    kind: "connector",
+    status: "beta",
+    platform: "Windows · macOS · ArchiCAD",
+    requiresProduct: null,
+    versions: [
+      {
+        version: "beta",
+        notes:
+          "In testing with a small group. Tell us about your ArchiCAD setup and we will include you.",
+        url: null,
+      },
+    ],
+  },
+  {
+    id: "planscape-cloud",
+    name: "Planscape cloud",
+    tagline:
+      "Shared project workspace, document register and issue tracking, with the mobile site app.",
+    kind: "cloud",
+    status: "in-development",
+    platform: "Web · iOS · Android",
+    requiresProduct: null,
+    versions: [],
+  },
+];
+
+export type Entitlement = "allowed" | "locked" | "unavailable";
+
+export interface EntitlementResult {
+  entitlement: Entitlement;
+  reason: string;
+}
+
+// Coarse by design: what a tenant may download is decided by whether their
+// subscription is live, not by which plan they are on. A tool that is not yet
+// released is "unavailable" to everyone regardless of subscription — being a
+// paying customer does not conjure software that does not exist.
+export function entitlementFor(
+  tool: Tool,
+  subscriptionStatus: string | null | undefined
+): EntitlementResult {
+  if (tool.status === "in-development") {
+    return {
+      entitlement: "unavailable",
+      reason: "Still in development — not available to download yet.",
+    };
+  }
+
+  switch (subscriptionStatus) {
+    case "trial":
+      return { entitlement: "allowed", reason: "Included in your trial." };
+    case "active":
+      return { entitlement: "allowed", reason: "Included in your plan." };
+    case "past_due":
+      // Don't cut off access the moment a payment bounces — dunning may still
+      // recover it, and locking a working tool over a card problem is a good
+      // way to lose a customer who intended to pay.
+      return {
+        entitlement: "allowed",
+        reason: "Your last payment did not go through — please update it to keep access.",
+      };
+    case "read_only":
+      return {
+        entitlement: "locked",
+        reason: "Your trial has ended. Choose a plan to download.",
+      };
+    case "cancelled":
+      return {
+        entitlement: "locked",
+        reason: "Your subscription has ended. Choose a plan to download again.",
+      };
+    default:
+      return { entitlement: "locked", reason: "Choose a plan to download." };
+  }
+}

--- a/marketing-site/functions/api/downloads/index.ts
+++ b/marketing-site/functions/api/downloads/index.ts
@@ -1,0 +1,60 @@
+// GET /api/downloads — the download catalogue, with per-tool entitlement
+// resolved against the caller's tenant. Any signed-in member can read it;
+// whether they may actually download is what `entitlement` reports.
+//
+// Requires auth rather than being public: the catalogue tells you what a
+// subscription is worth, and the entitlement reasons quote the tenant's own
+// billing state back at them.
+
+import { withHandler } from "../auth/_lib/handler";
+import { handlePreflight } from "../auth/_lib/cors";
+import { requireAuth } from "../auth/_lib/auth";
+import { unauthorized } from "../auth/_lib/errors";
+import { getTenantById } from "../auth/_lib/db";
+import { DOWNLOAD_CATALOG, entitlementFor } from "../_lib/downloads/catalog";
+
+export const onRequestOptions: PagesFunction = async ({ request }) =>
+  handlePreflight(request);
+
+export const onRequestGet = withHandler(async ({ request, env }) => {
+  const auth = await requireAuth(request, env);
+  const tenant = await getTenantById(env.WAITLIST_DB, auth.tenantId);
+  if (!tenant) throw unauthorized("Account no longer exists.");
+
+  const status = tenant.subscription_status;
+
+  const tools = DOWNLOAD_CATALOG.map((tool) => {
+    const { entitlement, reason } = entitlementFor(tool, status);
+    return {
+      id: tool.id,
+      name: tool.name,
+      tagline: tool.tagline,
+      kind: tool.kind,
+      status: tool.status,
+      platform: tool.platform ?? null,
+      docsUrl: tool.docsUrl ?? null,
+      entitlement,
+      entitlementReason: reason,
+      // Only hand out file URLs to a tenant actually entitled to them. A locked
+      // tenant still sees the catalogue — they just don't get the link.
+      versions:
+        entitlement === "allowed"
+          ? tool.versions.map((v) => ({
+              version: v.version,
+              hosts: v.hosts ?? null,
+              sizeMb: v.sizeMb ?? null,
+              releasedAt: v.releasedAt ?? null,
+              notes: v.notes ?? null,
+              url: v.url ?? null,
+              sha256: v.sha256 ?? null,
+            }))
+          : [],
+    };
+  });
+
+  return {
+    tools,
+    subscriptionStatus: status,
+    trialEndsAt: tenant.trial_ends_at ?? null,
+  };
+});

--- a/marketing-site/signup.html
+++ b/marketing-site/signup.html
@@ -287,7 +287,11 @@
     }).then(function(){
       // The signup response set the ps_refresh cookie; the account page mints an
       // access token from it. Head straight there.
-      window.location.href = '/account';
+      // Carry the plan the visitor picked on the pricing page through to the
+      // account page, which pre-selects it. Previously ?plan= was read by
+      // nobody, so choosing a plan then signing up silently forgot the choice.
+      var chosen = new URLSearchParams(window.location.search).get('plan');
+      window.location.href = chosen ? ('/account?plan=' + encodeURIComponent(chosen)) : '/account';
     }).catch(function(err){
       showError((err && err.msg) || 'Network error — please try again, or email hello@planscape.build.');
     });


### PR DESCRIPTION
Two gaps, both of which left a paying customer with nothing to use.

## 1. There was no way to get the software

No downloads page existed. Someone could sign up, pay, and still be waiting on a manual email. Adds **`/downloads`**, gated on the session cookie, showing per-tool entitlement resolved from the tenant's subscription status.

**The catalogue is data, not code** (`functions/api/_lib/downloads/catalog.ts`) — adding a tool or a version is one object, and both the API and the page pick it up unchanged:

- Tools that don't exist yet get `status: "in-development"` and show as "coming soon" rather than being invisible until launch day.
- A version with no `url` renders **"Request by email"** instead of a button that 404s. Set the url later and it lights up — no code change.

That's the extensibility story: StingBridge and whatever follows are **rows, not new pages**.

**Entitlement is coarse on purpose:**

| Status | Result |
|---|---|
| `trial`, `active` | Everything |
| `past_due` | Everything, with a warning — cutting off a working tool over a bounced card is a good way to lose a customer who meant to pay |
| `read_only`, `cancelled` | Catalogue visible, links **withheld server-side** (not merely hidden in the page) |

## 2. Signup discarded the plan the visitor chose

`pricing.html` sends people to `/signup?plan=planscape-studio`. **`signup.html` referenced `?plan=` nowhere at all.** The tenant was created with `plan_product = NULL`, and the account page then asked them to choose again — this time behind a payment button. The parameter now survives signup and pre-selects product and tier.

## Why Planscape cloud is listed as "in development" rather than offered as a trial

The destination doesn't exist:

- `api.planscape.build` → **HTTP 000**, not deployed
- The .NET server **cannot currently deploy**: 83 migration files carry only **2** `[Migration]` attributes, and `Program.cs:1321-1326` states outright that `Migrate()` cannot apply them in order
- D1 and .NET tokens are incompatible on three independent axes (signing secret, `iss` case, missing `aud`)

Promising a cloud trial today would promise a page that isn't there.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)