### PR TITLE
fix(bridge): archive the GLB with its input; stop stranding processing/ (R5)

### DIFF
--- a/StingBridge/tests/test_hot_folder.py
+++ b/StingBridge/tests/test_hot_folder.py
@@ -191,17 +191,45 @@ def test_orphans_left_by_a_crash_are_returned_to_the_root():
         assert not list((root / "processing").iterdir())
 
 
-def test_recovery_ignores_our_own_partial_output():
+def test_recovery_does_not_re_drop_our_own_partial_output():
     with _Root() as root:
         (root / "processing" / "model_sting.ifc").write_text("out", encoding="utf-8")
         assert hf.recover_orphans(root) == 0
-        assert (root / "processing" / "model_sting.ifc").exists()
+        # never fed back through the watcher…
+        assert not (root / "model_sting.ifc").exists()
+        # …and not abandoned in processing/ either
+        assert not (root / "processing" / "model_sting.ifc").exists()
 
 
-def test_recovery_ignores_non_ifc_files():
+def test_recovery_does_not_re_drop_non_ifc_files():
+    """Non-input files are not recovered to the root — they'd be re-ingested."""
     with _Root() as root:
         (root / "processing" / "notes.txt").write_text("x", encoding="utf-8")
         assert hf.recover_orphans(root) == 0
+        assert not (root / "notes.txt").exists()
+
+
+def test_recovery_clears_stranded_artefacts_out_of_processing():
+    """…but it must not leave them in processing/ forever either.
+
+    This previously asserted only `recover_orphans(...) == 0` and stopped there,
+    which is exactly how a stranded .glb went unnoticed: `processing/` stayed
+    non-empty after a completed run and nothing ever swept it. Recovery is the
+    one place that sees the folder at rest, so it is the place to clear it.
+    """
+    with _Root() as root:
+        proc = root / "processing"
+        (proc / "notes.txt").write_text("x", encoding="utf-8")
+        (proc / "model.glb").write_bytes(b"glTF-ish")
+        (proc / "model_sting.ifc").write_text("out", encoding="utf-8")
+
+        assert hf.recover_orphans(root) == 0        # none were INPUTS
+        assert not list(proc.iterdir()), "processing/ must be left empty"
+
+        moved = {p.name for p in (root / "failed").iterdir()}
+        assert moved == {"notes.txt", "model.glb", "model_sting.ifc"}
+        # and none of them were re-dropped for another ingest pass
+        assert [p.name for p in root.iterdir() if p.is_file()] == []
 
 
 def test_recovery_on_an_empty_folder_is_a_no_op():
@@ -277,3 +305,84 @@ if __name__ == "__main__":
                 print(f"  FAIL  {name}: {e}")
     print(f"\n{passed} passed, {failed} failed")
     sys.exit(1 if failed else 0)
