### PR TITLE
feat(cloud): identity handoff — planscape.build session opens the cloud app

### DIFF
--- a/Planscape.Server/docker/docker-compose.yml
+++ b/Planscape.Server/docker/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       - Jwt__Issuer=Planscape
       - Jwt__Audience=Planscape.Client
       - Redis__Connection=redis:6379
+      # Cloud handoff (docs/PLANSCAPE_IDENTITY_HANDOFF.md) — shared HMAC secret
+      # with planscape.build. Optional: the exchange endpoint 500s with a clear
+      # message when unset rather than failing the stack.
+      - PLANSCAPE_HANDOFF_SECRET=${PLANSCAPE_HANDOFF_SECRET:-}
       - ModelConverter__Provider=${MODEL_CONVERTER_PROVIDER:-null}
       - ModelConverter__IfcConvertPath=/usr/local/bin/IfcConvert
       - ModelConverter__ThumbnailProvider=${MODEL_THUMBNAIL_PROVIDER:-gltf-bounds}

--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -1018,11 +1018,21 @@ public class AuthController : ControllerBase
         var slug  = p.TenantSlug.Trim().ToLowerInvariant();
 
         // Email is the join key. An existing user keeps their existing tenant —
-        // the handoff never moves a user between tenants.
+        // the handoff never moves a user between tenants. Match regardless of
+        // IsActive (only exclude soft-deleted): filtering on IsActive here made
+        // the lookup miss a deactivated account and then collide with the
+        // (TenantId, Email) unique index trying to create a duplicate.
         var user = await _db.Users
             .IgnoreQueryFilters()
             .Include(u => u.Tenant)
-            .FirstOrDefaultAsync(u => u.Email == email && u.IsActive);
+            .FirstOrDefaultAsync(u => u.Email == email && !u.IsDeleted);
+
+        if (user != null && !user.IsActive)
+        {
+            // D1 is the entitlement authority and it just vouched for this
+            // user by minting the ticket — reactivate rather than refuse.
+            user.IsActive = true;
+        }
 
         if (user == null)
         {

--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -936,6 +936,192 @@ public class AuthController : ControllerBase
         return Ok(new { message = "Password has been reset. Please log in." });
     }
 
