### PR TITLE
feat(downloads): serve real builds from private R2, gated per request

### DIFF
--- a/marketing-site/downloads.html
+++ b/marketing-site/downloads.html
@@ -117,8 +117,8 @@
     // A version with no URL is not an error — it means we do not have a
     // self-serve link for it yet. Say so plainly and give the way that works,
     // rather than showing a button that goes nowhere.
-    var action = v.url
-      ? '<a class="btn-primary" href="' + esc(v.url) + '">Download</a>'
+    var action = v.downloadUrl
+      ? '<a class="btn-primary" href="' + esc(v.downloadUrl) + '">Download</a>'
       : '<a class="btn-secondary" href="mailto:hello@planscape.build?subject=' +
         encodeURIComponent('Download request: ' + t.name) +
         '">Request by email</a><span class="meta" style="margin:0">Self-serve download coming soon</span>';

--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -21,11 +21,11 @@ export interface ToolVersion {
   sizeMb?: number;
   releasedAt?: string; // ISO date
   notes?: string;
-  // Where the file actually lives. Null means "we don't have a self-serve URL
-  // yet" — the page then tells the user to request it by email rather than
-  // showing a button that 404s. Set this and the button lights up; no code
-  // change needed.
-  url?: string | null;
+  // Key of the object in the private R2 bucket. Set this and the download
+  // becomes self-serve, streamed through /api/downloads/:tool/:version with an
+  // entitlement check. Null means we have no file yet and the page falls back
+  // to "request by email" — no code change either way.
+  objectKey?: string | null;
   sha256?: string | null;
 }
 
@@ -57,11 +57,13 @@ export const DOWNLOAD_CATALOG: Tool[] = [
     docsUrl: "/guides/revit-plugin-setup.html",
     versions: [
       {
-        version: "current",
+        version: "2026-07-05",
         hosts: ["Revit 2025", "Revit 2026", "Revit 2027"],
+        sizeMb: 88,
+        releasedAt: "2026-07-05",
         notes:
-          "Tell us which Revit version you run and we will send the matching build with your licence.",
-        url: null,
+          "One package covers all three Revit versions — the installer puts the files in the right place. Includes an install guide and an uninstaller.",
+        objectKey: "sting-tools/2026-07-05/StingTools_Deploy_20260705.zip",
         sha256: null,
       },
     ],
@@ -80,7 +82,7 @@ export const DOWNLOAD_CATALOG: Tool[] = [
         version: "beta",
         notes:
           "In testing with a small group. Tell us about your ArchiCAD setup and we will include you.",
-        url: null,
+        objectKey: null,
       },
     ],
   },

--- a/marketing-site/functions/api/downloads/[tool]/[version].ts
+++ b/marketing-site/functions/api/downloads/[tool]/[version].ts
@@ -1,0 +1,81 @@
+// GET /api/downloads/:tool/:version — stream a build from R2, but only to a
+// tenant entitled to it.
+//
+// The bucket is private and has no public URL. Every byte goes through this
+// Function, which re-checks entitlement on each request. That is the point: a
+// direct link cannot be forwarded to someone who has not paid, and revoking a
+// subscription revokes downloads immediately rather than at the next cache
+// expiry.
+//
+// The object key comes from the catalogue, never from the URL, so a caller
+// cannot walk the bucket by editing the path.
+
+import { handlePreflight } from "../../auth/_lib/cors";
+import { requireAuth } from "../../auth/_lib/auth";
+import { getTenantById } from "../../auth/_lib/db";
+import { DOWNLOAD_CATALOG, entitlementFor } from "../../_lib/downloads/catalog";
+import type { Env } from "../../auth/_lib/types";
+
+interface DownloadsEnv extends Env {
+  DOWNLOADS: R2Bucket;
+}
+
+export const onRequestOptions: PagesFunction = async ({ request }) =>
+  handlePreflight(request);
+
+function deny(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestGet: PagesFunction<DownloadsEnv> = async ({
+  request,
+  env,
+  params,
+}) => {
+  let auth;
+  try {
+    auth = await requireAuth(request, env);
+  } catch {
+    return deny(401, "Sign in to download.");
+  }
+
+  const tenant = await getTenantById(env.WAITLIST_DB, auth.tenantId);
+  if (!tenant) return deny(401, "Account no longer exists.");
+
+  const toolId = String(params.tool);
+  const versionId = String(params.version);
+
+  const tool = DOWNLOAD_CATALOG.find((t) => t.id === toolId);
+  if (!tool) return deny(404, "Unknown download.");
+
+  const { entitlement, reason } = entitlementFor(tool, tenant.subscription_status);
+  if (entitlement !== "allowed") return deny(403, reason);
+
+  const version = tool.versions.find((v) => v.version === versionId);
+  // objectKey is what makes path traversal a non-issue: the key is whatever the
+  // catalogue says, and the URL only ever selects a catalogue entry.
+  if (!version || !version.objectKey) return deny(404, "That version is not available.");
+
+  const object = await env.DOWNLOADS.get(version.objectKey);
+  if (!object) {
+    console.error(
+      `R2 object missing for ${toolId}/${versionId}: ${version.objectKey}`
+    );
+    return deny(404, "That file is temporarily unavailable. Please contact support.");
+  }
+
+  const filename = version.objectKey.split("/").pop() || `${toolId}.zip`;
+  const headers = new Headers();
+  object.writeHttpMetadata(headers);
+  headers.set("Content-Type", "application/zip");
+  headers.set("Content-Disposition", `attachment; filename="${filename}"`);
+  headers.set("etag", object.httpEtag);
+  // Never cache at the edge: caching would serve the file to a later request
+  // without re-running the entitlement check above.
+  headers.set("Cache-Control", "private, no-store");
+
+  return new Response(object.body, { headers });
+};

--- a/marketing-site/functions/api/downloads/index.ts
+++ b/marketing-site/functions/api/downloads/index.ts
@@ -45,7 +45,11 @@ export const onRequestGet = withHandler(async ({ request, env }) => {
               sizeMb: v.sizeMb ?? null,
               releasedAt: v.releasedAt ?? null,
               notes: v.notes ?? null,
-              url: v.url ?? null,
+              // Point at our own gated endpoint, never at R2 directly. The
+              // bucket is private; this URL re-checks entitlement per request.
+              downloadUrl: v.objectKey
+                ? `/api/downloads/${tool.id}/${encodeURIComponent(v.version)}`
+                : null,
               sha256: v.sha256 ?? null,
             }))
           : [],

