### PR TITLE
test(server): pin Jwt:Key so the suite passes on a clean machine (R2)

### DIFF
--- a/Planscape.Server/tests/Planscape.Tests/PlanscapeWebApplicationFactory.cs
+++ b/Planscape.Server/tests/Planscape.Tests/PlanscapeWebApplicationFactory.cs
@@ -29,6 +29,27 @@ public class PlanscapeWebApplicationFactory : WebApplicationFactory<Program>
         // same loopback IP, so the production "auth" policy (5 attempts / 5 min per
         // IP) is exhausted almost immediately and unrelated tests fail with 429
         // instead of their real assertion. Rate limiting stays ON everywhere else.
+        // Program.cs fail-fasts when Jwt:Key is absent (Program.cs:104-115), so
+        // EVERY host-building test died unless the developer happened to have
+        // Jwt__Key exported in their shell — which is exactly why an earlier
+        // "the suite is fixed" claim did not reproduce on a clean machine
+        // (265 passed/155 failed clean, vs 347/73 with the var set).
+        //
+        // This MUST go through UseSetting, not ConfigureAppConfiguration.
+        // Program.cs reads builder.Configuration["Jwt:Key"] while the host is
+        // still being *built*; ConfigureAppConfiguration callbacks are applied
+        // after that read, so injecting there leaves the fail-fast untouched
+        // (verified — the run was byte-identical at 265/155).  UseSetting feeds
+        // DeferredHostBuilder's settings, which land as an in-memory source
+        // before any user code reads configuration.
+        //
+        // TEST-ONLY VALUE. Never leaves the in-process test host: it signs
+        // tokens for an in-memory database discarded when the factory is
+        // disposed. It must still clear Program.cs's guards — 32+ chars, not in
+        // the banned list, 4+ distinct characters — hence the random-looking
+        // literal rather than something readable like "test-key-padding-...".
+        builder.UseSetting("Jwt:Key", "qZ7v3Kx9TmR2wLp8Nc5FhJd6Bs4YgVt1Ae0UnXiOrEz");
+
         builder.ConfigureAppConfiguration(cfg =>
             cfg.AddInMemoryCollection(new Dictionary<string, string?>
             {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 210 — server test suite is self-contained on a clean machine)
+
+The suite could only reach its advertised pass count on a developer machine that
+happened to have `Jwt__Key` exported. On a clean checkout it collapsed.
+
+- **`Jwt:Key` pinned in `PlanscapeWebApplicationFactory`.** `Program.cs:104-115`
+  fail-fasts when the key is absent, so every host-building test threw
+  `InvalidOperationException` before reaching its assertion.
+- **Injected via `UseSetting`, not `AddInMemoryCollection`.** The first attempt
+  used `ConfigureAppConfiguration` and changed **nothing** — the run came back
+  byte-identical at 265/155. `Program.cs` reads `builder.Configuration["Jwt:Key"]`
+  while the host is still being built; `ConfigureAppConfiguration` callbacks are
+  applied after that read. `UseSetting` feeds `DeferredHostBuilder`'s settings,
+  which land before any user code reads configuration. The comment in the factory
+  records this so the next person does not repeat it.
+- **Measured, not assumed.** Baseline on this machine with `env -u Jwt__Key`:
+  **265 passed / 155 failed**. After the fix, same command: **347 passed /
+  73 failed** — the numbers previously reachable only with the variable set.
+
+**Gate:** zero host-construction failures with no `Jwt__Key` in the environment
+(**met** — every remaining failure is a real assertion reached past host
+construction). `AuthControllerTests` is **11/15, not the 15/15 the gate asked
+for**; the 4 stragglers are pre-existing failures in the 73 (register 409
+conflict, refresh 401, health 403, licence assert) that the fix *unmasked*
+rather than caused, and fixing them was explicitly out of scope for this phase.
+
 #### Completed (Phase 209 — go-live blocker: worker crash-loop on schema)
 
 Fixes a blocker that would have taken `planscape-worker` down on the very first


### PR DESCRIPTION
## What

The suite only reached its advertised pass count on a machine with `Jwt__Key`
exported. On a clean checkout it collapsed.

## Measured (not assumed)

| Run (`env -u Jwt__Key dotnet test`) | Passed | Failed |
|---|---|---|
| Baseline, before any change | **265** | **155** |
| After `ConfigureAppConfiguration` attempt | 265 | 155 (**no effect**) |
| After `UseSetting` fix | **347** | **73** |

The baseline reproduces the review's 265/155 exactly.

## The non-obvious part

My first fix — adding `["Jwt:Key"]` to the existing `AddInMemoryCollection` —
**did nothing**. `Program.cs` reads `builder.Configuration["Jwt:Key"]` while the
host is still being built; `ConfigureAppConfiguration` callbacks are applied
after that read. `UseSetting` feeds `DeferredHostBuilder`'s settings, which land
before any user code reads config. I left a comment at the call site so the next
person doesn't repeat the dead end.

The literal clears Program.cs's guards (32+ chars, not banned, 4+ distinct
chars) and is commented test-only.

## Gate — partially met, stated plainly

- **Zero host-construction failures with no `Jwt__Key` in the environment — MET.**
  Every remaining failure is a real assertion reached past host construction.
- **`AuthControllerTests` 15/15 — NOT met. It is 11/15.** The 4 stragglers are
  pre-existing failures the fix *unmasked*, not caused: register 409 conflict,
  refresh 401, health 403, licence assert false. They are part of the 73 this
  phase was told not to fix, so I left them. Flagging rather than silently
  reporting the gate green.

## The 73 pre-existing failures (66 unique names) — for a later burn-down

By class: CoreApiTests 30 · BimManagerRoleConfigTests 7 ·
TenantBimManagerRoleOverrideTests 5 · ProjectsControllerTests 4 ·
AuthControllerTests 4 · SecurityCriticalPathTests 3 ·
BimManagerOrAdminHandlerTests 3 · RevocationFloorHandlerTests 2 · nine others 1 each.

<details><summary>Full list</summary>

- AuthControllerTests.ActivateLicense_ValidKey_ReturnsSuccess
- AuthControllerTests.HealthCheck_ReturnsHealthy
- AuthControllerTests.RefreshToken_ValidToken_ReturnsNewTokens
- AuthControllerTests.Register_NewOrg_Returns201WithToken
- AuthHandlerConcurrentReadsTests.RevocationAndTenantOverride_LaunchInParallel
- BimManagerOrAdminHandlerTests.BimManagerProjectMember_Grants
- BimManagerOrAdminHandlerTests.InactiveProjectMember_Denies
- BimManagerOrAdminHandlerTests.UnrelatedRole_Denies
- BimManagerRoleConfigTests.AppUserIso19650Role_FollowsConfigList
- BimManagerRoleConfigTests.AppUserIso19650Role_GrantsWithoutProjectMember
- BimManagerRoleConfigTests.AppUserNotInTenant_DoesNotGrant
- BimManagerRoleConfigTests.ConfigRoles_AreCaseInsensitive
- BimManagerRoleConfigTests.ConfiguredRoles_NarrowingExcludesOldGrants
- BimManagerRoleConfigTests.ConfiguredRoles_OverrideDefaultK
- BimManagerRoleConfigTests.EmptyOrMalformedConfig_FallsBackToDefaultK
- CoreApiTests.Compliance_History_ReturnsArray
- CoreApiTests.Compliance_PushAndGetLatest
- CoreApiTests.Compliance_Trend_ReturnsDailyData
- CoreApiTests.Documents_CreateAndList
- CoreApiTests.Documents_GetHistory
- CoreApiTests.Documents_TransitionState_WipToShared
- CoreApiTests.Issues_CreateAndList
- CoreApiTests.Issues_SLAReport_ReturnsData
- CoreApiTests.Issues_Update_ChangesStatus
- CoreApiTests.Meetings_AddActionItem_AndGetOpen
- CoreApiTests.Meetings_CreateAndList
- CoreApiTests.Meetings_LogMinutes
- CoreApiTests.Members_AddAndList
- CoreApiTests.Members_GetRoles_ReturnsISO19650Roles
- CoreApiTests.Members_InviteByEmail
- CoreApiTests.Members_MemberRole_CannotAdd
- CoreApiTests.Mim_BulkCreateAssets
- CoreApiTests.Mim_CreateAssetAndList
- CoreApiTests.Mim_CreateMaintenanceTask
- CoreApiTests.Mim_Dashboard_ReturnsMetrics
- CoreApiTests.SeqSync_SyncAndGet
- CoreApiTests.TagSync_SyncElements
- CoreApiTests.TenantIsolation_OtherTenantCannotSyncTags
- CoreApiTests.Transmittals_CreateAndList
- CoreApiTests.Transmittals_MarkSent
- CoreApiTests.Warnings_PushReport
- CoreApiTests.Warnings_SaveBaseline
- CoreApiTests.Warnings_Trend_ReturnsData
- CoreApiTests.Workflows_LogRunAndGetHistory
- CoreApiTests.Workflows_Trend_ReturnsData
- DeliverableStateMachineTests.LoadOrDefault_ExplicitRolesWinOverInference
- PlatformKeywordTests.LoadOrDefault_PlatformAndProject_MergesWithProjectWinning
- ProjectVisibilityTests.ListProjects_AsTenantAdmin_SeesAllTenantProjects
- ProjectsControllerTests.CreateProject_DuplicateCode_Returns409
- ProjectsControllerTests.CreateProject_Valid_ReturnsCreated
- ProjectsControllerTests.GetDashboard_ValidProject_ReturnsDashboardData
- ProjectsControllerTests.GetProjects_Authenticated_ReturnsProjectList
- RevocationFloorHandlerTests.NoRevocationFloor_TokenWithoutIatStillGrants
- RevocationFloorHandlerTests.TokenIssuedAfterRevocation_StillGrants
- RoleExtensionTests.LoadOrDefault_TenantKeywordsCanOverrideCanonical
- RoleInferenceTests.LoadOrDefault_ExplicitRolesStillWinOverFuzzyInference
- SecurityCriticalPathTests.QuotaGuard_ProjectCap_AllowsBelowLimit
- SecurityCriticalPathTests.QuotaGuard_ProjectCap_DeniesAtTrialLimit
- SecurityCriticalPathTests.TenantQueryFilter_EmptyTenantId_ReturnsNoRows
- TagSyncConflictTests.SyncElements_StaleUpdate_KeepsServerData_AndRecordsConflict
- TenantBimManagerRoleOverrideTests.NullOverride_FallsBackToDeployment
- TenantBimManagerRoleOverrideTests.TenantOverride_AppliesToAppUserGrantPath
- TenantBimManagerRoleOverrideTests.TenantOverride_BroadensGrantBeyondDeployment
- TenantBimManagerRoleOverrideTests.TenantOverride_CaseInsensitive
- TenantBimManagerRoleOverrideTests.TenantOverride_NarrowsGrantBelowDeployment
- TenantKeywordL2CacheTests.ResolveAsync_HitsL2OnSecondCall

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)