### PR TITLE
fix(marketing): correct the-panel guide to match the real dock panel UI

### DIFF
--- a/marketing-site/guides/the-panel.html
+++ b/marketing-site/guides/the-panel.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>The STING panel, tab by tab — Planscape</title>
-<meta name="description" content="All nine tabs of the STING Tools panel in Revit explained in plain language — what each one is for and when you would use it.">
+<meta name="description" content="All ten tabs of the STING Tools panel in Revit explained in plain language — what each one is for and when you would use it.">
 <meta name="theme-color" content="#E8912D">
 <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
 <link rel="canonical" href="https://planscape.build/guides/the-panel.html">
@@ -28,9 +28,9 @@
 <article class="doc">
   <div class="breadcrumb"><a href="/guides/">Guides</a> &rsaquo; The panel, tab by tab</div>
   <h1>The panel, tab by tab</h1>
-  <div class="meta">📖 9-minute read · Beginner</div>
+  <div class="meta">📖 10-minute read · Beginner</div>
 
-  <p>Nearly everything STING Tools does happens in one panel docked to the right-hand side of Revit. This guide walks through all nine tabs so you know what each is for and when you would reach for it.</p>
+  <p>Nearly everything STING Tools does happens in one panel docked to the right-hand side of Revit. This guide walks through all ten tabs so you know what each is for and when you would reach for it.</p>
 
   <h2>Why a panel and not just a ribbon</h2>
   <p>Revit's ribbon is designed for commands you run once — draw a wall, place a door. It hides everything not on the current tab, and it resets as you move around the model.</p>
@@ -41,11 +41,10 @@
     <strong>If the panel isn't showing:</strong> in Revit go to <strong>View &rsaquo; User Interface</strong> and tick the STING Tools panel, or use the Toggle Panel button on the STING Tools ribbon tab. See <a href="/guides/revit-plugin-setup.html">Installing STING Tools</a> if it isn't there at all.
   </div>
 
-  <h2>The nine tabs at a glance</h2>
+  <h2>The ten tabs at a glance</h2>
   <table class="tbl">
     <thead><tr><th>Tab</th><th>Use it when you want to…</th></tr></thead>
     <tbody>
-      <tr><td><strong>HVAC</strong></td><td>Open the mechanical workspace — equipment, systems, duct sizing, heat loads</td></tr>
       <tr><td><strong>SELECT</strong></td><td>Pick the elements you want to work on, by discipline or by pattern</td></tr>
       <tr><td><strong>TAGGING</strong></td><td>Tag elements, tidy existing tags, colour them by discipline</td></tr>
       <tr><td><strong>DOCS</strong></td><td>Lay out sheets — align, distribute and renumber views</td></tr>
@@ -54,6 +53,8 @@
       <tr><td><strong>MODEL</strong></td><td>Create geometry and run model-wide audits</td></tr>
       <tr><td><strong>BIM</strong></td><td>Coordinate: clashes, warnings, federated model checks</td></tr>
       <tr><td><strong>TAG STUDIO</strong></td><td>Control exactly how tags look and where they sit</td></tr>
+      <tr><td><strong>INTEROP</strong></td><td>Move data in and out — Excel round-trips, IFC, batch exports, platform publishing</td></tr>
+      <tr><td><strong>HEALTHCARE</strong></td><td>Check a hospital or clinic model against healthcare rules</td></tr>
     </tbody>
   </table>
 
@@ -114,7 +115,7 @@
   <p>The Warnings Dashboard addresses a different problem: Revit's own warning list, which on an inherited model can run to thousands of entries that nobody has read in months. It groups warnings by type and severity so you can see which few actually matter, and <strong>Auto-Fix</strong> resolves the mechanical ones.</p>
 
   <h2>TAG STUDIO — how tags look</h2>
