### PR TITLE
feat(site): interop card on homepage + two more false billing claims fixed

### DIFF
--- a/marketing-site/index.html
+++ b/marketing-site/index.html
@@ -156,9 +156,10 @@
   <p class="lead">Built around the workflow ISO 19650 actually demands — and the connectivity East African sites actually have.</p>
   <div class="grid-3">
     <div class="card"><div class="icon">🧊</div><h3>Revit plugin included</h3><p>Tag, sync, publish models direct from Revit. No separate license, no extra seat cost.</p></div>
+    <div class="card"><div class="icon">🌉</div><h3>Beyond Revit — ArchiCAD &amp; IFC</h3><p>StingBridge (beta) links ArchiCAD live, and an IFC drop folder brings in models from Tekla, Vectorworks — any tool that exports IFC. Open formats throughout: IFC 4, BCF 2.1, COBie.</p></div>
     <div class="card"><div class="icon">📱</div><h3>Offline-first mobile</h3><p>Coordinators work on site without signal. Photos, voice notes, pins queue and replay automatically.</p></div>
     <div class="card"><div class="icon">📋</div><h3>ISO 19650 templates</h3><p>Transmittals, RFIs, NCRs, BEPs, MIDPs — pre-built and ready to issue from day one.</p></div>
-    <div class="card"><div class="icon">🌍</div><h3>Local invoicing</h3><p>UGX, KES, TZS, RWF, NGN, ZAR via Flutterwave. USD/EUR/GBP via Stripe. You pick.</p></div>
+    <div class="card"><div class="icon">🌍</div><h3>Local invoicing</h3><p>UGX, KES, TZS, RWF by mobile money via Pesapal. USD, EUR, GBP by card via Stripe. NGN &amp; ZAR coming soon.</p></div>
     <div class="card"><div class="icon">🔐</div><h3>Audit-grade trail</h3><p>Tamper-evident hash chain over every write. Court-admissible by construction.</p></div>
     <div class="card"><div class="icon">⚡</div><h3>Fast where it matters</h3><p>30k-element model save in &lt;1s. 200MB federation loads on a 3G phone.</p></div>
   </div>
@@ -249,7 +250,7 @@
     </details>
     <details class="faq-item">
       <summary class="faq-q">How does billing in local currency work?</summary>
-      <div class="faq-a">At signup you pick your currency. East African currencies (UGX, KES, TZS, RWF) and West African (NGN, ZAR) are processed via Flutterwave — mobile money, bank transfer, and card all supported. USD, EUR, and GBP go through Stripe. Invoices are issued in your chosen currency so you never pay a foreign-exchange spread on a software subscription.</div>
+      <div class="faq-a">Your billing currency is set by the country you choose at signup. Uganda, Kenya, Tanzania and Rwanda bill in local currency (UGX, KES, TZS, RWF) by mobile money or card via Pesapal; everywhere else bills in USD, EUR or GBP by card via Stripe. NGN and ZAR are coming soon — Nigerian and South African firms bill in USD for now. Invoices are issued in your billing currency, so you are not paying a foreign-exchange spread on a software subscription.</div>
     </details>
     <details class="faq-item">
       <summary class="faq-q">Can I migrate from Autodesk Construction Cloud?</summary>


### PR DESCRIPTION
Follow-up to #431. Homepage gains the Beyond Revit — ArchiCAD & IFC card (StingBridge beta, IFC drop folder, IFC 4 / BCF 2.1 / COBie). Also fixes two leftover pre-B3b billing claims found in passing: the feature card and FAQ still said NGN/ZAR via Flutterwave and 'you pick your currency' — billing is Pesapal, NGN/ZAR are deferred, and currency derives from the signup country. Zero Flutterwave mentions remain. Note: already deployed to production ahead of this merge due to a GitHub DNS blip mid-chain; content is identical to this branch.