--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -37,6 +37,17 @@ binding       = "WAITLIST_DB"
 database_name = "planscape-waitlist"
 database_id   = "b7029da2-6019-4ceb-bd87-22870a313db7"
 
+# R2 binding for the gated download area (functions/api/downloads/*).
+# Created via: wrangler r2 bucket create planscape-downloads
+# The bucket is PRIVATE — files are streamed through a Function that checks the
+# caller's subscription entitlement first, so a download link cannot be forwarded
+# to someone who has not paid. Never make this bucket public.
+# Upload a build:
+#   wrangler r2 object put planscape-downloads/<tool>/<version>/<file>.zip --file <path>
+[[r2_buckets]]
+binding     = "DOWNLOADS"
+bucket_name = "planscape-downloads"
+
 # Per-environment overrides
 [env.preview]
 name = "planscape-marketing-preview"
@@ -49,6 +60,10 @@ binding       = "WAITLIST_DB"
 database_name = "planscape-waitlist"
 database_id   = "b7029da2-6019-4ceb-bd87-22870a313db7"
 
+[[env.preview.r2_buckets]]
+binding     = "DOWNLOADS"
+bucket_name = "planscape-downloads"
+
 [env.production]
 name = "planscape-marketing"
 
@@ -59,3 +74,7 @@ SITE_URL = "https://planscape.build"
 binding       = "WAITLIST_DB"
 database_name = "planscape-waitlist"
 database_id   = "b7029da2-6019-4ceb-bd87-22870a313db7"
+
+[[env.production.r2_buckets]]
+binding     = "DOWNLOADS"
+bucket_name = "planscape-downloads"


### PR DESCRIPTION
The catalogue shipped in the previous commit, but every tool said "request by email" because there was nowhere to host a build — **Cloudflare Pages caps files at 25 MiB** and the plugin is **88 MB**.

## What this adds

- **R2 enabled** + `DOWNLOADS` binding (main, preview, production)
- **The real build uploaded** — `StingTools_Deploy_20260705`, the licence-gated 5 July package covering Revit 2025/2026/2027
- **`GET /api/downloads/:tool/:version`** — streams the object from R2 after re-checking entitlement

## Why it streams instead of redirecting to R2

The bucket is **private and has no public URL**. Every byte goes through the Function, which means:

- a download link **cannot be forwarded** to someone who hasn't paid
- revoking a subscription **revokes downloads immediately**, not whenever a cached URL expires (`Cache-Control: private, no-store`)
- the R2 object key comes from **the catalogue, never the request path** — a caller can't walk the bucket by editing the URL

## Publishing the next build

Upload to R2, change `objectKey` in `catalog.ts`. Nothing else moves.

A version with `objectKey: null` still falls back to "request by email" — which is how StingBridge stays listed while it's in testing.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)