### PR TITLE
docs(guides): plumbing, HVAC and electrical discipline guides

### DIFF
--- a/marketing-site/guides/electrical.html
+++ b/marketing-site/guides/electrical.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Electrical — cable sizing, voltage drop and fault current — Planscape</title>
+<meta name="description" content="Why cables are sized by voltage drop rather than current, what fault current and arc flash mean, and how STING calculates and schedules them in Revit.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/electrical.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Electrical</div>
+  <h1>Electrical — cables, voltage drop and fault current</h1>
+  <div class="meta">📖 11-minute read · Intermediate</div>
+
+  <p>Electrical design asks four questions of every circuit: is the cable big enough to carry the load without overheating, will enough voltage survive the journey, what happens when something shorts out, and how dangerous is the equipment to work on live. This guide covers each, then how STING calculates them.</p>
+
+  <h2>Why cables are not sized by current</h2>
+  <p>The intuitive approach is to look up the load current, find a cable rated for it, and stop. On short runs that works. On long runs it produces circuits that are technically compliant and functionally useless.</p>
+  <p>The reason is <strong>voltage drop</strong>. Every metre of cable has resistance, and current flowing through resistance loses voltage. Deliver 230&nbsp;V to a distribution board and the far end of a long circuit may see appreciably less. Motors run hot and start badly on low voltage, lighting dims and shifts colour, and electronics behave unpredictably.</p>
+  <p>So on any appreciable run, voltage drop — not current-carrying capacity — is what decides the size. <strong>BS 7671</strong> limits it to <strong>3% for lighting circuits and 5% for power circuits</strong>. Lighting is stricter because the effect is directly visible.</p>
+  <p>STING reflects this: rather than reading a size off an ampacity table, it works up through standard sizes and picks the first one whose voltage drop is within limits.</p>
+
+  <h3>Derating — the capacity you don't get</h3>
+  <p>A cable's tabulated rating assumes reference conditions. Real installations rarely match them, and the tabulated figure has to be corrected downwards for:</p>
+  <ul>
+    <li><strong>Installation method</strong> — a cable clipped to a surface in free air sheds heat well. The same cable buried in insulation cannot, and loses roughly a quarter of its capacity.</li>
+    <li><strong>Insulation type</strong> — cross-linked polyethylene tolerates a higher operating temperature than PVC, so the same conductor carries appreciably more.</li>
+    <li><strong>Ambient temperature</strong> — a cable in a hot plant room, or in a tropical climate, starts closer to its limit and can carry less.</li>
+  </ul>
+  <p>These multiply together. A cable in a poor installation method, in PVC, in a hot room, can end up with well under half its headline rating. This is the step most often skipped by hand, and it is the one that causes cables to run hot in service.</p>
+
+  <div class="callout warn">
+    <strong>Know what is not corrected for.</strong> STING applies installation method, insulation type and ambient temperature. It does <em>not</em> apply a grouping factor for cables bunched together, nor soil thermal resistivity or burial depth for buried cables. Where cables are grouped or buried, apply that correction yourself — it can be significant.
+  </div>
+
+  <h2>Fault current</h2>
+  <p>Voltage drop is about normal operation. Fault current is about the worst moment.</p>
+  <p>Short line and neutral together and the only thing limiting current is the impedance of the supply and the cable — so current surges to a value far beyond any normal load. Two things must be true: the protective device must interrupt it fast enough to prevent a fire, and the device must be <em>capable</em> of interrupting it at all.</p>
+  <p>That second point is the one that gets missed. Every breaker has a breaking capacity. Present it with more fault current than it can clear and it may fail to open — welding shut or failing violently. The available fault current at each board must be checked against the rating of the device installed there.</p>
+  <p>Fault current is highest near the supply and falls as you move away, because each length of cable adds impedance. So the main board needs the highest-rated devices, and a small final board far from the supply may need much less.</p>
+
+  <div class="callout warn">
+    <strong>Two assumptions to check.</strong> STING's fault calculation follows the simplified resistive method of <strong>IEC 60909</strong> — resistance only, no reactance, which is reasonable at low voltage but less so on large feeders. More importantly, where a feeder has no recorded length it assumes a conservative 5&nbsp;m and copper conductors. On a real feeder run of 40&nbsp;m that understates impedance and therefore <em>overstates</em> fault current downstream. Record feeder lengths before relying on the numbers.
+  </div>
+
+  <h2>Arc flash</h2>
+  <p>Arc flash is the safety case for the people who will maintain the installation, not the equipment.</p>
+  <p>When a fault arcs across an air gap inside a panel, the arc releases intense heat and light in milliseconds. The measure that matters is <strong>incident energy</strong> — how much energy would land on someone standing at working distance — expressed in calories per square centimetre. That number sets the protective clothing required to work on the equipment live, and the boundary beyond which it is safe to stand.</p>
+  <p>The counterintuitive part: incident energy depends on how <em>long</em> the arc burns as much as how large it is. Since clearing time comes from the upstream protective device, a slower upstream breaker can make a downstream panel far more dangerous without changing anything about the panel itself.</p>
+  <p>STING implements the <strong>IEEE 1584-2018</strong> model and maps the result to <strong>NFPA 70E</strong> protective equipment categories, producing labels for the equipment.</p>
+
+  <div class="callout warn">
+    <strong>Above 600 V the model is simplified,</strong> not the full IEEE 1584-2018 treatment. And the clearing time is a value you supply — STING does not read it from the upstream device's trip curve. Since incident energy scales directly with clearing time, an optimistic input produces an optimistic and unsafe label. Have arc flash results reviewed by a competent engineer before anything is fixed to a panel.
+  </div>
+
+  <h2>How STING approaches it</h2>
+  <p>Electrical work has its own panel with seven tabs: <strong>PNLS</strong>, <strong>CIRCTS</strong>, <strong>CALCS</strong>, <strong>CABLE</strong>, <strong>SLD</strong>, <strong>LITE</strong> and <strong>RPRT</strong>.</p>
+
+  <h3>Boards and circuits</h3>
+  <p><strong>PNLS</strong> handles distribution boards and their schedules. <strong>+ Spare</strong> and <strong>+ Space</strong> fill empty ways — a distinction worth keeping straight, since a spare is a fitted device with nothing connected while a space is an empty way with no device, and contractors price them differently. <strong>▶ Run Slot Fill</strong> does this across the project.</p>
+  <p><strong>CIRCTS</strong> covers circuit assignment: <strong>▶ Preview All</strong> before <strong>▶ Apply to Selected</strong>, <strong>▶ Propose Circuits (in panel)</strong> for suggestions, and <strong>▶ Apply Balance</strong> to even the load across phases. Phase balance matters more than it appears — an unbalanced three-phase supply puts current in the neutral and wastes capacity you have already paid for.</p>
+
+  <h3>Calculations</h3>
+  <p>On <strong>CALCS</strong>, the natural order is <strong>▶ Recalculate Load Summary</strong>, then <strong>▶ Calculate Fault Levels</strong> and <strong>▶ Stamp to Panels</strong>, then <strong>▶ Run BS 7671 Audit</strong>. <strong>▶ Flag Exceedances</strong> and <strong>▶ Auto-Upsize Failing</strong> deal with circuits outside limits.</p>
+  <p>Arc flash sits here too — <strong>⚡ Arc Flash Calc</strong>, then <strong>🏷 Arc Flash Label Sheet</strong> and <strong>📋 Arc Flash Schedule</strong>. <strong>📈 Selective Coordination Viewer</strong> addresses a related question: whether a fault at a final circuit trips only its local device, or takes out the main board and the whole building with it. Coordinated protection means the nearest device operates first.</p>
+
+  <h3>Cables</h3>
+  <p><strong>CABLE</strong> carries sizing and containment: <strong>▶ Calculate</strong> then <strong>▶ Apply to Circuit</strong>, plus <strong>Cable size</strong>, <strong>Voltage drop</strong>, <strong>CPC size</strong> and <strong>Route validate</strong>. <strong>▶ Calculate Fill</strong> and <strong>▶ Validate containment fill in model</strong> check that conduits and trays are not overfilled — overfilling traps heat, which derates every cable in the bundle.</p>
+
+  <div class="callout">
+    <strong>The sizing calculator does not write to the model.</strong> <strong>▶ Calculate</strong> reports a result; <strong>▶ Apply to Circuit</strong> and the <strong>Stamp</strong> buttons are what commit it. If sizes are not appearing on elements, that separation is usually why.
+  </div>
+
+  <h3>Diagrams and reports</h3>
+  <p><strong>SLD</strong> generates the single line diagram — the one drawing that shows the whole distribution system as a tree, from incoming supply through main board to sub-boards and final circuits. <strong>▶ Generate SLD Drafting View</strong> traces the circuits already in your model and draws them, so the diagram reflects the model rather than being maintained alongside it. <strong>▶ Generate Riser Diagram</strong> does the vertical equivalent.</p>
+  <p>If it reports finding no distribution roots, it means no electrical equipment is modelled as a supply origin — everything is wired as a downstream load, so there is no top of the tree to draw from.</p>
+  <p><strong>RPRT</strong> holds <strong>▶ Full Compliance Audit</strong>, register and schedule exports, and handoffs to specialist analysis tools.</p>
+
+  <div class="callout warn">
+    <strong>On placing panel schedules on sheets:</strong> the Revit feature for doing this automatically has been broken since Revit 2024. STING offers guided manual placement, conversion to a linked schedule, or export and embed — but this step is not fully automatic, and that is Revit's limitation rather than a missing feature.
+  </div>
+
+  <h2>A sensible order of work</h2>
+  <ol>
+    <li><strong>CIRCTS</strong> — get circuits assigned and phases balanced first. Everything downstream depends on it.</li>
+    <li><strong>CALCS</strong> &rsaquo; <strong>▶ Recalculate Load Summary</strong>.</li>
+    <li><strong>CABLE</strong> &rsaquo; <strong>▶ Calculate</strong>, check the results, then <strong>▶ Apply to Circuit</strong>.</li>
+    <li><strong>CALCS</strong> &rsaquo; <strong>▶ Calculate Fault Levels</strong> and <strong>▶ Stamp to Panels</strong> — with real feeder lengths recorded.</li>
+    <li><strong>CALCS</strong> &rsaquo; <strong>▶ Run BS 7671 Audit</strong> and clear what it raises.</li>
+    <li><strong>SLD</strong> &rsaquo; <strong>▶ Generate SLD Drafting View</strong>.</li>
+    <li><strong>RPRT</strong> &rsaquo; <strong>▶ Full Compliance Audit</strong> before issue.</li>
+  </ol>
+  <p>Circuits first is the rule worth internalising. Load summaries, cable sizes, fault levels and the single line diagram are all derived from the circuit tree — build it wrong and every calculation after it is confidently incorrect.</p>
+
+  <div class="cta-band">
+    <p>Next: <a href="/guides/">back to the guides index</a>. Bills of quantities and clash coordination are being written now.</p>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/hvac.html
+++ b/marketing-site/guides/hvac.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>HVAC — heat loads, duct sizing and noise — Planscape</title>
+<meta name="description" content="Why plant sized on the sum of zone peaks is too big, how duct sizing strategies differ, and what NC really measures — then how STING calculates it in Revit.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/hvac.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; HVAC</div>
+  <h1>HVAC — heat loads, duct sizing and noise</h1>
+  <div class="meta">📖 11-minute read · Intermediate</div>
+
+  <p>Three questions decide a mechanical design: how much heating and cooling the building needs, how big the ducts have to be to deliver it, and whether the result will be quiet enough to work in. This guide covers all three, engineering first.</p>
+
+  <h2>The oversizing problem</h2>
+  <p>Start with the single most common error in load calculation, because it is expensive and almost invisible.</p>
+  <p>Every zone in a building has a peak load — the worst moment it will face. It is tempting to size the central plant by adding those peaks together. That is what Revit's own heating and cooling load calculation does, and it is wrong.</p>
+  <p>The zones do not peak at the same time. An east-facing office peaks mid-morning when the sun is on it. The west-facing office peaks late afternoon. By the time the west side is at its worst, the east side has been in shade for hours. Adding their individual peaks sizes the plant for a moment that never occurs.</p>
+  <p>The correct method is to total the loads <em>hour by hour</em> across the whole system, and take the largest hourly total. That is the <strong>block load</strong> — the real worst moment for the plant, as opposed to the sum of the worst moments for each room.</p>
+  <p>The gap between the two is typically <strong>20–30%</strong> of plant capacity. Oversized plant costs more, occupies more space, and — because it spends its life running at part load, cycling rather than modulating — often controls worse and dehumidifies less effectively than correctly sized plant.</p>
+
+  <h3>Diversity, in one line</h3>
+  <p><strong>Diversity = block load ÷ sum of peaks.</strong> A diversity of 1.0 means every zone genuinely peaks together and there is nothing to save. A diversity of 0.75 means the plant only ever has to meet three-quarters of the added-up peaks. Size to the block, not the sum.</p>
+
+  <h2>What actually goes into a load</h2>
+  <p>A design-day load is the sum of everything adding or removing heat at a given hour:</p>
+  <ul>
+    <li><strong>Conduction</strong> through walls, roofs and glazing, driven by the difference between outside and setpoint</li>
+    <li><strong>Solar gain</strong> through glazing, which depends on orientation and time of day — the reason zone peaks separate at all</li>
+    <li><strong>Occupants</strong>, contributing both sensible heat and moisture</li>
+    <li><strong>Lighting and equipment</strong>, following their hourly usage profiles</li>
+    <li><strong>Ventilation and infiltration</strong> — conditioning outside air is often the largest single item</li>
+  </ul>
+  <p>Sensible load changes air temperature; latent load is the moisture. They are tracked separately because they are met by different means, and a design that ignores latent load produces cold, clammy spaces.</p>
+  <p>All of this depends on where the building is. STING carries design-day conditions for <strong>42 cities</strong> and corrects air density for site elevation — which matters more than people expect. At Nairobi's altitude, air is meaningfully less dense than at sea level, so the same air volume carries less heat.</p>
+
+  <div class="callout warn">
+    <strong>What this is and isn't.</strong> STING's load engine is a simplified Radiant Time Series with CIBSE Guide A weather, not a full dynamic simulation. It models the design day as a smooth temperature curve, assumes 50% relative humidity at setpoint, and ignores solar gain when finding the heating peak (heating design is the cold night case). It is well suited to sizing and to comparing options. For a certified energy model, export and run a dedicated tool.
+  </div>
+
+  <h2>Sizing ducts</h2>
+  <p>Duct size trades four things against each other: fan energy, noise, space, and material cost. Bigger ducts move air slowly and quietly but cost more and consume ceiling void; smaller ducts are cheaper and fit, but the fan works harder forever and the system is louder.</p>
+  <p>There are four established ways to resolve that trade, and STING implements all four:</p>
+  <table class="tbl">
+    <thead><tr><th>Strategy</th><th>How it decides</th><th>Use it when</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Velocity limit</strong></td><td>Smallest duct that keeps air below a speed limit</td><td>The default; simple and predictable</td></tr>
+      <tr><td><strong>Equal friction</strong></td><td>Same pressure loss per metre throughout</td><td>Standard practice for most commercial work</td></tr>
+      <tr><td><strong>Static regain</strong></td><td>Reduces velocity progressively so slowing air recovers pressure</td><td>Long runs with many branches; best balance, more work</td></tr>
+      <tr><td><strong>Constant pressure</strong></td><td>Holds branch pressure steady</td><td>Variable air volume systems</td></tr>
+    </tbody>
+  </table>
+  <p>The limits differ by what the duct is doing. A main can run faster than a runout because it is further from occupied space:</p>
+  <table class="tbl">
+    <thead><tr><th>Role</th><th>Max velocity</th><th>Max friction</th><th>Basis</th></tr></thead>
+    <tbody>
+      <tr><td>Main</td><td>8.0 m/s</td><td>1.2 Pa/m</td><td>CIBSE Guide B3</td></tr>
+      <tr><td>Branch</td><td>6.0 m/s</td><td>1.0 Pa/m</td><td>CIBSE Guide B3</td></tr>
+      <tr><td>Runout</td><td>4.5 m/s</td><td>0.8 Pa/m</td><td>CIBSE Guide B3</td></tr>
+      <tr><td>Outdoor air</td><td>4.0 m/s</td><td>0.8 Pa/m</td><td>ASHRAE 62.1</td></tr>
+      <tr><td>Exhaust</td><td>10.0 m/s</td><td>1.5 Pa/m</td><td>SMACNA</td></tr>
+      <tr><td>Kitchen exhaust</td><td>12.0 m/s</td><td>2.0 Pa/m</td><td>DW/172</td></tr>
+      <tr><td>Smoke</td><td>15.0 m/s</td><td>2.5 Pa/m</td><td>BS 9999</td></tr>
+    </tbody>
+  </table>
+  <p>These are editable. A project with tight acoustic requirements or generous ceiling voids should adjust them rather than accept the defaults.</p>
+
+  <h2>Noise, and what NC actually means</h2>
+  <p>NC — Noise Criteria — is not a single loudness number. Sound is measured across frequency bands, and human annoyance depends heavily on which frequencies dominate: a low rumble and a high hiss at the same overall level are not equally tolerable.</p>
+  <p>An NC curve is a shape across those bands. Your <strong>NC rating is the lowest curve your measured sound stays entirely under</strong> — one band poking above NC-30 makes the room NC-35, regardless of how quiet the rest is. It is a worst-band measure, which is why a single "too loud" frequency ruins a space.</p>
+  <p>Typical targets: office 35, meeting room 30, patient room 30, classroom 30, restaurant 40, plantroom 75.</p>
+  <p>Sound reaching a room is the fan's noise, minus what the ductwork absorbs along the way, plus new noise generated by air rushing past every bend, damper and diffuser. That last term is why oversizing a fan then throttling it with a damper is a poor solution — you have moved the noise from the fan to the damper, which is closer to the occupant.</p>
+
+  <div class="callout warn">
+    <strong>Treat NC results as indicative.</strong> Unless you have supplied a manufacturer's sound data for the fan, STING derives an approximate fan noise from flow and pressure. That is enough to compare routes and spot problems; it is not enough to certify compliance. For diffuser noise specifically, the manufacturer's catalogue figure at your design throw is the authoritative number.
+  </div>
+
+  <h2>How STING approaches it</h2>
+  <p>HVAC has its own panel with seven tabs: <strong>EQPT</strong>, <strong>SYS</strong>, <strong>CALCS</strong>, <strong>DUCT</strong>, <strong>LOADS</strong>, <strong>FAB</strong> and <strong>RPRT</strong>. Above them sits a header strip carrying project-wide context — design standard, region, pressure class, air density, sizing strategy and scope. Every calculation reads it, so set it before you calculate.</p>
+
+  <h3>Loads first</h3>
+  <p>On <strong>LOADS</strong>, <strong>Block load</strong> is the main event. It runs the hour-by-hour calculation across your spaces and reports the building block load, the sum of peaks, and the diversity between them — plus which hour the peak lands on and the worst zones. Reading those three numbers together tells you immediately whether the plant schedule you inherited is realistic.</p>
+  <p>It writes peak sensible load, peak latent load, peak hour and outside air quantity onto each space, so the results are available to schedules rather than trapped in a report.</p>
+  <p><strong>Audit envelope</strong> checks the construction data the calculation depends on, and <strong>Ventilation audit</strong> checks outside air rates. Both are worth running before you trust a load figure. <strong>Run loads (Revit)</strong> hands off to Revit's own calculation if you want to compare.</p>
+
+  <h3>Then sizing</h3>
+  <p>On <strong>CALCS</strong>, <strong>Auto-size</strong> is the one that changes the model — it sizes ducts using the strategy and pressure class from the header. <strong>Friction</strong>, <strong>Static regain</strong> and <strong>Equal friction</strong> are report-only calculators for checking individual cases.</p>
+  <p><strong>Balance</strong> distributes flow across branches, <strong>NC predict</strong> estimates noise at a terminal, and <strong>Run all validators</strong> is the catch-all check.</p>
+
+  <div class="callout">
+    <strong>If Auto-size reports sizes but changes nothing,</strong> the ducts in scope have sizes driven by their fittings and are read-only. STING says so explicitly rather than reporting a silent success.
+  </div>
+
+  <h3>Then the model, then reports</h3>
+  <p><strong>DUCT</strong> handles creation and routing — <strong>Create types</strong>, <strong>Place duct</strong>, <strong>Auto-drop</strong>, <strong>Generate layout</strong>, <strong>Place hangers</strong> and <strong>Validate fills</strong>. <strong>RPRT</strong> covers <strong>Pressure-class audit</strong>, <strong>Detect stale sizes</strong> — which finds ducts whose sizing no longer matches the loads that drove it — and <strong>Climate inspect</strong> to confirm which design weather is in use.</p>
+
+  <h2>A sensible order of work</h2>
+  <ol>
+    <li>Set the header context — standard, region, pressure class, strategy.</li>
+    <li><strong>RPRT</strong> &rsaquo; <strong>Climate inspect</strong>, and confirm the site is right. A wrong city invalidates everything downstream.</li>
+    <li><strong>LOADS</strong> &rsaquo; <strong>Audit envelope</strong> and <strong>Ventilation audit</strong>.</li>
+    <li><strong>LOADS</strong> &rsaquo; <strong>Block load</strong>. Note the diversity figure.</li>
+    <li><strong>CALCS</strong> &rsaquo; <strong>Auto-size</strong>, then <strong>Balance</strong>.</li>
+    <li><strong>CALCS</strong> &rsaquo; <strong>NC predict</strong> on the critical spaces.</li>
+    <li><strong>RPRT</strong> &rsaquo; <strong>Detect stale sizes</strong> before issuing.</li>
+  </ol>
+  <p>Step 2 is the one people skip and regret. Every load, every duct size and every fan selection descends from the design weather, and the default is London unless the project says otherwise.</p>
+
+  <div class="cta-band">
+    <p>Next: <a href="/guides/electrical.html">Electrical</a> covers cable sizing, voltage drop, fault current and panel schedules.</p>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/index.html
+++ b/marketing-site/guides/index.html
@@ -101,13 +101,29 @@
     </div>
   </div>
 
