### PR TITLE
docs(guides): tagging basics + drawing production

### DIFF
--- a/marketing-site/guides/drawing-production.html
+++ b/marketing-site/guides/drawing-production.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Drawing production — sheets, views and drawing types — Planscape</title>
+<meta name="description" content="Why drawings drift out of consistency, what a drawing type is, and how STING produces properly formatted, consistently numbered sheets in Revit.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/drawing-production.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Drawing production</div>
+  <h1>Drawing production — sheets, views and drawing types</h1>
+  <div class="meta">📖 10-minute read · Intermediate</div>
+
+  <p>A model is not a deliverable. What gets issued, checked, priced and built from is a set of drawings, and producing them consistently is where most project time quietly disappears. This guide explains why that happens and how STING attacks it.</p>
+
+  <h2>Why drawing sets drift</h2>
+  <p>Ask three engineers in the same office to produce a mechanical plan and you will get three drawings. Different scales, different line weights, different text heights, different crop extents, different title block entries, different numbering.</p>
+  <p>None of them is wrong exactly — each made reasonable choices. But together they read as three firms' work, and every inconsistency is a question the reviewer has to resolve. Worse, the choices are invisible: they live in each view's settings, so nobody can see the standard, only its results.</p>
+  <p>The usual response is a written standard nobody reads and a template that drifts. The better response is to make the standard something the software applies rather than something people remember.</p>
+
+  <h2>What a drawing type is</h2>
+  <p>A <strong>drawing type</strong> is a named bundle that answers every presentation question for one kind of drawing, in one place:</p>
+  <ul>
+    <li><strong>Sheet identity</strong> — paper size, title block family, orientation</li>
+    <li><strong>View appearance</strong> — scale, detail level, view template</li>
+    <li><strong>Cropping</strong> — follow a scope box, tighten to the geometry, follow a room boundary, or leave alone, plus the margin to leave</li>
+    <li><strong>Naming</strong> — the patterns that generate sheet number and sheet name</li>
+    <li><strong>Layout</strong> — where viewports sit on the sheet</li>
+    <li><strong>Annotation</strong> — what gets dimensioned and tagged automatically, and with which tag families</li>
+    <li><strong>Print appearance</strong> — colour scheme, line weight scaling, whether links go halftone</li>
+  </ul>
+  <p>"Architectural plan at 1:100 on A1" becomes a thing with a name that can be applied, audited and corrected — instead of a convention people approximate.</p>
+  <p>STING ships <strong>93</strong> of these covering architectural, structural, mechanical, electrical, public health, healthcare, coordination, fabrication and client-presentation work. They sit on <strong>A1</strong> and <strong>A3</strong>, at the scales those disciplines actually use.</p>
+
+  <h3>Text size follows scale</h3>
+  <p>One detail worth calling out because it is so often got wrong by hand: annotation text height is derived from drawing scale, not chosen per view. A drawing at 1:50 gets 2.5&nbsp;mm text — the ISO default — while 1:100 drops to 2.0&nbsp;mm and 1:20 rises to 3.5&nbsp;mm. Text that is legible at one scale is unreadable or overbearing at another, and deriving it removes the judgement call entirely.</p>
+
+  <h2>Routing — picking the right one automatically</h2>
+  <p>Having 93 drawing types would be worse than useless if someone had to choose correctly every time. Instead a routing table maps <em>discipline + project phase + document kind</em> to a drawing type. There are <strong>118</strong> routing rules, evaluated in order, first match wins.</p>
+  <p>So an electrical drawing in the presentation phase routes to a presentation type, while the same discipline in the construction phase routes to a production type — same model, different treatment, no decision required.</p>
+  <p>If nothing matches, STING deliberately does nothing rather than guessing. Your view keeps its existing settings. Silence means "no rule covered this", not "this is correct".</p>
+
+  <h2>Corporate standard versus project reality</h2>
+  <p>Every practice hits the same tension: there is a house standard, and there is what this particular client demands. STING handles it in layers.</p>
+  <p>The corporate catalogue is the baseline, and it is integrity-checked — each entry carries a fingerprint, so if a corporate definition is edited, STING notices and reclassifies it as a project-specific entry rather than pretending the house standard still applies. You cannot quietly diverge from the standard and still claim to be on it.</p>
+  <p>Project-specific drawing types layer on top and win where the identifiers match, and project routing rules are inserted ahead of corporate ones. The house standard on disk is never modified.</p>
+  <p>Project overrides are stored inside the Revit file itself, so they survive Save As and renaming the project — a common way this kind of configuration gets lost.</p>
+
+  <h3>View style packs</h3>
+  <p>A catalogue of 93 drawing types does not mean 93 visual styles. Most differ in scale and layout while sharing an appearance, so the graphics — line weights, text and dimension styles, hatching, filters, category overrides, link handling — are factored out into <strong>view style packs</strong>. STING ships 35, aligned to <strong>BS 1192:2007+A2:2016</strong>, <strong>ISO 13567</strong> and CIBSE discipline colours. Change a pack once and every drawing type using it follows.</p>
+
+  <h2>ISO 19650 naming</h2>
+  <p>Sheet numbers follow the container naming convention from <strong>BS EN ISO 19650-2</strong>: project, originator, volume, level, type, role, number, suitability and revision. Suitability is the part teams most often skip and most need — the code saying whether something is work in progress, shared for coordination, or issued for construction. A drawing without it is a drawing whose status is a matter of opinion.</p>
+
+  <h2>How STING approaches it</h2>
+  <p>Drawing work lives on the <strong>DOCS</strong> tab. It is a dense tab; these are the parts you will actually use.</p>
+
+  <h3>Laying out sheets</h3>
+  <p>The alignment row works on a viewport selection — <strong>↑Top</strong>, <strong>↕MidY</strong>, <strong>↓Bot</strong>, <strong>←Left</strong>, <strong>↔MidX</strong> — and <strong>L→R</strong> and <strong>T→B</strong> distribute them evenly. <strong>Grid Align</strong> snaps viewport centres to a grid, and <strong>Align Edges</strong> and <strong>Distribute</strong> handle the rest.</p>
+  <p>For a whole sheet, <strong>Auto-Layout</strong> arranges viewports in rows, and <strong>MaxRects</strong> uses a denser packing strategy that fits more onto the same paper. Both work out the usable area from the title block rather than assuming it, so a non-standard title block does not break the layout.</p>
+  <p><strong>Optimal Scale</strong> answers "what scale will actually fit" by comparing view extents to the available area and rounding to a standard scale — up, never down, so nothing gets clipped.</p>
+
+  <h3>Numbering</h3>
+  <p><strong>+1</strong> and <strong>-1</strong> shift a run of sheet numbers to make room for an inserted drawing, and <strong>Prefix</strong> and <strong>Suffix</strong> change a shared part across a set. <strong>Renumber</strong> handles the whole set in two passes, which avoids the collisions you get renaming sheets one at a time.</p>
+
+  <h3>Producing and checking</h3>
+  <p><strong>Produce Per Level</strong> and <strong>Produce Sections</strong> generate drawings from the routing rules rather than one at a time. <strong>Inspect</strong> shows which drawing type a view resolved to — the first thing to check when a drawing does not look how you expected. <strong>Doctor</strong> and <strong>Heal TBs</strong> repair drift, and <strong>Sync Styles</strong> pushes style changes back through the views that use them.</p>
+  <p><strong>ISO Check</strong> audits the sheet set against ten naming and completeness rules: empty or duplicated numbers and names, numbers that do not begin with a discipline letter or contain no sequence, spaces where hyphens belong, missing title blocks, sheets with no viewports, all-lowercase names, and characters that will break file export. It reports a compliance percentage and the worst offenders. <strong>Register</strong> exports the full sheet register.</p>
+
+  <div class="callout">
+    <strong>Run ISO Check before an issue, not after.</strong> Most of what it finds takes seconds to fix in the model and is genuinely painful to correct once drawings have been transmitted under those numbers.
+  </div>
+
+  <h2>A sensible order of work</h2>
+  <ol>
+    <li><strong>Inspect</strong> a representative view and confirm it resolves to the drawing type you expect.</li>
+    <li>If it does not, fix the routing rather than the individual view.</li>
+    <li><strong>Produce Per Level</strong> for the bulk of the set.</li>
+    <li><strong>Auto-Layout</strong> or <strong>MaxRects</strong>, then tidy with the alignment buttons.</li>
+    <li><strong>ISO Check</strong>, and clear what it raises.</li>
+    <li><strong>Register</strong> for the drawing register, then issue.</li>
+  </ol>
+  <p>The habit that pays off is fixing the rule instead of the drawing. Correcting one view takes a minute and lasts until the next revision; correcting the drawing type fixes every drawing that will ever route to it.</p>
+
+  <div class="cta-band">
+    <p>Next: <a href="/guides/iso-19650-workflow.html">ISO 19650 in practice</a> goes deeper into suitability codes, revisions and what the standard asks of a drawing set.</p>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/index.html
+++ b/marketing-site/guides/index.html
@@ -84,6 +84,20 @@
         <div class="ttl">ISO 19650 in practice</div>
         <div class="sub">What the standard actually asks of you, and which parts STING handles automatically.</div>
       </a>