-  <p>The TAGGING tab decides <em>what</em> gets tagged. Tag Studio decides <em>how those tags appear</em>. It has its own sub-tabs:</p>
+  <p>The TAGGING tab decides <em>what</em> gets tagged. Tag Studio decides <em>how those tags appear</em> — and it has grown to carry the deeper design tools as well. It has thirteen sub-tabs. The first five are the ones you will touch most:</p>
   <ul>
     <li><strong>Placement</strong> — where a tag sits relative to its element, and how hard to work at avoiding overlaps</li>
     <li><strong>Leader &amp; Elbow</strong> — the line joining tag to element: straight or elbowed, and which arrowhead</li>
@@ -122,16 +123,47 @@
     <li><strong>Tokens &amp; Depth</strong> — which parts of the tag are shown. A busy plan might show only discipline and number; a coordination view might show everything</li>
     <li><strong>Categories</strong> — which element categories get tagged at all, and which are excluded</li>
   </ul>
+  <p>The remaining eight go beyond appearance:</p>
+  <ul>
+    <li><strong>Tools</strong> — housekeeping: repair and validation passes, exports, and tag schedules</li>
+    <li><strong>Scale</strong> — how tags adapt when the view scale changes, so a 1:200 plan is not drowned in text sized for 1:50</li>
+    <li><strong>Automation</strong> — rule-driven helpers that create and check elements by discipline: stairs and railings, reinforcement, wind and seismic loads, equipment sizing</li>
+    <li><strong>Standards</strong> — calculators and reference notes for the standards those checks are built on</li>
+    <li><strong>MEP</strong> — auto-sizing for ducts, pipes and conduit, with the reference standards alongside</li>
+    <li><strong>Fabrication</strong> — settings for producing shop drawings: what to include, which rules to apply, and how the output is titled</li>
+    <li><strong>Routing</strong> — quick routing actions: drop connections from fixtures to the nearest run, check how full the containment is, place hangers</li>
+    <li><strong>Fixtures</strong> — quick placement: fixtures by rule, toilet-room layouts, lighting grids</li>
+  </ul>
   <p>These settings are why the same model can produce a clean tender drawing and a dense coordination drawing without re-tagging anything.</p>
 
-  <h2>HVAC and the other discipline panels</h2>
-  <p>Mechanical, electrical and plumbing work needs more room than a tab can give, so each has its own panel with its own set of tabs. The HVAC tab on the main panel opens the mechanical one.</p>
+  <h2>INTEROP — getting data in and out</h2>
+  <p>A model is only useful if its information can leave it in a form other people can use. INTEROP collects everything that moves data between Revit and the rest of the world.</p>
+  <p>The Excel tools are where most people start. <strong>Export</strong> writes element data to a spreadsheet anyone can edit; <strong>Import</strong> brings the edited values back with checks; and <strong>Round Trip</strong> does both in one pass — export, hand the file to whoever needs to fill it in, and read it back when it returns. The same round-trip works for whole schedules.</p>
+  <p>The batch exports produce the deliverable files: <strong>PDF</strong> for sheet sets, <strong>DWG</strong> for consultants who work in CAD, <strong>NWC</strong> for Navisworks review models, and <strong>IFC</strong> for anyone on other software. IFC works in both directions — a model from ArchiCAD or any other authoring tool can be imported with its properties intact.</p>
+  <p>The publishing tools send packages to whichever platform the project runs on — ACC/BIM 360, Procore, Trimble Connect, Aconex, ProjectWise or SharePoint — and <strong>BCF</strong> carries issues in and out in the format the coordination tools share. Also here: COBie handover data, sticky notes you can pin to elements and track to closure, team worksharing and backups, and a model explorer for hunting down unused families and stray CAD imports.</p>
+
+  <h2>HEALTHCARE — hospital and clinic checks</h2>
+  <p>Healthcare buildings carry rules ordinary projects never meet: isolation rooms must hold a pressure difference to the corridor, medical gas must reach every bed, imaging rooms need lead in the walls, and mental-health areas must avoid fittings a patient could use for self-harm. This tab checks the model against those rules.</p>
+  <p>Start by picking the facility type at the top — acute, community, dental, imaging-only or mental health — because that decides which checks apply. A dental practice is not audited for operating theatres.</p>
+  <p>It has six sub-tabs:</p>
   <ul>
