### PR TITLE
docs: remove stray StructuralAnalysisEngine paragraph above CHANGELOG heading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,3 @@
-StructuralAnalysisEngine general — deflection / punching / wind / vibration / SSI / progressive collapse are diffuse single-shot calcs. Each subcheck takes a different parameter set (member type × load case × code combination) so there's no clean one-pass model walker. Each needs its own phase. That's the genuinely-deferred remainder of the integration audit.
 # CHANGELOG — STINGTOOLS
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -674,8 +674,7 @@ A holistic review of the tagging subsystem was performed covering the full pipel
 | GAP-NLP-02 | NLP patterns for healthcare commands added in Phase 176 ("run pressure audit", "mgps verify", etc.) | 19 patterns were added to NLPCommandProcessor in the Healthcare Pack. Verify they are still present after this session's append. |
 | GAP-UI-01 | No UI surface for `AUTO_CORRECT_STATUS_FROM_PHASE` toggle | `ConfigEditorCommand` should expose this boolean alongside the existing toggle controls. Low risk but requires XAML + command handler changes. |
 | GAP-UI-02 | No UI surface for `LEADER_CLEARANCE_MARGIN_FT` | Same as above — could be added to the Smart Placement wizard or Config Editor as a numeric text box. |
-
-| GAP-STRUCT-01 | StructuralAnalysisEngine subchecks need per-subcheck phases | `StructuralAnalysisEngine` general — deflection / punching / wind / vibration / SSI / progressive collapse are diffuse single-shot calcs. Each subcheck takes a different parameter set (member type × load case × code combination) so there's no clean one-pass model walker. Each needs its own phase. (Note rescued during merge of `claude/stingtools-bim-research-8Kkwv` into `claude/continue-model-viewer-updates-4GJR4`; previously orphaned in a truncated CHANGELOG.md.) |
+| GAP-STRUCT-01 | StructuralAnalysisEngine subchecks need per-subcheck phases | `StructuralAnalysisEngine` general — deflection / punching / wind / vibration / SSI / progressive collapse are diffuse single-shot calcs. Each subcheck takes a different parameter set (member type × load case × code combination) so there's no clean one-pass model walker. Each needs its own phase. That's the genuinely-deferred remainder of the integration audit. (Note rescued during merge of `claude/stingtools-bim-research-8Kkwv` into `claude/continue-model-viewer-updates-4GJR4`; previously orphaned in a truncated CHANGELOG.md.) |
 
 #### Symbol library — Phase 188 closure status
 


### PR DESCRIPTION
## Summary
- docs/CHANGELOG.md had an orphaned paragraph on line 1, before the `# CHANGELOG — STINGTOOLS` heading, describing deferred StructuralAnalysisEngine work (deflection / punching / wind / vibration / SSI / progressive collapse).
- That content had already been rescued into docs/ROADMAP.md as the **GAP-STRUCT-01** row (Remaining Open Items table), so the CHANGELOG copy was a leftover duplicate — this PR deletes it so the file starts with the heading.
- In ROADMAP.md, the GAP-STRUCT-01 row was separated from its table by a blank line (a lone `|…|` row doesn't render as a table in Markdown). Joined it to the table and folded in the one sentence the row was missing ("That's the genuinely-deferred remainder of the integration audit.").

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)