### PR TITLE
release(stingbridge): 0.1.0-beta.2 — live on planscape.build/downloads

### DIFF
--- a/StingBridge/__init__.py
+++ b/StingBridge/__init__.py
@@ -5,4 +5,4 @@
 reports it under ``stingbridge --version``.
 """
 
-__version__ = "0.1.0b1"
+__version__ = "0.1.0b2"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 208 — StingBridge 0.1.0-beta.2 released)
+
+Cuts and ships the release carrying Phases 201–205: personal access tokens, SEQ
+minting, and the drop-folder contract. **Live on planscape.build/downloads**
+alongside beta.1, which stays listed.
+
+- **`__version__` → `0.1.0b2`.** Both wheels rebuilt on Python 3.13
+  (`stingbridge-0.1.0b2`, `stingtools_core-0.1.0`).
+- **Two artifacts**, matching beta.1's layout exactly (verified by pulling
+  beta.1 out of R2 and diffing the structure rather than guessing):
+  `win64` one-file PyInstaller EXE — 57 MB,
+  sha256 `1b7eada1…`; and `any` wheels zip with the `run.bat`/`run.sh`
+  launchers — 1 MB, sha256 `7353a062…`. Both carry `LICENSE.txt` +
+  `QUICKSTART.md`.
+- **Both smoke-tested from clean installs against a real API build** wired to
+  the docker Postgres. The EXE: `--version` → `0.1.0b2`, `--help` renders, and
+  `process-ifc` → 3 elements, **3 SEQ minted**, 3 synced, 0 errors, tokens
+  written back. The `any` zip: `run.bat` built its venv from the bundled wheels
+  on first run and completed the same `process-ifc` E2E.
+- **Uploaded** to the private `planscape-downloads` R2 bucket via
+  `release-download.mjs`, **catalogue entry added keeping beta.1**, and the site
+  deployed to production.
+
+**Verified live:** unauthenticated downloads of both beta.2 artifacts return
+**401** (gating intact), `/downloads` returns 200, and the setup guide resolves
+200. Both R2 objects were **re-downloaded and their sha256 confirmed to match
+the catalogue** — the release script computes hashes from the files themselves,
+so the catalogue cannot drift from the objects, and this closes the loop.
+
+**Not verified:** that the live *page* renders the beta.2 row. `/api/downloads`
+requires a subscriber session, and the gated download endpoint returns 401
+before it ever consults the catalogue — a bogus version number returns 401 too,
+so a 401 on beta.2 proves nothing about catalogue presence. What is established
+is that the objects exist with the right hashes and the deploy succeeded with
+beta.2 in `catalog.ts`. Confirming the rendered row needs one signed-in page
+load, which is an owner action.
+
 #### Completed (Phase 207 — multi-host Phase B: change feed + pull + reconcile engine)
 
 Push already existed — every host could send tags to the hub. Nothing could ask

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -317,9 +317,9 @@ retention release and the sign-off guard. Still open:
 - **QS import per-row accept/reject.** The import diff is whole-batch
   Apply/Cancel; per-row checkboxes would let a QS accept a subset.
 
-## StingBridge — remaining gaps (post 0.1.0-beta.1, Phase 199)
+## StingBridge — remaining gaps (post 0.1.0-beta.2)
 
-Shipped self-serve on planscape.build/downloads; these are the known gaps, roughly in value order:
+Shipped self-serve on planscape.build/downloads. **0.1.0-beta.2 is live** (SB-2, SB-3 and SB-4 closed; PATs added). Remaining gaps, roughly in value order:
 
 | # | Gap | Detail |
 |---|---|---|

--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -130,6 +130,28 @@ export const DOWNLOAD_CATALOG: Tool[] = [
     docsUrl: "/guides/stingbridge-setup.html",
     versions: [
       {
+        version: "0.1.0-beta.2",
+        releasedAt: "2026-07-20",
+        notes:
+          "Adds sequence numbers to ArchiCAD tags so they match Revit's 8-segment format, and files processed IFCs into done/ and failed/ folders so you can see at a glance what is still outstanding. Sign in with an access token instead of a password — the only option if you signed up on planscape.build.",
+        artifacts: [
+          {
+            label: "win64",
+            platform: "Windows 64-bit",
+            objectKey: "sting-bridge/0.1.0-beta.2/StingBridge_0.1.0-beta.2_win64.zip",
+            sizeMb: 57,
+            sha256: "1b7eada10cff762e4c0a74503fbc7321301117766f6882a5d0da91aa15bc81ca",
+          },
+          {
+            label: "any",
+            platform: "Any OS (Python 3.11+)",
+            objectKey: "sting-bridge/0.1.0-beta.2/StingBridge_0.1.0-beta.2_any.zip",
+            sizeMb: 1,
+            sha256: "7353a062fdec8057942bb98c98320f79e3b1efecc91ac55f0aeaa931aaeb572c",
+          },
+        ],
+      },
+      {
         version: "0.1.0-beta.1",
         releasedAt: "2026-07-19",
         notes:


### PR DESCRIPTION
Phase 7 of the go-live queue. Ships the release carrying Phases 201–205 (PATs,
SEQ minting, drop-folder contract). **Already live** — beta.1 stays listed.

## Artifacts

| label | what | size | sha256 |
|---|---|---|---|
| `win64` | one-file PyInstaller EXE | 57 MB | `1b7eada1…` |
| `any` | wheels zip + `run.bat`/`run.sh` | 1 MB | `7353a062…` |

Both built on Python 3.13 and carrying `LICENSE.txt` + `QUICKSTART.md`.

I matched beta.1's zip layout by **pulling beta.1 out of R2 and diffing the
structure**, rather than reconstructing it from memory — that's how the
`run.bat`/`run.sh` launchers came across byte-identical.

## Smoke tests — from clean installs, against a real API build

**EXE:** `--version` → `0.1.0b2`; `--help` renders; `process-ifc` →
`elements: 3  synced: 3  errors: 0`, with **3 SEQ minted** (Phase 202 working in
the shipped binary) and tokens written back to `_sting.ifc`.

**`any` zip:** extracted to an empty directory, `run.bat` built its venv from the
bundled wheels on first run, then completed the same `process-ifc` E2E.

## Live verification

```
unauthenticated download, beta.2 win64 : 401   (gating intact)
unauthenticated download, beta.2 any   : 401
/downloads                             : 200
/guides/stingbridge-setup.html         : 200 (after its 308 → extensionless)
```

Both R2 objects were **re-downloaded and their sha256 confirmed against the
catalogue**. The release script computes hashes from the files themselves, so the
catalogue can't drift from the objects — this closes that loop from the other end.

## What I could NOT verify — please read

**I have not confirmed the live page renders the beta.2 row.**

`/api/downloads` requires a subscriber session. And the gated download endpoint
returns 401 *before* it consults the catalogue — I checked, and
`9.9.9-nonexistent` returns 401 too. So **a 401 on beta.2 proves nothing about
catalogue presence**, and I'm not going to present it as if it did.

What is established: the objects exist in R2 with the correct hashes, the
catalogue source has the beta.2 entry in the right order (beta.2 first, beta.1
retained), and the deploy reported success. Confirming the rendered row takes one
signed-in page load — an owner action.

## Tests

All **208** green: 118 StingBridge (9 suites) + 90 stingtools-core including the
Phase A6 boundary lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)