+  <div class="guide-cat">
+    <h2>Engineering disciplines</h2>
+    <p class="sub" style="color:var(--muted);font-size:14px;margin:-8px 0 14px">Each starts with the engineering — what the task is and why it matters — before any buttons.</p>
+    <div class="guide-list">
+      <a href="/guides/plumbing.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> Plumbing</div>
+        <div class="sub">Fixture units, water supply sizing, why drains need fall — and why steeper is not safer.</div>
+      </a>
+      <a href="/guides/hvac.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> HVAC</div>
+        <div class="sub">Heat loads, duct sizing and noise — including why plant sized on the sum of zone peaks is 20–30% too big.</div>
+      </a>
+      <a href="/guides/electrical.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> Electrical</div>
+        <div class="sub">Cable sizing, voltage drop, fault current, arc flash and single line diagrams.</div>
+      </a>
+    </div>
+  </div>
+
   <div class="soon">
     <h2>Being written next</h2>
     <p>In this order. Each follows the same shape — the engineering first, then how STING does it.</p>
     <ul>
-      <li><strong>Plumbing</strong> — fixture units, pipe sizing, drainage falls and vent design</li>
-      <li><strong>HVAC</strong> — heat loads, duct sizing, air balance and noise</li>
-      <li><strong>Electrical</strong> — cable sizing, voltage drop, fault current and circuit schedules</li>
       <li><strong>Bills of quantities</strong> — measurement rules, rates and cost plans</li>
       <li><strong>Clash detection</strong> — running checks and getting to a coordinated model</li>
     </ul>