+
+
+# ── GLB companions (R5) ──────────────────────────────────────────────────────
+#
+# The GLB is written by IFCDropHandler._convert_to_glb next to the file being
+# converted (ifc_watcher.py:257). It was absent from _companions(), so archiving
+# the input left it behind in processing/ — invisible, because every existing
+# test wrote its own fake companions and none of them wrote a .glb.
+
+def test_complete_takes_the_glb_along():
+    with _Root() as root:
+        claimed = hf.claim(_drop(root), root)
+        claimed.with_suffix(".glb").write_bytes(b"glTF-ish")
+
+        hf.complete(claimed, root, when=datetime(2026, 7, 20))
+
+        assert not list((root / "processing").iterdir()), \
+            "the .glb was stranded in processing/"
+        assert {p.name for p in (root / "done").iterdir()} == \
+            {"20260720_model.ifc", "20260720_model.glb"}
+
+
+def test_complete_takes_the_sting_output_glb_along():
+    """The converter may run on the token-stamped output rather than the input."""
+    with _Root() as root:
+        claimed = hf.claim(_drop(root), root)
+        (claimed.parent / "model_sting.ifc").write_text("out", encoding="utf-8")
+        (claimed.parent / "model_sting.glb").write_bytes(b"glTF-ish")
+
+        hf.complete(claimed, root, when=datetime(2026, 7, 20))
+
+        assert not list((root / "processing").iterdir())
+        assert {p.name for p in (root / "done").iterdir()} == {
+            "20260720_model.ifc", "20260720_model_sting.ifc",
+            "20260720_model_sting.glb",
+        }
+
+
+def test_redropping_the_same_filename_with_a_glb_stays_clean():
+    """Repeat drops are the common case — fix model, re-export, same name."""
+    with _Root() as root:
+        for _ in range(2):
+            claimed = hf.claim(_drop(root), root)
+            claimed.with_suffix(".glb").write_bytes(b"glTF-ish")
+            hf.complete(claimed, root, when=datetime(2026, 7, 20))
+
+            assert not list((root / "processing").iterdir())
+            assert [p.name for p in root.iterdir() if p.is_file()] == []
+
+        # Four archived files, none overwritten: the collision suffix applies to
+        # the .glb exactly as it does to the .ifc.
+        names = sorted(p.name for p in (root / "done").iterdir())
+        assert len(names) == 4, names
+        assert len(set(names)) == 4, f"an archived file was overwritten: {names}"
+
+
+def test_failed_run_takes_the_glb_to_failed_too():
+    with _Root() as root:
+        claimed = hf.claim(_drop(root), root)
+        claimed.with_suffix(".glb").write_bytes(b"glTF-ish")
+
+        hf.fail(claimed, root, "converter blew up")
+
+        assert not list((root / "processing").iterdir())
+        assert "model.glb" in {p.name for p in (root / "failed").iterdir()}
+
+
+# ── _move fails fast on a vanished source (R5) ───────────────────────────────
+
+def test_move_of_a_vanished_source_fails_fast():
+    """A missing source is final — retrying for the full 30 s helps nobody."""
+    import time as _time
+    with _Root() as root:
+        started = _time.monotonic()
+        try:
+            hf._move(root / "gone.ifc", root / "processing" / "gone.ifc")
+            raise AssertionError("expected an OSError")
+        except OSError:
+            pass
+        assert _time.monotonic() - started < 2.0, \
+            "burned the retry budget on a source that will never reappear"

--- a/StingBridge/watch/hot_folder.py
+++ b/StingBridge/watch/hot_folder.py
@@ -31,9 +31,14 @@ DONE = "done"
 FAILED = "failed"
 SUBFOLDERS = (PROCESSING, DONE, FAILED)
 
-# Windows holds a share lock while the producing app finishes writing. The C#
-# watcher waits up to 30 s for an exclusive open; matching that order of
-# magnitude here keeps a large IFC export from being failed for being slow.
+# Windows holds a share lock while the producing app finishes writing, so a
+# large IFC export must not be failed for being slow.
+#
+# NB: this is deliberately LONGER than the C# watcher, which waits 5 s
+# (StingBridge/src/IFC/IfcDropWatcher.cs:63) — an earlier comment here claimed
+# the two matched, which was simply wrong. 30 s is kept because this path also
+# handles files written by slower producers over a network share; the C# side
+# only sees local drops.
 _MOVE_RETRY_S = 30.0
 _MOVE_BACKOFF_S = 0.25
 
@@ -82,6 +87,11 @@ def _move(src: Path, dst: Path, timeout_s: float = _MOVE_RETRY_S) -> Path:
         try:
             os.replace(src, final)
             return final
+        except FileNotFoundError as e:
+            # The source is gone — another worker claimed it, or it was deleted.
+            # Retrying cannot help, and burning the full timeout here delays the
+            # caller by 30 s for a condition that is already final.
+            raise OSError(f"{src.name} disappeared before it could be moved") from e
         except (PermissionError, OSError) as e:
             last = e
             time.sleep(_MOVE_BACKOFF_S)
@@ -109,13 +119,24 @@ def claim(src: Path, root: Path) -> Path | None:
 
 
 def _companions(processing_path: Path) -> list[Path]:
-    """Artefacts produced beside the source: `<stem>_sting.ifc` and sidecars."""
+    """Artefacts produced beside the source: `<stem>_sting.ifc`, the GLB, sidecars.
+
+    Anything the pipeline writes next to the input MUST be listed here. Whatever
+    is missed is left behind in `processing/` when the input is archived, where
+    it then sits invisibly forever. The GLB was missed:
+    `IFCDropHandler._convert_to_glb` writes `ifc_path.with_suffix(".glb")`
+    (ifc_watcher.py:257) into this same folder.
+    """
     stem = processing_path.stem
     parent = processing_path.parent
     candidates = [
         parent / f"{stem}_sting.ifc",
         parent / f"{stem}.sync_result.json",
         processing_path.with_suffix(".sync_result.json"),
+        # GLB for the Planscape viewer — written for BOTH the input and the
+        # token-stamped output, depending on which one was converted.
+        processing_path.with_suffix(".glb"),
+        parent / f"{stem}_sting.glb",
     ]
     seen: set[Path] = set()
     out = []
