### PR TITLE
chore(stingbridge): hardening from PR #415 review + Phase 199 docs

### DIFF
--- a/StingBridge/bridge.py
+++ b/StingBridge/bridge.py
@@ -49,8 +49,6 @@ def _configure_console_encoding() -> None:
             pass
 
 
-_configure_console_encoding()
-
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
@@ -268,6 +266,12 @@ def cmd_auto_publish(cfg: BridgeConfig, publisher_set_name: str | None) -> int:
 
 
 def main() -> None:
+    # Called here rather than at import so importing StingBridge.bridge as a
+    # library never mutates the host process's streams. reconfigure() mutates
+    # the stream objects in place, so the logging handler bound at import time
+    # picks up the new encoding too.
+    _configure_console_encoding()
+
     parser = argparse.ArgumentParser(
         prog="stingbridge",
         description="STING ArchiCAD ↔ Planscape sync bridge",

--- a/StingBridge/planscape/client.py
+++ b/StingBridge/planscape/client.py
@@ -146,11 +146,11 @@ class PlanscapeClient:
         worker-startup drift-check so a bridge running on a stale/forked
         shared/ifc copy is warned before it ingests against divergent enums.
         """
-        resp = self._session.get(
-            f"{self.base_url}/api/substrate/manifest", timeout=_TIMEOUT
+        resp = self._send(
+            "get", f"{self.base_url}/api/substrate/manifest", timeout=_TIMEOUT
         )
         if resp.status_code == 401:
-            raise PlanscapeAuthError("Token expired or invalid")
+            raise PlanscapeAuthError("Token expired or invalid (re-auth failed)")
         resp.raise_for_status()
         return resp.json()
 
@@ -244,7 +244,8 @@ class PlanscapeClient:
         if not self._token or not self.project_id or not guids:
             return {}
         try:
-            resp = self._session.post(
+            resp = self._send(
+                "post",
                 f"{self.base_url}/api/projects/{self.project_id}/tagsync/timestamps",
                 json={"guids": guids},
                 timeout=_TIMEOUT,
@@ -301,7 +302,8 @@ class PlanscapeClient:
 
     def get_compliance(self) -> dict:
         """GET latest compliance snapshot for the project."""
-        resp = self._session.get(
+        resp = self._send(
+            "get",
             f"{self.base_url}/api/projects/{self.project_id}/compliance",
             timeout=_TIMEOUT,
         )

--- a/StingBridge/sync/engine.py
+++ b/StingBridge/sync/engine.py
@@ -101,6 +101,14 @@ def _extract_guid(obj: Any) -> str:
     return ""
 
 
+def _read_zone_property_values(ac: ArchiCadClient, zone_guids: list[str]):
+    """Yield property-value rows for the zones in batches of 100 — same batch
+    discipline as element processing, so huge zone counts cannot produce one
+    oversized API request."""
+    for i in range(0, len(zone_guids), 100):
+        yield from ac.get_property_values(zone_guids[i : i + 100], _ZONE_PROPS_TO_READ)
+
+
 def _build_zone_index(ac: ArchiCadClient) -> dict[str, str]:
     """Map every zoned element's GUID → its zone's label (number, else name).
 
@@ -137,10 +145,11 @@ def _build_zone_index(ac: ArchiCadClient) -> dict[str, str]:
     if not zone_members:
         return {}
 
-    # Resolve each zone's label in one property read.
+    # Resolve the zone labels in batched property reads — a campus model can
+    # carry thousands of zones, and one giant request risks the API's limits.
     labels: dict[str, str] = {}
     try:
-        for epv in ac.get_property_values(list(zone_members), _ZONE_PROPS_TO_READ):
+        for epv in _read_zone_property_values(ac, list(zone_members)):
             zone_guid = _extract_guid(epv)
             if not zone_guid:
                 continue

--- a/StingBridge/tests/test_auth_refresh.py
+++ b/StingBridge/tests/test_auth_refresh.py
@@ -184,6 +184,46 @@ def test_upload_model_retries_after_expiry(tmp_path=None):
     assert all(ct is None for ct in s.sent_content_types), s.sent_content_types
 
 
+def test_timestamps_and_manifest_survive_expiry():
+    """The read endpoints (conflict-detection timestamps, substrate manifest,
+    compliance) route through the same refresh path as the writes — otherwise
+    a long-lived caller would silently lose conflict detection after an hour
+    (get_element_timestamps swallows errors and returns {})."""
+
+    class _ReadSession(_ExpiringSession):
+        def post(self, url, json=None, timeout=None, **kw):
+            if url.endswith("/tagsync/timestamps"):
+                sent = self.headers.get("Authorization", "")
+                self.posts.append((url, sent))
+                if sent != f"Bearer {self.current_token}":
+                    return _Resp(401)
+                return _Resp(200, {"guid-1": "2026-07-19T12:00:00Z"})
+            return super().post(url, json=json, timeout=timeout, **kw)
+
+        def get(self, url, timeout=None, **kw):
+            sent = self.headers.get("Authorization", "")
+            self.posts.append((url, sent))
+            if sent != f"Bearer {self.current_token}":
+                return _Resp(401)
+            return _Resp(200, {"sha256": "abc", "schemaVersion": 1,
+                               "totalEnums": 52, "compliancePercent": 97})
+
+    s = _ReadSession()
+    c = _client(s)
+
+    s.current_token = "rotated"  # server-side expiry before each call
+    ts = c.get_element_timestamps(["guid-1"])
+    assert list(ts) == ["guid-1"], "timestamps must re-auth, not return {}"
+
+    s.current_token = "rotated-2"
+    assert c.get_substrate_manifest()["totalEnums"] == 52
+
+    s.current_token = "rotated-3"
+    assert c.get_compliance()["compliancePercent"] == 97
+
+    assert s.login_count == 4  # initial + one re-login per rotated token
+
+
 if __name__ == "__main__":
     import traceback
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]