--- a/marketing-site/guides/plumbing.html
+++ b/marketing-site/guides/plumbing.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Plumbing — water supply, drainage and fixture units — Planscape</title>
+<meta name="description" content="What fixture units are, why drains need fall, and how STING sizes water supply and drainage pipes in Revit — the engineering first, then the buttons.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/plumbing.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Plumbing</div>
+  <h1>Plumbing — supply, drainage and fixture units</h1>
+  <div class="meta">📖 10-minute read · Intermediate</div>
+
+  <p>This guide covers the two halves of a building's water services: getting clean water to the fixtures at a usable pressure, and getting waste away from them reliably. It starts with the engineering, because the buttons only make sense once the reasoning does.</p>
+
+  <h2>The problem with adding up taps</h2>
+  <p>The obvious way to size a water main is to add up what every fixture draws when it is running, and size for that. On a fifty-flat residential block this gives you an absurd number — a main big enough to serve every WC, shower and tap flushing at the same instant, which will never happen.</p>
+  <p>It is also actively harmful. An oversized pipe carries water slowly, water sits in it longer, and warm stagnant water is where <em>Legionella</em> grows. Oversizing is not the safe conservative choice people assume it is.</p>
+
+  <h2>What a fixture unit actually is</h2>
+  <p>A fixture unit is a weighting number. It rolls up two things about a fixture — roughly how much it draws when running, and how often it is likely to be running — into a single figure you can add up.</p>
+  <p>A WC gets a higher unit value than a wash-hand basin, not only because it discharges more but because its demand arrives in a sharp burst. Once you have totalled the units on a branch, you convert that total to a <strong>design flow</strong> through a curve that already accounts for the fact that fixtures don't coincide. That conversion is the entire trick: the curve flattens as the count rises, because the more fixtures you serve, the smaller the fraction running at once.</p>
+  <p>You will meet three flavours of the same idea, and STING carries all three per fixture:</p>
+  <ul>
+    <li><strong>LU — loading units</strong>, the UK and European supply-side measure, converted to design flow per <strong>BS EN 806-3</strong>. STING tracks hot and cold separately.</li>
+    <li><strong>WSFU — water supply fixture units</strong>, the North American equivalent, converted using <strong>Hunter's method</strong>, with a separate curve depending on whether flush valves dominate.</li>
+    <li><strong>DU — drainage units</strong>, the waste-side measure, used to size drains per <strong>BS EN 12056-2</strong>.</li>
+  </ul>
+  <p>Supply and drainage need separate numbers because the questions differ. Supply asks "how much do I need to deliver at once"; drainage asks "how much arrives, and will it carry the solids with it".</p>
+
+  <h2>Sizing the supply</h2>
+  <p>With a design flow established, two checks decide the diameter.</p>
+  <p><strong>Velocity.</strong> Too fast and you get noise, water hammer and erosion of the pipe wall — copper is particularly unforgiving. Too slow and you get the stagnation problem above. The usable band is narrow.</p>
+  <p><strong>Pressure loss.</strong> Water loses pressure to friction as it travels. Add up the losses along the worst route — usually the highest, most distant fixture — plus the static lift of getting it up there, and check that what remains at the outlet is enough to work. A shower needs meaningful residual pressure; a bib tap does not.</p>
+  <p>STING computes friction by <strong>Hazen-Williams</strong> by default, and can use <strong>Darcy-Weisbach</strong> instead — with the Swamee-Jain approximation to Colebrook-White, falling back to Hagen-Poiseuille in laminar flow. You can drive sizing by velocity limit or by unitary head loss, the latter being the approach engineers trained on WRc and IPS methods will expect for trunk mains.</p>
+
+  <h2>Why drains need fall — and why more is not better</h2>
+  <p>Drainage is gravity-driven, so a drain needs slope. What surprises people is that steeper is not safer.</p>
+  <p>At too shallow a gradient the flow lacks the energy to move solids, and they strand. At too steep a gradient the water simply outruns the solids — it drains away and leaves them behind on a dry invert, which blocks just as effectively. What you are aiming for is a <strong>self-cleansing velocity</strong>, and STING checks against <strong>0.7 m/s</strong>.</p>
+  <p>Drains are also sized to run about <strong>half full</strong>, not full, per <strong>BS EN 12056-2 §6.2.3</strong>. The empty upper half is not waste — it is the air path that lets the system breathe. STING evaluates velocity by <strong>Chezy-Manning</strong>, with roughness varying by pipe material.</p>
+
+  <h2>Vents, and the smell test</h2>
+  <p>Every fixture has a trap holding a plug of water that stops sewer gas entering the building. That plug is fragile.</p>
+  <p>When a large discharge rushes down a stack it drags air with it, dropping the pressure behind it. If nothing replaces that air, the nearest trap seal gets siphoned out — and the room smells. Conversely a surge downstream can push pressure back up and blow a seal out into the room.</p>
+  <p>Vents exist to let air in and out fast enough that neither happens. STING sizes them per <strong>BS EN 12056-2 Annex B</strong>, or <strong>IPC 2021 Table 916.1</strong> if the project is set to a US code, and will flag where an air admittance valve is needed.</p>
+
+  <h2>Invert levels</h2>
+  <p>An invert is the inside bottom of the pipe — the surface water actually runs on. Below-ground drainage is set out by invert level rather than centreline, because that is what governs whether one drain can discharge into another and whether you have enough cover.</p>
+  <p>STING derives upstream and downstream inverts from the pipe centreline less the radius, referenced to the project base point, and checks cover depth against burial thresholds — 1.20 m under highway, 0.60 m under soft landscape.</p>
+
+  <div class="callout warn">
+    <strong>Check this one before you trust it:</strong> without surveyed ground levels in the model, STING treats the lowest point in the project as ground when testing cover depth. On a sloping site that assumption will be wrong. Read the cover-depth results as a prompt to check, not as a verdict.
+  </div>
+
+  <h2>How STING approaches it</h2>
+  <p>Plumbing has its own panel, with eight tabs that follow the order the work actually happens in.</p>
+  <table class="tbl">
+    <thead><tr><th>Tab</th><th>What it is for</th></tr></thead>
+    <tbody>
+      <tr><td><strong>SYSTEM</strong></td><td>Set the project context — which code, building type, and whether there is a recirculation loop</td></tr>
+      <tr><td><strong>SUPPLY</strong></td><td>Fixture unit scan, pipe sizing, pressure checks, expansion vessel</td></tr>
+      <tr><td><strong>DRAINAGE</strong></td><td>Drain sizing, slopes, vents, stack capacity, invert levels</td></tr>
+      <tr><td><strong>ROUTE</strong></td><td>Routing, traps, sleeves, hangers, and the fixture palette</td></tr>
+      <tr><td><strong>STORM</strong></td><td>Roof drainage, attenuation, rainwater harvesting, soakaways</td></tr>
+      <tr><td><strong>SPECIALTY</strong></td><td>Backflow and cross-connection checks</td></tr>
+      <tr><td><strong>AUDIT</strong></td><td>Run everything and get a red/amber/green picture</td></tr>
+      <tr><td><strong>DOCS</strong></td><td>Schedules, bills of quantities, commissioning packs</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Start on SYSTEM</h3>
+  <p>Set the standard first — <strong>BS EN 12056 (UK / EU)</strong>, <strong>IPC 2021 (US)</strong>, <strong>UPC 2021 (US)</strong> or <strong>NCC AU</strong> — along with building type and hot-water regime. Everything downstream reads these, so changing them later means re-running the sizing. <strong>💾 Save System Config</strong> keeps the choice with the project.</p>
+
+  <h3>Then supply</h3>
+  <p><strong>Scan Fixtures (DU / LU / WSFU)</strong> is always the first calculation. It walks the plumbing fixtures, matches each against the fixture-unit tables by family name, and writes the unit values onto the elements. Anything it cannot match is reported as unmatched rather than silently assumed — read that count, because an unmatched fixture contributes nothing and will quietly undersize the branch feeding it.</p>
+  <p>Then <strong>▶ Size DCW / DHW pipes</strong> accumulates units upstream of each pipe, converts to design flow, and sizes. <strong>Pressure Check (per level)</strong> confirms residual pressure at the outlets. <strong>Size Expansion Vessel (BS 7074-1)</strong> and <strong>Build TMV Register</strong> handle the hot-water side, and <strong>Dead-Leg Scan (HSG 274)</strong> finds the stagnant branches that matter for water hygiene.</p>
+
+  <h3>Then drainage</h3>
+  <p><strong>Size Drainage (preview)</strong> shows what would change; <strong>▶ Auto-Size Drainage</strong> applies it. <strong>Fix Slopes (auto-correct)</strong> brings gradients into range, <strong>Design Vents</strong> then <strong>▶ Create Vents</strong> handles venting, and <strong>Calculate Invert Levels</strong> sets out the below-ground work. <strong>Stack Capacity</strong> and <strong>Trap &amp; Vent Audit</strong> are the checks worth running before you issue anything.</p>
+  <p>Sizing writes back to the actual Revit pipe diameter, not only to a reported value — so the model and the calculation stay in step rather than drifting apart.</p>
+
+  <h3>Finish on AUDIT</h3>
+  <p><strong>▶ Run Full Audit</strong> runs the compliance domains together and gives you one dashboard: backflow categories per <strong>BS EN 1717</strong>, dead legs, stack capacity, trap and vent integrity, and material compatibility. It is the fastest honest answer to "is the plumbing ready to issue".</p>
+
+  <h2>A sensible order of work</h2>
+  <ol>
+    <li><strong>SYSTEM</strong> — set the code and building type before anything else.</li>
+    <li><strong>SUPPLY</strong> &rsaquo; <strong>Scan Fixtures</strong>, and check the unmatched count is zero.</li>
+    <li><strong>SUPPLY</strong> &rsaquo; <strong>Size DCW / DHW pipes</strong>, then <strong>Pressure Check</strong>.</li>
+    <li><strong>DRAINAGE</strong> &rsaquo; <strong>Size Drainage (preview)</strong> — read it before applying.</li>
+    <li><strong>DRAINAGE</strong> &rsaquo; <strong>Auto-Size Drainage</strong>, <strong>Fix Slopes</strong>, <strong>Design Vents</strong>.</li>
+    <li><strong>AUDIT</strong> &rsaquo; <strong>Run Full Audit</strong> and clear what it raises.</li>
+  </ol>
+  <p>The preview-then-apply habit matters here more than anywhere else in STING. Drainage sizing changes real geometry, and it is much easier to read a proposed change than to unpick an applied one.</p>
+
+  <div class="cta-band">
+    <p>Next: <a href="/guides/hvac.html">HVAC</a> covers heat loads, duct sizing and noise — including why plant sized on the sum of zone peaks is usually 20–30% too big.</p>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
Second of three batches. Adds the three discipline guides, each opening with the engineering before any UI.

