### PR TITLE
build(bridge): commit the PyInstaller spec that makes the EXE reproducible (F1)

### DIFF
--- a/StingBridge/BUILD.md
+++ b/StingBridge/BUILD.md
@@ -1,0 +1,76 @@
+# Building StingBridge release artifacts
+
+Two artifacts ship per release, and the gated downloads area expects both:
+
+| Label   | What it is                                    |
+|---------|-----------------------------------------------|
+| `win64` | one-file PyInstaller EXE                      |
+| `any`   | the two wheels + `run.bat` / `run.sh` launchers |
+
+## 1. The EXE (`win64`)
+
+From the **repo root**, in a clean venv:
+
+```bash
+python -m venv .buildvenv
+.buildvenv/Scripts/pip install -r StingBridge/requirements.txt pyinstaller
+.buildvenv/Scripts/pip install ./stingtools-core/python      # NOT -e, see below
+.buildvenv/Scripts/pyinstaller --clean --noconfirm StingBridge/StingBridge.spec
+# -> dist/stingbridge.exe
+```
+
+The build is defined by [`StingBridge.spec`](StingBridge.spec). Change the build
+by changing that file — never by typing flags at the shell. The 0.1.0-beta.3 EXE
+was built from a hand-typed command, and the flag that mattered
+(`collect_data_files("ifcopenshell")`) survived only in a shell history.
+
+### Two traps, both of which have already bitten
+
+**`collect_data_files("ifcopenshell")` is load-bearing.** ifcopenshell opens JSON
+schema tables by path at runtime; PyInstaller cannot see them. Drop that line and
+the EXE still builds, still passes `--version`, and still processes a fresh IFC —
+then fails write-back on a **re-drop**, because the map is only consulted when a
+`STING_TOKENS` pset already exists. Verified both ways:
+
+```
+without collect_data_files:  run 1 errors: 0   run 2 errors: 1
+                             ("No such file ... entity_to_type_map_2x3.json")
+with collect_data_files:     run 1 errors: 0   run 2 errors: 0
+```
+
+**Install `stingtools-core` non-editable.** `pip install -e` resolves through a
+path hook PyInstaller's analysis does not follow: the build succeeds and the EXE
+dies at startup with `ModuleNotFoundError: No module named 'stingtools_core'`.
+
+## 2. The wheels zip (`any`)
+
+```bash
+python -m build --wheel --outdir dist/wheels StingBridge
+python -m build --wheel --outdir dist/wheels stingtools-core/python
+```
+
+Zip them under a single top-level `StingBridge_<version>/` folder containing
+`wheels/`, `LICENSE.txt`, `QUICKSTART.md`, `run.bat`, `run.sh`. The launchers are
+version-agnostic (`pip install --find-links wheels stingbridge`), so they need no
+edit between releases.
+
+## 3. Before publishing — the smoke test that actually matters
+
+Run **both** passes against a live API. A single fresh-IFC run is not sufficient
+and has already let a broken EXE through:
+
+```bash
+stingbridge.exe process-ifc model.ifc            # expect: N SEQ minted, errors: 0
+stingbridge.exe process-ifc model_sting.ifc      # expect: NO minting, errors: 0,
+                                                 #         SEQ values unchanged
+```
+
+The second pass is the regression test for both the SEQ re-mint (Phase 211) and
+the packaging bug above.
+
+## 4. Publishing
+
+See `marketing-site/tools/release-download.mjs`. It computes sha256 and size from
+the files themselves and prints the catalogue block to paste into
+`functions/api/_lib/downloads/catalog.ts`, so the catalogue cannot drift from the
+uploaded objects. Keep prior versions listed.

