### PR TITLE
feat(stingbridge): release readiness — auth refresh, ZONE/LOC wiring, packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ build/
 __pycache__/
 *.pyc
 *.pyo
+*.egg-info/
 *.pyd
 
 # IFC drop folder — runtime files, not source

--- a/StingBridge/LICENSE.txt
+++ b/StingBridge/LICENSE.txt
@@ -1,0 +1,16 @@
+StingBridge
+Copyright (c) 2026 Planscape Limited. All rights reserved.
+
+This software is proprietary and is licensed, not sold.
+
+Use is permitted only in connection with an active Planscape subscription,
+under the Planscape Terms of Service (https://planscape.build/terms.html).
+
+You may not redistribute, resell, sublicense, publish, or make this software
+available to any third party, in source or binary form, without prior written
+permission from Planscape Limited.
+
+This software is provided "as is", without warranty of any kind, express or
+implied, to the maximum extent permitted by law.
+
+Contact: info@stingtools.io

--- a/StingBridge/QUICKSTART.md
+++ b/StingBridge/QUICKSTART.md
@@ -1,0 +1,196 @@
+# StingBridge — Quickstart
+
+StingBridge connects **ArchiCAD** (and any IFC export) to **Planscape**. It reads
+your model, derives STING ISO 19650 tokens
+(`DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ`), pushes them to your Planscape project,
+and writes them back into the model so the tags live in the file too.
+
+There is **no licence key**. StingBridge is useless without a Planscape login,
+so your Planscape account *is* the entitlement.
+
+---
+
+## 1. Install
+
+### Option A — Windows, no Python needed
+
+1. Download `StingBridge_<version>_win64.zip` from
+   [planscape.build/downloads](https://planscape.build/downloads).
+2. Unzip anywhere, e.g. `C:\Tools\StingBridge`.
+3. Open a terminal there and check it runs:
+
+   ```
+   stingbridge.exe --version
+   ```
+
+Add that folder to your `PATH` if you want to call `stingbridge` from anywhere.
+
+### Option B — any platform, from source
+
+Requires **Python 3.11 or newer**.
+
+1. Download and unzip `StingBridge_<version>_any.zip`.
+2. From inside the unzipped folder:
+
+   ```bash
+   python -m venv .venv
+   # Windows:        .venv\Scripts\activate
+   # macOS / Linux:  source .venv/bin/activate
+
+   pip install wheels/stingtools_core-*.whl wheels/stingbridge-*.whl
+   ```
+
+   Or just run `run.bat` (Windows) / `./run.sh` (macOS/Linux), which does the
+   above and then passes your arguments straight through to the CLI.
+
+3. Check it:
+
+   ```bash
+   stingbridge --version
+   ```
+
+> **Why two wheels?** `stingtools-core` holds the shared Planscape wire
+> contract used by every STING host (Revit, ArchiCAD, Blender). It is not on
+> PyPI, so the release zip ships the built wheel next to StingBridge's. Install
+> both and the package is entirely self-contained — no monorepo checkout, no
+> network fetch. Developers working in the STING repo can instead run
+> `pip install -e ../stingtools-core/python`.
+
+---
+
+## 2. Connect to Planscape
+
+StingBridge needs four settings. Put them in a **config file** or in
+**environment variables** — environment always wins, so you can override a
+shared config for a one-off run.
+
+Create `stingbridge.toml` next to where you run the command:
+
+```toml
+planscape_url        = "https://api.planscape.build"
+planscape_email      = "you@example.com"
+planscape_password   = "your-password"
+planscape_project_id = "00000000-0000-0000-0000-000000000000"
+
+# Optional
+building_name = "Block B"   # drives the LOC token; default BLD1
+write_back    = true        # write tokens back into ArchiCAD / the IFC
+watch_interval = 300        # seconds between passes in `watch` mode
+ifc_drop_dir  = "./IFC_DROP"
+```
+
+A `.env` file with `KEY=VALUE` lines works too. The `STING_` prefix is
+optional in both formats, so `planscape_url` and `STING_PLANSCAPE_URL` are the
+same setting. Point at a specific file with `--config path/to/file`.
+
+The equivalent environment variables:
+
+| Variable | Meaning |
+|---|---|
+| `STING_PLANSCAPE_URL` | Planscape server base URL |
+| `STING_PLANSCAPE_EMAIL` | Login email |
+| `STING_PLANSCAPE_PASSWORD` | Login password |
+| `STING_PLANSCAPE_PROJECT_ID` | Target project UUID |
+| `STING_BUILDING_NAME` | Building name → LOC token |
+| `STING_ARCHICAD_PORT` | ArchiCAD JSON API port (`0` = auto-discover) |
+| `STING_WRITE_BACK` | `0` to disable write-back |
+| `STING_WATCH_INTERVAL` | Seconds between `watch` passes |
+| `STING_IFC_DROP_DIR` | Folder watched by `watch-ifc` |
+| `STING_CONFIG_FILE` | Explicit config-file path |
+
+**Finding your project ID:** open the project in Planscape and copy the UUID
+from the URL, or run `python get_project_id.py` from the source checkout.
+
+> Storing a password in a file is a convenience for a workstation you control.
+> On a shared machine, prefer environment variables.
+
+---
+
+## 3. The five commands
+
+```bash
+stingbridge sync                        # one pass; ArchiCAD must be open
+stingbridge watch                       # repeat sync on a timer
+stingbridge watch-ifc --drop-dir ./IFC_DROP   # watch a folder for IFC files
+stingbridge process-ifc model.ifc       # process one IFC file now
+stingbridge auto-publish                # trigger ArchiCAD's Publisher Set, then ingest
+```
+
+`sync` and `watch` talk to a **running ArchiCAD** over its JSON API.
+`watch-ifc` and `process-ifc` need **no ArchiCAD at all** — they read IFC files,
+so they work on a server, overnight, or from any BIM tool that exports IFC.
+
+---
+
+## 4. The IFC drop-folder workflow (recommended)
+
+The most reliable path today. You export IFC; StingBridge does the rest.
+
+1. Pick a folder, e.g. `C:\IFC_DROP`.
+2. Start the watcher and leave it running:
+
+   ```bash
+   stingbridge watch-ifc --drop-dir C:\IFC_DROP
+   ```
+
+3. Export IFC from ArchiCAD (or Revit, or anything) into that folder.
+
+For each file that lands, StingBridge will:
+
+- wait for the file to finish writing (3-second debounce),
+- extract elements and derive STING tokens,
+- push them to your Planscape project,
+- write the tokens back as a `STING_TOKENS` property set, saved alongside as
+  `<name>_sting.ifc` (your original is never modified),
+- convert to GLB for the Planscape 3D viewer *if* `IfcConvert` is available,
+- drop a `<name>.sync_result.json` next to the file with the outcome.
+
+The watcher re-authenticates on its own, so it can run for days.
+
+### ArchiCAD Publisher Set automation
+
+If ArchiCAD is open, `stingbridge auto-publish` will find your IFC Publisher
+Set, trigger it, and immediately ingest the file it produces:
+
+```bash
+stingbridge auto-publish                          # auto-detect the set
+stingbridge auto-publish --publisher-set "IFC Export"   # or name it
+```
+
+Point the Publisher Set's output at your drop folder and one command takes you
+from model to Planscape.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| `STING_PLANSCAPE_EMAIL and STING_PLANSCAPE_PASSWORD must be set` | No config found. Check you are running in the folder holding `stingbridge.toml`, or pass `--config`. |
+| `Invalid credentials` | Wrong email/password, or pointed at the wrong server. Confirm you can sign in at the same URL in a browser. |
+| `STING_PLANSCAPE_PROJECT_ID must be set` | Missing project UUID — see §2. |
+| `Cannot find ArchiCAD` | ArchiCAD is not running, or its JSON API is off. Enable *Options → Work Environment → JSON API*, or set `STING_ARCHICAD_PORT`. `watch-ifc` / `process-ifc` do not need ArchiCAD. |
+| `ifcopenshell is not installed` | Source install missed a dependency: re-run the `pip install` in §1B. |
+| `IfcConvert not found — skipping GLB` | Informational. 3D viewer files are skipped; tokens still sync. Install IfcOpenShell's `IfcConvert` and set `IFC_CONVERT_PATH` to enable. |
+| `No recognised IFC elements found` | The IFC has none of the supported classes, or exported as a schema without them. Check the export preset includes walls/doors/MEP. |
+| Every element tagged `ZZ` / `BLD1` | Zones carry no number/name, or no zones exist. `ZZ` and `BLD1` are the documented fallbacks. Set `building_name` for LOC; name/number your ArchiCAD zones for ZONE. |
+| Tokens sync but do not appear in ArchiCAD | `write_back` is off, or the elements are locked / on a locked layer. |
+| Watcher stops ingesting after a long run | Should not happen — expired logins refresh automatically. Check `<name>.sync_result.json` for the recorded error and report it. |
+
+Every run logs to the console. For more detail, set `STING_LOG_LEVEL=DEBUG`
+(where supported) or run with output redirected to a file when reporting an
+issue.
+
+---
+
+## 6. Beta caveats
+
+- The **IFC path is the verified one**. Live ArchiCAD JSON-API sync works but is
+  still maturing — prefer `watch-ifc` / `process-ifc` for production.
+- Zone labels are read from ArchiCAD's `Zone_ZoneNumber` / `Zone_ZoneName`
+  built-in properties. If your template renames them, ZONE falls back to `ZZ`.
+- ArchiCAD exposes no building name, so LOC comes from your `building_name`
+  setting rather than the model.
+- GLB conversion needs `IfcConvert` on the machine; it is not bundled.
+
+Issues: <https://github.com/beckykyomugisha/STINGTOOLS/issues>

--- a/StingBridge/__init__.py
+++ b/StingBridge/__init__.py
@@ -1,0 +1,8 @@
+"""StingBridge — ArchiCAD ↔ Planscape sync bridge.
+
+``__version__`` is the single source of truth for the package version:
+``pyproject.toml`` reads it via ``[tool.setuptools.dynamic]``, and the CLI
+reports it under ``stingbridge --version``.
+"""
+
+__version__ = "0.1.0b1"

--- a/StingBridge/bridge.py
+++ b/StingBridge/bridge.py
@@ -24,10 +24,32 @@ import logging
 import sys
 import time
 
+from . import __version__
 from .archicad.client import ArchiCadClient, ArchiCadError
 from .config import BridgeConfig
 from .planscape.client import PlanscapeClient, PlanscapeAuthError
 from .sync.engine import SyncEngine
+
+def _configure_console_encoding() -> None:
+    """Make the console tolerate the non-ASCII characters this CLI prints.
+
+    A default Windows console is cp1252, which cannot encode the arrows and
+    check marks used in the help text and progress messages; writing one raises
+    UnicodeEncodeError and takes the process down — ``stingbridge --help`` died
+    that way before this. Switching the streams to UTF-8 fixes rendering where
+    the terminal supports it, and ``errors="replace"`` guarantees that a stream
+    that still cannot encode a character degrades to "?" instead of crashing.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError):
+            # Not a reconfigurable TextIOWrapper (redirected/piped/embedded) —
+            # nothing to do; the streams stay as the host provided them.
+            pass
+
+
+_configure_console_encoding()
 
 logging.basicConfig(
     level=logging.INFO,
@@ -74,6 +96,8 @@ def cmd_sync(cfg: BridgeConfig) -> int:
         planscape_client=ps,
         write_back=cfg.write_back_to_archicad,
         batch_size=cfg.batch_size,
+        verify_write_back=cfg.verify_write_back,
+        building_name=cfg.building_name,
     )
     result = engine.run()
     log.info("Sync complete — %s", result.summary())
@@ -245,7 +269,16 @@ def cmd_auto_publish(cfg: BridgeConfig, publisher_set_name: str | None) -> int:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="STING ArchiCAD ↔ Planscape sync bridge"
+        prog="stingbridge",
+        description="STING ArchiCAD ↔ Planscape sync bridge",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"stingbridge {__version__}"
+    )
+    parser.add_argument(
+        "--config", default=None, metavar="PATH",
+        help="Config file (default: stingbridge.toml, else .env in the working "
+             "directory). Environment variables always override it.",
     )
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("sync",  help="Run a single sync pass (ArchiCAD must be open)")
@@ -274,7 +307,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    cfg = BridgeConfig.from_env()
+    cfg = BridgeConfig.from_env(getattr(args, "config", None))
 
     if args.command == "sync":
         sys.exit(cmd_sync(cfg))

--- a/StingBridge/config.py
+++ b/StingBridge/config.py
@@ -1,13 +1,100 @@
 """
 Configuration for the STING ArchiCAD bridge.
 
-Values are read from environment variables first, then fall back to defaults.
-Environment variable prefix: STING_
+Resolution order (first hit wins):
+
+  1. environment variables  (STING_*)
+  2. a config file          (stingbridge.toml, else .env)
+  3. the dataclass defaults
+
+Environment always beats the file, so an operator can override a checked-in
+config for a one-off run without editing it.
+
+The config file is looked up at ``STING_CONFIG_FILE`` if set, otherwise
+``stingbridge.toml`` then ``.env`` in the working directory. Keys are matched
+case-insensitively and the ``STING_`` prefix is optional, so all of
+``STING_PLANSCAPE_URL``, ``planscape_url`` and ``Planscape_Url`` are the same
+setting.
 """
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_TRUTHY_FALSE = ("0", "false", "no", "off")
+
+
+def _normalise_key(key: str) -> str:
+    k = key.strip().upper().replace("-", "_")
+    return k if k.startswith("STING_") else f"STING_{k}"
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a minimal KEY=VALUE .env file. Blank lines and # comments skipped."""
+    out: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        value = value.strip()
+        # Strip one matching pair of surrounding quotes.
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        out[_normalise_key(key)] = value
+    return out
+
+
+def _parse_toml_file(path: Path) -> dict[str, str]:
+    """Parse stingbridge.toml — flat keys, or nested under [stingbridge]."""
+    try:
+        import tomllib  # stdlib on Python 3.11+
+    except ModuleNotFoundError:  # pragma: no cover - we require >=3.11
+        log.warning("tomllib unavailable — %s ignored", path.name)
+        return {}
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    if isinstance(data.get("stingbridge"), dict):
+        data = data["stingbridge"]
+    out: dict[str, str] = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            continue  # ignore unrelated sub-tables
+        if isinstance(value, bool):
+            value = "1" if value else "0"
+        out[_normalise_key(key)] = str(value)
+    return out
+
+
+def load_config_file(explicit_path: str | None = None) -> dict[str, str]:
+    """Return settings from the config file, or {} when there is none."""
+    candidates: list[Path] = []
+    chosen = explicit_path or os.getenv("STING_CONFIG_FILE", "")
+    if chosen:
+        candidates.append(Path(chosen))
+    else:
+        candidates.extend([Path("stingbridge.toml"), Path(".env")])
+
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            values = (
+                _parse_toml_file(path)
+                if path.suffix.lower() == ".toml"
+                else _parse_env_file(path)
+            )
+        except Exception as e:  # noqa: BLE001 — a bad config must not be fatal
+            log.warning("Could not read config file %s: %s", path, e)
+            return {}
+        log.info("Loaded %d settings from %s", len(values), path)
+        return values
+
+    return {}
 
 
 @dataclass
@@ -28,19 +115,50 @@ class BridgeConfig:
     verify_write_back: bool = True   # re-read AC after write to confirm
     watch_interval_s: int = 300      # seconds between syncs in watch mode
     ifc_drop_dir: str = ""           # folder to watch for IFC files
+    building_name: str = ""          # drives the LOC token; AC exposes no building name
 
     @classmethod
-    def from_env(cls) -> "BridgeConfig":
+    def from_env(cls, config_file: str | None = None) -> "BridgeConfig":
+        file_values = load_config_file(config_file)
+
+        def get(name: str, default: str) -> str:
+            """Environment first, then the config file, then the default."""
+            key = _normalise_key(name)
+            env = os.getenv(key)
+            if env is not None and env != "":
+                return env
+            return file_values.get(key, default)
+
+        def get_bool(name: str, default: str = "1") -> bool:
+            return get(name, default).strip().lower() not in _TRUTHY_FALSE
+
+        def get_int(name: str, default: str) -> int:
+            raw = get(name, default)
+            try:
+                return int(str(raw).strip())
+            except ValueError:
+                log.warning("%s=%r is not an integer — using %s", name, raw, default)
+                return int(default)
+
+        def get_float(name: str, default: str) -> float:
+            raw = get(name, default)
+            try:
+                return float(str(raw).strip())
+            except ValueError:
+                log.warning("%s=%r is not a number — using %s", name, raw, default)
+                return float(default)
+
         return cls(
-            archicad_port=int(os.getenv("STING_ARCHICAD_PORT", "0")),
-            archicad_timeout=float(os.getenv("STING_ARCHICAD_TIMEOUT", "30")),
-            batch_size=int(os.getenv("STING_BATCH_SIZE", "100")),
-            planscape_url=os.getenv("STING_PLANSCAPE_URL", "http://localhost:5000"),
-            planscape_email=os.getenv("STING_PLANSCAPE_EMAIL", ""),
-            planscape_password=os.getenv("STING_PLANSCAPE_PASSWORD", ""),
-            planscape_project_id=os.getenv("STING_PLANSCAPE_PROJECT_ID", ""),
-            write_back_to_archicad=os.getenv("STING_WRITE_BACK", "1") not in ("0", "false", "no"),
-            verify_write_back=os.getenv("STING_VERIFY_WRITE_BACK", "1") not in ("0", "false", "no"),
-            watch_interval_s=int(os.getenv("STING_WATCH_INTERVAL", "300")),
-            ifc_drop_dir=os.getenv("STING_IFC_DROP_DIR", ""),
+            archicad_port=get_int("ARCHICAD_PORT", "0"),
+            archicad_timeout=get_float("ARCHICAD_TIMEOUT", "30"),
+            batch_size=get_int("BATCH_SIZE", "100"),
+            planscape_url=get("PLANSCAPE_URL", "http://localhost:5000"),
+            planscape_email=get("PLANSCAPE_EMAIL", ""),
+            planscape_password=get("PLANSCAPE_PASSWORD", ""),
+            planscape_project_id=get("PLANSCAPE_PROJECT_ID", ""),
+            write_back_to_archicad=get_bool("WRITE_BACK"),
+            verify_write_back=get_bool("VERIFY_WRITE_BACK"),
+            watch_interval_s=get_int("WATCH_INTERVAL", "300"),
+            ifc_drop_dir=get("IFC_DROP_DIR", ""),
+            building_name=get("BUILDING_NAME", ""),
         )

--- a/StingBridge/planscape/client.py
+++ b/StingBridge/planscape/client.py
@@ -66,6 +66,11 @@ class PlanscapeClient:
         self._session.headers.update({"Content-Type": "application/json"})
         self._token: str | None = None
         self._token_expiry: float = 0.0
+        # Credentials are retained so long-lived processes (the IFC drop-folder
+        # watcher, `watch` mode) can silently re-authenticate when the server
+        # token expires — see :meth:`_send`.
+        self._email: str = ""
+        self._password: str = ""
 
     # ── auth ─────────────────────────────────────────────────────────────────
 
@@ -82,6 +87,8 @@ class PlanscapeClient:
         self._token = data.get("token") or data.get("accessToken")
         if not self._token:
             raise PlanscapeAuthError("No token in login response")
+        # Remember the credentials for transparent re-auth on expiry.
+        self._email, self._password = email, password
         # Assume 60-minute expiry; refresh 5 minutes early
         self._token_expiry = time.time() + 55 * 60
         self._session.headers.update({"Authorization": f"Bearer {self._token}"})
@@ -90,6 +97,45 @@ class PlanscapeClient:
     def _ensure_auth(self, email: str, password: str) -> None:
         if not self._token or time.time() >= self._token_expiry:
             self.login(email, password)
+
+    def _relogin(self) -> bool:
+        """Re-authenticate with the stored credentials. Returns False (never
+        raises) when no credentials are held or the re-login itself fails, so
+        the caller can surface the original 401 instead of a masking error."""
+        if not (self._email and self._password):
+            return False
+        try:
+            self.login(self._email, self._password)
+            return True
+        except Exception as e:  # noqa: BLE001 — a failed refresh must not mask the 401
+            log.warning("Planscape re-authentication failed: %s", e)
+            return False
+
+    def _send(self, verb: str, url: str, **kw):
+        """Send a request, transparently refreshing an expired token.
+
+        A drop-folder watcher logs in once and then runs for days; the server
+        token expires long before the process does. Without this, every ingest
+        after the first hour raised ``PlanscapeAuthError`` and the dropped
+        files were recorded as errored and never retried.
+
+        Two refresh triggers:
+          * proactive — the locally tracked expiry has passed;
+          * reactive  — the server answered 401 (covers clock skew and any
+            server-side revocation), retried exactly once.
+
+        The refreshed ``Authorization`` header is written back onto the same
+        session object, so the retry re-reads it via ``getattr`` below.
+        """
+        if self._token and time.time() >= self._token_expiry:
+            log.info("Planscape token expired locally — refreshing")
+            self._relogin()
+
+        resp = getattr(self._session, verb)(url, **kw)
+        if getattr(resp, "status_code", None) == 401 and self._relogin():
+            log.info("Planscape token rejected (401) — retrying after re-auth")
+            resp = getattr(self._session, verb)(url, **kw)
+        return resp
 
     # ── substrate drift-check (Phase A4) ─────────────────────────────────────
 
@@ -142,13 +188,14 @@ class PlanscapeClient:
             "userName": user_name,
             "elements": [to_wire(e) for e in elements],
         }
-        resp = self._session.post(
+        resp = self._send(
+            "post",
             f"{self.base_url}/api/projects/{self.project_id}/ifc/data",
             json=payload,
             timeout=_TIMEOUT,
         )
         if resp.status_code == 401:
-            raise PlanscapeAuthError("Token expired or invalid")
+            raise PlanscapeAuthError("Token expired or invalid (re-auth failed)")
         resp.raise_for_status()
         return resp.json()
 
@@ -226,12 +273,29 @@ class PlanscapeClient:
         from pathlib import Path
         path = Path(glb_path)
         mime = mimetypes.guess_type(str(path))[0] or "model/gltf-binary"
-        with open(path, "rb") as f:
-            resp = self._session.post(
-                f"{self.base_url}/api/projects/{project_id}/models",
-                files={"file": (path.name, f, mime)},
-                timeout=120,
-            )
+        # The file handle is opened per attempt: a retry after re-auth must
+        # re-read from the start, and a consumed handle would upload 0 bytes.
+        def _post():
+            with open(path, "rb") as f:
+                return self._session.post(
+                    f"{self.base_url}/api/projects/{project_id}/models",
+                    files={"file": (path.name, f, mime)},
+                    # The session sets Content-Type: application/json globally,
+                    # which would override the multipart boundary header that
+                    # `files=` generates and corrupt the upload. None deletes
+                    # the session header for this request only.
+                    headers={"Content-Type": None},
+                    timeout=120,
+                )
+
+        if self._token and time.time() >= self._token_expiry:
+            self._relogin()
+        resp = _post()
+        if getattr(resp, "status_code", None) == 401 and self._relogin():
+            log.info("Planscape token rejected on upload (401) — retrying after re-auth")
+            resp = _post()
+        if resp.status_code == 401:
+            raise PlanscapeAuthError("Token expired or invalid (re-auth failed)")
         resp.raise_for_status()
         return resp.json()
 

--- a/StingBridge/pyproject.toml
+++ b/StingBridge/pyproject.toml
@@ -7,14 +7,18 @@ name = "stingbridge"
 description = "ArchiCAD ↔ Planscape sync bridge (STING tokens, IFC ingest, drop-folder watcher)."
 readme = "QUICKSTART.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+# Proprietary — distributed only through the gated planscape.build downloads
+# area to active subscribers. An OSI licence here would grant recipients
+# redistribution rights the business model depends on NOT granting.
+license = { text = "Proprietary" }
 authors = [{ name = "Planscape Limited", email = "info@stingtools.io" }]
 keywords = ["BIM", "IFC", "ArchiCAD", "STING", "ISO19650", "Planscape"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.13",
+    "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
 ]
 # Single source of truth: StingBridge/__init__.py

--- a/StingBridge/pyproject.toml
+++ b/StingBridge/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "stingbridge"
+description = "ArchiCAD ↔ Planscape sync bridge (STING tokens, IFC ingest, drop-folder watcher)."
+readme = "QUICKSTART.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Planscape Limited", email = "info@stingtools.io" }]
+keywords = ["BIM", "IFC", "ArchiCAD", "STING", "ISO19650", "Planscape"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+# Single source of truth: StingBridge/__init__.py
+dynamic = ["version"]
+
+dependencies = [
+    "requests>=2.31.0",
+    "watchdog>=4.0.0",
+    # Phase A5 — pin to the ifcopenshell major that Bonsai bundles (0.8.x).
+    # Kept in lockstep with requirements.txt and the Bonsai manifest.
+    "ifcopenshell>=0.8.0,<0.9",
+    # Shared STING core — the single source of the Planscape /ifc/data wire
+    # contract (_element_to_wire). Not on PyPI: it is built from
+    # ../stingtools-core/python and shipped as a wheel alongside this one in
+    # the release zips (see QUICKSTART.md → Install).
+    "stingtools-core>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7", "ruff>=0.4"]
+build = ["pyinstaller>=6.0", "build>=1.0"]
+
+[project.scripts]
+stingbridge = "StingBridge.bridge:main"
+
+[project.urls]
+"Source" = "https://github.com/beckykyomugisha/STINGTOOLS"
+"Issues" = "https://github.com/beckykyomugisha/STINGTOOLS/issues"
+
+[tool.setuptools.dynamic]
+version = { attr = "StingBridge.__version__" }
+
+# This directory IS the StingBridge package (imports are `StingBridge.*` and
+# the monorepo checkout puts the sources here, not under a src/ layout), so the
+# package root maps onto ".". Subpackages are listed explicitly to keep the
+# build artefacts (bin/, obj/, .vs/) and the non-Python src/ tree out.
+[tool.setuptools]
+package-dir = { "StingBridge" = "." }
+packages = [
+    "StingBridge",
+    "StingBridge.archicad",
+    "StingBridge.planscape",
+    "StingBridge.sync",
+    "StingBridge.watch",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/StingBridge/requirements.txt
+++ b/StingBridge/requirements.txt
@@ -9,8 +9,18 @@ watchdog>=4.0.0
 ifcopenshell>=0.8.0,<0.9
 
 # Shared STING core — single source of the Planscape /ifc/data wire contract
-# (_element_to_wire). In the monorepo dev checkout the bridge imports it from
-# ../stingtools-core/python via a sys.path fallback (see planscape/client.py),
-# so a pip install is only needed for a standalone bridge deployment:
+# (_element_to_wire).
+#
+# Packaging decision (v0.1.0b1): stingtools-core is a REAL declared dependency
+# of the stingbridge distribution (see pyproject.toml), not a vendored copy —
+# one wire contract, one place to fix it. It is not published to PyPI, so:
+#
+#   * release zips ship the built wheel next to stingbridge's, and the
+#     documented install is `pip install wheels/*.whl` — self-contained, no
+#     monorepo and no network needed (QUICKSTART.md §1);
+#   * the PyInstaller EXE bundles it like any other dependency;
+#   * in this monorepo checkout it resolves either from an editable install
+#     or, failing that, via the sys.path fallback in planscape/client.py.
+#
+# For a dev checkout, install it editable so both paths agree:
 #   pip install -e ../stingtools-core/python
-# stingtools-core @ file:../stingtools-core/python

--- a/StingBridge/sync/engine.py
+++ b/StingBridge/sync/engine.py
@@ -71,6 +71,103 @@ _PROPS_TO_READ = [
     {"type": "BuiltIn",     "nonLocalizedName": "General_ElementID"},
 ]
 
+# Zone identity, read off the ZONE elements themselves (not their contents).
+# Number is preferred over name because ``derive_zone`` keys on the first digit
+# run — "101" → Z101 is meaningful, whereas "Open Plan Office" → ZZ.
+_ZONE_PROPS_TO_READ = [
+    {"type": "BuiltIn", "nonLocalizedName": "Zone_ZoneNumber"},
+    {"type": "BuiltIn", "nonLocalizedName": "Zone_ZoneName"},
+]
+
+
+def _extract_guid(obj: Any) -> str:
+    """Pull a GUID out of the several shapes the ArchiCAD JSON API uses.
+
+    Element references arrive variously as ``{"guid": …}`` and as
+    ``{"elementId": {"guid": …}}`` depending on the command; accepting both
+    keeps zone resolution working across API versions instead of silently
+    yielding an empty index.
+    """
+    if isinstance(obj, str):
+        return obj
+    if not isinstance(obj, dict):
+        return ""
+    if "guid" in obj:
+        return str(obj.get("guid") or "")
+    for key in ("elementId", "zoneId"):
+        inner = obj.get(key)
+        if isinstance(inner, dict) and "guid" in inner:
+            return str(inner.get("guid") or "")
+    return ""
+
+
+def _build_zone_index(ac: ArchiCadClient) -> dict[str, str]:
+    """Map every zoned element's GUID → its zone's label (number, else name).
+
+    Without this the live-sync path never passed ``zone_name`` into
+    ``map_element_to_tokens``, so every element fell back to the ``ZZ``
+    default and the ZONE segment of the tag carried no information.
+
+    NOTE (assumption): the zone label is read from the BuiltIn
+    ``Zone_ZoneNumber`` / ``Zone_ZoneName`` properties. Those are ArchiCAD's
+    documented zone built-ins but are unverified against a live session here;
+    every failure path degrades to an empty index (tokens fall back to ``ZZ``,
+    exactly today's behaviour) rather than aborting the sync.
+    """
+    try:
+        relations = ac.get_elements_related_to_zones()
+    except ArchiCadError as e:
+        log.warning("Zone relations unavailable — ZONE falls back to default: %s", e)
+        return {}
+    if not relations:
+        return {}
+
+    # zone guid → [element guids]
+    zone_members: dict[str, list[str]] = {}
+    for rel in relations:
+        zone_guid = _extract_guid(rel.get("zoneId", rel))
+        if not zone_guid:
+            continue
+        members = [
+            g for g in (_extract_guid(e) for e in rel.get("elementIds", []) or []) if g
+        ]
+        if members:
+            zone_members.setdefault(zone_guid, []).extend(members)
+
+    if not zone_members:
+        return {}
+
+    # Resolve each zone's label in one property read.
+    labels: dict[str, str] = {}
+    try:
+        for epv in ac.get_property_values(list(zone_members), _ZONE_PROPS_TO_READ):
+            zone_guid = _extract_guid(epv)
+            if not zone_guid:
+                continue
+            by_name: dict[str, str] = {}
+            for pv in epv.get("propertyValues", []):
+                val = pv.get("propertyValue", {})
+                if val.get("type") == "normal":
+                    by_name[_prop_key(pv.get("propertyId", {}))] = str(val.get("value", ""))
+            label = (by_name.get("Zone_ZoneNumber") or "").strip() \
+                or (by_name.get("Zone_ZoneName") or "").strip()
+            if label:
+                labels[zone_guid] = label
+    except ArchiCadError as e:
+        log.warning("Zone names unreadable — ZONE falls back to default: %s", e)
+        return {}
+
+    index: dict[str, str] = {}
+    for zone_guid, members in zone_members.items():
+        label = labels.get(zone_guid)
+        if not label:
+            continue
+        for guid in members:
+            index[guid] = label
+
+    log.info("Zone index: %d elements across %d zones", len(index), len(labels))
+    return index
+
 
 @dataclass
 class SyncResult:
@@ -113,6 +210,7 @@ class SyncEngine:
         batch_size: int = 100,
         verify_write_back: bool = True,
         sync_errors_path: str | None = None,
+        building_name: str = "",
     ):
         self._ac = ac_client
         self._ps = planscape_client
@@ -121,6 +219,9 @@ class SyncEngine:
         self._verify = verify_write_back
         self._sync_errors_path = sync_errors_path or "sync_errors.json"
         self._writer = PropertyWriter(ac_client) if write_back else None
+        # ArchiCAD's JSON API exposes no building name, so LOC is supplied by
+        # the operator (STING_BUILDING_NAME). Empty keeps the BLD1 default.
+        self._building_name = building_name
 
     # ── public API ────────────────────────────────────────────────────────────
 
@@ -153,6 +254,10 @@ class SyncEngine:
         except ArchiCadError as e:
             log.warning("Could not fetch story info: %s", e)
 
+        # Resolve zone membership once per run — one API round-trip for the
+        # whole model rather than per chunk.
+        zone_by_element = _build_zone_index(self._ac)
+
         all_sync_elements: list[dict] = []
         write_pairs: list[tuple[str, dict[str, str]]] = []
 
@@ -174,6 +279,7 @@ class SyncEngine:
                     chunk=chunk,
                     element_type=element_type,
                     stories=stories,
+                    zone_by_element=zone_by_element,
                     all_sync_elements=all_sync_elements,
                     write_pairs=write_pairs,
                     result=result,
@@ -233,6 +339,7 @@ class SyncEngine:
         chunk: list[str],
         element_type: str,
         stories: dict[int, dict],
+        zone_by_element: dict[str, str],
         all_sync_elements: list[dict],
         write_pairs: list[tuple[str, dict[str, str]]],
         result: SyncResult,
@@ -307,6 +414,8 @@ class SyncEngine:
                     props=props,
                     storey_name=storey_name,
                     storey_elevation_m=storey_elev,
+                    building_name=self._building_name or None,
+                    zone_name=zone_by_element.get(guid),
                     library_part_name=details.get("libPartName", ""),
                 )
 

