### PR TITLE
fix(render): pserv services cannot carry healthCheckPath

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -142,7 +142,9 @@ services:
     branch: main
     region: frankfurt
     plan: starter
-    healthCheckPath: /health
+    # NB: pserv (private service) types cannot carry healthCheckPath — the
+    # Blueprint validator rejects it. The sidecar still exposes /health for
+    # the API's own liveness probing over the private network.
     autoDeploy: true
     envVars:
       - key: PORT
@@ -186,7 +188,8 @@ services:
     dockerCommand: server /data --console-address ":9001"
     region: frankfurt
     plan: starter
-    healthCheckPath: /minio/health/live    # MinIO liveness (port 9000)
+    # (no healthCheckPath — pserv types cannot carry one; MinIO liveness is
+    # still available to peers at /minio/health/live on port 9000)
     disk:
       name: minio-data
       mountPath: /data


### PR DESCRIPTION
The validator names it exactly:

```
services[3]  pserv service type cannot have a health check path
services[5]  pserv service type cannot have a health check path
```

`healthCheckPath` is for publicly-routed web services; pserv types aren't HTTP-routed by Render, so the field is rejected. Removed from `planscape-converter` and `planscape-minio` — both still expose their health endpoints on the private network for peers.