+      <a href="/guides/tagging-basics.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> Tagging basics</div>
+        <div class="sub">What the eight parts of a tag mean, where each comes from, and why numbering restarts per level.</div>
+      </a>
+    </div>
+  </div>
+
+  <div class="guide-cat">
+    <h2>Producing drawings</h2>
+    <div class="guide-list">
+      <a href="/guides/drawing-production.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> Drawing production</div>
+        <div class="sub">Sheets, views, title blocks and drawing types — how a set stays consistent without anyone remembering the standard.</div>
+      </a>
     </div>
   </div>
 
@@ -91,8 +105,6 @@
     <h2>Being written next</h2>
     <p>In this order. Each follows the same shape — the engineering first, then how STING does it.</p>
     <ul>
-      <li><strong>Tagging basics</strong> — what an ISO 19650 tag is made of, and how STING assembles one</li>
-      <li><strong>Drawing production</strong> — sheets, views, title blocks and drawing types</li>
       <li><strong>Plumbing</strong> — fixture units, pipe sizing, drainage falls and vent design</li>
       <li><strong>HVAC</strong> — heat loads, duct sizing, air balance and noise</li>
       <li><strong>Electrical</strong> — cable sizing, voltage drop, fault current and circuit schedules</li>

--- a/marketing-site/guides/tagging-basics.html
+++ b/marketing-site/guides/tagging-basics.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Tagging basics — what a tag is made of — Planscape</title>
+<meta name="description" content="What the eight parts of an ISO 19650 tag mean, why elements need a unique identity, and how STING assembles and checks tags in Revit.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/tagging-basics.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Tagging basics</div>
+  <h1>Tagging basics — what a tag is made of</h1>
+  <div class="meta">📖 9-minute read · Beginner</div>
+
+  <p>A tag is the name an element answers to for the rest of its life. It appears on drawings, in schedules, in the handover data the facilities team inherits, and in the clash report someone opens two years from now. This guide explains what goes into one and why, then how STING builds them.</p>
+
+  <h2>Why "AHU-1" is not enough</h2>
+  <p>Most projects start by numbering equipment in the order it was drawn: AHU-1, AHU-2, AHU-3. This survives until the second building arrives, or a second floor gets its own air handling unit, and suddenly there are two things called AHU-2 in the same information model.</p>
+  <p>The deeper problem is that a bare number carries no meaning. Given "AHU-2" alone you cannot tell which discipline owns it, which building or floor it serves, or what system it belongs to. Every one of those questions then has to be answered by opening the model — which is exactly the manual lookup that coordinated information is supposed to eliminate.</p>
+  <p>A structured tag answers all of them in the name itself.</p>
+
+  <h2>The eight parts</h2>
+  <p>STING assembles tags from eight parts joined by hyphens, in a fixed order:</p>
+  <table class="tbl">
+    <thead><tr><th>Part</th><th>Answers</th><th>Examples</th></tr></thead>
+    <tbody>
+      <tr><td><strong>DISC</strong></td><td>Which discipline owns it</td><td>M, E, P, A, S, FP, LV, G</td></tr>
+      <tr><td><strong>LOC</strong></td><td>Which building or site area</td><td>BLD1, BLD2, EXT</td></tr>
+      <tr><td><strong>ZONE</strong></td><td>Which zone within that</td><td>Z01, Z02</td></tr>
+      <tr><td><strong>LVL</strong></td><td>Which level</td><td>L01, L02</td></tr>
+      <tr><td><strong>SYS</strong></td><td>Which system</td><td>HVAC, DCW, DHW, SAN, LV</td></tr>
+      <tr><td><strong>FUNC</strong></td><td>What it does in that system</td><td>SUP, HTG, DCW, SAN, PWR</td></tr>
+      <tr><td><strong>PROD</strong></td><td>What kind of thing it is</td><td>AHU, LUM, DB, DR, COL</td></tr>
+      <tr><td><strong>SEQ</strong></td><td>Which one of those</td><td>0001, 0042</td></tr>
+    </tbody>
+  </table>
+  <p>Put together, a supply air handling unit on level 2 of building 1 reads:</p>
+  <pre><code>M-BLD1-Z01-L02-HVAC-SUP-AHU-0003</code></pre>
+  <p>You can read that without opening anything. Mechanical, building 1, zone 1, level 2, HVAC system, supply function, air handling unit, the third one. That legibility is the whole point.</p>
+
+  <h2>Where each part comes from</h2>
+  <p>Almost none of this is typed by hand — that is what makes it viable at scale.</p>
+  <p><strong>DISC and PROD</strong> come from what the element already is. A lighting fixture is electrical and gets <code>LUM</code>; a duct is mechanical and gets <code>DU</code>; a structural column gets <code>COL</code>. STING keeps a lookup from Revit category to discipline and product code, and refines it using the family name — so a mechanical equipment family named as a chiller does not get labelled as an air handling unit just because both live in the same category.</p>
+  <p><strong>SYS and FUNC</strong> come from the element's system where one exists. A pipe assigned to a domestic cold water system gets <code>DCW</code>, and its function follows from the system. Where no system is assigned, STING falls back to a sensible default for the category — which is one reason unassigned MEP elements are worth fixing before a big tagging run.</p>
+  <p><strong>LVL</strong> comes from the element's level. <strong>LOC and ZONE</strong> are inferred from the room the element sits in, matched against name patterns — a room named "Block A" resolves to <code>BLD1</code>, something in "car park" or "landscape" resolves to <code>EXT</code>. These patterns are yours to adjust; the defaults are a starting point, not a standard.</p>
+
+  <h2>How numbering works, and why it surprises people</h2>
+  <p><strong>SEQ</strong> is the only part that is genuinely arbitrary, and it is the part that causes the most confusion.</p>
+  <p>STING does not keep one running counter for the whole project. It keeps a separate counter for each combination of discipline, system and level. So the first supply-air unit on level 1 and the first on level 2 are <em>both</em> numbered <code>0001</code> — they are distinguished by the <code>L01</code> and <code>L02</code> parts, not by the number.</p>
+  <p>This is deliberate. Per-level numbering means adding a floor does not renumber the floors below it, and each level's schedule reads from 1 rather than starting at 47. If you would rather include zone or location in the counter, that is configurable.</p>
+
+  <div class="callout">
+    <strong>Four digits means 9,999 per counter.</strong> That is ample per discipline-system-level, but it is a real ceiling. STING refuses to wrap around silently — if a counter runs out it reports the failure rather than producing a duplicate.
+  </div>
+
+  <h2>Collisions</h2>
+  <p>When STING is about to write a tag that already exists, it has three ways to behave, and you choose:</p>
+  <ul>
+    <li><strong>Auto-increment</strong> — take the next free number. The default, and usually what you want.</li>
+    <li><strong>Skip</strong> — leave anything already tagged completely alone. Right when you are adding to a model whose existing tags are correct and issued.</li>
+    <li><strong>Overwrite</strong> — replace existing tags with newly generated ones. Right when you have inherited an inconsistent model and want to re-tag from scratch.</li>
+  </ul>
+  <p>Overwrite is the one to be careful with. If tags have already gone out on a drawing, overwriting them breaks the link between the issued document and the model.</p>
+
+  <h2>How STING approaches it</h2>
+  <p>Tagging lives on the <strong>TAGGING</strong> tab of the main panel. The buttons are grouped by what they do, and the order below is the order you would normally use them.</p>
+
+  <h3>Audit before you write</h3>
+  <p><strong>Pre-Audit</strong> is a complete dry run that changes nothing. It reports what would be tagged, what would be skipped, which collisions would occur and how they would resolve, which elements are missing information, and a breakdown by discipline. It asks whether you want to audit the <strong>Active View</strong> or the <strong>Entire Project</strong>.</p>
+  <p>On a model you did not build, run this first. It is the cheapest way to discover that half the pipework has no system assigned, before rather than after you have written several thousand tags.</p>
+
+  <h3>Then tag</h3>
+  <ul>
+    <li><strong>Auto Tag</strong> — tags what is in the current view, filtered to the disciplines that view is actually about.</li>
+    <li><strong>Batch Tag</strong> — tags the whole project. It sorts elements by level, then discipline, then category first, so that numbering runs in a sensible contiguous order instead of scattering.</li>
+    <li><strong>Tag New</strong> — only what has appeared since the last run. This is the one to use on a live model.</li>
+    <li><strong>Tag+Combine</strong> — tags and assembles the combined text in a single pass.</li>
+    <li><strong>Re-Tag</strong>, <strong>Copy Tags</strong>, <strong>Swap Tags</strong>, <strong>Fix Dupes</strong> — repair operations for inherited models.</li>
+  </ul>
+  <p>Both tagging commands skip elements you do not own in a shared model, and skip demolished elements, so running them on a workshared project will not fight your colleagues.</p>
+
+  <h3>Then tidy</h3>
+  <p><strong>▶ SMART ORGANISE</strong> deals with the separate problem of tags that exist but sit badly — overlapping, covering geometry, or trailing leaders across a drawing. <strong>Quick</strong> is a fast pass, <strong>Deep</strong> works harder, and <strong>Anneal</strong> keeps rearranging until it settles on the least-crowded result it can find. <strong>↻ Undo</strong> reverses a run.</p>
+  <p>Use Quick during the working day and save Deep or Anneal for just before an issue — they are slower by design.</p>
+
+  <div class="callout warn">
+    <strong>Known gap worth checking:</strong> fire alarm devices are assigned the discipline code <code>FLS</code>, but <code>FLS</code> is not in the built-in list of codes the strict validator accepts. If you tag fire alarm devices and see validation complaints, add <code>FLS</code> to the accepted discipline codes in your project settings — the tags themselves are fine.
+  </div>
+
+  <h2>A sensible first run</h2>
+  <ol>
+    <li><strong>Pre-Audit</strong> on the active view. Read it properly.</li>
+    <li>Fix what it flags — usually unassigned systems and missing levels.</li>
+    <li><strong>Auto Tag</strong> on one view, with collisions set to skip.</li>
+    <li>Check a handful of resulting tags read the way you expect.</li>
+    <li>Only then <strong>Batch Tag</strong> the project.</li>
+  </ol>
+  <p>Tagging a whole model is easy to do and tedious to undo. The audit step costs a minute and routinely saves an afternoon.</p>
+
+  <div class="cta-band">
+    <p>Next: <a href="/guides/drawing-production.html">Drawing production</a> covers how those tagged elements end up on properly formatted, consistently numbered sheets.</p>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/privacy.html
+++ b/marketing-site/privacy.html
@@ -40,7 +40,7 @@ footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;bor
     <a href="/#how-it-works">How it works</a>
     <a href="/#compare">Compare</a>
     <a href="/api/pricing/html">Pricing</a>