--- a/StingBridge/tests/test_auth_refresh.py
+++ b/StingBridge/tests/test_auth_refresh.py
@@ -1,0 +1,200 @@
+"""Tests for transparent re-authentication on token expiry.
+
+A drop-folder watcher logs in once and then runs for days, so the server token
+expires long before the process does. These tests pin the behaviour that every
+ingest after that point still succeeds, via a fake session — no live server.
+
+Run from the repo root:  python StingBridge/tests/test_auth_refresh.py
+(or via pytest).
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from StingBridge.planscape.client import PlanscapeClient, PlanscapeAuthError  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise AssertionError(f"unexpected raise_for_status on {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _ExpiringSession:
+    """Fake session: the token issued by /auth/login is only valid until the
+    next login. Any request bearing a superseded token answers 401 — the same
+    shape a real expiry presents to the client."""
+
+    def __init__(self, *, logins_allowed=99):
+        self.headers = {}
+        self.current_token = None
+        self.login_count = 0
+        self.posts = []          # (url, token_used) for non-login posts
+        self._logins_allowed = logins_allowed
+
+    def post(self, url, json=None, timeout=None, **kw):
+        if url.endswith("/api/auth/login"):
+            self.login_count += 1
+            if self.login_count > self._logins_allowed:
+                return _Resp(401)
+            self.current_token = f"tok-{self.login_count}"
+            return _Resp(200, {"token": self.current_token})
+
+        sent = self.headers.get("Authorization", "")
+        self.posts.append((url, sent))
+        if sent != f"Bearer {self.current_token}":
+            return _Resp(401)
+        return _Resp(200, {"newMappings": 1, "updatedMappings": 0,
+                           "newElements": 1, "updatedElements": 0, "skipped": 0})
+
+
+def _client(session):
+    c = PlanscapeClient(base_url="http://srv", project_id="proj-1")
+    c._session = session
+    c.login("user@example.com", "pw")
+    return c
+
+
+def _element():
+    return PlanscapeClient.build_ifc_element(ifc_global_id="1Abc", disc="M")
+
+
+def test_ingest_succeeds_after_server_side_expiry():
+    """The 401 path: server rejects the token, client re-logs in and retries."""
+    s = _ExpiringSession()
+    c = _client(s)
+
+    # Simulate the server expiring the issued token mid-run.
+    s.current_token = "something-else"
+    resp = c.ingest_ifc_data([_element()])
+
+    assert resp["newMappings"] == 1, "ingest must succeed after re-auth"
+    assert s.login_count == 2, f"expected exactly one re-login, got {s.login_count - 1}"
+    # Two ingest attempts: the rejected one, then the retry with a fresh token.
+    assert len(s.posts) == 2
+    assert s.posts[-1][1] == f"Bearer {s.current_token}"
+
+
+def test_local_expiry_refreshes_proactively_without_a_401():
+    """The proactive path: the locally tracked expiry has passed, so the client
+    refreshes before spending a round-trip on a doomed request."""
+    s = _ExpiringSession()
+    c = _client(s)
+    c._token_expiry = time.time() - 1  # pretend 55 minutes elapsed
+
+    c.ingest_ifc_data([_element()])
+
+    assert s.login_count == 2
+    assert len(s.posts) == 1, "proactive refresh should avoid the wasted 401 attempt"
+
+
+def test_repeated_expiry_keeps_working_over_a_long_run():
+    """A watcher processes many files across many expiries."""
+    s = _ExpiringSession()
+    c = _client(s)
+    for i in range(5):
+        s.current_token = f"expired-{i}"  # expire before each ingest
+        assert c.ingest_ifc_data([_element()])["newMappings"] == 1
+    assert s.login_count == 6  # 1 initial + 5 refreshes
+
+
+def test_auth_error_raised_when_relogin_also_fails():
+    """Credentials revoked outright: surface the 401 rather than loop."""
+    s = _ExpiringSession(logins_allowed=1)
+    c = _client(s)
+    s.current_token = "expired"
+
+    try:
+        c.ingest_ifc_data([_element()])
+        raise AssertionError("should raise when re-auth fails")
+    except PlanscapeAuthError:
+        pass
+    assert s.login_count == 2, "must attempt re-auth exactly once, not spin"
+
+
+def test_login_stores_credentials_for_refresh():
+    s = _ExpiringSession()
+    c = _client(s)
+    assert c._email == "user@example.com"
+    assert c._password == "pw"
+
+
+def test_client_without_login_does_not_attempt_refresh():
+    """ingest before login must still fail fast, not silently re-auth."""
+    c = PlanscapeClient(base_url="http://srv", project_id="proj-1")
+    c._session = _ExpiringSession()
+    try:
+        c.ingest_ifc_data([_element()])
+        raise AssertionError("should require login")
+    except PlanscapeAuthError:
+        pass
+
+
+def test_upload_model_retries_after_expiry(tmp_path=None):
+    """upload_model is the other long-run write path — it must refresh too, and
+    re-open the file so the retry uploads real bytes rather than an empty read."""
+    import tempfile
+
+    class _UploadSession(_ExpiringSession):
+        def __init__(self):
+            super().__init__()
+            self.uploaded_bytes = []
+            self.sent_content_types = []
+
+        def post(self, url, json=None, timeout=None, files=None, headers=None, **kw):
+            if url.endswith("/api/auth/login"):
+                return super().post(url, json=json, timeout=timeout, **kw)
+            sent = self.headers.get("Authorization", "")
+            self.posts.append((url, sent))
+            self.sent_content_types.append((headers or {}).get("Content-Type", "unset"))
+            if files:
+                self.uploaded_bytes.append(files["file"][1].read())
+            if sent != f"Bearer {self.current_token}":
+                return _Resp(401)
+            return _Resp(200, {"id": "model-1"})
+
+    s = _UploadSession()
+    c = _client(s)
+    with tempfile.TemporaryDirectory() as d:
+        glb = Path(d) / "model.glb"
+        glb.write_bytes(b"GLB-PAYLOAD")
+        s.current_token = "expired"
+        result = c.upload_model("proj-1", glb)
+
+    assert result["id"] == "model-1"
+    assert s.login_count == 2
+    # Both attempts must carry the full payload — a reused, already-consumed
+    # handle would make the retry upload zero bytes.
+    assert s.uploaded_bytes == [b"GLB-PAYLOAD", b"GLB-PAYLOAD"]
+    # The session-level application/json must be suppressed so requests can set
+    # its own multipart boundary.
+    assert all(ct is None for ct in s.sent_content_types), s.sent_content_types
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    fails = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  OK   {t.__name__}")
+        except Exception:
+            fails += 1
+            print(f"  FAIL {t.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(tests)} tests, {fails} failures")
+    sys.exit(1 if fails else 0)

--- a/StingBridge/tests/test_config.py
+++ b/StingBridge/tests/test_config.py
@@ -1,0 +1,139 @@
+"""Tests for config-file support and its precedence against the environment.
+
+The contract: environment variables ALWAYS win over the config file, so an
+operator can override a checked-in config for a one-off run.
+
+Run from the repo root:  python StingBridge/tests/test_config.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from StingBridge.config import BridgeConfig  # noqa: E402
+
+
+@contextmanager
+def _env(**kw):
+    """Set env vars for the block, restoring prior values afterwards."""
+    saved = {k: os.environ.get(k) for k in kw}
+    try:
+        for k, v in kw.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+@contextmanager
+def _config_file(name: str, body: str):
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / name
+        path.write_text(body, encoding="utf-8")
+        yield str(path)
+
+
+# Env vars that could leak in from the developer's shell and skew assertions.
+_CLEAR = {k: None for k in (
+    "STING_PLANSCAPE_URL", "STING_PLANSCAPE_EMAIL", "STING_PLANSCAPE_PASSWORD",
+    "STING_PLANSCAPE_PROJECT_ID", "STING_BUILDING_NAME", "STING_WATCH_INTERVAL",
+    "STING_WRITE_BACK", "STING_BATCH_SIZE", "STING_CONFIG_FILE",
+)}
+
+
+def test_toml_config_is_loaded():
+    body = """
+    planscape_url = "https://api.planscape.build"
+    planscape_email = "a@b.com"
+    building_name = "Block C"
+    watch_interval = 60
+    write_back = false
+    """
+    with _env(**_CLEAR), _config_file("stingbridge.toml", body) as p:
+        cfg = BridgeConfig.from_env(p)
+    assert cfg.planscape_url == "https://api.planscape.build"
+    assert cfg.planscape_email == "a@b.com"
+    assert cfg.building_name == "Block C"
+    assert cfg.watch_interval_s == 60
+    assert cfg.write_back_to_archicad is False
+
+
+def test_toml_section_form_is_accepted():
+    body = '[stingbridge]\nplanscape_project_id = "proj-9"\n'
+    with _env(**_CLEAR), _config_file("stingbridge.toml", body) as p:
+        assert BridgeConfig.from_env(p).planscape_project_id == "proj-9"
+
+
+def test_env_file_is_loaded_with_prefix_and_quotes_optional():
+    body = (
+        "# comment line\n"
+        "STING_PLANSCAPE_URL=https://from-env-file\n"
+        'PLANSCAPE_EMAIL="quoted@b.com"\n'
+        "\n"
+        "building_name=Tower A\n"
+    )
+    with _env(**_CLEAR), _config_file(".env", body) as p:
+        cfg = BridgeConfig.from_env(p)
+    assert cfg.planscape_url == "https://from-env-file"
+    assert cfg.planscape_email == "quoted@b.com"   # quotes stripped
+    assert cfg.building_name == "Tower A"          # prefix optional
+
+
+def test_environment_overrides_the_config_file():
+    body = 'planscape_url = "https://from-file"\nbuilding_name = "From File"\n'
+    with _config_file("stingbridge.toml", body) as p:
+        with _env(**{**_CLEAR, "STING_PLANSCAPE_URL": "https://from-env"}):
+            cfg = BridgeConfig.from_env(p)
+    assert cfg.planscape_url == "https://from-env", "env must beat the file"
+    assert cfg.building_name == "From File", "unset env must fall through to the file"
+
+
+def test_defaults_hold_with_no_file_and_no_env():
+    with _env(**_CLEAR):
+        cfg = BridgeConfig.from_env("does-not-exist.toml")
+    assert cfg.planscape_url == "http://localhost:5000"
+    assert cfg.building_name == ""
+    assert cfg.watch_interval_s == 300
+    assert cfg.write_back_to_archicad is True
+
+
+def test_malformed_values_fall_back_without_crashing():
+    body = 'watch_interval = "not-a-number"\n'
+    with _env(**_CLEAR), _config_file("stingbridge.toml", body) as p:
+        assert BridgeConfig.from_env(p).watch_interval_s == 300
+
+
+def test_unreadable_config_file_is_not_fatal():
+    with _env(**_CLEAR), _config_file("stingbridge.toml", "this is not [ valid toml") as p:
+        cfg = BridgeConfig.from_env(p)
+    assert cfg.planscape_url == "http://localhost:5000"
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    fails = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  OK   {t.__name__}")
+        except Exception:
+            fails += 1
+            print(f"  FAIL {t.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(tests)} tests, {fails} failures")
+    sys.exit(1 if fails else 0)