@@ -187,16 +208,40 @@ def recover_orphans(root: Path) -> int:
         return 0
 
     recovered = 0
+    leftovers: list[Path] = []
+
     for f in sorted(proc.iterdir()):
-        if not f.is_file() or f.suffix.lower() != ".ifc":
+        if not f.is_file():
             continue
-        if f.stem.endswith("_sting"):
-            continue  # our own output, not an unprocessed input
+
+        # Non-.ifc files (and our own _sting.ifc) are pipeline OUTPUT, never
+        # unprocessed input. Re-dropping them at the root would feed them back
+        # through the watcher; the previous code skipped them entirely, which
+        # instead left them in processing/ forever. Neither is right.
+        is_input = f.suffix.lower() == ".ifc" and not f.stem.endswith("_sting")
+        if not is_input:
+            leftovers.append(f)
+            continue
+
         try:
             _move(f, root / f.name, timeout_s=5.0)
             recovered += 1
         except OSError as e:
             log.warning("Could not recover orphan %s: %s", f.name, e)
+
+    # Everything left is stale output from the run that abandoned this folder.
+    # The inputs above were just re-dropped for a fresh pass, which regenerates
+    # them, so keeping the old copies only re-creates the stranding this sweep
+    # exists to end. (recover_orphans is a startup operation — if a worker were
+    # live, moving its input out from under it would already be destructive.)
+    for f in leftovers:
+        try:
+            _move(f, root / FAILED / f.name, timeout_s=5.0)
+        except OSError as e:
+            log.warning("Could not clear stranded artefact %s: %s", f.name, e)
+    if leftovers:
+        log.info("Moved %d stranded artefact(s) out of %s/ into %s/",
+                 len(leftovers), PROCESSING, FAILED)
 
     if recovered:
         log.info("Recovered %d file(s) stranded in %s/ by a previous run",

--- a/StingBridge/watch/ifc_watcher.py
+++ b/StingBridge/watch/ifc_watcher.py
@@ -273,6 +273,24 @@ class IFCDropHandler:
             return None
 
         import subprocess
+
+        # IfcConvert refuses to clobber an existing output and prompts instead,
+        # which under capture_output blocks until the 300 s timeout and reports
+        # as a conversion failure. That happens on any re-drop of the same
+        # filename — the common case for "fix the model and export again".
+        #
+        # The documented remedy is a -y/--yes overwrite flag, but the flag name
+        # has moved between IfcOpenShell releases and no IfcConvert binary is
+        # installed in this environment to confirm it against (`_find_ifc_convert`
+        # returns None here), so passing an unverified flag risks an "unknown
+        # option" failure on the very versions this is meant to help. Removing
+        # the stale file first is version-independent and needs no flag.
+        if glb_path.exists():
+            try:
+                glb_path.unlink()
+            except OSError as e:
+                log.warning("Could not remove stale GLB %s: %s", glb_path.name, e)
+
         self._emit(f"Converting to GLB ({glb_path.name})…")
         try:
             subprocess.run(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 213 — drop-folder: the GLB stops getting stranded)
+
+Five findings against the drop-folder contract, one of which silently broke every
+real user of the viewer path.
+
+- **The GLB is archived with its input.** `_convert_to_glb` writes
+  `ifc_path.with_suffix(".glb")` into `processing/` (ifc_watcher.py:257), but
+  `_companions()` never listed it, so completing a drop archived the `.ifc` and
+  left the `.glb` behind. `processing/` was never empty and the viewer asset was
+  orphaned. Both variants are covered — the GLB beside the input and beside the
+  `_sting.ifc` output.
+  **Why no test caught it:** every existing companion test wrote its own fake
+  companions, and not one of them wrote a `.glb`. The new tests produce a real
+  file at the path the converter actually uses.
+- **`recover_orphans` no longer strands non-`.ifc` files.** It skipped them
+  entirely, which kept them out of the re-ingest loop (correct) but left them in
+  `processing/` forever (not). They now go to `failed/`, where the run that
+  abandoned them belongs.
+- **Re-running the converter over an existing GLB.** IfcConvert refuses to
+  clobber its output and prompts, which under `capture_output` blocks until the
+  300 s timeout and reports as a conversion failure — on any re-drop of the same
+  filename. The stale file is now removed first. A `-y`/`--yes` flag would be the
+  documented fix, but the flag name has moved between IfcOpenShell releases and
+  **no IfcConvert binary exists in this environment to verify against**
+  (`_find_ifc_convert()` returns `None`), so an unverified flag risked failing on
+  exactly the versions it was meant to help. Deleting first is version-independent.
+- **`_move` fails fast when the source has vanished.** `FileNotFoundError` was
+  retried for the full 30 s, delaying the caller for a condition that is already
+  final.
+- **Corrected a false comment.** It claimed the 30 s retry "matches the C#
+  exclusive-open wait"; `IfcDropWatcher.cs:63` waits **5 s**. The 30 s is kept —
+  with the actual reason recorded.
+
+**Gate:** `test_hot_folder` **30 passed**, full StingBridge suite **126 passed**.
+The four GLB tests were confirmed to **fail without the `_companions` fix**, so
+they test the bug rather than the implementation.
+
 #### Completed (Phase 212 — handoff provisioning no longer costs the user their session)
 
 `EnsureStarterProjectAsync` promises "a failure here must never cost the user


### PR DESCRIPTION
## 1. The GLB was stranded (the one that bites real users)

`_convert_to_glb` writes `ifc_path.with_suffix(".glb")` into `processing/`
(`ifc_watcher.py:257`), but `_companions()` never listed it. Completing a drop
archived the `.ifc` and left the `.glb` behind, so `processing/` was never empty
and the viewer asset was orphaned. Both variants now travel: the GLB beside the
input and the one beside the `_sting.ifc` output.

**Why no existing test caught it:** every companion test wrote its *own* fake
companions, and not one wrote a `.glb`. The new tests create a real file at the
path the converter actually uses — and I confirmed all four go **red without the
`_companions` fix**:

```
FAILED test_complete_takes_the_glb_along
FAILED test_complete_takes_the_sting_output_glb_along
FAILED test_redropping_the_same_filename_with_a_glb_stays_clean
FAILED test_failed_run_takes_the_glb_to_failed_too
```

## 2. `recover_orphans` no longer strands non-`.ifc` files

It skipped them entirely — right about not re-dropping output into the ingest
loop, wrong about leaving them in `processing/` forever. They now go to
`failed/`, alongside the run that abandoned them.

I first made this input-aware (leave companions alone while their `.ifc` is still
present) and wrote a test for it, then **removed both**: the premise was wrong.
If recovery re-drops the input for a fresh pass, the stale companions get
regenerated, so keeping them just re-creates the stranding. Recovery is a startup
operation; if a worker were live, moving its input would already be destructive.

## 3. Re-converting over an existing GLB

IfcConvert refuses to clobber its output and prompts instead — under
`capture_output` that blocks to the 300 s timeout and reports as a conversion
failure, on **any re-drop of the same filename** (fix model → re-export → same
name, i.e. the normal case). The stale file is removed first.

A `-y`/`--yes` flag is the documented remedy, but the flag name has moved between
IfcOpenShell releases and **no IfcConvert binary exists here to verify against**
(`_find_ifc_convert()` returns `None` — checked, not assumed). Passing an
unverified flag risks "unknown option" on exactly the versions it should help, so
I took the instruction's stated fallback: delete first, which needs no flag.

## 4 & 5. Nits

- `_move` raises immediately on `FileNotFoundError` instead of retrying a final
  condition for 30 s (test asserts it returns in < 2 s).
- The comment claiming the 30 s retry "matches the C# exclusive-open wait" was
  false — `IfcDropWatcher.cs:63` waits **5 s**. 30 s kept, real reason recorded.

## Gate

| Check | Result |
|---|---|
| `test_hot_folder` | **30 passed** |
| Full StingBridge pytest | **126 passed** |
| GLB tests fail without the fix | **confirmed (4/4 red)** |

## Not verified

The IfcConvert overwrite behaviour itself — no binary available in this
environment. The fix is reasoned from the documented prompt-on-existing-output
behaviour and is a no-op when the output does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)