### PR TITLE
docs: BOQ + clash guides, Phase 206 changelog, handoff-secret ordering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 206 — planscape.build web funnel, self-serve licensing, and the guides library)
+
+The commercial front end of Planscape — everything a customer touches before the
+plugin loads. Landed across several branches; recorded here as one arc because the
+pieces only make sense together.
+
+**Web funnel (Phases 1–2).** Marketing site, signup, and the account area on
+Cloudflare Pages Functions backed by D1, which is canonical for identity. Pricing is
+derived per-visitor rather than hardcoded, after a currency-derivation defect that
+showed some visitors the wrong local figure; existing rows were backfilled rather
+than left inconsistent.
+
+**Downloads + licensing.** StingTools and StingBridge ship from a private R2 bucket
+through gated Functions that stream the artifact rather than exposing a bucket URL.
+Licence issuing is self-serve with seat caps enforced at issue time. StingBridge is
+deliberately licence-key-free — the Planscape account is the entitlement — and
+released at `0.1.0-beta.1`. (Detail in Phase 199.)
+
+**Identity handoff.** The cloud→server handoff from D1 to the .NET API, proven
+end-to-end locally. (Detail in Phase 201.) Note the production-side secret is still
+unset — see `docs/DEPLOY_RUNBOOK.md` §3e for the ordering constraint.
+
+**Deployment.** Render blueprint corrections and the runbook validation pass.
+(Detail in Phase 200.)
+
+**Guides library.** Rebuilt from 41 dead links to zero, then extended from
+installation-only coverage to the full subject set: tagging basics, drawing
+production, plumbing, HVAC, electrical, bills of quantities, and clash
+coordination. Each opens with the engineering — what a fixture unit is, why the sum
+of zone peaks oversizes plant, why voltage drop rather than current sizes a long
+cable — before naming a button. UI facts were read from the XAML, which caught
+CLAUDE.md being stale on the drawing-type counts (93 types / 118 routing rules, not
+40/43), the view style pack count (35), the panel tab list, and the plumbing panel's
+file type. Engine caveats that affect built work are stated in the guides rather
+than omitted: indicative NC prediction, the simplified load model, the assumed 5 m
+feeder in fault-current propagation, and simplified arc flash above 600 V.
+
+**Production-site corrections.** Four defects fixed on the live site: the homepage
+was redirecting to `/blog/`; a fabricated testimonial was removed; plan pricing was
+corrected from $15/$35 to $25/$60; and the comparison table was showing an 11×
+figure that the underlying numbers did not support.
+
+---
+
 #### Completed (Phase 205 — SB-3: token inference single-sourced into core + ArchiCAD HostAdapter)
 
 `StingBridge/sync/token_mapper.py` + `archicad/element_types.py` held their own

--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -100,6 +100,7 @@ Render dashboard → **Env Groups → planscape-shared** → set:
 |---|---|
 | `Jwt__Key` | the `openssl rand -base64 48` output |
 | `PLANSCAPE_OWNER_PASSWORD` | the owner login password |
+| `PLANSCAPE_HANDOFF_SECRET` | another `openssl rand -base64 48` output. **Shared with Cloudflare** — the same value must later be set on the Pages side. See §3e. |
 | `Storage__S3__ServiceUrl` | **MinIO default:** the `planscape-minio` internal URL (Render → planscape-minio → Connect → Internal URL, e.g. `http://planscape-minio:9000`). **R2/S3:** their endpoint, or blank for AWS S3. |
 | `Storage__S3__AccessKey` | **= `MINIO_ROOT_USER`** (same value as 3d) — or the R2/S3 access key |
 | `Storage__S3__SecretKey` | **= `MINIO_ROOT_PASSWORD`** (same value as 3d) — or the R2/S3 secret key |
@@ -146,6 +147,37 @@ If you chose Cloudflare R2 / AWS S3 instead, suspend or delete `planscape-minio`
 
 After setting secrets, **Manual Deploy → Clear build cache & deploy** (or just
 redeploy) each service so it picks them up.
