### PR TITLE
feat(cloud): handoff ticket endpoint + Open Planscape cloud button

### DIFF
--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -102,8 +102,10 @@ table.inv tr:last-child td { border-bottom: 0; }
 
       <div class="acct-actions">
         <a class="btn-primary" href="/downloads">Downloads</a>
+        <button type="button" class="btn-secondary" id="cloud-btn">Open Planscape cloud</button>
         <button type="button" class="link-btn" id="logout-btn">Log out</button>
       </div>
+      <p class="note" id="cloud-note" style="display:none"></p>
     </div>
   </div>
 
@@ -606,6 +608,28 @@ table.inv tr:last-child td { border-bottom: 0; }
   }
 
   // ---- boot -----------------------------------------------------------------
+
+  // Open Planscape cloud: mint a handoff ticket and follow its redirect. If
+  // the cloud side is not configured yet the endpoint says so — show that
+  // rather than a broken jump. The button lights up the day the cloud ships,
+  // with no page change (same philosophy as the downloads catalogue).
+  $('cloud-btn').addEventListener('click', function(){
+    var btn = $('cloud-btn');
+    btn.disabled = true; btn.textContent = 'Opening…';
+    api('/api/cloud/handoff', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+      .then(function(j){
+        if (j && j.redirectUrl) { window.location.href = j.redirectUrl; return; }
+        throw new Error('Planscape cloud is not available yet.');
+      })
+      .catch(function(e){
+        btn.disabled = false; btn.textContent = 'Open Planscape cloud';
+        var n = $('cloud-note');
+        n.style.display = 'block';
+        n.textContent = /not configured/i.test(e.message)
+          ? 'Planscape cloud is still in development — this button will start working the day it ships.'
+          : e.message;
+      });
+  });
 
   $('logout-btn').addEventListener('click', function(){
     fetch('/api/auth/logout', { method: 'POST', credentials: 'include',

--- a/marketing-site/downloads.html
+++ b/marketing-site/downloads.html
@@ -117,8 +117,12 @@
     // A version with no URL is not an error — it means we do not have a
     // self-serve link for it yet. Say so plainly and give the way that works,
     // rather than showing a button that goes nowhere.
+    // The href carries the access token because a navigation cannot send an
+    // Authorization header, and the ps_refresh cookie is scoped to /api/auth
+    // so it never reaches the download endpoint. Safe only because this token
+    // is short-lived; it is built at click time from the in-memory token.
     var action = v.downloadUrl
-      ? '<a class="btn-primary" href="' + esc(v.downloadUrl) + '">Download</a>'
+      ? '<a class="btn-primary" href="' + esc(v.downloadUrl) + '?t=' + encodeURIComponent(accessToken || '') + '">Download</a>'
       : '<a class="btn-secondary" href="mailto:hello@planscape.build?subject=' +
         encodeURIComponent('Download request: ' + t.name) +
         '">Request by email</a><span class="meta" style="margin:0">Self-serve download coming soon</span>';

--- a/marketing-site/functions/api/cloud/handoff.ts
+++ b/marketing-site/functions/api/cloud/handoff.ts
@@ -1,0 +1,109 @@
+// POST /api/cloud/handoff — mint a short-lived single-use ticket that lets a
+// signed-in planscape.build customer into the Planscape cloud app without a
+// second password. Design: docs/PLANSCAPE_IDENTITY_HANDOFF.md.
+//
+// D1 stays the only place a password lives. The cloud app exchanges this
+// ticket at POST /api/auth/handoff/exchange (.NET API) for a normal session;
+// the exchange find-or-creates the mirror Tenant/AppUser there.
+//
+// Wire format (mirrors the licence format so the codebase has one convention):
+//   base64url(utf8(payloadJson)) + "." + base64url(hmacSha256(payloadBytes))
+//
+// TTL is 120 seconds and the jti is single-use at the exchange side. The
+// ticket travels in a URL — browser history, referrer headers, proxy logs —
+// which is acceptable ONLY because it is dead within two minutes and spent
+// after one use.
+
+import { withHandler } from "../auth/_lib/handler";
+import { handlePreflight } from "../auth/_lib/cors";
+import { requireAuth } from "../auth/_lib/auth";
+import { forbidden, serverError, unauthorized } from "../auth/_lib/errors";
+import { getTenantById, getUserById, audit } from "../auth/_lib/db";
+import { uuid } from "../auth/_lib/tokens";
+import type { Env } from "../auth/_lib/types";
+
+interface HandoffEnv extends Env {
+  // Shared HMAC secret with the .NET API (PLANSCAPE_HANDOFF_SECRET there too).
+  // 32+ random bytes; independent of either side's JWT key.
+  PLANSCAPE_HANDOFF_SECRET?: string;
+  // Where the cloud app lives. Defaults to production.
+  CLOUD_APP_ORIGIN?: string;
+}
+
+const TICKET_TTL_SECONDS = 120;
+
+function b64url(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export const onRequestOptions: PagesFunction = async ({ request }) =>
+  handlePreflight(request);
+
+export const onRequestPost = withHandler(async ({ request, env }) => {
+  const e = env as HandoffEnv;
+  const auth = await requireAuth(request, e);
+
+  if (!e.PLANSCAPE_HANDOFF_SECRET) {
+    console.error("Handoff requested but PLANSCAPE_HANDOFF_SECRET is unset");
+    throw serverError("Planscape cloud is not configured yet.");
+  }
+
+  const tenant = await getTenantById(e.WAITLIST_DB, auth.tenantId);
+  if (!tenant) throw unauthorized("Account no longer exists.");
+  const user = await getUserById(e.WAITLIST_DB, auth.userId);
+  if (!user) throw unauthorized("Account no longer exists.");
+
+  // Same entitlement gate as downloads and licensing: a lapsed tenant does not
+  // get into the cloud app. This is the practical enforcement point — there is
+  // deliberately no reverse sync deleting mirror accounts over there.
+  if (
+    tenant.subscription_status === "read_only" ||
+    tenant.subscription_status === "cancelled"
+  ) {
+    throw forbidden("Your access has ended. Choose a plan to use Planscape cloud.");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    jti: uuid(),
+    email: user.email,
+    tenantSlug: tenant.slug,
+    tenantName: tenant.name,
+    firstName: user.first_name,
+    lastName: user.last_name,
+    role: user.role,
+    tier: tenant.plan_tier,
+    iat: now,
+    exp: now + TICKET_TTL_SECONDS,
+  };
+
+  const data = new TextEncoder().encode(JSON.stringify(payload));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(e.PLANSCAPE_HANDOFF_SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key, data));
+  const ticket = `${b64url(data)}.${b64url(sig)}`;
+
+  await audit(e.WAITLIST_DB, {
+    tenantId: tenant.id,
+    actorUserId: auth.userId,
+    action: "cloud.handoff",
+    target: tenant.slug,
+    metadata: { jti: payload.jti },
+    ip: request.headers.get("CF-Connecting-IP"),
+    userAgent: request.headers.get("User-Agent"),
+  });
+
+  const origin = (e.CLOUD_APP_ORIGIN || "https://app.planscape.build").replace(/\/+$/, "");
+  return {
+    ticket,
+    expiresInSeconds: TICKET_TTL_SECONDS,
+    redirectUrl: `${origin}/handoff?ticket=${encodeURIComponent(ticket)}`,
+  };
+});

--- a/marketing-site/functions/api/downloads/[tool]/[version].ts
+++ b/marketing-site/functions/api/downloads/[tool]/[version].ts
@@ -12,9 +12,8 @@
 
 import { handlePreflight } from "../../auth/_lib/cors";
 import { requireAuth } from "../../auth/_lib/auth";
-import { getTenantById, getSessionByTokenHash, getUserById } from "../../auth/_lib/db";
-import { readRefreshCookie } from "../../auth/_lib/session";
-import { sha256Hex } from "../../auth/_lib/tokens";
+import { getTenantById } from "../../auth/_lib/db";
+import { verifyJwt } from "../../auth/_lib/jwt";
 import { DOWNLOAD_CATALOG, entitlementFor } from "../../_lib/downloads/catalog";
 import type { Env } from "../../auth/_lib/types";
 
@@ -37,25 +36,26 @@ export const onRequestGet: PagesFunction<DownloadsEnv> = async ({
   env,
   params,
 }) => {
-  // A download is triggered by a plain browser navigation (<a href>), which
-  // sends NO Authorization header — the access token lives in memory in the
-  // page, not in a cookie. So Bearer auth alone always failed here with "Sign
-  // in to download" for a user who was very much signed in.
+  // A download is a plain browser navigation (<a href>), which sends no
+  // Authorization header — the access token lives in memory in the page. The
+  // ps_refresh cookie cannot help either: it is deliberately scoped to
+  // Path=/api/auth, so it is never sent here (that scoping is a good thing and
+  // is left alone).
   //
-  // Fall back to the HttpOnly ps_refresh cookie, which the browser DOES send on
-  // a same-origin navigation (SameSite=Strict). Bearer is still accepted first
-  // so scripted clients keep working.
+  // So the page passes the access token it already holds as ?t=. The token is
+  // the same short-lived JWT used everywhere else, verified identically. It
+  // ends up in browser history and any intermediary log, which is acceptable
+  // only because it expires quickly — never accept a long-lived credential this
+  // way.
   let auth: { userId: string; tenantId: string } | null = null;
   try {
-    auth = await requireAuth(request, env);
+    const ctx = await requireAuth(request, env);
+    auth = { userId: ctx.userId, tenantId: ctx.tenantId };
   } catch {
-    const presented = readRefreshCookie(request);
-    if (presented) {
-      const session = await getSessionByTokenHash(env.WAITLIST_DB, await sha256Hex(presented));
-      if (session && new Date(session.expires_at).getTime() > Date.now() && !session.revoked_at) {
-        const user = await getUserById(env.WAITLIST_DB, session.user_id);
-        if (user) auth = { userId: user.id, tenantId: user.tenant_id };
-      }
+    const t = new URL(request.url).searchParams.get("t");
+    if (t) {
+      const claims = await verifyJwt(t, env.JWT_SECRET);
+      if (claims) auth = { userId: claims.sub, tenantId: claims.tid };
     }
   }
   if (!auth) return deny(401, "Sign in to download.");


### PR DESCRIPTION
The D1 half of the identity handoff (`docs/PLANSCAPE_IDENTITY_HANDOFF.md` on branch `claude/planscape-cloud-handoff`, .NET half in the same branch).

## What

- **`POST /api/cloud/handoff`** — mints a 120-second, single-use HMAC ticket for a signed-in customer. The cloud app exchanges it at the .NET API for a normal session. **D1 remains the only place a password lives.**
- **"Open Planscape cloud" button** on the account page, following the ticket's `redirectUrl`.

## Why it is safe to deploy today

Until `PLANSCAPE_HANDOFF_SECRET` + `CLOUD_APP_ORIGIN` are set, the endpoint answers "not configured" and the button shows **"still in development"** — honest today, lights up the day the cloud ships, no page change needed.

**Do NOT set the Cloudflare secret before the Render side is live** — the button would redirect customers to a dead origin.

## Design notes

- Entitlement gate = same as downloads/licensing: `read_only` / `cancelled` refused. That's the practical enforcement point; there is deliberately no reverse-sync deleting mirror accounts on the cloud side.
- TTL 120s because the ticket travels in a URL (history, referrers, proxy logs) — dead before anyone reads a log, and the `jti` is spent after one use anyway.

Typecheck clean.
