### PR TITLE
docs(deploy): validate Render blueprint + correct the schema story for go-live

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 200 — Planscape Server go-live prep: blueprint validation + corrected schema story)
+
+Deployment-readiness pass on the Render blueprint. **No deployment happened** —
+`api.planscape.build` still does not resolve; actual go-live is owner-side
+(Render dashboard + registrar DNS). This phase makes that a zero-improvisation
+task and fixes a documentation contradiction that would have misled it.
+
+- **Blueprint validated against the real code.** The API image builds clean from
+  the committed Dockerfile (`docker build -f Planscape.Server/docker/Dockerfile .`
+  → exit 0, 1.04 GB). `healthCheckPath: /health` matches a live endpoint. All 47
+  env-var keys in `render.yaml` were checked against actual config reads:
+  `Cors__Origins__*` binds through `GetSection("Cors:Origins").Get<string[]>()`,
+  `Serilog__*` through `ReadFrom.Configuration`, and `Smtp__Username`/`Smtp__Password`
+  through `EmailServiceBase.Cfg` → `Smtp:Username`/`Smtp:Password`. The remaining
+  unmatched keys are correctly scoped elsewhere (converter sidecar's own
+  `API_BASE`/`API_BEARER`/`CONVERTER_TOKEN`/`IFCCONVERT_URL`, MinIO's
+  `MINIO_ROOT_*`, Next.js's `NEXT_PUBLIC_API_BASE`/`NODE_VERSION`, and the
+  framework's `ASPNETCORE_*`). `Planscape.Server/render.yaml` was confirmed to be
+  a stale copy that already self-marks as SUPERSEDED.
+
+- **Corrected the schema story (`DEPLOY_RUNBOOK.md` §1).** The runbook claimed
+  production calls `db.Database.Migrate()` and instructed the operator to run
+  `dotnet ef migrations has-pending-model-changes` and hand-author an
+  `HvacEngineSnapshots` migration. That contradicted the committed `render.yaml`,
+  which sets `PLANSCAPE_USE_ENSURE_CREATED=true` — so `Program.cs` (~line 1327)
+  takes the **EnsureCreated** branch: probe for `Tenants`, `creator.CreateTables()`
+  from `OnModelCreating` on a fresh DB, then idempotent patchers
+  (`PatchDevSchemaAsync`, `PlatformSchemaPatcher.ApplyAsync`) in both branches.
+  Per `adr/0001-schema-management.md` this is the official mechanism, not a
+  workaround. **Answer for day 1: no EF migration step**, and the HVAC snapshot
+  tables are created correctly by the EnsureCreated path.
+
+- **New `docs/SERVER_GO_LIVE.md`** — ordered critical path, the two secret pairs
+  that must match each other, the day-1 schema answer, and a
+  "looks-broken-but-isn't" table (notably: `/swagger` returns 404 in production
+  **by design** — it is gated behind `Swagger:Enabled=true` because schema
+  disclosure aids endpoint enumeration; an earlier draft of the smoke test
+  wrongly asserted a 200).
+
+- **Handoff secret is unset on the cloud side.** `wrangler pages secret list
+  --project-name planscape-marketing` shows 12 secrets, and
+  `PLANSCAPE_HANDOFF_SECRET` is **not** among them — the cloud→server identity
+  handoff is not yet wired in production. It is a *shared* secret and must be set
+  identically on Render (api **and** worker) and on Cloudflare Pages. Recorded in
+  both the go-live doc and the owner checklist.
+
+- **Owner package generated outside the repo** at `C:\Dev\planscape-render-golive\`
+  (`SECRETS.txt` + `GO-LIVE-CHECKLIST.md`) — pre-generated `Jwt__Key` (48 bytes),
+  owner password, handoff secret, converter token and MinIO credentials, each
+  labelled with its destination, plus paste-ready smoke commands. Never committed.
+
+Housekeeping: removed the `REAUTH_TEST_GUID_01` test element left in the local
+"Tendo testing" project by an earlier session (one `TaggedElements` row + one
+`ExternalElementMappings` row; local dev DB only).
+
 #### Completed (Phase 199 — StingBridge 0.1.0-beta.1 release + self-serve downloads, PRs #415–#417)
 
 StingBridge became a shipped product: packaged, released through the gated planscape.build

--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -38,37 +38,40 @@ And choose the owner password (for `davis@planscape.build`).
 
 ---
 
-## 1. Pre-deploy migration check (one-time, on a dev machine)
+## 1. Schema — no pre-deploy migration step
 
-Production **auto-applies committed EF migrations on boot** (`Program.cs` calls
-`db.Database.Migrate()` in non-Development). So you don't run `database update`
-by hand — but you MUST make sure every mapped entity has a migration, or those
-tables won't exist and their endpoints will 500.
+> **Corrected 2026-07-20.** This section previously said production calls
+> `db.Database.Migrate()` and told you to run a pending-model-changes check.
+> That is **not** what the committed `render.yaml` does. Skip the old steps.
 
-```bash
-cd Planscape.Server
-# EF 8: detect entities mapped in the model but missing from migrations.
-dotnet ef migrations has-pending-model-changes \
-  --project src/Planscape.Infrastructure --startup-project src/Planscape.API
-```
+`render.yaml` sets **`PLANSCAPE_USE_ENSURE_CREATED=true`** on `planscape-api`
+and `planscape-worker`. `Program.cs` (~line 1327) therefore takes the
+**EnsureCreated** branch, not `Migrate()`:
 
-- If it reports **no pending model changes** → you're done; skip to step 2.
-- If it reports **pending changes** (known gap: the **HVAC snapshot** tables
-  `HvacLoadSnapshots` / `HvacNcSnapshots` / `HvacRefrigerantSizings` are in the
-  model snapshot but have no `CreateTable` migration), generate and commit it:
+1. It probes `information_schema` for the `Tenants` table.
+2. If absent (fresh DB), `creator.CreateTables()` materialises the whole schema
+   from `OnModelCreating`, which always matches the current entity classes.
+3. In **both** branches, idempotent patchers run (`PatchDevSchemaAsync`,
+   `PlatformSchemaPatcher.ApplyAsync`) with `ADD COLUMN IF NOT EXISTS` /
+   `CREATE TABLE IF NOT EXISTS`, so pre-existing DBs pick up later additions.
 
-```bash
-dotnet ef migrations add HvacEngineSnapshots \
-  --project src/Planscape.Infrastructure --startup-project src/Planscape.API
-git add src/Planscape.Infrastructure/Data/Migrations/*
-git commit -m "Add HvacEngineSnapshots migration"
-git push
-```
+This is the **official** schema-management mechanism for this codebase — see
+[adr/0001-schema-management.md](adr/0001-schema-management.md). The
+hand-authored migrations under `Planscape.Infrastructure/Data/Migrations/` are
+missing their `.Designer.cs` companions and the model snapshot is stale, so
+`Migrate()` cannot apply them in order; that is exactly why the flag exists.
+A startup schema-drift self-check fails loudly if an EF entity was never
+mirrored into the patcher.
 
-Already present (no action): `HealthcarePack` (`20260515…`),
-`IfcIngestSubstrate` (`20260519…`, incl. `ExternalElementMappings`), and ACC
-token columns (on `PlatformConnections`, base schema). The `#345` ACC issue
-sync needs **no** migration (it reuses `ConfigJson`).
+**So: nothing to do here before deploying.** (This also means the HVAC snapshot
+tables `HvacLoadSnapshots` / `HvacNcSnapshots` / `HvacRefrigerantSizings`, which
+have no `CreateTable` migration, are created correctly by the EnsureCreated
+path — the old instruction to generate an `HvacEngineSnapshots` migration is
+unnecessary.)
+
+If you ever **remove** `PLANSCAPE_USE_ENSURE_CREATED`, the `Migrate()` branch
+takes over and a complete, regenerated migration set becomes a hard
+prerequisite — regenerate it before flipping that switch.
 
 ---
 
@@ -167,7 +170,7 @@ Render once the CNAME verifies.)
 ## 5. First-boot verification
 
 ```bash
-# API healthy + migrations applied
+# API healthy + schema materialised (EnsureCreated path — see §1)
 curl -fsS https://api.planscape.build/health         # → 200
 
 # Owner login works (PlatformOwnerSeeder ran)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -304,6 +304,22 @@ Shipped self-serve on planscape.build/downloads; these are the known gaps, rough
 | SB-6 | **macOS notarized binary** | `any` zip covers macOS today; a signed native build is deliberate future work. |
 | SB-7 | **Beta feedback loop** | Optional `download_log` table (D1) on the gated endpoint so beta testers can be followed up without the old request-by-email list. |
 
+## Planscape Server — deployment gaps (Phase 200)
+
+The blueprint is validated and the owner package is written; what remains is
+owner-side or follow-on work. Status verified 2026-07-20.
+
+| # | Gap | Detail |
+|---|---|---|
+| DEP-1 | **Server is not deployed** | `api.planscape.build` does not resolve. Owner-only: apply the Render Blueprint, paste secrets, add the custom domain + registrar CNAME. Prep is complete — see [`SERVER_GO_LIVE.md`](SERVER_GO_LIVE.md) and the local package at `C:\Dev\planscape-render-golive\`. |
+| DEP-2 | **`PLANSCAPE_HANDOFF_SECRET` unset on Cloudflare** | `wrangler pages secret list --project-name planscape-marketing` returns 12 secrets and this is not one of them, so cloud→server handoff cannot work in production yet. It is a *shared* secret: set the identical value on Render (`planscape-api` **and** `planscape-worker`) and on Cloudflare Pages. Rotate both sides together. |
+| DEP-3 | **Handoff provisions no Project** | `AuthController.HandoffExchange` find-or-creates `Tenant` + `AppUser` but never a `Project`/`ProjectMember`, so a freshly handed-off subscriber lands in an empty account and any client needing a project id has nothing to target. |
+| DEP-4 | **Handoff accounts cannot log in with a password — by design** | The mirror `AppUser` is created with `PasswordHash = HashPassword(Guid+Guid)`, an intentionally unusable hash, so the account is reachable *only* via a fresh 120-second ticket. There is **no** personal-access-token/API-key path anywhere in `Planscape.Server/src`, and StingBridge is a pure email+password client — so a subscriber provisioned this way currently cannot authenticate StingBridge at all. |
+| DEP-5 | **`/api/auth/license/activate` is unrate-limited** | It is the only `AuthController` endpoint without `[EnableRateLimiting("auth")]`, leaving the licence-key space brute-forceable. It returns entitlement facts (`Valid`, `Tier`, `MimEnabled`, `ServerUrl`, `ExpiresAt`) rather than a JWT, so the blast radius is disclosure + activation-count burn, not session theft. |
+| DEP-6 | **Handoff single-use check fails open** | The `jti` replay guard is a Redis `SET … When.NotExists`; when Redis is unavailable the exchange logs a warning and proceeds, so a captured ticket could be replayed within its 120 s TTL during a Redis outage. Acceptable given the TTL, but it is an availability-over-integrity choice worth making deliberately. |
+| DEP-7 | **`PLANSCAPE_IDENTITY_HANDOFF.md` status line is stale** | It reads "design agreed 2026-07-18, not yet implemented"; the feature is in fact implemented on all three sides (Cloudflare Pages Function, `AuthController`, Next.js `/handoff` page). The doc's own line references still resolve, so only the status line drifted. Its role table also says `project_lead` → `ProjectLead`, but `UserRole` has no such member and the code maps it to `Manager`. |
+| DEP-8 | **StingBridge token-expiry constant is wrong** | `client.py` assumes a 60-minute access token (`_token_expiry = time.time() + 55*60`) but `AuthController` sets `AccessTokenLifetime = 30 minutes`, so the proactive refresh never fires before the token is ~25 minutes dead. Masked today by the reactive-401 retry added in Phase 199. |
+
 ## Sub-system reviews
 
 - [`PLACEMENT_CENTRE_GUIDE.md`](PLACEMENT_CENTRE_GUIDE.md) — plain-English user guide to the Placement Centre: every button, every editor field, background concepts (anchors, regex, mounting reference, provenance, standards), worked walk-throughs, troubleshooting and a cheat-sheet (2026-04-25).

--- a/docs/SERVER_GO_LIVE.md
+++ b/docs/SERVER_GO_LIVE.md
@@ -1,0 +1,108 @@
+# Planscape Server — Go-Live
+
+Short, ordered path from "nothing deployed" to "`api.planscape.build` answers".
+For the long-form reference (per-secret tables, cost notes, optional feature
+smoke tests) see **[DEPLOY_RUNBOOK.md](DEPLOY_RUNBOOK.md)**.
+
+> **Status as of 2026-07-20:** `api.planscape.build` does not resolve — the
+> server is not deployed. The Cloudflare side (marketing site, auth/billing on
+> D1, gated downloads on R2) *is* in production and independent of this.
+
+Secrets live outside the repo and are never committed. The go-live package
+(`SECRETS.txt` + `GO-LIVE-CHECKLIST.md`) is generated locally for the owner.
+
+---
+
+## Pre-flight — verified 2026-07-20
+
+| Check | Result |
+|---|---|
+| Canonical blueprint | `/render.yaml` (repo root). `Planscape.Server/render.yaml` is a stale copy, self-marked SUPERSEDED. |
+| API image builds from committed Dockerfile | ✅ `docker build -f Planscape.Server/docker/Dockerfile .` → exit 0 |
+| `healthCheckPath: /health` matches a real endpoint | ✅ returns `{"status":"healthy"}` + database/redis/push sub-checks |
+| Every `render.yaml` env var is read by the server | ✅ CORS binds as `string[]`; Serilog via `ReadFrom.Configuration`; `Smtp__Username`/`Smtp__Password` via `EmailServiceBase.Cfg` |
+
+## Order of operations
+
+1. **Blueprint** — Render → Blueprints → New Blueprint Instance → this repo,
+   branch `main`. Expect 7 services (api, worker, web, converter, redis, minio,
+   db). Services fail health checks until secrets are set; that is expected.
+2. **Secrets** — set the `sync:false` values (see runbook §3 for the full table).
+   Two pairs *must match each other*:
+   `Converter__Token` = `CONVERTER_TOKEN`, and
+   `Storage__S3__AccessKey`/`SecretKey` = `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`.
+3. **Internal URLs** — only knowable after the first deploy:
+   `Storage__S3__ServiceUrl` (minio internal URL) and `Converter__BaseUrl`
+   (converter internal URL, set on **both** api and worker). Redeploy after.
+4. **Handoff secret** — `PLANSCAPE_HANDOFF_SECRET` is shared with the marketing
+   site and must be set on **both** sides (see below).
+5. **DNS** — `api.planscape.build` → planscape-api, `app.planscape.build` →
+   planscape-web, both CNAME to the `.onrender.com` host Render shows. TLS is
+   automatic once the CNAME verifies. Both hosts are already in the CORS
+   allow-list and `NEXT_PUBLIC_API_BASE` is baked to `https://api.planscape.build`.
+6. **Smoke test** — runbook §5.
+
+### The handoff secret spans two providers
+
+`PLANSCAPE_HANDOFF_SECRET` is the shared signing secret between the marketing
+site (mints handoff tickets) and the server (redeems them). It must be
+**identical** on:
+
+- Render → `planscape-api` **and** `planscape-worker`
+- Cloudflare Pages → project `planscape-marketing`:
+  `npx wrangler pages secret put PLANSCAPE_HANDOFF_SECRET --project-name planscape-marketing`
+
+As of 2026-07-20 it was **not yet set on the Cloudflare project** (verified via
+`wrangler pages secret list`), so first go-live sets a fresh value on both sides.
+Rotations must be simultaneous or cloud→server login breaks.
+
+---
+
+## Day 1 after deploy — you do NOT run EF migrations
+
+**The container does not auto-migrate, by design.**
+
+`render.yaml` sets `PLANSCAPE_USE_ENSURE_CREATED=true`, which makes startup
+(`Program.cs` ~line 1327) take the **EnsureCreated** branch instead of
+`db.Database.Migrate()`:
+
+1. Probe `information_schema` for the `Tenants` table.
+2. If absent (fresh DB), `creator.CreateTables()` materialises the entire schema
+   from `OnModelCreating` — by construction in sync with the entity classes.
+3. In **both** branches, idempotent patchers then run (`PatchDevSchemaAsync`,
+   `PlatformSchemaPatcher.ApplyAsync`) using `ADD COLUMN IF NOT EXISTS` /
+   `CREATE TABLE IF NOT EXISTS`, so long-lived DBs pick up later entity additions.
+
+This is deliberate, not a workaround-in-waiting: the hand-authored migrations
+under `Planscape.Infrastructure/Data/Migrations/` lack `.Designer.cs` companions
+and the model snapshot is stale, so `Migrate()` cannot apply them in order. This
+is the documented mechanism — see
+[adr/0001-schema-management.md](adr/0001-schema-management.md).
+
+A startup **schema-drift self-check** asserts the live schema matches the EF
+model, so an entity nobody mirrored into the patcher fails loudly at boot rather
+than as a production 500.
+
+**Consequence:** the pre-deploy `dotnet ef migrations has-pending-model-changes`
+step is *not* part of go-live while `PLANSCAPE_USE_ENSURE_CREATED=true` is set.
+If that flag is ever removed, the `Migrate()` branch takes over and a complete,
+regenerated migration set becomes a hard prerequisite first.
+
+## Things that look broken but aren't
+
+| Symptom | Why |
+|---|---|
+| `/swagger` returns 404 in production | Deliberate — schema disclosure aids attackers. Opt in with `Swagger__Enabled=true`, then remove it again. |
+| Services red immediately after Apply | Secrets aren't set yet (step 2). |
+| IFC upload rejected / heavy jobs never run | `planscape-worker` or `planscape-converter` suspended — the API degrades gracefully by design. |
+| Email never arrives | No `Email__Provider`/`Resend__ApiKey`; mail is logged only. The default sender domain `planscape.build` must be verified with the provider. |
+
+## Production hygiene
+
+- Never set `PLANSCAPE_ALLOW_DEMO_SEED` in production (it would seed the demo
+  tenant and `admin@planscape.demo`). `ASPNETCORE_ENVIRONMENT=Production`
+  already gates it off.
+- Rotate the owner password via change-password after first login, not by
+  editing the env var.
+- `planscape-minio` is single-node on one disk (no HA) — back it up or move to
+  R2/S3 (drop-in `Storage__S3__*` swap) before real data volume.


### PR DESCRIPTION
Phase 1 of the go-live queue. **Docs + validation only — no code, no deployment.**
`api.planscape.build` still does not resolve; actual go-live is owner-side
(Render dashboard + registrar DNS), which is out of scope by design.

## Gate: passed

- ✅ **The API image builds from the committed Dockerfile.**
  `docker build -f Planscape.Server/docker/Dockerfile -t planscape-api-golivetest .`
  → exit 0, 1.04 GB.
- ✅ **`healthCheckPath: /health` matches a real endpoint** — verified live against the
  local stack: `{"status":"healthy",...}` with database/redis/push sub-checks.
- ✅ **Every `render.yaml` env var maps to config the server actually reads.**
  All 47 keys checked. The interesting ones:
  `Cors__Origins__*` binds via `GetSection("Cors:Origins").Get<string[]>()`;
  `Serilog__*` via `ReadFrom.Configuration`; `Smtp__Username`/`Smtp__Password`
  resolve through `EmailServiceBase.Cfg` → `Smtp:Username`/`Smtp:Password`
  (confirmed at `SmtpEmailService.cs:26-27`). The keys that *didn't* match
  `Planscape.Server/src` are correctly scoped elsewhere — the converter sidecar's
  own `API_BASE`/`API_BEARER`/`CONVERTER_TOKEN`/`IFCCONVERT_URL`, MinIO's
  `MINIO_ROOT_*`, Next.js's `NEXT_PUBLIC_API_BASE`/`NODE_VERSION`, and the
  framework's `ASPNETCORE_*`.
- ✅ `Planscape.Server/render.yaml` is a stale copy that already self-marks
  SUPERSEDED — no action needed.

## The substantive fix: the runbook contradicted the blueprint

`DEPLOY_RUNBOOK.md` §1 said production **auto-applies EF migrations** via
`db.Database.Migrate()`, and instructed the operator to run
`dotnet ef migrations has-pending-model-changes` and hand-author an
`HvacEngineSnapshots` migration before deploying.

That is not what the committed `render.yaml` does. It sets
`PLANSCAPE_USE_ENSURE_CREATED=true`, so `Program.cs` (~line 1327) takes the
**other** branch: probe `information_schema` for `Tenants` → on a fresh DB call
`creator.CreateTables()` from `OnModelCreating` → then run idempotent patchers
(`PatchDevSchemaAsync`, `PlatformSchemaPatcher.ApplyAsync`) in **both** branches.
Per `adr/0001-schema-management.md` this is the *official* mechanism, precisely
because the hand-authored migrations lack `.Designer.cs` companions and the model
snapshot is stale, so `Migrate()` cannot apply them in order.

**Day-1 answer: no EF migration step.** The HVAC snapshot tables that §1 worried
about are created correctly by the EnsureCreated path. §1 is rewritten and the
stale "migrations applied" comment in §5 is fixed.

## Also caught while writing the smoke test

`/swagger` returns **404 in production by design** — it is gated behind
`Swagger:Enabled=true` because schema disclosure hands an attacker every endpoint
shape for free (`Program.cs:1050-1056`). My first draft of the smoke test asserted
a 200 and would have sent the owner chasing a non-bug. Documented as expected
behaviour instead.

## New findings recorded in ROADMAP (DEP-1..DEP-8)

The two that matter most for the next phase:

- **DEP-2 — `PLANSCAPE_HANDOFF_SECRET` is not set on Cloudflare.**
  `wrangler pages secret list --project-name planscape-marketing` returns 12
  secrets and this is not among them, so the cloud→server identity handoff
  cannot work in production yet. It is a *shared* secret and must be set
  identically on Render (api **and** worker) and on Cloudflare Pages.
- **DEP-3 / DEP-4 — a handed-off subscriber cannot use StingBridge.**
  `AuthController.HandoffExchange` find-or-creates `Tenant` + `AppUser` but no
  `Project`, and gives the mirror account a deliberately unusable
  `HashPassword(Guid+Guid)`. There is no PAT/API-key path anywhere in
  `Planscape.Server/src`, and StingBridge is a pure email+password client — so
  such a user has no way to authenticate it. That is Phase 2's problem statement.

Plus DEP-5 (`/api/auth/license/activate` is the one auth endpoint with no rate
limiter), DEP-6 (handoff replay guard fails open when Redis is down), DEP-7
(`PLANSCAPE_IDENTITY_HANDOFF.md` still says "not yet implemented" — it is
implemented on all three sides; its role table also says `project_lead` →
`ProjectLead`, but `UserRole` has no such member and the code maps to `Manager`),
DEP-8 (StingBridge assumes a 60-min token; the server issues 30-min).

## Owner package (not committed)

Generated at `C:\Dev\planscape-render-golive\`:
- `SECRETS.txt` — pre-generated `Jwt__Key` (64 base64 chars → 48 bytes), owner
  password, handoff secret, converter token, MinIO credentials, each labelled
  with its exact destination, plus the pairs that must match each other.
- `GO-LIVE-CHECKLIST.md` — Blueprint → secrets → handoff secret on both
  providers → DNS → paste-ready smoke commands → day-1 schema answer.

The third-party credentials I cannot generate (LiveKit, Firebase, Resend, ACC)
are called out explicitly with what breaks if each is skipped.

## Not verified

Nothing here was run against a deployed Render environment — no such environment
exists yet. The image build, the `/health` check and the config-key validation
were all done locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)