### PR TITLE
release(bridge): StingBridge 0.1.0-beta.3 + fix SEQ allocation 500 on Postgres (R9)

### DIFF
--- a/Planscape.Server/src/Planscape.Infrastructure/Services/SequenceCounterService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/SequenceCounterService.cs
@@ -59,9 +59,23 @@ public sealed class SequenceCounterService : ISequenceCounterService
                     ""UpdatedAt""    = now()
             RETURNING ""CurrentValue""";
 
-        var newValue = await _db.Database
+        // ToListAsync, NOT FirstAsync. `INSERT … ON CONFLICT … RETURNING` is
+        // non-composable SQL: FirstAsync tries to wrap it in a `SELECT … LIMIT 1`
+        // and Npgsql throws
+        //   "'FromSql' or 'SqlQuery' was called with non-composable SQL and with
+        //    a query composing over it"
+        // …at execution time, so it is a 500 in production and invisible to any
+        // test on the EF InMemory provider. ToListAsync executes the command as
+        // written and materialises whatever RETURNING produced — exactly one row.
+        //
+        // Found by running /seq/reserve against real Postgres; the whole server
+        // unit suite is green on InMemory with this bug present. TransmittalsController
+        // allocates through this same method, so transmittal numbering was
+        // affected too.
+        var rows = await _db.Database
             .SqlQueryRaw<int>(sql, tenantId, projectId, counterKey, seedFloor, count, updatedBy ?? "system")
-            .FirstAsync(ct);
+            .ToListAsync(ct);
+        var newValue = rows.First();
 
         // The returned value is the highest allocated. Caller starts
         // its loop at (newValue - count + 1).

--- a/StingBridge/__init__.py
+++ b/StingBridge/__init__.py
@@ -5,4 +5,4 @@
 reports it under ``stingbridge --version``.
 """
 
-__version__ = "0.1.0b2"
+__version__ = "0.1.0b3"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 217 — StingBridge 0.1.0-beta.3 released)
+
+Ships the two fixes that bit real drop-folder users in beta.2: the SEQ re-mint
+(Phase 211) and the stranded GLB (Phase 213). **Live on planscape.build/downloads**
+alongside beta.2 and beta.1, both of which stay listed.
+
+- **`__version__` → `0.1.0b3`**; both wheels rebuilt on Python 3.13.
+- **Two artifacts, layout diffed against beta.2 pulled out of R2** rather than
+  assumed: `win64` one-file PyInstaller EXE — 55 MB, sha256 `e0d0fa8c…`; `any`
+  wheels zip with the `run.bat`/`run.sh` launchers — 1 MB, sha256 `dfa645b7…`.
+  Both carry `LICENSE.txt` + `QUICKSTART.md`.
+
+**Two real bugs were found by smoke-testing, both invisible to every test suite:**
+
+- **`ISequenceCounterService` 500s on Postgres.** `SqlQueryRaw(...).FirstAsync()`
+  composes a `SELECT … LIMIT 1` over non-composable `INSERT … ON CONFLICT …
+  RETURNING`, which Npgsql rejects at execution time. `/seq/reserve` returned
+  **HTTP 500** and the bridge degraded to 7-segment tags. The whole 423-test
+  server suite is green with this bug present, because EF InMemory never
+  generates the SQL. Phase 211 routed `/seq/reserve` through this method, so the
+  regression is mine; `TransmittalsController` allocates the same way, so
+  transmittal numbering was affected too. Fixed with `ToListAsync` + `First()`.
+- **The PyInstaller EXE was missing `ifcopenshell`'s data files.** The pset
+  *update* path needs `entity_to_type_map_2x3.json`, which only executes on a
+  **re-drop** — so the first run looked perfect and the second failed write-back.
+  Precisely the case beta.3 exists to fix, and the first build of it shipped
+  broken. Rebuilt with `--collect-data ifcopenshell`.
+
+**Smoke-tested from clean installs against a real API build** wired to the docker
+Postgres. EXE: `--version` → `0.1.0b3`, `--help` renders, `process-ifc` → 3
+elements, **3 SEQ minted**, 3 synced, 0 errors. `any` zip: `run.bat` built its
+venv from the bundled wheels on first run and completed the same E2E.
+
+**Re-drop idempotency verified end-to-end** — the regression this release exists
+for. Processing the written-back IFC again: **no SEQ minted, 0 errors, and the
+sequence numbers unchanged (`0019/0020/0021` both runs)**. On beta.2 this
+re-mints every time.
+
+**Verified live:** both R2 objects **re-downloaded and their sha256 confirmed to
+match the catalogue**; unauthenticated `GET /api/downloads/sting-bridge/0.1.0-beta.3?artifact=…`
+returns **401** for both artifacts; `/downloads` returns 200; the setup guide
+resolves 200.
+
+**Not verified:** that the live *page* renders the beta.3 row — `/api/downloads`
+needs a subscriber session, and the gated endpoint 401s before consulting the
+catalogue, so a 401 proves gating, not catalogue presence. What is established is
+that the objects exist with the right hashes and the deploy succeeded with
+beta.3 in `catalog.ts`. One signed-in page load would close it; that is an owner
+action.
+
 #### Completed (Phase 216 — stale cross-references swept)
 
 - **ROADMAP SB-4: "DONE Phase 203" → 204.** Checked against the CHANGELOG rather

