### PR TITLE
fix(deploy): PLANSCAPE_USE_ENSURE_CREATED on planscape-worker (R1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 209 — go-live blocker: worker crash-loop on schema)
+
+Fixes a blocker that would have taken `planscape-worker` down on the very first
+Render deploy, plus the docs that asserted it was already handled.
+
+- **`PLANSCAPE_USE_ENSURE_CREATED=true` added to `planscape-worker`.** The
+  schema block in `Program.cs` (~line 1341) is **not** gated by `isWorker` —
+  both roles execute it. The worker runs with
+  `ASPNETCORE_ENVIRONMENT=Production`, so `IsDevelopment()` is false, and
+  without the flag it took the `db.Database.Migrate()` branch. That collides
+  with the API's EnsureCreated schema on the non-idempotent
+  `20260626203153_SustainabilitySnapshots` `CreateTable` and crash-loops.
+  Verified by reading the branch, not by deploying.
+- **`PLANSCAPE_HANDOFF_SECRET` declared (`sync: false`) on the worker**, so the
+  Blueprint prompts for it on both services. ROADMAP DEP-2 already said both;
+  the blueprint disagreed.
+- **Docs corrected to match the blueprint exactly.**
+  `docs/DEPLOY_RUNBOOK.md` §1 and `docs/SERVER_GO_LIVE.md` both claimed the flag
+  was already on both services / that "the container does not auto-migrate" —
+  true for the API, false for the worker as merged. Both now name the two
+  services explicitly and carry a callout explaining *why* the flag cannot be
+  API-only.
+
+**Gate:** `render.yaml` parses under PyYAML; a scripted check confirms both
+`planscape-api` and `planscape-worker` carry both env keys; the two docs match
+the blueprint. **Not verified:** no actual Render deploy — the crash-loop is
+established by reading the un-gated branch in `Program.cs`, not observed.
+
 #### Completed (Phase 208 — StingBridge 0.1.0-beta.2 released)
 
 Cuts and ships the release carrying Phases 201–205: personal access tokens, SEQ

--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -44,9 +44,9 @@ And choose the owner password (for `davis@planscape.build`).
 > `db.Database.Migrate()` and told you to run a pending-model-changes check.
 > That is **not** what the committed `render.yaml` does. Skip the old steps.
 
-`render.yaml` sets **`PLANSCAPE_USE_ENSURE_CREATED=true`** on `planscape-api`
-and `planscape-worker`. `Program.cs` (~line 1327) therefore takes the
-**EnsureCreated** branch, not `Migrate()`:
+`render.yaml` sets **`PLANSCAPE_USE_ENSURE_CREATED=true`** on **both**
+`planscape-api` and `planscape-worker`. `Program.cs` (~line 1341) therefore
+takes the **EnsureCreated** branch, not `Migrate()`:
 
 1. It probes `information_schema` for the `Tenants` table.
 2. If absent (fresh DB), `creator.CreateTables()` materialises the whole schema
@@ -72,6 +72,12 @@ unnecessary.)
 If you ever **remove** `PLANSCAPE_USE_ENSURE_CREATED`, the `Migrate()` branch
 takes over and a complete, regenerated migration set becomes a hard
 prerequisite — regenerate it before flipping that switch.
+
+> **The flag must stay on both services.** The schema block in `Program.cs` is
+> not gated by `isWorker`; both roles execute it. Setting the flag on
+> `planscape-api` only leaves the worker on the `Migrate()` branch, where it
+> collides with the API's EnsureCreated schema on the non-idempotent
+> `20260626203153_SustainabilitySnapshots` `CreateTable` and crash-loops.
 
 ---
 

--- a/docs/SERVER_GO_LIVE.md
+++ b/docs/SERVER_GO_LIVE.md
@@ -60,11 +60,14 @@ Rotations must be simultaneous or cloud→server login breaks.
 
 ## Day 1 after deploy — you do NOT run EF migrations
 
