### PR TITLE
feat(site): ArchiCAD/IFC interop via StingBridge on the features page

### DIFF
--- a/marketing-site/features.html
+++ b/marketing-site/features.html
@@ -248,9 +248,14 @@
   <p class="lead">Standards-based, well-documented APIs and import/export paths into the rest of your AEC stack.</p>
   <div class="grid-3">
     <div class="card">
+      <div class="icon">🌉</div>
+      <h3>ArchiCAD &amp; IFC — StingBridge <span style="font-size:11px;font-weight:700;color:var(--accent);vertical-align:2px">BETA</span></h3>
+      <p>Not a Revit-only shop? StingBridge connects ArchiCAD models to Planscape over ArchiCAD&rsquo;s own live connection, and watches a drop folder so any tool that exports IFC — ArchiCAD, Tekla, Vectorworks — feeds the same coordination workflows. <a href="/guides/stingbridge-setup.html">Setup guide</a> · <a href="/downloads">Download</a></p>
+    </div>
+    <div class="card">
       <div class="icon">🌐</div>
       <h3>IFC 4 import/export</h3>
-      <p>Substrate-driven IFC layer with 52 enums, 5 Psets, 5 IDS files, bSDD publication plan. Host-agnostic — Revit + Bonsai + (planned) ArchiCAD.</p>
+      <p>Substrate-driven IFC layer with 52 enums, 5 Psets, 5 IDS files, bSDD publication plan. Host-agnostic — Revit, Bonsai, and ArchiCAD via StingBridge (beta).</p>
     </div>
     <div class="card">
       <div class="icon">📦</div>


### PR DESCRIPTION
StingBridge 0.1.0-beta.1 is shipped and downloadable, which made the features page stale in one place and silent in another:

- The IFC 4 card said ArchiCAD was **"(planned)"** — it isn't any more. Now: "ArchiCAD via StingBridge (beta)".
- **New card** leading the Platform & Integration grid: ArchiCAD live connection + the IFC drop-folder path (covers any IFC-exporting tool — ArchiCAD, Tekla, Vectorworks). Labelled **BETA**, linking to the setup guide and the gated download.

Wording stays within what the download catalogue itself claims — the drop-folder workflow is the verified one; live ArchiCAD sync is described as maturing. No new capability promised.