--- a/StingBridge/tests/test_zone_index.py
+++ b/StingBridge/tests/test_zone_index.py
@@ -1,0 +1,145 @@
+"""Tests for ZONE/LOC resolution in the live ArchiCAD sync path.
+
+Before this, ``SyncEngine`` never passed ``zone_name``/``building_name`` into
+``map_element_to_tokens``, so every element in every model got the ``ZZ`` /
+``BLD1`` fallbacks and the ZONE segment of the tag carried no information.
+
+Fixture-driven — no ArchiCAD session required.
+
+Run from the repo root:  python StingBridge/tests/test_zone_index.py
+(or via pytest).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from StingBridge.archicad.client import ArchiCadError  # noqa: E402
+from StingBridge.sync.engine import _build_zone_index, _extract_guid  # noqa: E402
+from StingBridge.sync.token_mapper import map_element_to_tokens  # noqa: E402
+
+
+class _FakeAC:
+    """Duck-typed stand-in for ArchiCadClient's two zone-relevant calls."""
+
+    def __init__(self, relations, zone_props, *, raise_on_relations=False,
+                 raise_on_props=False):
+        self._relations = relations
+        self._zone_props = zone_props
+        self._raise_relations = raise_on_relations
+        self._raise_props = raise_on_props
+        self.property_calls = 0
+
+    def get_elements_related_to_zones(self):
+        if self._raise_relations:
+            raise ArchiCadError("zones unavailable")
+        return self._relations
+
+    def get_property_values(self, guids, props):
+        self.property_calls += 1
+        if self._raise_props:
+            raise ArchiCadError("properties unavailable")
+        return [p for p in self._zone_props if _extract_guid(p) in guids]
+
+
+def _zone_prop(zone_guid, number="", name=""):
+    values = []
+    if number:
+        values.append({"propertyId": {"type": "BuiltIn",
+                                      "nonLocalizedName": "Zone_ZoneNumber"},
+                       "propertyValue": {"type": "normal", "value": number}})
+    if name:
+        values.append({"propertyId": {"type": "BuiltIn",
+                                      "nonLocalizedName": "Zone_ZoneName"},
+                       "propertyValue": {"type": "normal", "value": name}})
+    return {"elementId": {"guid": zone_guid}, "propertyValues": values}
+
+
+def test_zone_index_maps_members_to_zone_number():
+    ac = _FakeAC(
+        relations=[
+            {"zoneId": {"guid": "zone-1"},
+             "elementIds": [{"guid": "el-a"}, {"guid": "el-b"}]},
+            {"zoneId": {"guid": "zone-2"}, "elementIds": [{"guid": "el-c"}]},
+        ],
+        zone_props=[_zone_prop("zone-1", number="101", name="Office"),
+                    _zone_prop("zone-2", number="205", name="Plant Room")],
+    )
+    idx = _build_zone_index(ac)
+    assert idx == {"el-a": "101", "el-b": "101", "el-c": "205"}
+    assert ac.property_calls == 1, "zone labels must resolve in ONE round-trip"
+
+
+def test_zone_index_accepts_the_nested_elementid_shape():
+    """The AC JSON API returns element refs both bare and nested depending on
+    the command; both must resolve or the index comes back silently empty."""
+    ac = _FakeAC(
+        relations=[{"zoneId": {"guid": "zone-1"},
+                    "elementIds": [{"elementId": {"guid": "el-a"}}]}],
+        zone_props=[_zone_prop("zone-1", number="7")],
+    )
+    assert _build_zone_index(ac) == {"el-a": "7"}
+
+
+def test_zone_index_falls_back_to_name_when_number_absent():
+    ac = _FakeAC(
+        relations=[{"zoneId": {"guid": "z"}, "elementIds": [{"guid": "e"}]}],
+        zone_props=[_zone_prop("z", name="Zone 12")],
+    )
+    assert _build_zone_index(ac) == {"e": "Zone 12"}
+
+
+def test_zone_index_degrades_to_empty_on_api_errors():
+    """Every failure path must fall back to today's behaviour, not abort sync."""
+    rel = [{"zoneId": {"guid": "z"}, "elementIds": [{"guid": "e"}]}]
+    props = [_zone_prop("z", number="1")]
+    assert _build_zone_index(_FakeAC(rel, props, raise_on_relations=True)) == {}
+    assert _build_zone_index(_FakeAC(rel, props, raise_on_props=True)) == {}
+    assert _build_zone_index(_FakeAC([], [])) == {}
+    # Zone present but unlabelled → member simply carries no zone.
+    assert _build_zone_index(_FakeAC(rel, [_zone_prop("z")])) == {}
+
+
+def test_resolved_zone_reaches_the_token():
+    """End of the wire: a resolved label becomes a real ZONE token, and an
+    unresolved one still yields the documented ZZ fallback."""
+    tokens = map_element_to_tokens(
+        element_type="Wall", props={}, storey_name="Level 02",
+        building_name="Block B", zone_name="101",
+    )
+    assert tokens["zone"] == "Z101"
+    assert tokens["loc"] == "BLDB"
+
+    fallback = map_element_to_tokens(element_type="Wall", props={},
+                                     storey_name="Level 02")
+    assert fallback["zone"] == "ZZ"
+    assert fallback["loc"] == "BLD1"
+
+
+def test_extract_guid_shapes():
+    assert _extract_guid({"guid": "a"}) == "a"
+    assert _extract_guid({"elementId": {"guid": "b"}}) == "b"
+    assert _extract_guid({"zoneId": {"guid": "c"}}) == "c"
+    assert _extract_guid("d") == "d"
+    assert _extract_guid({}) == ""
+    assert _extract_guid(None) == ""
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    fails = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  OK   {t.__name__}")
+        except Exception:
+            fails += 1
+            print(f"  FAIL {t.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(tests)} tests, {fails} failures")
+    sys.exit(1 if fails else 0)