+    // ── Cloud handoff (planscape.build → this API) ──────────────────────────
+    //
+    // planscape.build (Cloudflare D1) owns signup, passwords and billing. This
+    // API owns project data. A customer who signed up there has no AppUser row
+    // here, so the marketing site mints a short-lived single-use HMAC ticket
+    // and the web app exchanges it here for a NORMAL session — same JWT, same
+    // refresh flow as /login. Design: docs/PLANSCAPE_IDENTITY_HANDOFF.md.
+    //
+    // The ticket is NOT a password and no password ever transits this path.
+    // Mirror accounts are created with a random unusable hash; they can only
+    // ever be entered via a fresh ticket.
+
+    /// <summary>Exchange a planscape.build handoff ticket for a session.</summary>
+    /// <response code="200">Session issued.</response>
+    /// <response code="401">Ticket invalid, expired, or already used.</response>
+    [AllowAnonymous]
+    [HttpPost("handoff/exchange")]
+    [EnableRateLimiting("auth")]
+    public async Task<ActionResult> HandoffExchange([FromBody] HandoffExchangeRequest req)
+    {
+        var secret = Environment.GetEnvironmentVariable("PLANSCAPE_HANDOFF_SECRET");
+        if (string.IsNullOrEmpty(secret))
+        {
+            _logger.LogError("Handoff exchange attempted but PLANSCAPE_HANDOFF_SECRET is unset");
+            return StatusCode(500, new { message = "Handoff is not configured." });
+        }
+
+        var ticket = req.Ticket ?? "";
+        var dot = ticket.IndexOf('.');
+        if (dot <= 0 || dot == ticket.Length - 1)
+            return Unauthorized(new { message = "Invalid ticket." });
+
+        byte[] payloadBytes, sig;
+        try
+        {
+            payloadBytes = Base64UrlDecodeHandoff(ticket[..dot]);
+            sig          = Base64UrlDecodeHandoff(ticket[(dot + 1)..]);
+        }
+        catch { return Unauthorized(new { message = "Invalid ticket." }); }
+
+        using (var hmac = new System.Security.Cryptography.HMACSHA256(Encoding.UTF8.GetBytes(secret)))
+        {
+            var expected = hmac.ComputeHash(payloadBytes);
+            if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(expected, sig))
+                return Unauthorized(new { message = "Invalid ticket." });
+        }
+
+        HandoffTicketPayload? p;
+        try { p = System.Text.Json.JsonSerializer.Deserialize<HandoffTicketPayload>(payloadBytes); }
+        catch { p = null; }
+        if (p == null || string.IsNullOrWhiteSpace(p.Jti)
+                      || string.IsNullOrWhiteSpace(p.Email)
+                      || string.IsNullOrWhiteSpace(p.TenantSlug))
+            return Unauthorized(new { message = "Invalid ticket." });
+
+        // TTL is 120s at mint; enforce expiry here so clock skew on the minting
+        // side cannot extend a ticket's life.
+        if (p.Exp <= DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+            return Unauthorized(new { message = "Ticket expired — go back to planscape.build and try again." });
+
+        // Single use. A ticket travels in a URL, so anything that replays the
+        // URL (prefetch, back button, shared link) must not mint a second
+        // session. Redis-down fails OPEN with a warning, consistent with the
+        // other Redis-degraded paths in this controller: the worst case is a
+        // duplicate session for the same legitimate user inside a 120s window.
+        try
+        {
+            var redisDb = _redis.GetDatabase();
+            var fresh = await redisDb.StringSetAsync(
+                $"handoff:jti:{p.Jti}", 1, TimeSpan.FromMinutes(5), When.NotExists);
+            if (!fresh)
+                return Unauthorized(new { message = "Ticket already used — go back to planscape.build and try again." });
+        }
+        catch (Exception ex) when (ex is RedisException or TimeoutException or System.Net.Sockets.SocketException)
+        {
+            _logger.LogWarning(ex, "Redis unavailable during handoff jti check; single-use protection degraded.");
+        }
+
+        var email = p.Email.Trim().ToLowerInvariant();
+        var slug  = p.TenantSlug.Trim().ToLowerInvariant();
+
+        // Email is the join key. An existing user keeps their existing tenant —
+        // the handoff never moves a user between tenants.
+        var user = await _db.Users
+            .IgnoreQueryFilters()
+            .Include(u => u.Tenant)
+            .FirstOrDefaultAsync(u => u.Email == email && u.IsActive);
+
+        if (user == null)
+        {
+            var tenant = await _db.Tenants.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(t => t.Slug == slug);
+            if (tenant == null)
+            {
+                var limits = BillingPlanLimits.For(BillingPlan.Network);
+                tenant = new Tenant
+                {
+                    Name         = string.IsNullOrWhiteSpace(p.TenantName) ? slug : p.TenantName!,
+                    Slug         = slug,
+                    ContactEmail = email,
+                    Tier         = LicenseTier.Starter,
+                    // Billing truth lives in planscape.build's D1, not here —
+                    // the handoff endpoint refuses cancelled/read_only tenants
+                    // before minting a ticket. Provision the mirror generously
+                    // so this side never locks out a customer D1 considers
+                    // paid; reconciliation is deliberately out of scope
+                    // (docs/PLANSCAPE_IDENTITY_HANDOFF.md).
+                    Plan           = BillingPlan.Trial,
+                    Currency       = "USD",
+                    BillingCycle   = BillingCycle.Monthly,
+                    MaxUsers       = limits.MaxAuthors + limits.MaxCoordinators,
+                    MaxProjects    = limits.MaxProjects,
+                    MimEnabled     = false,
+                    TrialExpiresAt = DateTime.UtcNow.AddDays(365)
+                };
+                _db.Tenants.Add(tenant);
+            }
+
+            // Explicit map, defaulting DOWN. Never pass the role string
+            // through — a rename on the D1 side must not escalate here.
+            var role = (p.Role ?? "").ToLowerInvariant() switch
+            {
+                "owner"        => UserRole.Owner,
+                "admin"        => UserRole.Admin,
+                "project_lead" => UserRole.Manager,
+                "coordinator"  => UserRole.Coordinator,
+                _              => UserRole.Viewer
+            };
+
+            var display = ($"{p.FirstName} {p.LastName}").Trim();
+            user = new AppUser
+            {
+                TenantId     = tenant.Id,
+                Tenant       = tenant,
+                Email        = email,
+                DisplayName  = string.IsNullOrWhiteSpace(display) ? email : display,
+                // Random, never disclosed, never usable: this account can only
+                // be entered via a handoff ticket.
+                PasswordHash = HashPassword(Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N")),
+                Role         = role,
+                Iso19650Role = "A"
+            };
+            _db.Users.Add(user);
+            await _db.SaveChangesAsync();
+        }
+
+        // From here, identical to a successful /login.
+        var token = GenerateJwt(user);
+        var refreshToken = Guid.NewGuid().ToString("N");
+        user.RefreshToken = HashRefreshToken(refreshToken);
+        user.RefreshTokenExpiresAt = DateTime.UtcNow.AddDays(7);
+        user.LastLoginAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        try
+        {
+            await _redis.GetDatabase().StringSetAsync(
+                RefreshActivityKey(refreshToken),
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                TimeSpan.FromDays(7));
+        }
+        catch (Exception ex) when (ex is RedisException or TimeoutException or System.Net.Sockets.SocketException)
+        {
+            _logger.LogWarning(ex, "Redis unavailable while seeding refresh activity for handoff session.");
+        }
+
+        return Ok(new
+        {
+            accessToken  = token,
+            refreshToken,
+            expiresAt    = DateTime.UtcNow.Add(AccessTokenLifetime),
+            userName     = user.DisplayName,
+            role         = user.Role.ToString(),
+            tier         = user.Tenant?.Tier.ToString() ?? "Starter",
+            mimEnabled   = user.Tenant?.MimEnabled ?? false,
+            tenantSlug   = user.Tenant?.Slug ?? slug
+        });
+    }
+
+    private static byte[] Base64UrlDecodeHandoff(string s)
+    {
+        var b64 = s.Replace('-', '+').Replace('_', '/');
+        switch (b64.Length % 4) { case 2: b64 += "=="; break; case 3: b64 += "="; break; }
+        return Convert.FromBase64String(b64);
+    }
+
     private string GenerateJwt(Core.Entities.AppUser user)
     {
         // P1 — tag newly issued tokens with kid=current so future rotations can
@@ -1017,3 +1203,24 @@ public class AuthController : ControllerBase
 
 public record SwitchTenantRequest(Guid TenantId);
 public record AcceptInvitationRequest(string Token, string Email, string Password);
+
+// ── Handoff DTOs (docs/PLANSCAPE_IDENTITY_HANDOFF.md) ──────────────────────────
+
+public sealed class HandoffExchangeRequest
+{
+    public string? Ticket { get; set; }
+}
+
+internal sealed class HandoffTicketPayload
+{
+    [System.Text.Json.Serialization.JsonPropertyName("jti")]        public string? Jti { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("email")]      public string? Email { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("tenantSlug")] public string? TenantSlug { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("tenantName")] public string? TenantName { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("firstName")]  public string? FirstName { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("lastName")]   public string? LastName { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("role")]       public string? Role { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("tier")]       public string? Tier { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("iat")]        public long Iat { get; set; }
+    [System.Text.Json.Serialization.JsonPropertyName("exp")]        public long Exp { get; set; }
+}

--- a/docs/PLANSCAPE_IDENTITY_HANDOFF.md
+++ b/docs/PLANSCAPE_IDENTITY_HANDOFF.md
@@ -1,0 +1,140 @@
+# Planscape identity handoff (Option B)
+
+**Status:** design agreed 2026-07-18, not yet implemented.
+**Problem it solves:** a customer signs up on `planscape.build` (Cloudflare D1) but
+the cloud app authenticates against the .NET API backed by Postgres. Those are
+two separate identity systems, so today a D1 customer cannot open the cloud app
+at all.
+
+## Why not the obvious alternatives
+
+**Shared JWT secret / cross-validating tokens.** A D1 token fails against the
+.NET API on three independent axes — different signing key, `iss` is `planscape`
+vs `Planscape`, and D1 emits no `aud` while the API sets
+`ValidateAudience = true`. Aligning all three couples the two systems' token
+formats forever, and still leaves the harder half unsolved: the .NET side needs a
+`Tenant` row and an `AppUser` row to exist before `ProjectsController` will do
+anything (`ProjectsController.cs:112-113` → 404 "Tenant not found").
+
+**Mirroring passwords at signup (Option A).** Simplest to build, but the plaintext
+password transits a second service, and password changes then have to stay in
+sync forever. That failure is silent for months and then surfaces as "I changed
+my password and the cloud app locked me out" — expensive to debug, and it lands
+on the customer.
+
+## The design
+
+D1 stays the only place a password lives. The cloud app never sees credentials.
+
+```
+planscape.build                     api.planscape.build
+(Cloudflare D1)                     (.NET / Postgres)
+      |                                     |
+ 1. user clicks "Open Planscape cloud"      |
+      |                                     |
+ 2. POST /api/cloud/handoff                 |
+    -> short-lived signed ticket            |
+      |                                     |
+ 3. redirect to app.planscape.build/handoff?ticket=...
+                                            |
+                              4. POST /api/auth/handoff/exchange
+                                 - verify HMAC + expiry + single-use
+                                 - find-or-create Tenant + AppUser
+                                 - return a NORMAL .NET session
+```
+
+From step 4 onward the cloud app behaves exactly as it does today — same JWT,
+same refresh flow, same `AppShell` guard. Nothing downstream needs to know a
+handoff happened.
+
+## The ticket
+
+HMAC-SHA256 over the compact JSON payload, using a secret both sides hold as
+`PLANSCAPE_HANDOFF_SECRET` (32+ random bytes; set independently on Cloudflare
+and Render — it is not either side's JWT key).
+
+Wire format, mirroring the licence format already in use so there is one
+convention in the codebase:
+
+```
+base64url(utf8(payloadJson)) + "." + base64url(hmacSha256(payloadBytes))
+```
+
+Payload:
+
+| field | meaning |
+|---|---|
+| `jti` | uuid v4 — single-use key, see replay below |
+| `email` | normalised, lowercase — the join key between the two systems |
+| `tenantSlug` | D1 tenant slug; becomes the Postgres `Tenant.Slug` |
+| `tenantName` | display name, used only when creating |
+| `firstName` / `lastName` | used only when creating the `AppUser` |
+| `role` | D1 role, mapped below |
+| `tier` | D1 `plan_tier`, so the API can set `Tenant.Tier` / `MaxProjects` |
+| `iat` / `exp` | issued/expiry unix seconds. **TTL 120 seconds.** |
+
+**TTL is deliberately tiny.** The ticket travels in a URL, so it will land in
+browser history, referrer headers and any proxy log in between. Two minutes is
+enough to redirect and exchange, and short enough that a leaked URL is worthless
+by the time anyone reads the log.
+
+**Single use.** The exchange endpoint records `jti` and rejects a repeat. Without
+this, anything that replays the URL — a browser prefetch, a shared link, a back
+button — mints a second session.
+
+## Role mapping
+
+D1 roles do not match .NET roles one-for-one. Map explicitly rather than passing
+the string through, so a rename on one side cannot silently escalate on the
+other:
+
+| D1 | .NET |
+|---|---|
+| `owner` | `Owner` |
+| `admin` | `Admin` |
+| `project_lead` | `ProjectLead` |
+| `coordinator` | `Coordinator` |
+| anything else | `Viewer` |
+
+Default to the least privilege on an unrecognised value. Never default upward.
+
+## What each side needs
+
+**D1 — `POST /api/cloud/handoff`** (`marketing-site/functions/api/cloud/handoff.ts`)
+- `requireAuth`; load tenant.
+- Refuse when `subscription_status` is `read_only` or `cancelled` — the same
+  entitlement gate the downloads and licence endpoints use.
+- Mint and return `{ ticket, redirectUrl }`.
+
+**.NET — `POST /api/auth/handoff/exchange`** (`AuthController`)
+- `[AllowAnonymous]`. Verify HMAC, `exp`, and that `jti` is unseen (a small table
+  or the existing Redis instance; Redis with a 5-minute TTL is the natural fit
+  since `jti` need not outlive the ticket).
+- Find-or-create `Tenant` by slug, then `AppUser` by email. Set a random
+  unusable password hash on creation — this account never logs in directly.
+- Reuse `GenerateJwt(AppUser)` (`AuthController.cs:939`) and the existing refresh
+  path so the response is identical in shape to `/api/auth/login`.
+
+**planscape-web — `/handoff`** (`app/handoff/page.tsx`)
+- Read `?ticket=`, POST it to the exchange, store the returned token exactly as
+  `lib/auth.tsx` does after a normal login, then `router.replace('/projects')`.
+- On failure, send the user to `/login` with a plain message. Never echo the
+  ticket back into the page.
+
+## Ordering
+
+Build and test entirely against the local docker stack (`localhost:5000`) with
+`planscape-web` on `localhost:3100` before provisioning Render. The stack already
+runs healthy with a 134-table schema, so none of this needs paid infrastructure
+to prove.
+
+## Deliberately out of scope
+
+- **Reverse sync.** Changes made in the cloud app do not flow back to D1. D1 stays
+  authoritative for identity and billing; Postgres holds project data.
+- **Deleting a user in D1 does not delete them in Postgres.** Handoff refuses on a
+  cancelled subscription, which is the practical control; tidying orphaned
+  Postgres accounts is a separate job.
+- **One tenant per user.** The .NET side supports multi-tenant switching
+  (`/api/auth/tenants`, `/api/auth/switch-tenant`); D1 does not model it, so the
+  handoff carries exactly one tenant.

--- a/planscape-web/app/handoff/page.tsx
+++ b/planscape-web/app/handoff/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+// Landing point for the planscape.build → cloud handoff
+// (docs/PLANSCAPE_IDENTITY_HANDOFF.md). The marketing site mints a short-lived
+// single-use ticket and redirects here; we exchange it for a normal session and
+// land the user on /projects.
+//
+// The exchange result is stored exactly as a password login would store it
+// (setToken → localStorage), and we then do a FULL navigation rather than a
+// router push: AuthProvider reads the token once on mount, so a soft navigation
+// would leave the in-memory auth state stale.
+//
+// On any failure the user goes to /login with a plain message. The ticket is
+// never echoed back into the page — it is already in the URL bar, which is
+// exposure enough; we also strip it from history before leaving.
+
+import { useEffect, useRef, useState } from 'react';
+import { API_BASE, setToken } from '@/lib/api';
+
+export default function HandoffPage() {
+  const [message, setMessage] = useState('Signing you in…');
+  const ran = useRef(false);
+
+  useEffect(() => {
+    // React StrictMode mounts effects twice in dev. The ticket is single-use on
+    // the server, so a second POST would burn it and bounce a legitimate user.
+    if (ran.current) return;
+    ran.current = true;
+
+    const ticket = new URLSearchParams(window.location.search).get('ticket');
+    if (!ticket) {
+      window.location.replace('/login');
+      return;
+    }
+    // Take the ticket out of the address bar / history immediately.
+    window.history.replaceState(null, '', '/handoff');
+
+    (async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/auth/handoff/exchange`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ticket }),
+        });
+        if (!res.ok) {
+          let msg = 'Sign-in link expired — please try again from planscape.build.';
+          try {
+            const body = await res.json();
+            msg = body.message || body.error || msg;
+          } catch {
+            /* keep generic */
+          }
+          setMessage(msg);
+          setTimeout(() => window.location.replace('/login'), 2500);
+          return;
+        }
+        const data = (await res.json()) as { accessToken?: string; token?: string };
+        const token = data.accessToken || data.token;
+        if (!token) throw new Error('no token');
+        setToken(token);
+        window.location.replace('/projects');
+      } catch {
+        setMessage('Could not reach Planscape — please try again from planscape.build.');
+        setTimeout(() => window.location.replace('/login'), 2500);
+      }
+    })();
+  }, []);
+
+  return (
+    <main className="grid min-h-screen place-items-center p-4">
+      <div className="text-center">
+        <p className="text-lg font-medium">{message}</p>
+        <p className="mt-2 text-sm text-neutral-500">Planscape cloud</p>
+      </div>
+    </main>
+  );
+}

--- a/render.yaml
+++ b/render.yaml
@@ -44,6 +44,17 @@ services:
         value: Production
       - key: ASPNETCORE_URLS
         value: http://+:8080
+      # Schema management: the EF migration set is incomplete by design
+      # (Program.cs:1318-1380 — EnsureCreated + idempotent patchers is the
+      # official mechanism). Without this flag a FRESH database takes the
+      # Migrate() branch and comes up nearly empty.
+      - key: PLANSCAPE_USE_ENSURE_CREATED
+        value: "true"
+      # Cloud handoff shared secret — MUST equal the value set on the
+      # planscape.build Cloudflare Pages project. See
+      # docs/PLANSCAPE_IDENTITY_HANDOFF.md.
+      - key: PLANSCAPE_HANDOFF_SECRET
+        sync: false
       # Database — injected automatically from planscape-db below.
       - key: ConnectionStrings__Default
         fromDatabase:


### PR DESCRIPTION
Option B from `docs/PLANSCAPE_IDENTITY_HANDOFF.md` (included in this PR). A customer who signed up on planscape.build (Cloudflare D1) can open the Planscape cloud app without a second password. D1 remains the only place a password lives; no credential ever transits this path.

## The three pieces

- **.NET `POST /api/auth/handoff/exchange`** — verifies the HMAC ticket (constant-time), enforces the 120s expiry server-side, single-use jti via Redis SETNX (fails open with a warning, consistent with this controller's other degraded paths), find-or-creates the mirror Tenant/AppUser, then issues a session identical to `/login`. Role map is explicit and defaults **down** — an unknown D1 role becomes Viewer, never higher.
- **`planscape-web /handoff`** — exchanges the ticket, stores the token exactly as a password login would, strips the ticket from history, guards against StrictMode double-mount burning the single-use ticket.
- **`render.yaml`** — `PLANSCAPE_USE_ENSURE_CREATED=true` (without it a fresh Render DB takes the `Migrate()` branch and comes up nearly empty — 81 of 83 migration files carry no `[Migration]` attribute; EnsureCreated + patchers is the codebase's own documented mechanism, Program.cs:1318-1380) and `PLANSCAPE_HANDOFF_SECRET` as `sync: false`.

The D1 half (ticket mint + account-page button) merged separately in #409 and is live — the button reports "still in development" until the secrets are configured.

## Proven end to end, in a real browser, against the local stack

- Ticket exchange → 200, Owner session, tenant `planscape`
- **Replay of the same ticket → 401. Forged signature → 401.**
- Token accepted by `/api/auth/me` and `/api/projects`
- A project created through the UI — "Handoff Proof — First Project" (HANDOFF-01) — landed in Postgres

First E2E run caught a real bug, fixed in the second commit: seeded users with `IsActive=false` were missed by the lookup and collided with the `(TenantId, Email)` unique index. The handoff now matches any non-deleted user and reactivates — D1 is the entitlement authority and just vouched for them.

API compiles with 0 errors; `planscape-web` tsc clean.