-    <li><strong>HVAC</strong> — equipment, systems, calculations, duct sizing, heat loads, fabrication and reports</li>
-    <li><strong>Electrical</strong> — distribution boards, circuits, calculations, cable sizing, single-line diagrams and lighting</li>
-    <li><strong>Plumbing</strong> — supply and drainage sizing, routing, storm water, audits and documentation</li>
+    <li><strong>Validators</strong> — the check list. Tick what you want — room pressure, medical gas, water safety, radiation shielding, anti-ligature, department adjacency and more — and run them together for one pass/fail picture.</li>
+    <li><strong>MGPS</strong> — medical gas: audits the pipework gas by gas (oxygen, medical air, vacuum and the rest) and walks the formal verification steps.</li>
+    <li><strong>Radiation</strong> — works out how much lead a wall needs for an X-ray, CT or radiotherapy room, compares it with what the wall provides, and audits MRI zoning.</li>
+    <li><strong>Rooms / RDS</strong> — room data sheets: issue the per-room specification documents and check their completeness.</li>
+    <li><strong>Specialist</strong> — audits for the unusual departments: hybrid operating rooms, pharmacy clean rooms, behavioural health, mortuary, maternity, dialysis.</li>
+    <li><strong>Workflows</strong> — preset sequences that chain the checks together for commissioning and recurring audits.</li>
   </ul>
-  <p>Each of these gets its own guide, covering the engineering behind the numbers as well as the buttons.</p>
+  <p>On a non-healthcare project you will never open this tab, and that is fine.</p>
+
+  <h2>The discipline panels — HVAC, Electrical, Plumbing</h2>
+  <p>Mechanical, electrical and plumbing design each need more room than one tab can give, so each has its own separate panel with its own set of tabs. They are not tabs on the main panel — they open from the ribbon: on the <strong>STING Tools</strong> ribbon tab, the <strong>STING Panels</strong> group has a button for each.</p>
+  <ul>
+    <li><strong><a href="/guides/hvac.html">HVAC</a></strong> — equipment, systems, calculations, duct sizing, heat loads, fabrication and reports</li>
+    <li><strong><a href="/guides/electrical.html">Electrical</a></strong> — distribution boards, circuits, calculations, cable sizing, single-line diagrams and lighting</li>
+    <li><strong><a href="/guides/plumbing.html">Plumbing</a></strong> — supply and drainage sizing, routing, storm water, audits and documentation</li>
+  </ul>
+  <p>Each has its own guide, covering the engineering behind the numbers as well as the buttons.</p>
 
   <h2>A sensible first hour</h2>
   <ol>


### PR DESCRIPTION
The live guide at planscape.build/guides/the-panel was factually wrong about the plugin's own UI: it said nine tabs, listed HVAC as a main-panel tab, omitted INTEROP and HEALTHCARE, and listed only 5 of TAG STUDIO's 13 sub-tabs.

Verified against `StingTools/UI/StingDockPanel.xaml` on origin/main (line-number analysis of the `tabMain` TabControl):

- **Overview table** — now the real 10 tabs: SELECT, TAGGING, DOCS, SETUP, CREATE TAGS, MODEL, BIM, TAG STUDIO, INTEROP, HEALTHCARE. HVAC row removed (the XAML explicitly fences HVAC out of the main panel).
- **TAG STUDIO** — full 13 sub-tab list: Placement, Leader & Elbow, Style & Color, Tokens & Depth, Categories, Tools, Scale, Automation, Standards, MEP, Fabrication, Routing, Fixtures.
- **New INTEROP section** — written from the actual tab content (Excel round-trips, IFC both ways, PDF/DWG/NWC batch exports, platform publishing, BCF, COBie, sticky notes, worksharing, model explorer).
- **New HEALTHCARE section** — written from the actual tab content: facility-type gate + the 6 real sub-tabs (Validators, MGPS, Radiation, Rooms / RDS, Specialist, Workflows).
- **Discipline panels reframed** — HVAC/Electrical/Plumbing are separate dockable panels opened from the STING Panels ribbon group, now linked to their own guides.

Voice kept consistent with the sibling guides (plumbing.html): plain language, no developer jargon.

Deploy to Cloudflare Pages follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)