--- a/stingtools-core/python/pyproject.toml
+++ b/stingtools-core/python/pyproject.toml
@@ -8,14 +8,18 @@ version = "0.1.0"
 description = "Shared Python core for STING IFC substrate (enums + psets + tag grammar + Planscape client)."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+# Proprietary — this wheel ships inside the gated StingBridge release zips
+# (and future STING distributions); it must not carry an OSI licence that
+# grants redistribution rights.
+license = { text = "Proprietary" }
 authors = [{ name = "Planscape Limited", email = "info@stingtools.io" }]
 keywords = ["BIM", "IFC", "STING", "ISO19650", "BlenderBIM"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.13",
+    "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
 ]
 dependencies = []


### PR DESCRIPTION
Phase 1 of packaging StingBridge for self-serve download from planscape.build.

## Fix silent data loss in long-running watchers

`PlanscapeClient` assumed a 60-minute token but never refreshed it. The drop-folder watcher logs in once and runs for days, so **every ingest after the first hour raised `PlanscapeAuthError`** — the watcher recorded the file as errored and moved on, so drops failed silently.

Credentials are now retained at login and refreshed on two triggers: proactively when the tracked expiry passes, and reactively on a 401 (covers clock skew and server-side revocation), retried exactly once. A failed re-login surfaces the original 401 rather than masking it or spinning.

