### PR TITLE
feat(downloads): per-platform artifacts for multi-build tools + release script

### DIFF
--- a/marketing-site/downloads.html
+++ b/marketing-site/downloads.html
@@ -106,6 +106,27 @@
     }
   }
 
+  // The download href carries the access token because a navigation cannot
+  // send an Authorization header, and the ps_refresh cookie is scoped to
+  // /api/auth so it never reaches the download endpoint. Safe only because
+  // this token is short-lived; it is built from the in-memory token.
+  function tokenHref(url){
+    return esc(url) + (url.indexOf('?') === -1 ? '?' : '&') +
+      't=' + encodeURIComponent(accessToken || '');
+  }
+
+  function artifactRow(a){
+    var bits = [];
+    if (a.platform) bits.push(esc(a.platform));
+    if (a.sizeMb) bits.push(a.sizeMb + ' MB');
+    if (a.sha256) bits.push('<span title="SHA-256: ' + esc(a.sha256) + '" style="cursor:help">sha256 ' +
+      esc(a.sha256.slice(0, 12)) + '…</span>');
+    var meta = bits.length ? '<span class="meta" style="margin:0">' + bits.join(' &middot; ') + '</span>' : '';
+    var text = a.label ? 'Download — ' + esc(a.label) : 'Download';
+    return '<div class="acts" style="margin-bottom:8px"><a class="btn-primary" href="' +
+      tokenHref(a.downloadUrl) + '">' + text + '</a>' + meta + '</div>';
+  }
+
   function versionBlock(t, v){
     var bits = [];
     if (v.version && v.version !== 'current') bits.push('Version ' + esc(v.version));
@@ -114,20 +135,25 @@
     var meta = bits.length ? '<p class="meta">' + bits.join(' &middot; ') + '</p>' : '';
     var note = v.notes ? '<p class="meta">' + esc(v.notes) + '</p>' : '';
 
-    // A version with no URL is not an error — it means we do not have a
+    // One button per downloadable file. Most tools have exactly one; a
+    // cross-platform tool (e.g. StingBridge) lists a build per platform.
+    // A version with no files is not an error — it means we do not have a
     // self-serve link for it yet. Say so plainly and give the way that works,
     // rather than showing a button that goes nowhere.
-    // The href carries the access token because a navigation cannot send an
-    // Authorization header, and the ps_refresh cookie is scoped to /api/auth
-    // so it never reaches the download endpoint. Safe only because this token
-    // is short-lived; it is built at click time from the in-memory token.
-    var action = v.downloadUrl
-      ? '<a class="btn-primary" href="' + esc(v.downloadUrl) + '?t=' + encodeURIComponent(accessToken || '') + '">Download</a>'
-      : '<a class="btn-secondary" href="mailto:hello@planscape.build?subject=' +
+    var arts = (v.artifacts || []).filter(function(a){ return a.downloadUrl; });
+    var action;
+    if (arts.length) {
+      action = arts.map(artifactRow).join('');
+    } else if (v.downloadUrl) {
+      // Fallback for an API that predates artifacts (deploy skew).
+      action = '<div class="acts"><a class="btn-primary" href="' + tokenHref(v.downloadUrl) + '">Download</a></div>';
+    } else {
+      action = '<div class="acts"><a class="btn-secondary" href="mailto:hello@planscape.build?subject=' +
         encodeURIComponent('Download request: ' + t.name) +
-        '">Request by email</a><span class="meta" style="margin:0">Self-serve download coming soon</span>';
+        '">Request by email</a><span class="meta" style="margin:0">Self-serve download coming soon</span></div>';
+    }
 
-    return '<div class="ver">' + meta + note + '<div class="acts">' + action + '</div></div>';
+    return '<div class="ver">' + meta + note + action + '</div>';
   }
 
   function render(data){

--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -10,8 +10,33 @@
 // below. It is intentionally coarse: trial and active tenants get everything.
 // Per-product entitlement (STING Tools subscribers get only the plugin) would go
 // here too, via requiresProduct, once the plans justify it.
+//
+// Releasing a build: use tools/release-download.mjs — it uploads the files to
+// R2, computes sha256 + size from the bytes, and prints the entry to paste
+// here, so the catalogue cannot drift from what is actually in the bucket.
 
 export type ToolStatus = "available" | "beta" | "in-development";
+
+// One downloadable file within a version. A cross-platform tool ships several
+// (a Windows EXE zip, a platform-neutral source zip); a single-platform tool
+// keeps using ToolVersion.objectKey and never declares these.
+//
+// Ship ZIPS ONLY: the streaming endpoint serves everything as application/zip,
+// which is also kinder to browsers than a bare .exe download.
+//
+// Use tools/release-download.mjs to upload the files and generate this block —
+// it computes the sha256 and size so they can never drift from the object.
+export interface ToolArtifact {
+  // URL-safe slug, unique within the version (e.g. "win64", "any"). Shown on
+  // the download button and passed back as ?artifact= to select the file.
+  label: string;
+  // Short human label for where it runs, e.g. "Windows 64-bit" or
+  // "Any OS (Python 3.11+)". Display only.
+  platform?: string;
+  objectKey: string;
+  sizeMb?: number;
+  sha256?: string | null;
+}
 
 export interface ToolVersion {
   version: string;
@@ -27,6 +52,28 @@ export interface ToolVersion {
   // to "request by email" — no code change either way.
   objectKey?: string | null;
   sha256?: string | null;
+  // Multi-file alternative to objectKey for tools that ship more than one
+  // build per version. When present it wins over objectKey.
+  artifacts?: ToolArtifact[];
+}
+
+// Normalise the two shapes: a version's downloadable files as a single list.
+// Single-file versions (objectKey) come back as one artifact with an empty
+// label, which the endpoint serves without needing ?artifact= — so existing
+// STING Tools links keep working unchanged.
+export function resolveArtifacts(v: ToolVersion): ToolArtifact[] {
+  if (v.artifacts && v.artifacts.length) return v.artifacts;
+  if (v.objectKey) {
+    return [
+      {
+        label: "",
+        objectKey: v.objectKey,
+        sizeMb: v.sizeMb,
+        sha256: v.sha256 ?? null,
+      },
+    ];
+  }
+  return [];
 }
 
 export interface Tool {

--- a/marketing-site/functions/api/downloads/[tool]/[version].ts
+++ b/marketing-site/functions/api/downloads/[tool]/[version].ts
@@ -14,7 +14,11 @@ import { handlePreflight } from "../../auth/_lib/cors";
 import { requireAuth } from "../../auth/_lib/auth";
 import { getTenantById } from "../../auth/_lib/db";
 import { verifyJwt } from "../../auth/_lib/jwt";
-import { DOWNLOAD_CATALOG, entitlementFor } from "../../_lib/downloads/catalog";
+import {
+  DOWNLOAD_CATALOG,
+  entitlementFor,
+  resolveArtifacts,
+} from "../../_lib/downloads/catalog";
 import type { Env } from "../../auth/_lib/types";
 
 interface DownloadsEnv extends Env {
@@ -73,19 +77,32 @@ export const onRequestGet: PagesFunction<DownloadsEnv> = async ({
   if (entitlement !== "allowed") return deny(403, reason);
 
   const version = tool.versions.find((v) => v.version === versionId);
-  // objectKey is what makes path traversal a non-issue: the key is whatever the
-  // catalogue says, and the URL only ever selects a catalogue entry.
-  if (!version || !version.objectKey) return deny(404, "That version is not available.");
+  if (!version) return deny(404, "That version is not available.");
 
-  const object = await env.DOWNLOADS.get(version.objectKey);
+  // The object key is what makes path traversal a non-issue: the key is
+  // whatever the catalogue says, and the URL only ever selects a catalogue
+  // entry — ?artifact= picks between the files a version declares, nothing
+  // more. With no selector, a single-file version serves its one file (this is
+  // the pre-artifacts URL shape, so old links keep working); a multi-file
+  // version refuses to guess.
+  const artifacts = resolveArtifacts(version);
+  const wanted = new URL(request.url).searchParams.get("artifact");
+  const artifact = wanted
+    ? artifacts.find((a) => a.label === wanted)
+    : artifacts.length === 1
+      ? artifacts[0]
+      : undefined;
+  if (!artifact) return deny(404, "That file is not available.");
+
+  const object = await env.DOWNLOADS.get(artifact.objectKey);
   if (!object) {
     console.error(
-      `R2 object missing for ${toolId}/${versionId}: ${version.objectKey}`
+      `R2 object missing for ${toolId}/${versionId}: ${artifact.objectKey}`
     );
     return deny(404, "That file is temporarily unavailable. Please contact support.");
   }
 
-  const filename = version.objectKey.split("/").pop() || `${toolId}.zip`;
+  const filename = artifact.objectKey.split("/").pop() || `${toolId}.zip`;
   const headers = new Headers();
   object.writeHttpMetadata(headers);
   headers.set("Content-Type", "application/zip");

--- a/marketing-site/functions/api/downloads/index.ts
+++ b/marketing-site/functions/api/downloads/index.ts
@@ -11,7 +11,11 @@ import { handlePreflight } from "../auth/_lib/cors";
 import { requireAuth } from "../auth/_lib/auth";
 import { unauthorized } from "../auth/_lib/errors";
 import { getTenantById } from "../auth/_lib/db";
-import { DOWNLOAD_CATALOG, entitlementFor } from "../_lib/downloads/catalog";
+import {
+  DOWNLOAD_CATALOG,
+  entitlementFor,
+  resolveArtifacts,
+} from "../_lib/downloads/catalog";
 
 export const onRequestOptions: PagesFunction = async ({ request }) =>
   handlePreflight(request);
@@ -39,19 +43,34 @@ export const onRequestGet = withHandler(async ({ request, env }) => {
       // tenant still sees the catalogue — they just don't get the link.
       versions:
         entitlement === "allowed"
-          ? tool.versions.map((v) => ({
-              version: v.version,
-              hosts: v.hosts ?? null,
-              sizeMb: v.sizeMb ?? null,
-              releasedAt: v.releasedAt ?? null,
-              notes: v.notes ?? null,
-              // Point at our own gated endpoint, never at R2 directly. The
-              // bucket is private; this URL re-checks entitlement per request.
-              downloadUrl: v.objectKey
-                ? `/api/downloads/${tool.id}/${encodeURIComponent(v.version)}`
-                : null,
-              sha256: v.sha256 ?? null,
-            }))
+          ? tool.versions.map((v) => {
+              const base = `/api/downloads/${tool.id}/${encodeURIComponent(v.version)}`;
+              const artifacts = resolveArtifacts(v).map((a) => ({
+                label: a.label || null,
+                platform: a.platform ?? null,
+                sizeMb: a.sizeMb ?? null,
+                sha256: a.sha256 ?? null,
+                // Point at our own gated endpoint, never at R2 directly. The
+                // bucket is private; this URL re-checks entitlement per
+                // request. The label selects the file for multi-artifact
+                // versions; a single-file version needs no selector.
+                downloadUrl: a.label
+                  ? `${base}?artifact=${encodeURIComponent(a.label)}`
+                  : base,
+              }));
+              return {
+                version: v.version,
+                hosts: v.hosts ?? null,
+                sizeMb: v.sizeMb ?? null,
+                releasedAt: v.releasedAt ?? null,
+                notes: v.notes ?? null,
+                artifacts,
+                // Legacy single-file fields, kept so a cached copy of the page
+                // keeps working across the deploy that introduces artifacts.
+                downloadUrl: v.objectKey ? base : null,
+                sha256: v.sha256 ?? null,
+              };
+            })
           : [],
     };
   });

--- a/marketing-site/tools/release-download.mjs
+++ b/marketing-site/tools/release-download.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Release a build to the gated downloads area.
+//
+// Uploads one or more files to the private planscape-downloads R2 bucket and
+// prints the exact `artifacts` block to paste into
+// functions/api/_lib/downloads/catalog.ts — sha256 and size are computed from
+// the files themselves, so the catalogue can never drift from the objects.
+//
+// Run from the marketing-site directory (wrangler.toml lives here):
+//
+//   node tools/release-download.mjs --tool sting-bridge --version 0.1.0-beta.1 \
+//     --file "win64:Windows 64-bit:C:/builds/StingBridge_0.1.0-beta.1_win64.zip" \
+//     --file "any:Any OS (Python 3.11+):C:/builds/StingBridge_0.1.0-beta.1_any.zip"
+//
+//   --file LABEL:PLATFORM:PATH   repeatable; LABEL is the URL-safe slug shown
+//                                on the button and used as ?artifact=LABEL.
+//                                For a single-file tool use one --file and
+//                                paste the objectKey/sha256 into the version
+//                                fields instead of an artifacts block.
+//   --dry-run                    hash + print, skip the R2 upload.
+//
+// Requires wrangler auth (`npx wrangler whoami` to check). Ship ZIPS ONLY —
+// the download endpoint serves everything as application/zip.
+
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { basename } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const BUCKET = "planscape-downloads";
+
+function fail(msg) {
+  console.error(`error: ${msg}`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { files: [], dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--tool") args.tool = argv[++i];
+    else if (a === "--version") args.version = argv[++i];
+    else if (a === "--file") args.files.push(argv[++i]);
+    else if (a === "--dry-run") args.dryRun = true;
+    else fail(`unknown argument: ${a}`);
+  }
+  if (!args.tool) fail("--tool is required (catalogue tool id, e.g. sting-bridge)");
+  if (!args.version) fail("--version is required (e.g. 0.1.0-beta.1)");
+  if (!args.files.length) fail("at least one --file LABEL:PLATFORM:PATH is required");
+  return args;
+}
+
+function parseFileSpec(spec) {
+  // LABEL:PLATFORM:PATH — PATH may itself contain ":" (C:/...), so split
+  // only the first two separators.
+  const first = spec.indexOf(":");
+  const second = spec.indexOf(":", first + 1);
+  if (first === -1 || second === -1) {
+    fail(`--file must be LABEL:PLATFORM:PATH, got: ${spec}`);
+  }
+  const label = spec.slice(0, first).trim();
+  const platform = spec.slice(first + 1, second).trim();
+  const path = spec.slice(second + 1).trim();
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(label)) {
+    fail(`label must be URL-safe (letters, digits, . _ -), got: ${label}`);
+  }
+  return { label, platform, path };
+}
+
+const { tool, version, files, dryRun } = parseArgs(process.argv.slice(2));
+
+const artifacts = files.map((spec) => {
+  const { label, platform, path } = parseFileSpec(spec);
+  let bytes;
+  try {
+    bytes = readFileSync(path);
+  } catch (e) {
+    fail(`cannot read ${path}: ${e.message}`);
+  }
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const sizeMb = Math.max(1, Math.round(statSync(path).size / 1048576));
+  const objectKey = `${tool}/${version}/${basename(path)}`;
+  return { label, platform, path, objectKey, sha256, sizeMb };
+});
+
+const labels = artifacts.map((a) => a.label);
+if (new Set(labels).size !== labels.length) {
+  fail(`artifact labels must be unique within a version: ${labels.join(", ")}`);
+}
+
+for (const a of artifacts) {
+  console.log(`\n${a.path}`);
+  console.log(`  key    ${BUCKET}/${a.objectKey}`);
+  console.log(`  sha256 ${a.sha256}`);
+  console.log(`  size   ${a.sizeMb} MB`);
+  if (dryRun) {
+    console.log("  upload skipped (--dry-run)");
+    continue;
+  }
+  execFileSync(
+    "npx",
+    ["wrangler", "r2", "object", "put", `${BUCKET}/${a.objectKey}`, "--file", a.path],
+    { stdio: "inherit", shell: process.platform === "win32" }
+  );
+}
+
+const block = artifacts
+  .map(
+    (a) => `          {
+            label: ${JSON.stringify(a.label)},
+            platform: ${JSON.stringify(a.platform)},
+            objectKey: ${JSON.stringify(a.objectKey)},
+            sizeMb: ${a.sizeMb},
+            sha256: ${JSON.stringify(a.sha256)},
+          },`
+  )
+  .join("\n");
+
+console.log(`\nPaste into the "${tool}" version "${version}" entry in`);
+console.log("functions/api/_lib/downloads/catalog.ts:\n");
+console.log(`        artifacts: [\n${block}\n        ],`);
+console.log("\nThen deploy: npm run deploy (from marketing-site/).");


### PR DESCRIPTION
Phase 3 of the StingBridge release plan — the downloads area learns to serve more than one file per version, ahead of the StingBridge beta artifacts (Windows EXE zip + platform-neutral source zip) landing from PR #415's Phase 2.

## What changed
- **catalog.ts** — new `ToolArtifact` type + `artifacts[]` on `ToolVersion`, with a `resolveArtifacts()` normaliser. The existing single-`objectKey` shape is untouched: STING Tools' entry and its live download URL work exactly as before.
- **index.ts** — emits an `artifacts` array per version, each with its own gated `downloadUrl`. Legacy `downloadUrl`/`sha256` fields kept so a cached page survives the deploy.
- **[version].ts** — `?artifact=<label>` selects the file. The object key still comes only from the catalogue (path traversal remains a non-issue); a multi-file version with no selector 404s rather than guessing; a single-file version serves without a selector so pre-existing links keep working.
- **downloads.html** — one Download button per artifact with platform, size, and truncated sha256 (full hash on hover). The request-by-email fallback for versions with no files is unchanged.
- **tools/release-download.mjs** — release helper: hashes the files, uploads to the private R2 bucket via wrangler, prints the exact catalogue block to paste — sha256/size can never drift from the object in the bucket.

## Verification
- `npm run typecheck` clean (tsc against the Functions).
- Release script dry-run produces upload keys + a paste-ready catalogue block.
- Page rendering exercised against a stubbed API covering all four states (single-file tool / multi-artifact tool / beta with no file → mailto / in-development); download hrefs verified as `…?artifact=win64&t=<token>`.

## Not in this PR
- The StingBridge catalogue flip (needs Phase 2's real artifacts — done via the new release script).
- `sha256` backfill for the existing STING Tools object (needs Cloudflare-authed `wrangler r2 object get` to hash the canonical bucket copy — one command for whoever holds the auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)