### PR TITLE
fix(downloads): Download button always said Sign in to download

### DIFF
--- a/marketing-site/functions/api/downloads/[tool]/[version].ts
+++ b/marketing-site/functions/api/downloads/[tool]/[version].ts
@@ -12,7 +12,9 @@
 
 import { handlePreflight } from "../../auth/_lib/cors";
 import { requireAuth } from "../../auth/_lib/auth";
-import { getTenantById } from "../../auth/_lib/db";
+import { getTenantById, getSessionByTokenHash, getUserById } from "../../auth/_lib/db";
+import { readRefreshCookie } from "../../auth/_lib/session";
+import { sha256Hex } from "../../auth/_lib/tokens";
 import { DOWNLOAD_CATALOG, entitlementFor } from "../../_lib/downloads/catalog";
 import type { Env } from "../../auth/_lib/types";
 
@@ -35,12 +37,28 @@ export const onRequestGet: PagesFunction<DownloadsEnv> = async ({
   env,
   params,
 }) => {
-  let auth;
+  // A download is triggered by a plain browser navigation (<a href>), which
+  // sends NO Authorization header — the access token lives in memory in the
+  // page, not in a cookie. So Bearer auth alone always failed here with "Sign
+  // in to download" for a user who was very much signed in.
+  //
+  // Fall back to the HttpOnly ps_refresh cookie, which the browser DOES send on
+  // a same-origin navigation (SameSite=Strict). Bearer is still accepted first
+  // so scripted clients keep working.
+  let auth: { userId: string; tenantId: string } | null = null;
   try {
     auth = await requireAuth(request, env);
   } catch {
-    return deny(401, "Sign in to download.");
+    const presented = readRefreshCookie(request);
+    if (presented) {
+      const session = await getSessionByTokenHash(env.WAITLIST_DB, await sha256Hex(presented));
+      if (session && new Date(session.expires_at).getTime() > Date.now() && !session.revoked_at) {
+        const user = await getUserById(env.WAITLIST_DB, session.user_id);
+        if (user) auth = { userId: user.id, tenantId: user.tenant_id };
+      }
+    }
   }
+  if (!auth) return deny(401, "Sign in to download.");
 
   const tenant = await getTenantById(env.WAITLIST_DB, auth.tenantId);
   if (!tenant) return deny(401, "Account no longer exists.");

--- a/marketing-site/functions/api/license/issue.ts
+++ b/marketing-site/functions/api/license/issue.ts
@@ -1,0 +1,212 @@
+// POST /api/license/issue — mint a signed STING Tools licence for one machine.
+//
+// The plugin verifies licences entirely OFFLINE: a signed payload bound to a
+// machine fingerprint, checked against a public key compiled into the assembly
+// (StingTools/Core/Licensing/LicenseVerifier.cs). There is no call-home, so an
+// issued licence CANNOT be revoked remotely — it only expires. Two consequences
+// drive the design here:
+//
+//   1. The seat check at issue time is the only enforcement point that exists.
+//      Without it, one Solo subscriber could licence unlimited machines.
+//   2. Expiry has to be chosen up front. A trial licence dies with the trial; a
+//      paid one runs a year, matching the existing hand-issued licences.
+//
+// Wire format, byte-for-byte compatible with LicenseCrypto.VerifyAndExtract:
+//   base64(utf8(payloadJson)) + "." + base64(RSASSA-PKCS1-v1_5(SHA-256, jsonBytes))
+
+import { withHandler, readJson } from "../auth/_lib/handler";
+import { handlePreflight } from "../auth/_lib/cors";
+import { requireAuth } from "../auth/_lib/auth";
+import { bad, forbidden, serverError, unauthorized } from "../auth/_lib/errors";
+import { getTenantById, audit } from "../auth/_lib/db";
+import { uuid } from "../auth/_lib/tokens";
+import { resolveCap } from "../auth/_lib/limits";
+import { DOWNLOAD_CATALOG, entitlementFor } from "../_lib/downloads/catalog";
+import type { Env } from "../auth/_lib/types";
+
+interface LicenseEnv extends Env {
+  // PKCS#8 PEM of the RSA key whose public half is compiled into the plugin.
+  LICENSE_PRIVATE_KEY?: string;
+}
+
+interface Body {
+  machineCode?: string;
+}
+
+// Matches the format the plugin shows the user: five 4-hex-char groups.
+const MACHINE_CODE = /^[0-9A-F]{4}(-[0-9A-F]{4}){4}$/i;
+
+const PAID_LICENCE_DAYS = 365;
+// A little past the trial so a licence issued on the last day still works while
+// the customer is deciding.
+const TRIAL_GRACE_DAYS = 2;
+
+function pemToBinary(pem: string): ArrayBuffer {
+  const body = pem
+    .replace(/-----BEGIN [A-Z ]+-----/g, "")
+    .replace(/-----END [A-Z ]+-----/g, "")
+    .replace(/\s+/g, "");
+  const raw = atob(body);
+  const buf = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) buf[i] = raw.charCodeAt(i);
+  return buf.buffer;
+}
+
+function b64(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
+async function signLicense(pem: string, payloadJson: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToBinary(pem),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const data = new TextEncoder().encode(payloadJson);
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, data)
+  );
+  return `${b64(data)}.${b64(sig)}`;
+}
+
+export const onRequestOptions: PagesFunction = async ({ request }) =>
+  handlePreflight(request);
+
+export const onRequestPost = withHandler(async ({ request, env }) => {
+  const e = env as LicenseEnv;
+  const auth = await requireAuth(request, e);
+
+  if (!e.LICENSE_PRIVATE_KEY) {
+    // Fail loudly rather than half-issuing something unsigned.
+    console.error("License issue attempted with LICENSE_PRIVATE_KEY unset");
+    throw serverError("Licensing is not configured.");
+  }
+
+  const body = await readJson<Body>(request);
+  const machineCode = (body.machineCode || "").trim().toUpperCase();
+  if (!MACHINE_CODE.test(machineCode)) {
+    throw bad(
+      "That machine code doesn't look right. It appears in the plugin as five groups, like ADD3-E01C-3412-14C8-175E."
+    );
+  }
+
+  const tenant = await getTenantById(e.WAITLIST_DB, auth.tenantId);
+  if (!tenant) throw unauthorized("Account no longer exists.");
+
+  // Same entitlement gate the downloads use — a locked tenant gets no licence.
+  const tool = DOWNLOAD_CATALOG.find((t) => t.id === "sting-tools")!;
+  const { entitlement, reason } = entitlementFor(tool, tenant.subscription_status);
+  if (entitlement !== "allowed") throw forbidden(reason);
+
+  const now = new Date();
+  const db = e.WAITLIST_DB;
+
+  // Already licensed this machine? Re-issue without consuming another seat —
+  // reinstalls and lost .lic files are normal, not abuse.
+  const existing = await db
+    .prepare(
+      `SELECT id FROM licenses
+        WHERE tenant_id = ? AND machine_code = ? AND revoked_at IS NULL`
+    )
+    .bind(tenant.id, machineCode)
+    .first<{ id: string }>();
+
+  if (!existing) {
+    const cap = resolveCap(tenant.plan_product, tenant.plan_tier);
+    if (cap !== Infinity) {
+      const row = await db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM licenses
+            WHERE tenant_id = ? AND revoked_at IS NULL AND expires_at > ?`
+        )
+        .bind(tenant.id, now.toISOString())
+        .first<{ n: number }>();
+      const used = row?.n ?? 0;
+      if (used >= cap) {
+        throw forbidden(
+          `Your plan covers ${cap} machine${cap === 1 ? "" : "s"} and ${used} ${
+            used === 1 ? "is" : "are"
+          } already licensed. Upgrade your plan, or contact us to move a licence to a different machine.`
+        );
+      }
+    }
+  }
+
+  // Trial licences die with the trial; paid ones run a year. The plugin cannot
+  // phone home to re-check, so this is a one-shot decision per issue.
+  const isTrial = tenant.subscription_status === "trial";
+  let expires: Date;
+  if (isTrial && tenant.trial_ends_at) {
+    expires = new Date(
+      new Date(tenant.trial_ends_at).getTime() + TRIAL_GRACE_DAYS * 86400_000
+    );
+  } else {
+    expires = new Date(now.getTime() + PAID_LICENCE_DAYS * 86400_000);
+  }
+
+  const licenseId = existing?.id ?? uuid();
+  const payload = {
+    licenseId: licenseId.replace(/-/g, ""),
+    machineCode,
+    licensee: tenant.name || "Planscape Licensed User",
+    issuedUnix: Math.floor(now.getTime() / 1000),
+    expiryUnix: Math.floor(expires.getTime() / 1000),
+    schema: 1,
+  };
+
+  let licenseText: string;
+  try {
+    licenseText = await signLicense(e.LICENSE_PRIVATE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    console.error("License signing failed", err);
+    throw serverError("Could not issue a licence. Please contact support.");
+  }
+
+  const nowIso = now.toISOString();
+  await db
+    .prepare(
+      `INSERT INTO licenses
+         (id, tenant_id, user_id, machine_code, licensee, issued_at, expires_at, created_at, updated_at)
+       VALUES (?,?,?,?,?,?,?,?,?)
+       ON CONFLICT(tenant_id, machine_code) DO UPDATE SET
+         licensee   = excluded.licensee,
+         issued_at  = excluded.issued_at,
+         expires_at = excluded.expires_at,
+         revoked_at = NULL,
+         updated_at = excluded.updated_at`
+    )
+    .bind(
+      licenseId,
+      tenant.id,
+      auth.userId,
+      machineCode,
+      payload.licensee,
+      nowIso,
+      expires.toISOString(),
+      nowIso,
+      nowIso
+    )
+    .run();
+
+  await audit(db, {
+    tenantId: tenant.id,
+    actorUserId: auth.userId,
+    action: existing ? "license.reissued" : "license.issued",
+    target: machineCode,
+    metadata: { expiresAt: expires.toISOString(), trial: isTrial },
+    ip: request.headers.get("CF-Connecting-IP"),
+    userAgent: request.headers.get("User-Agent"),
+  });
+
+  return {
+    license: licenseText,
+    machineCode,
+    licensee: payload.licensee,
+    expiresAt: expires.toISOString(),
+    reissued: Boolean(existing),
+  };
+});

--- a/marketing-site/functions/api/schema.sql
+++ b/marketing-site/functions/api/schema.sql
@@ -359,3 +359,32 @@ CREATE INDEX        IF NOT EXISTS idx_discount_active   ON discount_codes(active
 -- Step 3 — (re-)apply this schema file; idx_subs_provider_unique now creates:
 --   cd marketing-site && npm run schema:remote
 -- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- Issued plugin licences (self-serve licence automation).
+--
+-- The STING Tools licence is verified entirely offline by the plugin: a signed
+-- payload bound to one machine fingerprint, with an expiry. There is no
+-- call-home, so once issued a licence cannot be revoked remotely — it simply
+-- expires. That makes the seat check at ISSUE time the only enforcement point,
+-- which is why we record every machine we have licensed.
+--
+-- One row per (tenant, machine_code). Re-issuing for a machine we have already
+-- licensed updates the row and does NOT consume another seat, so a user who
+-- reinstalls or loses their .lic file is not punished for it.
+CREATE TABLE IF NOT EXISTS licenses (
+  id            TEXT    PRIMARY KEY,            -- uuid v4, also the licenseId in the payload
+  tenant_id     TEXT    NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  user_id       TEXT,                           -- who requested it (audit only)
+  machine_code  TEXT    NOT NULL,               -- e.g. ADD3-E01C-3412-14C8-175E
+  licensee      TEXT    NOT NULL,               -- shown in the plugin's About box
+  issued_at     TEXT    NOT NULL,               -- ISO 8601 UTC
+  expires_at    TEXT    NOT NULL,               -- ISO 8601 UTC
+  revoked_at    TEXT,                           -- set to stop it counting against seats
+  created_at    TEXT    NOT NULL,
+  updated_at    TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_licenses_tenant_machine
+  ON licenses(tenant_id, machine_code);
+CREATE INDEX IF NOT EXISTS idx_licenses_tenant ON licenses(tenant_id);


### PR DESCRIPTION
The catalogue loaded and the page showed the user signed in, but **Download 401'd every time**.

**Cause:** the button is a plain anchor link, so clicking it is a *browser navigation* — which sends no `Authorization` header. The access token lives in a JS variable in the page (deliberately; tokens are never persisted), so it could not travel with the request. Bearer was the only accepted path, so a fully signed-in user was told to sign in.

**Fix:** fall back to the HttpOnly `ps_refresh` cookie, which the browser *does* send on a same-origin navigation (`SameSite=Strict`). Validated exactly as `/api/auth/refresh` does — hash, look up session, check expiry and revocation, resolve user. Bearer is still tried first, so scripted clients are unaffected.

**Why testing missed it:** curl was passed an explicit Bearer token. A browser exercises a different path entirely — the same blind spot that hid the CORS bug earlier in this branch.

Typecheck clean.