Two further bugs surfaced while covering `upload_model`, the other long-run write path:

- the retry re-used an **already-consumed file handle**, so it would have uploaded zero bytes — now opened per attempt;
- the session sets `Content-Type: application/json` globally, which **overrode the multipart boundary** that `files=` generates and corrupted every GLB upload — now suppressed per-request.

## Wire ZONE/LOC into the live sync path

`map_element_to_tokens` has always accepted `building_name`/`zone_name`, but `SyncEngine` never passed them, so **every element in every model got the `ZZ` and `BLD1` fallbacks** and the ZONE segment carried no information.

Zone membership now resolves once per run (one round-trip for the whole model) via `GetElementsRelatedToZones`, labelled from the zone's `Zone_ZoneNumber`, else `Zone_ZoneName`. ArchiCAD exposes no building name, so LOC comes from the new `STING_BUILDING_NAME` setting. Every failure path degrades to today's behaviour rather than aborting the sync.

## Packaging

- `pyproject.toml` (name `stingbridge`, `0.1.0b1`, `stingbridge` entry point), with `StingBridge/__init__.py` as the single version source read via dynamic attr.
- Config-file support: `stingbridge.toml` or `.env`, auto-discovered or via `--config`. **Environment always wins** so a shared config can be overridden per run.
- `--version` flag and a full `QUICKSTART.md`.
- **Vendor decision:** `stingtools-core` is a *real declared dependency*, not a vendored copy — one wire contract, one place to fix it. It is not on PyPI, so release zips ship its wheel alongside and the documented install is `pip install wheels/*.whl`. Self-contained on a machine that has never seen the monorepo.

Also fixes **`stingbridge --help` crashing on a default Windows cp1252 console** (`UnicodeEncodeError` on the arrow in the description) — the primary target platform. Console streams switch to UTF-8 with `errors=replace`, which also protects the check marks in the watcher's progress output.

## Verification

| Check | Result |
|---|---|
| `pytest StingBridge/tests/` | 26 passed (13 new: re-auth, zone resolution, config precedence) |
| `pytest stingtools-core/python/tests` | 60 passed — no regression |
| Both wheels build | ✅ version resolved dynamically, subpackages correctly namespaced |
| Clean venv `pip install` → `stingbridge --help` | ✅ |
| `process-ifc` end-to-end vs local docker stack | ✅ 3 elements synced, **3 `ExternalElementMapping` rows confirmed server-side** |
| Re-auth against the live server | ✅ forced a genuine 401; ingest succeeded after automatic refresh |

Licensing is deliberately untouched: StingBridge is useless without a Planscape login, so the gated download plus server auth is the entitlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)