+
+### 3e. Cloudflare Pages side — set these LAST
+
+Two values live on the marketing site (Cloudflare Pages, project
+`planscape-marketing`), not on Render. They are what lets the account page hand a
+signed-in customer across to the cloud app:
+
+| Key | Value |
+|---|---|
+| `PLANSCAPE_HANDOFF_SECRET` | **the same string** set on Render in §3a. Both sides verify against it; a mismatch rejects every handoff. |
+| `CLOUD_APP_ORIGIN` | `https://app.planscape.build` — where the customer is sent |
+
+```bash
+cd marketing-site
+npx wrangler pages secret put PLANSCAPE_HANDOFF_SECRET --project-name=planscape-marketing
+npx wrangler pages secret put CLOUD_APP_ORIGIN --project-name=planscape-marketing
+```
+
+> **Ordering rule — do this only after Render is answering.**
+> Setting `CLOUD_APP_ORIGIN` is what activates the cloud button on the customer
+> account page. Set it before `app.planscape.build` resolves and serves, and the
+> button goes live pointing at an origin that is not there yet — so paying
+> customers get sent to a dead host. The consumer of these values is
+> `marketing-site/functions/api/cloud/handoff.ts`.
+>
+> Correct order: Render deployed (§2–§3d) → DNS resolving and TLS issued (§4) →
+> first-boot checks passing (§5) → **then** §3e.
+>
+> Until §3e is done the site is in a safe state: the handoff simply stays
+> disabled. An unset secret is a disabled feature; a wrong one is a broken
+> customer journey.
 
 ---
 