## Ships
- `guides/plumbing.html` — fixture units and diversity, supply sizing, why steeper drains are not safer, vents and trap seals, invert levels
- `guides/hvac.html` — block load vs sum-of-peaks (and the 20–30% oversizing it causes), diversity, four duct sizing strategies with real limits, what NC actually measures
- `guides/electrical.html` — voltage-drop-driven sizing, derating, fault current and breaking capacity, arc flash and incident energy, SLD
- `guides/index.html` — new "Engineering disciplines" section; only BOQ and clash remain listed as pending

## Accuracy corrections found
CLAUDE.md was wrong on several points; none of these are repeated in the guides:
- `DrainageSizer` uses **Chezy-Manning**, not the "Maguire formula"; it cites neither **BS EN 752** nor **BS EN 274**
- The plumbing panel is **XAML**, not the C# file CLAUDE.md names
- Climate data holds **42** cities, not 41
- `CableSizerEngine` is read-only and writes nothing to the model

## Honesty notes carried into the guides
Each is stated in the code and now stated to users, because these numbers get built from:
- NC prediction is **indicative** without manufacturer fan data
- Load engine is a **simplified** Radiant Time Series, not dynamic simulation
- Fault current assumes a **5 m copper feeder** when no length is recorded → overstates downstream fault current
- Arc flash **>600 V is simplified**; clearing time is a user input, so results need competent review before labels are fixed to panels
- Cable derating covers installation method / insulation / ambient only — **no grouping or burial factor**

## Verification
- `npm run typecheck` → exit 0
- Dead internal page links → 0
- Banned-jargon sweep → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)