--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -130,6 +130,28 @@ export const DOWNLOAD_CATALOG: Tool[] = [
     docsUrl: "/guides/stingbridge-setup.html",
     versions: [
       {
+        version: "0.1.0-beta.3",
+        releasedAt: "2026-07-20",
+        notes:
+          "Fixes re-processing the same IFC: sequence numbers are now kept instead of being handed out again, so re-exporting a corrected model no longer renumbers everything. Viewer files (.glb) are filed into done/ with their IFC instead of being left behind, and re-running a conversion over an existing file no longer hangs.",
+        artifacts: [
+          {
+            label: "win64",
+            platform: "Windows 64-bit",
+            objectKey: "sting-bridge/0.1.0-beta.3/StingBridge_0.1.0-beta.3_win64.zip",
+            sizeMb: 55,
+            sha256: "e0d0fa8c361603445751a9838717d11a7d0c4d57cffb25517cc36249f983bab7",
+          },
+          {
+            label: "any",
+            platform: "Any OS (Python 3.11+)",
+            objectKey: "sting-bridge/0.1.0-beta.3/StingBridge_0.1.0-beta.3_any.zip",
+            sizeMb: 1,
+            sha256: "dfa645b7263bbdbe46ab545c7382e00313ebe98ff8bdabc346d5bed6a8a8d055",
+          },
+        ],
+      },
+      {
         version: "0.1.0-beta.2",
         releasedAt: "2026-07-20",
         notes:


### PR DESCRIPTION
Ships the two fixes that bit real drop-folder users in beta.2: the SEQ re-mint
(Phase 211 / R3) and the stranded GLB (Phase 213 / R5). **Live on
planscape.build/downloads** alongside beta.2 and beta.1, both still listed.

## Two real bugs found by smoke-testing — neither visible to any test suite

### 1. `ISequenceCounterService` 500s on Postgres — a regression from R3

`SqlQueryRaw(...).FirstAsync()` composes a `SELECT … LIMIT 1` over
**non-composable** `INSERT … ON CONFLICT … RETURNING`, which Npgsql rejects at
execution time:

```
System.InvalidOperationException: 'FromSql' or 'SqlQuery' was called with
non-composable SQL and with a query composing over it.
```

`/seq/reserve` returned **HTTP 500** and the bridge silently degraded to
7-segment tags. **The entire 423-test server suite is green with this bug
present**, because EF InMemory never generates the SQL — only a real-Postgres
run surfaces it.

R3 (#435) routed `/seq/reserve` through this method, so **this regression is
mine**. `TransmittalsController` allocates through the same method, so
transmittal numbering was affected too — that part is pre-existing. Fixed with
`ToListAsync()` + `First()`.

### 2. The PyInstaller EXE omitted `ifcopenshell`'s data files

The pset *update* path needs `entity_to_type_map_2x3.json`, and it only executes
on a **re-drop** — so the first run looked perfect and the second failed
write-back. That is precisely the case this release exists to fix, and the first
build of it shipped broken. Caught only because I ran the re-drop check rather
than trusting run 1. Rebuilt with `--collect-data ifcopenshell`.

## Artifacts

Layout **diffed against beta.2 pulled out of R2**, not assumed.

| Artifact | Size | sha256 |
|---|---|---|
| `win64` (one-file EXE) | 55 MB | `e0d0fa8c361603445751a9838717d11a7d0c4d57cffb25517cc36249f983bab7` |
| `any` (wheels + launchers) | 1 MB | `dfa645b7263bbdbe46ab545c7382e00313ebe98ff8bdabc346d5bed6a8a8d055` |

## Smoke tests — clean installs, real API + docker Postgres

- **EXE**: `--version` → `0.1.0b3`, `--help` renders, `process-ifc` → 3 elements,
  **3 SEQ minted**, 3 synced, **0 errors**.
- **`any` zip**: `run.bat` built its venv from the bundled wheels on first run and
  completed the same E2E.

### Re-drop idempotency — the whole point of this release

```
SEQ run1: ['0019', '0020', '0021']
=== RE-DROP ===
IFC processed — elements: 3  synced: 3  errors: 0      ← no "Minted" line
SEQ run2: ['0019', '0020', '0021']
```

No SEQ minted on the second pass, numbers unchanged. On beta.2 this re-mints
every time.

## Gate

| Check | Result |
|---|---|
| R2 objects re-downloaded, sha256 vs catalogue | **match, both** |
| `GET /api/downloads/sting-bridge/0.1.0-beta.3?artifact=…` unauthenticated | **401** (both artifacts) |
| `/downloads` | **200** |
| Setup guide | **200** |
| beta.1 + beta.2 retained in catalogue | **both present** |
| Server suite vs `origin/main` | **0 new failures** |

My first gate attempt used the wrong URL shape (`?version=`) and got 200 — that
was SPA fallback HTML, and beta.2 *and a bogus version* returned it too. The real
route is `/api/downloads/<tool>/<version>`. Worth recording: a 200 that looks
like a gating failure was actually a bad test.

## Not verified

That the live **page renders the beta.3 row**. `/api/downloads` needs a
subscriber session, and the gated endpoint 401s before consulting the catalogue —
so a 401 proves gating, not catalogue presence. Established: the objects exist
with the right hashes and the deploy succeeded with beta.3 in `catalog.ts`. One
signed-in page load closes it; that is an owner action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)