--- a/marketing-site/guides/boq-and-cost.html
+++ b/marketing-site/guides/boq-and-cost.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Bills of quantities — measurement, rates and cost — Planscape</title>
+<meta name="description" content="What NRM2 measurement rules are for, where rates come from and how much to trust them, and how STING produces a bill of quantities from a Revit model.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/boq-and-cost.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Bills of quantities</div>
+  <h1>Bills of quantities — measurement, rates and cost</h1>
+  <div class="meta">📖 10-minute read · Intermediate</div>
+
+  <p>A bill of quantities is a priced list of everything a project requires, written so that several contractors pricing it independently arrive at comparable numbers. This guide explains what makes that possible, then how STING produces one from a model.</p>
+
+  <h2>Why measurement needs rules</h2>
+  <p>Ask two quantity surveyors to measure the same wall and you can easily get two answers. Does the area include the door opening or not? Is the wall measured to the underside of the slab or to finished floor level above? Are returns at corners counted twice?</p>
+  <p>None of these has a naturally correct answer — but if the two surveyors resolve them differently, their totals differ, and tenders based on them cannot be compared. The whole point of tendering is that the difference between bids reflects the contractors' pricing, not their measuring.</p>
+  <p>A <strong>measurement standard</strong> settles those questions in advance. It fixes what unit each item is measured in, what is included in the rate, what gets deducted, and how items are described and grouped. Everyone measures the same way, so the numbers mean the same thing.</p>
+
+  <h3>The standards STING implements</h3>
+  <table class="tbl">
+    <thead><tr><th>Standard</th><th>Used for</th></tr></thead>
+    <tbody>
+      <tr><td><strong>NRM2</strong> (RICS, 2nd ed.)</td><td>Building work. The default, and the UK norm.</td></tr>
+      <tr><td><strong>CESMM4</strong></td><td>Civil engineering work.</td></tr>
+      <tr><td><strong>POMI</strong> (RICS)</td><td>International projects.</td></tr>
+      <tr><td><strong>ICMS 3</strong></td><td>Cost <em>and</em> carbon reporting together.</td></tr>
+      <tr><td><strong>MMHW</strong></td><td>Highway works.</td></tr>
+    </tbody>
+  </table>
+  <p>They genuinely differ. Reinforcement is measured in kilograms under NRM2 but in tonnes under CESMM4 — the same steel, a different number, because the trades pricing it think in different units.</p>
+
+  <h3>De-minimis, or why small holes are ignored</h3>
+  <p>One rule worth understanding because it looks like an error. Measurement standards do not deduct every opening. Below a threshold, a hole in a wall is <em>not</em> taken out of the measured area.</p>
+  <p>This is deliberate. A bricklayer working around a small opening does more work per square metre, not less — cutting, forming a reveal, making good. Deducting the hole would under-pay work that is actually harder. So openings below the threshold stay in the measurement, and the rate absorbs the extra effort. STING defaults to 0.5&nbsp;m² for openings and 1.0&nbsp;m² for voids.</p>
+
+  <h2>Where rates come from</h2>
+  <p>A quantity is only half a bill. The other half is the rate — the price per unit — and rates come from sources of very different reliability.</p>
+  <p>STING resolves them in priority order, taking the first source that has a usable answer:</p>
+  <ol>
+    <li><strong>A rate you set on the element itself</strong> — an explicit decision, so it beats everything.</li>
+    <li><strong>A stored per-element override</strong> — a previous priced decision that persists in the model.</li>
+    <li><strong>The material library</strong> — rates attached to materials.</li>
+    <li><strong>The project rate card</strong> — what the quantity surveyor has priced for this job. This deliberately sits above the corporate defaults.</li>
+    <li><strong>The corporate rate tables</strong> — matched first on category plus system, then category, then product code, then material code. Each step down is a looser match and carries lower confidence.</li>
+    <li><strong>The baseline defaults</strong> — global benchmark figures, last resort.</li>
+  </ol>
+  <p>Every resolved rate carries where it came from and a <strong>confidence score</strong>. A rate matched on category and system is worth more than one matched on a material code alone, and the export records the difference. If nothing matches, STING returns a zero rate with low confidence and says so explicitly, rather than inventing a plausible number.</p>
+
+  <div class="callout">
+    <strong>Read the confidence column before the totals.</strong> A bill where most lines resolved from the baseline defaults is an order-of-magnitude estimate. One where most lines came from the project rate card is a tender document. The grand total looks identical either way.
+  </div>
+
+  <h3>Waste is applied to quantity, not rate</h3>
+  <p>Materials are ordered with an allowance for offcuts and breakage. That allowance belongs on the quantity, not in the rate — if it were folded into both, it would compound, and two 5% allowances would silently become 10.25%.</p>
+  <p>Waste also only applies to measured items. You can waste 5% of a tonne of screed; you cannot waste 5% of a pump. STING applies waste to area, volume, length and mass, and never to counted items.</p>
+
+  <h2>Carbon alongside cost</h2>
+  <p>Embodied carbon is measured from the same quantities as cost — the same cubic metre of concrete has both a price and a footprint — so it belongs in the same process rather than a separate exercise months later.</p>
+  <p>STING looks for a carbon factor in order of authority, starting with a verified environmental product declaration for the specific product, and falling back through material properties and reference tables to a regional default. As with rates, the source is recorded, so a figure backed by a manufacturer's declaration is distinguishable from a generic default.</p>
+  <p>The export prints the <strong>RIBA 2030 benchmark of 300 kgCO₂e per m² of floor area</strong> alongside your result, so the number has a reference point instead of being an abstract quantity.</p>
+
+  <h2>How STING approaches it</h2>
+  <p>Quantities come off the model by rule: each category maps to a measurement source — a length, a volume, a computed area, or a named property — with the unit conversion attached. Rules are corporate by default and can be overridden per project.</p>
+
+  <div class="callout warn">
+    <strong>A zero quantity is a signal, not a nil.</strong> When a measured item cannot be measured — geometry missing, property empty — STING reports <strong>0</strong> rather than defaulting to 1. A quiet 1 would price as a real item and be nearly impossible to spot in a thousand-line bill. Zeroes on measured lines mean "this needs looking at", and the at-risk summary collects them.
+  </div>
+
+  <h3>What the export contains</h3>
+  <p>The bill exports as a workbook with a sheet per purpose:</p>
+  <ul>
+    <li><strong>BOQ Summary</strong> — the priced bill, grouped by work section with subtotals</li>
+    <li><strong>Item Schedule</strong> — the full detail, including rate confidence and the labour, plant and material split</li>
+    <li><strong>Material Schedule</strong> — quantities by material</li>
+    <li><strong>Provisional Sums</strong> and <strong>Preliminaries</strong> — the latter only if itemised</li>
+    <li><strong>NRM2 Reference</strong> — the work-section structure behind the grouping</li>
+    <li><strong>Carbon &amp; Lifecycle</strong> — carbon by line, with data quality and factor source</li>
+    <li><strong>Audit Trail</strong> — every line traced back to its element, rate source and pricing date</li>
+    <li><strong>Snapshot Comparison</strong> — appears once there are two snapshots to compare</li>
+  </ul>
+  <p>Totals are written as live spreadsheet formulas rather than fixed values, so a quantity surveyor can adjust a rate and watch the bill respond. The totals run in the conventional order: subtotal, preliminaries, contingency, overhead and profit, grand total.</p>
+  <p>The Audit Trail is the sheet that matters in a dispute. Any line can be traced to the element it was measured from and the rate source that priced it — which is the difference between a bill you can defend and a spreadsheet you have to re-do.</p>
+
+  <div class="callout">
+    <strong>On the descriptions:</strong> the narrative descriptions are STING-authored, written to follow NRM2 work-section structure. They are not reproduced from the RICS NRM2 document, and the export says so on the sheet.
+  </div>
+
+  <h2>A sensible order of work</h2>
+  <ol>
+    <li>Confirm the measurement standard for the project — NRM2 unless there is a reason.</li>
+    <li>Load the project rate card if the quantity surveyor has priced one. This single step moves most lines from low to high confidence.</li>
+    <li>Export, then read the Item Schedule <em>before</em> the Summary.</li>
+    <li>Investigate every zero on a measured line — those are missing quantities, not free items.</li>
+    <li>Check the confidence spread. If the bill leans on baseline defaults, describe it as an estimate.</li>
+    <li>Re-export as the model develops and use the Snapshot Comparison to see what moved.</li>
+  </ol>
+  <p>The discipline that matters is reading the audit columns before the grand total. A bill of quantities is only as good as its worst-sourced rate, and the total conceals that entirely.</p>
+
+  <div class="cta-band">
+    <p>Next: <a href="/guides/clash-coordination.html">Clash detection and coordination</a> — how detection actually works, and how to get to a genuinely coordinated model.</p>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/clash-coordination.html
+++ b/marketing-site/guides/clash-coordination.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Clash detection and coordination — Planscape</title>
+<meta name="description" content="What a clash actually is, why tolerance and clearance are not what they sound like, and how to get from thousands of raw hits to a coordinated model.">
+<meta name="theme-color" content="#E8912D">
+<link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
+<link rel="canonical" href="https://planscape.build/guides/clash-coordination.html">
+<link rel="stylesheet" href="/assets/site.css">
+</head>
+<body>
+
+<nav class="site">
+  <a href="/" class="brand">Plan<span class="dot">·</span>scape</a>
+  <button class="menu-toggle" onclick="document.getElementById('nav-links').classList.toggle('open')" aria-label="Toggle menu">☰</button>
+  <div class="links" id="nav-links">
+    <a href="/features.html">Features</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="/guides/" style="color:var(--accent)">Guides</a>
+    <a href="/about.html">About</a>
+    <a href="/contact.html">Contact</a>
+  </div>
+  <a href="/signup" class="cta">Start free trial</a>
+</nav>
+
+<article class="doc">
+  <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; Clash coordination</div>
+  <h1>Clash detection and getting to a coordinated model</h1>
+  <div class="meta">📖 10-minute read · Intermediate</div>
+
+  <p>Clash detection is easy to run and hard to use. The first run on a real project returns thousands of hits, most of which do not matter, and teams routinely abandon the process at that point. This guide is about the difference between finding clashes and resolving them.</p>
+
+  <h2>What a clash actually is</h2>
+  <p>At its simplest, a clash is two pieces of geometry occupying the same space. A duct through a beam. A pipe through a column.</p>
+  <p>But "occupying the same space" is a poor definition of a problem. Consider:</p>
+  <ul>
+    <li>A pipe passing through a wall — intended, that is what a sleeve is for.</li>
+    <li>Insulation touching the pipe it insulates — a mathematical overlap, not a conflict.</li>
+    <li>A beam meeting a column at a joint — that is the structure working.</li>
+    <li>Two ducts 5&nbsp;mm apart — no overlap at all, but nobody can install either one.</li>
+  </ul>
+  <p>The last is the important one. <strong>Geometric overlap and buildability are different questions.</strong> Things that do not touch can still be impossible to build, and things that overlap can be perfectly correct. A clash report that only answers the geometry question is mostly noise.</p>
+
+  <h2>How detection works</h2>
+  <p>Testing every element against every other element is unworkable — a model with 50,000 elements would need over a billion comparisons. So detection runs in stages, each cheap and approximate, narrowing the field for the next.</p>
+  <ol>
+    <li><strong>Broad phase.</strong> Every element is reduced to a simple box and boxes are tested for overlap. Crude, but it eliminates almost everything instantly. The boxes are padded by about 50&nbsp;mm so near-misses survive into the next stage.</li>
+    <li><strong>Narrow phase.</strong> Surviving pairs are tested against a tree of tighter, rotated boxes — which matters for anything long and diagonal, where an upright box is a poor fit.</li>
+    <li><strong>Triangle test.</strong> Only pairs that survive both get an exact surface-against-surface test.</li>
+  </ol>
+  <p>This is why a run takes minutes rather than days, and why the reported <em>volume</em> of a clash is an estimate rather than an exact intersection — computing true intersection volumes for every hit would cost far more than it is worth for a number used to sort a list.</p>
+
+  <h2>Tolerance and clearance — not what they sound like</h2>
+  <p>This is the part most worth reading carefully, because the names are misleading.</p>
+  <p>Which pairs of things get checked, and how strictly, is set by a matrix of rules. Each rule pairs two categories and gives them a tolerance:</p>
+  <table class="tbl">
+    <thead><tr><th>Pair</th><th>Tolerance</th><th>Severity</th></tr></thead>
+    <tbody>
+      <tr><td>Duct vs structural beam</td><td>Hard</td><td>High</td></tr>
+      <tr><td>Structural column vs architectural wall</td><td>Hard</td><td>High</td></tr>
+      <tr><td>Sprinkler vs duct</td><td>Clearance 100&nbsp;mm</td><td>High</td></tr>
+      <tr><td>Duct vs duct</td><td>Clearance 100&nbsp;mm</td><td>Medium</td></tr>
+      <tr><td>Pipe vs pipe</td><td>Clearance 50&nbsp;mm</td><td>Medium</td></tr>
+      <tr><td>Light fitting vs ceiling</td><td>Clearance 50&nbsp;mm</td><td>Low</td></tr>
+    </tbody>
+  </table>
+  <p>Services against structure are <strong>hard</strong> — any overlap is a problem, because you cannot route a duct through a beam without someone approving a penetration.</p>
+
+  <div class="callout warn">
+    <strong>A clearance setting relaxes detection; it does not widen it.</strong> "Clearance 50&nbsp;mm" does <em>not</em> mean "report anything within 50&nbsp;mm". It means "tolerate up to 50&nbsp;mm of genuine overlap before treating it as a clash". Two pipes 30&nbsp;mm apart are not reported at all, because they do not overlap. If you need true proximity checking for access or insulation space, do not rely on clearance rules to provide it.
+  </div>
+  <p>Each rule also carries an owning discipline and a stage gate, so structural conflicts can be raised at design development while service-against-service congestion waits for coordination stage — matching the order in which the work is actually resolvable.</p>
+
+  <h2>Filtering the noise</h2>
+  <p>Separately from the matrix, a set of rules classifies hits as genuine, intentional, or artefacts of how geometry is represented. Curved surfaces are approximated by flat triangles, and two nominally touching curved surfaces will overlap slightly — a real number, not a real problem.</p>
+  <p>Thresholds matter enormously here, and one example is instructive. The rule that recognises structural joints originally ignored overlaps below a 10&nbsp;cm cube. Real beam-to-column joints routinely overlap 30–80&nbsp;cm in each direction, so every joint in the building was reported as a clash. The threshold is now around 500 litres. A filter set too tight is indistinguishable from no filter at all.</p>
+  <p>Where several rules apply, the strictest verdict wins rather than the first one matched — so the order rules are listed in cannot silently change the result.</p>
+
+  <h2>Grouping — 3,000 clashes into 40 problems</h2>
+  <p>The single biggest step from raw output to usable output. One misrouted duct crossing twenty beams is <em>one</em> mistake with one fix, but naive detection reports it as twenty clashes. STING groups in three passes:</p>
+  <ul>
+    <li><strong>By element</strong> — the same element appearing repeatedly becomes one group. Fix the duct, clear twenty hits.</li>
+    <li><strong>By pattern</strong> — evenly spaced repetition, such as a riser hitting every floor or a light row hitting every ceiling tile, becomes one group with a recognisable shape.</li>
+    <li><strong>By location</strong> — whatever remains clusters spatially, so one congested plant room is one item on the list rather than sixty.</li>
+  </ul>
+  <p>The spatial grid adapts to what is being grouped: small light fittings cluster at around a metre, large plant against structure at several metres. A fixed grid over-clusters the small things and under-clusters the large ones.</p>
+
+  <h2>How STING approaches it</h2>
+  <p>Clash tools sit on the <strong>BIM</strong> tab of the main panel.</p>
+  <ul>
+    <li><strong>Detect</strong> — run detection.</li>
+    <li><strong>Run</strong> — the full pipeline through to stored results.</li>
+    <li><strong>X-Model</strong> — extend across linked models. This is where the real conflicts live: your services against someone else's structure. A model checked only against itself will look far cleaner than the project actually is.</li>
+    <li><strong>Matrix</strong> — edit which pairs are checked and how strictly.</li>
+    <li><strong>Refresh</strong> — re-run against the current model.</li>
+    <li><strong>Manager</strong> — work through results.</li>
+    <li><strong>BCF</strong> — export findings.</li>
+  </ul>
+  <p>Detection runs inside Revit against your model. It is not a streamed feed from a server, so results reflect the model as it is on your machine right now.</p>
+
+  <h3>Getting issues to the rest of the team</h3>
+  <p>BCF is the open format for construction issues, and STING exports <strong>BCF 2.1</strong> — readable by Solibri, BIMcollab, Navisworks and Autodesk Construction Cloud. Each issue carries a viewpoint, so opening it puts the recipient's camera on the problem rather than leaving them to find it.</p>
+  <p>One detail that matters more than it sounds: each issue gets an identifier derived from the clash itself, so re-exporting after a second run produces the <em>same</em> identifier for an unresolved clash. Without that, every weekly export would land as a fresh batch of duplicates and the issue tracker would become useless within a month.</p>
+  <p>Severity maps onto the priority levels those tools expect, so a critical clash arrives as critical rather than flattening to a default.</p>
+
+  <h2>Getting to a coordinated model</h2>
+  <ol>
+    <li><strong>Set the matrix before the first run.</strong> Running everything against everything produces a number so large it teaches the team the report is not worth reading.</li>
+    <li><strong>Run cross-model.</strong> Single-model results are reassuring and misleading.</li>
+    <li><strong>Work groups, not clashes.</strong> The list of forty grouped problems is the real agenda. Twenty hits from one duct is one conversation.</li>
+    <li><strong>Fix causes.</strong> If a service crosses a structural zone repeatedly, the route is wrong — nudging each crossing individually guarantees they return next week.</li>
+    <li><strong>Export to BCF and assign owners.</strong> A clash nobody owns does not get fixed.</li>
+    <li><strong>Re-run and compare.</strong> What matters is the trend: are groups closing faster than new ones appear.</li>
+  </ol>
+  <p>The number to watch is not clashes found — that number reflects how much of the building is modelled as much as how well it is coordinated. Watch how many grouped problems are open, and how long they stay open.</p>
+
+  <div class="cta-band">
+    <p>That completes the current guide set. If something you needed is not covered, email <a href="mailto:hello@planscape.build">hello@planscape.build</a> — the answer usually becomes the next guide.</p>
+  </div>
+</article>
+
+<footer class="site">
+  <div class="footer-grid">
+    <div class="col">
+      <div class="brand-row">Plan<span class="dot">·</span>scape</div>
+      <p>ISO 19650 BIM coordination built for East &amp; West African AEC firms.</p>
+      <p>📍 Kampala, Uganda</p>
+      <p><a href="mailto:hello@planscape.build">hello@planscape.build</a></p>
+    </div>
+    <div class="col">
+      <h4>Product</h4>
+      <a href="/features.html">Features</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/signup">Start trial</a>
+      <a href="/contact.html#demo">Book a demo</a>
+    </div>
+    <div class="col">
+      <h4>Learn</h4>
+      <a href="/guides/">Guides</a>
+      <a href="/contact.html">Contact support</a>
+    </div>
+    <div class="col">
+      <h4>Company</h4>
+      <a href="/about.html">About</a>
+      <a href="/privacy.html">Privacy</a>
+      <a href="/terms.html">Terms</a>
+    </div>
+  </div>
+  <div class="legal">© 2026 Planscape Ltd · Kampala, Uganda · All rights reserved</div>
+</footer>
+
+</body>
+</html>

