### PR TITLE
feat(downloads): StingBridge 0.1.0-beta.1 goes self-serve + setup guide

### DIFF
--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -106,12 +106,15 @@ export const DOWNLOAD_CATALOG: Tool[] = [
       {
         version: "2026-07-05",
         hosts: ["Revit 2025", "Revit 2026", "Revit 2027"],
-        sizeMb: 88,
+        sizeMb: 89,
         releasedAt: "2026-07-05",
         notes:
           "One package covers all three Revit versions — the installer puts the files in the right place. Includes an install guide and an uninstaller.",
         objectKey: "sting-tools/2026-07-05/StingTools_Deploy_20260705.zip",
-        sha256: null,
+        // Hashed from the canonical bucket object (wrangler r2 object get →
+        // sha256), 2026-07-19.
+        sha256:
+          "9ed1036ad08c12653e15f1501cd282f773a6edf06523f770af1565697f91b00c",
       },
     ],
   },
@@ -122,14 +125,31 @@ export const DOWNLOAD_CATALOG: Tool[] = [
       "Connects ArchiCAD models to Planscape, and watches a folder for IFC files to bring in automatically.",
     kind: "connector",
     status: "beta",
-    platform: "Windows · macOS · ArchiCAD",
+    platform: "Windows · macOS · ArchiCAD (and any IFC-exporting tool)",
     requiresProduct: null,
+    docsUrl: "/guides/stingbridge-setup.html",
     versions: [
       {
-        version: "beta",
+        version: "0.1.0-beta.1",
+        releasedAt: "2026-07-19",
         notes:
-          "In testing with a small group. Tell us about your ArchiCAD setup and we will include you.",
-        objectKey: null,
+          "First public beta. The IFC drop-folder and single-file workflows are verified end-to-end; live ArchiCAD JSON-API sync ships but is still maturing — tell us how it goes.",
+        artifacts: [
+          {
+            label: "win64",
+            platform: "Windows 64-bit",
+            objectKey: "sting-bridge/0.1.0-beta.1/StingBridge_0.1.0-beta.1_win64.zip",
+            sizeMb: 51,
+            sha256: "976401ecce06c9c3231c1d92477c1fe3185ba167232ee3bf8ce4a857e0bc6d26",
+          },
+          {
+            label: "any",
+            platform: "Any OS (Python 3.11+)",
+            objectKey: "sting-bridge/0.1.0-beta.1/StingBridge_0.1.0-beta.1_any.zip",
+            sizeMb: 1,
+            sha256: "22f1ed6805f79e5fa2b64dc91a6b0a8c5a7475dd640dd68cbf48fc34ac425cc2",
+          },
+        ],
       },
     ],
   },

--- a/marketing-site/guides/index.html
+++ b/marketing-site/guides/index.html
@@ -62,6 +62,10 @@
         <div class="ttl">Installing STING Tools in Revit</div>
         <div class="sub">Where the files go, how to confirm it loaded, and what to do if the panel doesn't appear.</div>
       </a>
+      <a href="/guides/stingbridge-setup.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> StingBridge — ArchiCAD &amp; IFC</div>
+        <div class="sub">Connect ArchiCAD, or any IFC-exporting tool, to Planscape: drop-folder sync, live sync, Publisher automation.</div>
+      </a>
       <a href="/guides/the-panel.html" class="guide-row">
         <div class="ttl"><span class="badge">NEW</span> The panel, tab by tab</div>
         <div class="sub">All nine tabs in plain language — what each is for and when you would reach for it.</div>

--- a/marketing-site/guides/revit-plugin-setup.html
+++ b/marketing-site/guides/revit-plugin-setup.html
@@ -47,7 +47,7 @@
   </table>
 
   <h2>Step 1 — Download the plugin</h2>
-  <p>Email <a href="mailto:hello@planscape.build">hello@planscape.build</a> and we will send you the installer and your licence. Say which version of Revit you run &mdash; 2025, 2026 or 2027 &mdash; so we send the right build. A self-serve download area is being built; until then this step is manual at our end, so allow a working day.</p>
+  <p>Sign in and download it from the <a href="/downloads">downloads page</a> — one package covers Revit 2025, 2026 and 2027, with the SHA-256 checksum shown next to the button. (If you need a build for an older Revit version, email <a href="mailto:hello@planscape.build">hello@planscape.build</a>.)</p>
   <p>You get a single ZIP file: <code>StingTools.zip</code> (around 45 MB). It contains:</p>
   <ul>
     <li><code>StingTools.addin</code> — the Revit manifest</li>

