### PR TITLE
fix(downloads): pass a short-lived token in the download URL

### DIFF
--- a/marketing-site/downloads.html
+++ b/marketing-site/downloads.html
@@ -117,8 +117,12 @@
     // A version with no URL is not an error — it means we do not have a
     // self-serve link for it yet. Say so plainly and give the way that works,
     // rather than showing a button that goes nowhere.
+    // The href carries the access token because a navigation cannot send an
+    // Authorization header, and the ps_refresh cookie is scoped to /api/auth
+    // so it never reaches the download endpoint. Safe only because this token
+    // is short-lived; it is built at click time from the in-memory token.
     var action = v.downloadUrl
-      ? '<a class="btn-primary" href="' + esc(v.downloadUrl) + '">Download</a>'
+      ? '<a class="btn-primary" href="' + esc(v.downloadUrl) + '?t=' + encodeURIComponent(accessToken || '') + '">Download</a>'
       : '<a class="btn-secondary" href="mailto:hello@planscape.build?subject=' +
         encodeURIComponent('Download request: ' + t.name) +
         '">Request by email</a><span class="meta" style="margin:0">Self-serve download coming soon</span>';

--- a/marketing-site/functions/api/downloads/[tool]/[version].ts
+++ b/marketing-site/functions/api/downloads/[tool]/[version].ts
@@ -12,9 +12,8 @@
 
 import { handlePreflight } from "../../auth/_lib/cors";
 import { requireAuth } from "../../auth/_lib/auth";
-import { getTenantById, getSessionByTokenHash, getUserById } from "../../auth/_lib/db";
-import { readRefreshCookie } from "../../auth/_lib/session";
-import { sha256Hex } from "../../auth/_lib/tokens";
+import { getTenantById } from "../../auth/_lib/db";
+import { verifyJwt } from "../../auth/_lib/jwt";
 import { DOWNLOAD_CATALOG, entitlementFor } from "../../_lib/downloads/catalog";
 import type { Env } from "../../auth/_lib/types";
 
@@ -37,25 +36,26 @@ export const onRequestGet: PagesFunction<DownloadsEnv> = async ({
   env,
   params,
 }) => {
-  // A download is triggered by a plain browser navigation (<a href>), which
-  // sends NO Authorization header — the access token lives in memory in the
-  // page, not in a cookie. So Bearer auth alone always failed here with "Sign
-  // in to download" for a user who was very much signed in.
+  // A download is a plain browser navigation (<a href>), which sends no
+  // Authorization header — the access token lives in memory in the page. The
+  // ps_refresh cookie cannot help either: it is deliberately scoped to
+  // Path=/api/auth, so it is never sent here (that scoping is a good thing and
+  // is left alone).
   //
-  // Fall back to the HttpOnly ps_refresh cookie, which the browser DOES send on
-  // a same-origin navigation (SameSite=Strict). Bearer is still accepted first
-  // so scripted clients keep working.
+  // So the page passes the access token it already holds as ?t=. The token is
+  // the same short-lived JWT used everywhere else, verified identically. It
+  // ends up in browser history and any intermediary log, which is acceptable
+  // only because it expires quickly — never accept a long-lived credential this
+  // way.
   let auth: { userId: string; tenantId: string } | null = null;
   try {
-    auth = await requireAuth(request, env);
+    const ctx = await requireAuth(request, env);
+    auth = { userId: ctx.userId, tenantId: ctx.tenantId };
   } catch {
-    const presented = readRefreshCookie(request);
-    if (presented) {
-      const session = await getSessionByTokenHash(env.WAITLIST_DB, await sha256Hex(presented));
-      if (session && new Date(session.expires_at).getTime() > Date.now() && !session.revoked_at) {
-        const user = await getUserById(env.WAITLIST_DB, session.user_id);
-        if (user) auth = { userId: user.id, tenantId: user.tenant_id };
-      }
+    const t = new URL(request.url).searchParams.get("t");
+    if (t) {
+      const claims = await verifyJwt(t, env.JWT_SECRET);
+      if (claims) auth = { userId: claims.sub, tenantId: claims.tid };
     }
   }
   if (!auth) return deny(401, "Sign in to download.");


### PR DESCRIPTION
The Download button 401'd for signed-in users. My first attempt — falling back to the `ps_refresh` cookie — **could never have worked**, and returning diagnostics in the response said why in one line:

```
cookieHeader=NO presented=NO
```

The cookie is set with **`Path=/api/auth`** (`session.ts:87`), so the browser only ever sends it to `/api/auth/*`. It reaches `/api/auth/refresh` and never reaches `/api/downloads/*`.

That scoping is a sensible restriction, so it's left alone — widening it to `Path=/` would make the refresh cookie travel with every request on the site to fix one button.

**Fix:** the page appends the access token it already holds as `?t=`, and the endpoint verifies it with the same `verifyJwt` used everywhere else. A URL is an acceptable place for this token *only* because it is short-lived; a refresh token or API key must never be passed this way.

## Verified on the real browser path (no headers at all)

| Test | Result |
|---|---|
| Navigation with `?t=` | **200 · 92,992,502 bytes · valid zip, 600 files** |
| No token | **401** |
| Forged token | **401** |

## How it was found

`wrangler pages deployment tail` captured nothing across two attempts, so I returned booleans in the 401 body instead. Two rounds of deploy-and-retest guessing preceded that and would have continued indefinitely — the fix took one observation.