--- a/StingBridge/StingBridge.spec
+++ b/StingBridge/StingBridge.spec
@@ -1,0 +1,98 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the one-file StingBridge EXE.
+
+    Build (from the repo root, in a clean venv):
+
+        python -m venv .buildvenv
+        .buildvenv/Scripts/pip install -r StingBridge/requirements.txt pyinstaller
+        .buildvenv/Scripts/pip install ./stingtools-core/python     # NOT -e
+        .buildvenv/Scripts/pyinstaller --clean --noconfirm StingBridge/StingBridge.spec
+
+    Output: dist/stingbridge.exe
+
+    The `pip install ./stingtools-core/python` must be a REAL install, not
+    `-e`. An editable install resolves through a path hook that PyInstaller's
+    analysis does not follow, so the build succeeds and the EXE then dies at
+    startup with `ModuleNotFoundError: No module named 'stingtools_core'`.
+    A release build installs the wheel anyway; this just makes a dev build
+    match it.
+
+WHY THIS FILE EXISTS
+--------------------
+The 0.1.0-beta.3 EXE was built with a hand-typed command line. The first
+attempt omitted ifcopenshell's data files and shipped an EXE whose IFC
+write-back worked on a fresh file and failed on a RE-DROP — the one case that
+release existed to fix. The flags that fixed it lived nowhere but a shell
+history and a CHANGELOG sentence, so the next release would have regressed
+silently, and silently in the worst way: the smoke test everyone runs first
+(process a new IFC) passes.
+
+Encoding the build here makes the fix reviewable, diffable, and impossible to
+forget. Change the build by changing this file.
+
+THE NON-OBVIOUS PART
+--------------------
+`collect_data_files("ifcopenshell")` is load-bearing. ifcopenshell is not pure
+Python: it ships JSON schema tables next to its modules (notably
+`util/entity_to_type_map_2x3.json`) that are read at runtime, and PyInstaller's
+module graph cannot see a file that is only ever opened by path. Dropping that
+line reproduces the beta.3 bug exactly.
+
+The failure is delayed, which is what makes it dangerous: the map is consulted
+by `ifcopenshell.util.element.get_psets`, which the token writer only calls when
+a STING_TOKENS pset ALREADY EXISTS — i.e. on the second pass over the same file.
+Anything that tests a single fresh IFC will report success.
+"""
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+# Data files first — see the module docstring. This is the line the beta.3
+# build was missing.
+datas = collect_data_files("ifcopenshell")
+
+hiddenimports = (
+    # ifcopenshell dispatches to schema-specific submodules by name at runtime,
+    # so static analysis under-collects it.
+    collect_submodules("ifcopenshell")
+    # stingtools_core is a real declared dependency, resolved from the installed
+    # wheel. Collected explicitly so a monorepo build and a wheel build produce
+    # the same EXE.
+    + collect_submodules("stingtools_core")
+    + collect_submodules("StingBridge")
+)
+
+a = Analysis(
+    # NOT bridge.py. Freezing that file directly makes it __main__ with no
+    # package context and its relative imports die at startup with
+    # "attempted relative import with no known parent package". The shim is
+    # imported as part of the package, so they resolve normally.
+    ["_pyinstaller_entry.py"],
+    # Repo root + the core package, so the build works from a monorepo checkout
+    # as well as from an environment where both are pip-installed.
+    pathex=[".", "..", "../stingtools-core/python"],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="stingbridge",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,          # UPX mangles some native deps; size is not the constraint
+    console=True,       # it is a CLI — a windowed build would swallow all output
+    disable_windowed_traceback=False,
+    onefile=True,
+)

--- a/StingBridge/_pyinstaller_entry.py
+++ b/StingBridge/_pyinstaller_entry.py
@@ -1,0 +1,22 @@
+"""PyInstaller entry point — the frozen equivalent of the `stingbridge` console script.
+
+PyInstaller cannot freeze ``StingBridge/bridge.py`` directly. Handing it that
+file makes it the ``__main__`` module with no package context, so its relative
+imports (``from ..planscape.client import ...``) fail at startup with::
+
+    ImportError: attempted relative import with no known parent package
+
+This shim is imported AS PART OF the package, so the relative imports resolve
+exactly as they do under ``python -m`` or the installed console script. It
+mirrors ``[project.scripts] stingbridge = "StingBridge.bridge:main"`` in
+pyproject.toml — same target, one for wheels and one for the frozen build.
+
+Kept as a real committed file rather than generated at build time: the
+uncommitted version of it is half the reason the beta.3 build was not
+reproducible.
+"""
+
+from StingBridge.bridge import main
+
+if __name__ == "__main__":
+    main()

--- a/StingBridge/requirements.txt
+++ b/StingBridge/requirements.txt
@@ -6,6 +6,17 @@ watchdog>=4.0.0
 # coordinate engine (Phase C) relies on landed in 0.8 and shift across majors.
 # Bump this ceiling deliberately, in lockstep with the Bonsai range pinned in
 # stingtools-bonsai/blender_manifest.toml.
+#
+# PACKAGING: ifcopenshell is NOT pure Python. It ships JSON schema tables next
+# to its modules (notably util/entity_to_type_map_2x3.json) that are opened by
+# path at runtime, so PyInstaller's module graph cannot see them. A frozen build
+# MUST pull them in with collect_data_files("ifcopenshell") — see
+# StingBridge/StingBridge.spec, which encodes this.
+#
+# Omitting it produces an EXE that passes the obvious smoke test and fails
+# later: the map is only consulted when a STING_TOKENS pset already exists, so
+# a fresh IFC works and a RE-DROP of the written-back file fails write-back.
+# That shipped once, in the first 0.1.0-beta.3 build.
 ifcopenshell>=0.8.0,<0.9
 
 # Shared STING core — single source of the Planscape /ifc/data wire contract
@@ -18,7 +29,11 @@ ifcopenshell>=0.8.0,<0.9
 #   * release zips ship the built wheel next to stingbridge's, and the
 #     documented install is `pip install wheels/*.whl` — self-contained, no
 #     monorepo and no network needed (QUICKSTART.md §1);
-#   * the PyInstaller EXE bundles it like any other dependency;
+#   * the PyInstaller EXE bundles it like any other dependency — true here
+#     because it IS pure Python, unlike ifcopenshell above. Note the build must
+#     install it non-editable: an editable install resolves through a path hook
+#     PyInstaller does not follow, and the EXE then dies with
+#     ModuleNotFoundError at startup;
 #   * in this monorepo checkout it resolves either from an editable install
 #     or, failing that, via the sys.path fallback in planscape/client.py.
 #

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 218 — the EXE build is now a committed, reproducible definition)
+
+The beta.3 packaging fix existed only as a sentence in this file. No spec, no
+script, no CI step — so the next release would have regressed it silently, and
+silently in the worst way: the smoke test everyone runs first (process a fresh
+IFC) passes.
+
+- **`StingBridge/StingBridge.spec`** now encodes the build. The load-bearing
+  line is `collect_data_files("ifcopenshell")`: ifcopenshell opens JSON schema
+  tables by path at runtime and PyInstaller's module graph cannot see them.
+- **`StingBridge/_pyinstaller_entry.py`** — the frozen equivalent of the
+  `stingbridge` console script. Freezing `bridge.py` directly makes it
+  `__main__` with no package context and its relative imports die at startup.
+  The beta.3 build used an equivalent shim that was **never committed**, which
+  is the other half of why that build was not reproducible. Found by building
+  from the spec rather than assuming it worked.
+- **`StingBridge/BUILD.md`** — both artifacts, both traps, and the two-pass
+  smoke test that a single fresh-IFC run does not substitute for.
+- **`requirements.txt` corrected.** The review flagged line 21 as asserting the
+  wrong thing; on reading it, that line is about `stingtools_core` — pure Python,
+  where the claim is true. The real gap was that **nothing warned about
+  ifcopenshell at all**. Added that warning at the pin, and qualified line 21
+  (including that `stingtools-core` must be installed non-editable, or the EXE
+  dies with `ModuleNotFoundError`).
+
+**Gate — built from the committed spec in a clean venv, then run against a live
+API build on the docker Postgres:**
+
+| Build | run 1 (fresh IFC) | run 2 (re-drop of `_sting.ifc`) |
+|---|---|---|
+| with `collect_data_files` | `errors: 0`, 3 SEQ minted | **`errors: 0`, no minting, SEQ unchanged** |
+| line removed (temporarily, to prove it) | `errors: 0` | **`errors: 1`** — `No such file … entity_to_type_map_2x3.json` |
+
+The red-then-green pair is the point: the failure is invisible to run 1.
+
+**No re-release.** beta.3 in R2 stands as shipped — the EXE already in the bucket
+was built with these flags; this phase makes that repeatable, not different.
+
 #### Completed (Phase 217 — StingBridge 0.1.0-beta.3 released)
 
 Ships the two fixes that bit real drop-folder users in beta.2: the SEQ re-mint


### PR DESCRIPTION
## What

The beta.3 packaging fix existed only as a sentence in `docs/CHANGELOG.md:31`.
No spec, no script, no CI step — the next release regresses it invisibly, and
invisibly in the worst way: **the smoke test everyone runs first passes.**

## Added

- **`StingBridge/StingBridge.spec`** — the build definition. Load-bearing line is
  `collect_data_files("ifcopenshell")`: ifcopenshell opens JSON schema tables by
  path at runtime, and PyInstaller's module graph cannot see a file that is only
  ever opened by path.
- **`StingBridge/_pyinstaller_entry.py`** — the frozen equivalent of the
  `stingbridge` console script.
- **`StingBridge/BUILD.md`** — both artifacts, both traps, and the two-pass smoke
  test.

## Two things I only found by actually building from the spec

Neither was in the finding; both would have made a committed-but-untested spec
useless:

1. **Freezing `bridge.py` directly does not work.** It becomes `__main__` with no
   package context and dies at startup with `attempted relative import with no
   known parent package`. beta.3 used an equivalent shim that was **never
   committed** — the other half of why that build wasn't reproducible.
2. **`stingtools-core` must be installed non-editable.** `pip install -e`
   resolves through a path hook PyInstaller's analysis doesn't follow: the build
   succeeds, then `ModuleNotFoundError: No module named 'stingtools_core'` at
   startup. Documented in the spec and BUILD.md.

## Gate — red-then-green, both proven

Built from the committed spec in a **clean venv**, run against a live API build
wired to the docker Postgres:

| Build | run 1 (fresh IFC) | run 2 (re-drop of `_sting.ifc`) |
|---|---|---|
| **with** `collect_data_files` | `errors: 0`, 3 SEQ minted, SEQ `0025/0026/0027` | **`errors: 0`, no minting, SEQ unchanged** |
| line removed, temporarily | `errors: 0` | **`errors: 1`** — `No such file … entity_to_type_map_2x3.json` |

The pair is the whole point: run 1 is green in both columns. Any release process
that stops after a fresh-IFC test cannot see this bug. The spec was restored
after the negative build and the final artifact rebuilt green.

## On the `requirements.txt:21` finding — partial disagreement

The finding says line 21 asserts *"the PyInstaller EXE bundles it like any other
dependency"*, calling that "the exact wrong assumption that caused the bug".
Reading it in context, **"it" is `stingtools_core`, not `ifcopenshell`** — that
block is the packaging note for the core wheel, and for a pure-Python package the
claim is correct.

The real gap was adjacent: **nothing in the file warned about ifcopenshell at
all.** So I added that warning at the pin (line 9), and qualified line 21 with
the pure-Python caveat plus the non-editable requirement I hit above. Net effect
is what the finding wanted; the attribution differed.

## Not verified

No CI integration — F3 covers the workflow. `dist/` and `build/` are not
committed; beta.3 in R2 stands as shipped (this makes the build repeatable, not
different).

🤖 Generated with [Claude Code](https://claude.com/claude-code)