--- a/marketing-site/guides/stingbridge-setup.html
+++ b/marketing-site/guides/stingbridge-setup.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>StingBridge setup — ArchiCAD &amp; IFC to Planscape — Planscape</title>
+<meta name="description" content="Install StingBridge and connect ArchiCAD — or any IFC-exporting tool — to Planscape: drop-folder sync, live ArchiCAD sync, and Publisher Set automation.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/stingbridge-setup.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; StingBridge setup</div>
+  <h1>StingBridge setup — ArchiCAD &amp; IFC to Planscape</h1>
+  <div class="meta">📖 6-minute read · Beginner · Last updated 2026-07-19 · v0.1.0-beta.1</div>
+
+  <p>StingBridge connects <strong>ArchiCAD</strong> — or <em>any</em> tool that can export IFC — to your Planscape project. It reads the model, derives STING ISO 19650 tokens (<code>DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ</code>), pushes them to Planscape, and writes them back into the model so the tags live in the file too.</p>
+
+  <p>There is <strong>no licence key</strong>. StingBridge signs in with your Planscape account — your subscription is the entitlement.</p>
+
+  <h2>Which download do I want?</h2>
+  <table>
+    <thead><tr><th>Build</th><th>Pick it when</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Windows 64-bit</strong> (<code>_win64.zip</code>)</td><td>You are on Windows and want zero setup — a single <code>stingbridge.exe</code>, no Python needed.</td></tr>
+      <tr><td><strong>Any OS</strong> (<code>_any.zip</code>)</td><td>You are on macOS/Linux, or you already have Python 3.11+ and prefer a smaller download. Ships the wheels plus <code>run.bat</code>/<code>run.sh</code> launchers that set everything up on first run.</td></tr>
+    </tbody>
+  </table>
+  <p>Both are on the <a href="/downloads">downloads page</a>, with SHA-256 checksums shown next to each button.</p>
+
+  <h2>Step 1 — Install</h2>
+  <h3>Windows EXE</h3>
+  <ol>
+    <li>Unzip anywhere, e.g. <code>C:\Tools\StingBridge</code>.</li>
+    <li>Open a terminal there and check it runs: <code>stingbridge.exe --version</code></li>
+  </ol>
+  <h3>Any OS (Python)</h3>
+  <ol>
+    <li>Unzip, then run <code>run.bat</code> (Windows) or <code>./run.sh</code> (macOS/Linux) — the first run creates a local environment and installs the bundled wheels.</li>
+    <li>Check: <code>./run.sh --version</code></li>
+  </ol>
+
+  <h2>Step 2 — Connect to Planscape</h2>
+  <p>Create a <code>stingbridge.toml</code> next to the executable (or set the same values as <code>STING_*</code> environment variables — environment always wins):</p>
+  <pre><code>planscape_url        = "https://api.planscape.build"
+planscape_email      = "you@yourfirm.com"
+planscape_password   = "your-planscape-password"
+planscape_project_id = "&lt;project UUID from Planscape&gt;"
+
+# Optional
+building_name        = "Block A"   # drives the LOC token, default BLD1
+ifc_drop_dir         = "C:/Projects/IFC_DROP"</code></pre>
+  <p>Your project's UUID is in the Planscape web app under the project's settings, or ask your BIM manager.</p>
+
+  <h2>Step 3 — Pick your workflow</h2>
+
+  <h3>A. IFC drop folder (recommended — works with any authoring tool)</h3>
+  <pre><code>stingbridge watch-ifc --drop-dir "C:/Projects/IFC_DROP"</code></pre>
+  <p>Leave it running. Every <code>.ifc</code> file that lands in the folder is parsed, tagged, synced to Planscape, and written back out as <code>&lt;name&gt;_sting.ifc</code> with a <code>STING_TOKENS</code> property set on every element. A <code>.sync_result.json</code> sidecar records what happened per file.</p>
+  <p>In ArchiCAD, point a <strong>Publisher Set</strong> (IFC translator) at the drop folder and publishing becomes your sync button. The same works from Tekla, Vectorworks, Allplan — anything that exports IFC.</p>
+
+  <h3>B. One file, right now</h3>
+  <pre><code>stingbridge process-ifc "C:/Projects/model.ifc"</code></pre>
+
+  <h3>C. Live ArchiCAD sync (beta)</h3>
+  <p>With ArchiCAD open (AC 28/29) and a project loaded:</p>
+  <pre><code>stingbridge sync          # one pass
+stingbridge watch         # every 5 minutes
+stingbridge auto-publish  # trigger the IFC Publisher Set, then ingest</code></pre>
+  <p>Live sync reads elements over ArchiCAD&rsquo;s JSON API, writes STING tokens back as User-Defined properties in a <code>STING</code> property group, and verifies what it wrote. It is the newest path in the beta — if anything looks off, use the drop-folder workflow and <a href="mailto:hello@planscape.build">tell us</a>.</p>
+
+  <h2>Optional — 3D viewer uploads</h2>
+  <p>If <code>IfcConvert</code> (from IfcOpenShell) is installed and on your <code>PATH</code>, processed models are also converted to GLB and uploaded to the Planscape 3D viewer automatically. Without it, everything else still works.</p>
+
+  <h2>Troubleshooting</h2>
+  <table>
+    <thead><tr><th>Symptom</th><th>Fix</th></tr></thead>
+    <tbody>
+      <tr><td><code>ArchiCAD not found on ports 19723&ndash;19726</code></td><td>ArchiCAD must be running with a project open, and the JSON API enabled.</td></tr>
+      <tr><td><code>Invalid credentials</code></td><td>Check <code>planscape_email</code>/<code>planscape_password</code> — same details you use on planscape.build.</td></tr>
+      <tr><td>Elements sync with <code>ZZ</code> zone / <code>BLD1</code> location</td><td>Zones need ArchiCAD zone numbers/names; set <code>building_name</code> for LOC. IFC files need spatial structure for levels.</td></tr>
+      <tr><td>Watcher stops syncing after an hour</td><td>Fixed in 0.1.0-beta.1 — the bridge re-authenticates automatically. Update if you are on anything older.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Beta caveats</h2>
+  <ul>
+    <li>Live ArchiCAD sync (workflow C) is verified against IFC round-trips; a live-model check on <em>your</em> ArchiCAD version is part of what the beta is for.</li>
+    <li>macOS users use the <code>_any</code> build — a signed native binary comes later.</li>
+  </ul>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      
+
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="https://wa.me/256700000000" target="_blank" rel="noopener">WhatsApp</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/tools/release-download.mjs
+++ b/marketing-site/tools/release-download.mjs
@@ -99,7 +99,9 @@ for (const a of artifacts) {
   }
   execFileSync(
     "npx",
-    ["wrangler", "r2", "object", "put", `${BUCKET}/${a.objectKey}`, "--file", a.path],
+    // --remote is required: wrangler 4 defaults r2 object commands to the LOCAL
+    // simulator, which silently uploads to nowhere the production bucket reads.
+    ["wrangler", "r2", "object", "put", `${BUCKET}/${a.objectKey}`, "--file", a.path, "--remote"],
     { stdio: "inherit", shell: process.platform === "win32" }
   );
 }


### PR DESCRIPTION
Phase 4 — the StingBridge beta becomes a real download on planscape.build/downloads.

- **Catalogue flip**: `sting-bridge` now lists version 0.1.0-beta.1 with two artifacts already uploaded to the private R2 bucket — `win64` (one-file EXE, 51 MB) and `any` (wheels + launchers, 1 MB), each with sha256 computed from the uploaded bytes.
- **Both artifacts verified**: clean-install smoke tests plus a full `process-ifc` E2E against the live local Planscape stack (3 elements parsed → synced → tokens written back into the IFC, 0 errors). Wheels carry Proprietary licence metadata and bundle LICENSE.txt.
- **release-download.mjs fix**: wrangler 4 defaults `r2 object put` to the *local* simulator — added `--remote` (first real run caught it).
- **STING Tools sha256 backfilled** by hashing the canonical bucket object (`9ed1036a…`); sizeMb corrected to 89.
- **New guide** `guides/stingbridge-setup.html` (+ guides index entry), and the Revit guide's stale "email us for the installer" step now points at the live downloads page.

Deploy: `npm run deploy` from marketing-site after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)