--- a/StingBridge/tests/test_zone_index.py
+++ b/StingBridge/tests/test_zone_index.py
@@ -120,6 +120,22 @@ def test_resolved_zone_reaches_the_token():
     assert fallback["loc"] == "BLD1"
 
 
+def test_zone_property_reads_are_batched():
+    """Thousands of zones must not produce one oversized API request — reads
+    go out in chunks of 100, and every zone still resolves."""
+    n = 250
+    relations = [
+        {"zoneId": {"guid": f"zone-{i}"}, "elementIds": [{"guid": f"el-{i}"}]}
+        for i in range(n)
+    ]
+    props = [_zone_prop(f"zone-{i}", number=str(i)) for i in range(n)]
+    ac = _FakeAC(relations=relations, zone_props=props)
+    idx = _build_zone_index(ac)
+    assert len(idx) == n
+    assert idx["el-249"] == "249"
+    assert ac.property_calls == 3, "250 zones → ceil(250/100) = 3 batched reads"
+
+
 def test_extract_guid_shapes():
     assert _extract_guid({"guid": "a"}) == "a"
     assert _extract_guid({"elementId": {"guid": "b"}}) == "b"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 199 — StingBridge 0.1.0-beta.1 release + self-serve downloads, PRs #415–#417)
+
+StingBridge became a shipped product: packaged, released through the gated planscape.build
+downloads area, and live in production. All merged to main; artifacts verified end-to-end
+against the local docker Planscape stack before upload.
+
+- **Release readiness (PR #415, branch `claude/stingbridge-release`)** — transparent
+  re-authentication on token expiry (proactive + reactive-401, retried once; fixes the
+  drop-folder watcher dying silently after ~1 h); ZONE/LOC finally wired in the live sync
+  path (`_build_zone_index` via `GetElementsRelatedToZones` + `Zone_ZoneNumber`/`Zone_ZoneName`
+  built-ins, `STING_BUILDING_NAME` drives LOC); `upload_model` re-opens the file per retry
+  (a consumed handle uploaded 0 bytes) and suppresses the session's global
+  `Content-Type: application/json` that corrupted every multipart GLB upload;
+  `--help` no longer crashes on cp1252 consoles; `pyproject.toml` packaging
+  (`stingbridge` 0.1.0b1, entry point, dynamic version) + `stingbridge.toml`/`.env` config
+  file support (env > file > defaults); QUICKSTART.md. **Licence metadata set to
+  Proprietary** in both `StingBridge/pyproject.toml` and
+  `stingtools-core/python/pyproject.toml` (both said MIT — which would have granted every
+  download recipient redistribution rights) + `StingBridge/LICENSE.txt`.
+- **Downloads multi-artifact support (PR #416)** — `artifacts[]` per catalogue version
+  (label/platform/objectKey/sha256), `?artifact=<label>` selector on the gated streaming
+  endpoint (single-file versions keep their selector-less URLs), one Download button per
+  artifact on the page, and `marketing-site/tools/release-download.mjs` (hash → upload →
+  print-the-catalogue-block; **must pass `--remote` — wrangler 4 defaults `r2 object put`
+  to the local simulator**).
+- **Release + flip (PR #417)** — built on Python 3.13: `win64` one-file PyInstaller EXE
+  (51 MB, sha256 `976401ec…`) and `any` wheels zip with `run.bat`/`run.sh` launchers
+  (sha256 `22f1ed68…`); both smoke-tested from clean installs including a full
+  `process-ifc` E2E (3 elements → server → token write-back, 0 errors). Uploaded to the
+  private `planscape-downloads` R2 bucket; catalogue flipped from request-by-email to
+  self-serve; STING Tools sha256 backfilled from the canonical bucket object; new
+  `guides/stingbridge-setup.html`; Revit guide's stale "email us" step now points at
+  `/downloads`. Deployed to production and verified live (gating 401s, page + guide 200).
+- **Hardening (this branch)** — remaining review findings: `get_element_timestamps` /
+  `get_substrate_manifest` / `get_compliance` routed through the same `_send` refresh path
+  as the writes; zone property reads batched (100/request) for campus-scale zone counts;
+  console-encoding reconfigure moved from import time into `main()`. 28 tests pass.
+- **Deliberate decisions**: StingBridge carries **no offline licence key** — it is useless
+  without a Planscape server login, so the account is the entitlement (unlike the Revit
+  plugin's machine-locked keys). macOS ships via the `any` zip; a notarized binary is
+  deferred.
+
 #### Completed (Phase 198b — MEP print-ready cross-check punch-list, branch `claude/mep-punchlist`)
 
 Fixes the correctness/consistency defects a cross-check found in Phase 198's MEP work. Base

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -290,6 +290,20 @@ retention release and the sign-off guard. Still open:
 - **QS import per-row accept/reject.** The import diff is whole-batch
   Apply/Cancel; per-row checkboxes would let a QS accept a subset.
 
+## StingBridge — remaining gaps (post 0.1.0-beta.1, Phase 199)
+
+Shipped self-serve on planscape.build/downloads; these are the known gaps, roughly in value order:
+
+| # | Gap | Detail |
+|---|---|---|
+| SB-1 | **Live-ArchiCAD verification** | Two documented-but-unverified assumptions need one session against real ArchiCAD (AC 28/29): (a) `_ifc_global_id_from_acguid` presumes ArchiCAD derives the IFC-export GlobalId from the JSON-API element GUID — if wrong, the live-sync and IFC-watcher paths mint two mapping rows per element; (b) zone labels read from `Zone_ZoneNumber`/`Zone_ZoneName` built-ins. Both degrade gracefully today. |
+| SB-2 | **SEQ minting** | The bridge never assigns sequence numbers, so ArchiCAD tags stay 7-segment. Server already has `SeqSyncController` (the Revit plugin uses it) — mint from the same per-key counters for cross-host parity. |
+| SB-3 | **Token inference single-sourcing** | `StingBridge/sync/token_mapper.py` + `archicad/element_types.py` duplicate what `stingtools_core/hosts/inference.py` owns — same drift class the wire contract fixed after Drift 5. Fold into core; StingBridge should also implement the `HostAdapter` contract (its sync engine predates it). |
+| SB-4 | **Hot-folder contract mismatch** | The Python watcher leaves processed files in place with sidecar JSONs; the C#-side Revit watcher uses `processing/done/failed` subfolders (`ifc_drop/`). Pick one contract. |
+| SB-5 | **Multi-host Phase B/C** | Pull + reconcile (bidirectional sync replacing the 60-s-grace heuristic) and the LoGeoRef coordinate engine — see `docs/MULTI_HOST_INTEGRATION_PLAN.md` §1.4 / Part 2. |
+| SB-6 | **macOS notarized binary** | `any` zip covers macOS today; a signed native build is deliberate future work. |
+| SB-7 | **Beta feedback loop** | Optional `download_log` table (D1) on the gated endpoint so beta testers can be followed up without the old request-by-email list. |
+
 ## Sub-system reviews
 
 - [`PLACEMENT_CENTRE_GUIDE.md`](PLACEMENT_CENTRE_GUIDE.md) — plain-English user guide to the Placement Centre: every button, every editor field, background concepts (anchors, regex, mounting reference, provenance, standards), worked walk-throughs, troubleshooting and a cheat-sheet (2026-04-25).


### PR DESCRIPTION
Closes out the StingBridge release cycle: the three non-blocking findings from the #415 review (read-endpoint auth refresh, batched zone reads, import-time side effect), 2 new tests (28 total pass), the Phase 199 CHANGELOG entry, and a ROADMAP section (SB-1..SB-7) recording the known gaps — live-ArchiCAD verification being the top one.

No behaviour change to the shipped 0.1.0-beta.1 artifacts is required; these ride until beta.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)