-**The container does not auto-migrate, by design.**
+**Neither container auto-migrates, by design.**
 
-`render.yaml` sets `PLANSCAPE_USE_ENSURE_CREATED=true`, which makes startup
-(`Program.cs` ~line 1327) take the **EnsureCreated** branch instead of
-`db.Database.Migrate()`:
+`render.yaml` sets `PLANSCAPE_USE_ENSURE_CREATED=true` on **both**
+`planscape-api` and `planscape-worker`, which makes startup (`Program.cs`
+~line 1341) take the **EnsureCreated** branch instead of
+`db.Database.Migrate()`. The flag is required on both because the schema block
+is not gated by `isWorker` — a worker without it takes the `Migrate()` branch
+and crash-loops against the API's schema:
 
 1. Probe `information_schema` for the `Tenants` table.
 2. If absent (fresh DB), `creator.CreateTables()` materialises the entire schema

--- a/render.yaml
+++ b/render.yaml
@@ -95,6 +95,18 @@ services:
         value: http://+:8080          # Kestrel still binds; the worker just isn't HTTP-routed
       - key: PLANSCAPE_ROLE
         value: worker
+      # REQUIRED on the worker too — the schema block in Program.cs (~line 1341)
+      # is NOT gated by `isWorker`, so both roles run it. Without this flag the
+      # worker (ASPNETCORE_ENVIRONMENT=Production ⇒ IsDevelopment() false) takes
+      # the db.Database.Migrate() branch, collides with the API's EnsureCreated
+      # schema on the non-idempotent 20260626203153_SustainabilitySnapshots
+      # CreateTable, and crash-loops. Keep in lockstep with planscape-api.
+      - key: PLANSCAPE_USE_ENSURE_CREATED
+        value: "true"
+      # Same shared secret as the API — the worker resolves handoff-provisioned
+      # identities in background jobs. See docs/PLANSCAPE_IDENTITY_HANDOFF.md.
+      - key: PLANSCAPE_HANDOFF_SECRET
+        sync: false
       - key: ConnectionStrings__Default
         fromDatabase:
           name: planscape-db


### PR DESCRIPTION
## What

Go-live blocker from the #419-#428 review round. `planscape-worker` would have
crash-looped on the first Render deploy.

## Findings implemented

1. **`PLANSCAPE_USE_ENSURE_CREATED=true` added to `planscape-worker`.**
   Verified the finding rather than taking it on trust: the schema block at
   `Planscape.Server/src/Planscape.API/Program.cs:1341` is inside a bare
   `{ ... }` scope with no `isWorker` guard — `isWorker` is only used at
   `:552-553` (Hangfire queues) and `:650`. The worker sets
   `ASPNETCORE_ENVIRONMENT=Production`, so `app.Environment.IsDevelopment()` is
   false and, absent the env var, `useEnsureCreated` is false → `db.Database.Migrate()`.
2. **`PLANSCAPE_HANDOFF_SECRET` declared `sync: false` on the worker** so the
   Blueprint prompts for it on both services (ROADMAP DEP-2 already said both).
3. **Docs corrected.** `docs/DEPLOY_RUNBOOK.md` §1 and `docs/SERVER_GO_LIVE.md`
   both asserted the flag was already on both services. That was true of the API
   and false of the worker — the docs described the intent, the blueprint shipped
   something else. Both now name the services explicitly and explain why it can't
   be API-only. Also corrected the stale `Program.cs ~line 1327` line refs to 1341.

## Gate

```
YAML PARSE: OK
planscape-api    | ENSURE_CREATED: True | HANDOFF_SECRET: True
planscape-worker | ENSURE_CREATED: True | HANDOFF_SECRET: True
```

## Not verified

**No actual Render deploy was performed** (out of scope — owner action). The
crash-loop is established by reading the un-gated branch in `Program.cs`, not by
observing it. The `20260626203153_SustainabilitySnapshots` non-idempotent
`CreateTable` collision is likewise reasoned from the migration source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)