-    <a href="/docs/">Docs</a>
+    <a href="/guides/">Guides</a>
   </div>
   <a href="/signup" class="cta">Start free trial</a>
 </nav>

--- a/marketing-site/terms.html
+++ b/marketing-site/terms.html
@@ -40,7 +40,7 @@ footer{padding:32px 24px;text-align:center;color:var(--muted);font-size:13px;bor
     <a href="/#how-it-works">How it works</a>
     <a href="/#compare">Compare</a>
     <a href="/api/pricing/html">Pricing</a>
-    <a href="/docs/">Docs</a>
+    <a href="/guides/">Guides</a>
   </div>
   <a href="/signup" class="cta">Start free trial</a>
 </nav>


### PR DESCRIPTION
First of three batches completing the seven subject guides listed as "being written next" on the guides index.

## Ships
- `guides/tagging-basics.html` — the eight tag parts, where each is derived from, per-level sequence numbering, collision modes
- `guides/drawing-production.html` — why sets drift, what a drawing type bundles, routing, corporate-vs-project layering, ISO Check
- `guides/index.html` — both moved from "being written next" into real cards; remaining five still listed honestly
- `privacy.html` / `terms.html` — stale `/docs/` nav link repointed to `/guides/` (only dead internal page link on the site)

## Accuracy notes
All UI facts read from the XAML, not CLAUDE.md. Corrections found along the way:
- Drawing catalogue is **93 types / 118 routing rules**, not 40/43
- **No A2 paper size exists** — A1 and A3 only
- View style packs: **35**, not 8
- Main panel has **10 tabs** (SELECT · TAGGING · DOCS · SETUP · CREATE TAGS · MODEL · BIM · TAG STUDIO · INTEROP · HEALTHCARE) and **no top-level HVAC tab** — the existing `the-panel.html` says nine and lists HVAC. Flagged, not changed in this PR.

Documented the `FLS` discipline-code validation gap rather than omitting it.

## Verification
- `npm run typecheck` → exit 0
- Dead internal page links → 0
- Banned-jargon sweep (API/JSON/CSV/schema/token/database/…) → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)