--- a/marketing-site/guides/index.html
+++ b/marketing-site/guides/index.html
@@ -120,13 +120,18 @@
     </div>
   </div>
 
-  <div class="soon">
-    <h2>Being written next</h2>
-    <p>In this order. Each follows the same shape — the engineering first, then how STING does it.</p>
-    <ul>
-      <li><strong>Bills of quantities</strong> — measurement rules, rates and cost plans</li>
-      <li><strong>Clash detection</strong> — running checks and getting to a coordinated model</li>
-    </ul>
+  <div class="guide-cat">
+    <h2>Cost and coordination</h2>
+    <div class="guide-list">
+      <a href="/guides/boq-and-cost.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> Bills of quantities</div>
+        <div class="sub">Why measurement needs rules, where rates come from, and how much to trust the grand total.</div>
+      </a>
+      <a href="/guides/clash-coordination.html" class="guide-row">
+        <div class="ttl"><span class="badge">NEW</span> Clash detection</div>
+        <div class="sub">How detection works, why clearance is not what it sounds like, and getting from 3,000 hits to 40 problems.</div>
+      </a>
+    </div>
   </div>
 
   <div class="soon">


### PR DESCRIPTION
Final batch. Completes the seven-guide set and adds the changelog + runbook work.

## Ships
- `guides/boq-and-cost.html` — why measurement needs rules, de-minimis, rate priority and confidence, waste on quantity not rate, carbon alongside cost
- `guides/clash-coordination.html` — the three-stage detection pipeline, tolerance vs clearance, noise filtering, grouping, BCF 2.1
- `guides/index.html` — "being written next" list removed; nothing left on it
- `docs/CHANGELOG.md` — one Phase 206 entry for the whole commercial front end
- `docs/DEPLOY_RUNBOOK.md` — §3e handoff secret + ordering rule

## Notable corrections carried into the guides
- **There is no SMM7 implementation.** CLAUDE.md claims one. The real set is NRM2 / CESMM4 / POMI / ICMS 3 / MMHW.
- **"Clearance 50 mm" does not find near-misses.** It tolerates up to 50 mm of *real overlap* before flagging. Anyone expecting proximity checking would get silent false confidence, so the guide states this in a warning callout.

## Scope adjustments (parallel sessions got there first)
- Changelog: Phases **199 / 200 / 201** already cover StingBridge release, blueprint validation and the identity handoff. Cross-referenced rather than restated, so the entry is one arc not nine.
- Runbook: a full Render checklist (§0–§6, incl. custom domains) already existed from the go-live pass. Added **only** the genuinely missing piece — `PLANSCAPE_HANDOFF_SECRET` as a shared Render/Cloudflare value, `CLOUD_APP_ORIGIN`, and the hard ordering rule that the Cloudflare side goes last.

## Verification
- `npm run typecheck` → exit 0
- Dead internal page links → 0
- Banned-jargon sweep → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)