### PR TITLE
test(server): real Postgres tests for AllocateAsync + a CI gate that means something (F3)

### DIFF
--- a/.github/workflows/planscape-server.yml
+++ b/.github/workflows/planscape-server.yml
@@ -25,6 +25,25 @@ jobs:
       run:
         working-directory: Planscape.Server
 
+    # A real PostgreSQL. The suite's other DbContexts are EF InMemory / SQLite,
+    # and neither emits the SQL that broke /seq/reserve in production (PR #441:
+    # FirstAsync composing over non-composable INSERT … RETURNING). Without a
+    # server in CI that whole bug class stays invisible.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: planscape_test
+          POSTGRES_USER: planscape
+          POSTGRES_PASSWORD: planscape_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,9 +59,42 @@ jobs:
       - name: Build
         run: dotnet build Planscape.sln --no-restore --configuration Release
 
-      - name: Run tests
-        run: dotnet test Planscape.sln --no-build --configuration Release --verbosity normal
-        continue-on-error: true  # No tests yet — don't fail CI
+      # ── Gate 1: the Postgres integration tests must be 100% green ──────────
+      #
+      # Small, new, and carrying no legacy debt, so "all must pass" is a
+      # meaningful bar. They SKIP (not pass) when PLANSCAPE_TEST_PG is unset,
+      # which is why it is set explicitly here — a silent skip in CI would be
+      # the same false comfort this gate exists to remove.
+      - name: Run Postgres integration tests
+        env:
+          PLANSCAPE_TEST_PG: "Host=localhost;Port=5432;Database=planscape_test;Username=planscape;Password=planscape_ci"
+          Jwt__Key: "ci-only-3xJ9pQ7wR2mV5nB8kL4hT6yG1sD0aZfE"
+        run: |
+          dotnet test Planscape.sln --no-build --configuration Release             --filter "FullyQualifiedName~Postgres" --verbosity normal
+
+      # ── Gate 2: no NEW failures in the rest of the suite ───────────────────
+      #
+      # WHY NOT "zero failures": the suite carries 66 uniquely-named
+      # pre-existing failures (73 cases). Gating on zero makes CI permanently
+      # red and therefore ignored — which is exactly how this step ended up with
+      # `continue-on-error: true` and a comment claiming "No tests yet" while
+      # 400+ tests existed. Gating on "nothing NEW broke" is enforceable today.
+      #
+      # Fixing a baseline entry: delete its line from
+      # Planscape.Server/tests/known-failing-tests.txt in the same PR, and the
+      # check then guards the fix.
+      - name: Run full test suite
+        id: fullsuite
+        env:
+          PLANSCAPE_TEST_PG: "Host=localhost;Port=5432;Database=planscape_test;Username=planscape;Password=planscape_ci"
+          Jwt__Key: "ci-only-3xJ9pQ7wR2mV5nB8kL4hT6yG1sD0aZfE"
+        run: |
+          set +e
+          dotnet test Planscape.sln --no-build --configuration Release             --verbosity normal 2>&1 | tee /tmp/test-output.txt
+          exit 0            # the diff below decides pass/fail, not the exit code
+
+      - name: Fail only on NEW test failures
+        run: bash tests/check-new-failures.sh /tmp/test-output.txt
 
       - name: Generate OpenAPI spec
         working-directory: Planscape.Server

--- a/Planscape.Server/tests/Planscape.Tests/Planscape.Tests.csproj
+++ b/Planscape.Server/tests/Planscape.Tests/Planscape.Tests.csproj
@@ -18,6 +18,11 @@
          concurrent-redemption race on (TenantId, Code). In-memory SQLite is a
          real relational provider and does enforce them. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <!-- Real Postgres integration tests must SKIP (not silently pass, and not
+         fail) when no database is configured. xunit 2.x cannot skip from inside
+         a test without this. -->
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/Planscape.Server/tests/Planscape.Tests/PostgresSequenceCounterTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/PostgresSequenceCounterTests.cs
@@ -1,0 +1,306 @@
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// <see cref="SequenceCounterService"/> against a REAL PostgreSQL.
+///
+/// WHY THIS FILE HAS TO EXIST
+/// --------------------------
+/// The bug fixed in PR #441 was `SqlQueryRaw(...).FirstAsync()` composing a
+/// `SELECT … LIMIT 1` over non-composable `INSERT … ON CONFLICT … RETURNING`.
+/// Npgsql rejects that at execution time, so `/seq/reserve` returned **HTTP 500**
+/// in production — and the entire 423-test suite was green, because every other
+/// DbContext in it is EF InMemory or SQLite and neither ever generates the SQL
+/// that fails. The whole bug class is invisible without a real server.
+///
+/// So these tests are not "more coverage of AllocateAsync". They are the only
+/// place in the suite where raw SQL is actually handed to PostgreSQL.
+///
+/// SKIPPING, NOT PASSING
+/// ---------------------
+/// Without `PLANSCAPE_TEST_PG` these tests report **Skipped**, never Passed. A
+/// test that silently no-ops when its dependency is missing is worse than absent:
+/// it reports safety it did not check. That is precisely the failure this round
+/// exists to correct.
+///
+///     # locally, against the docker compose stack:
+///     export PLANSCAPE_TEST_PG="Host=localhost;Port=5432;Database=planscape;Username=planscape;Password=Planscape2026!"
+///     dotnet test --filter FullyQualifiedName~Postgres
+///
+/// The tests write only to `SeqCounters`, keyed on GUIDs minted per test, and
+/// delete their own rows — safe to point at a shared dev database.
+/// </summary>
+public class PostgresSequenceCounterTests
+{
+    private static string? ConnectionString =>
+        Environment.GetEnvironmentVariable("PLANSCAPE_TEST_PG");
+
+    /// <summary>Reason string when the suite runs without a database, or null when it can run.</summary>
+    private static string? SkipReason =>
+        string.IsNullOrWhiteSpace(ConnectionString)
+            ? "PLANSCAPE_TEST_PG is not set — no PostgreSQL to test against."
+            : null;
+
+    private static PlanscapeDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<PlanscapeDbContext>()
+            .UseNpgsql(ConnectionString)
+            .Options);
+
+    private static SequenceCounterService NewService(PlanscapeDbContext db) => new(db);
+
+    /// <summary>
+    /// Materialise the schema once per test run if the target database is empty.
+    ///
+    /// Locally this is a no-op: the docker compose database already has the full
+    /// schema, and EnsureCreated short-circuits when any table exists. In CI the
+    /// service container starts empty, so this is what makes the run possible at
+    /// all — without it every test fails with `relation "SeqCounters" does not
+    /// exist`, which would look like a code regression rather than a missing
+    /// fixture.
+    ///
+    /// EnsureCreated (rather than Migrate) is deliberate: it is this project's
+    /// documented schema mechanism — see docs/adr/0001-schema-management.md and
+    /// PLANSCAPE_USE_ENSURE_CREATED in render.yaml.
+    /// </summary>
+    private static readonly Lazy<bool> SchemaReady = new(() =>
+    {
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        return true;
+    });
+
+    /// <summary>A counter key no other test or run will collide with.</summary>
+    private static string FreshKey() => $"test_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Create a real tenant + project to hang counters off, and return a disposer
+    /// that removes them.
+    ///
+    /// Needed because `SeqCounters.ProjectId` carries a FOREIGN KEY to `Projects`
+    /// — allocating against a random GUID fails with
+    /// `23503: violates foreign key constraint "FK_SeqCounters_Projects_ProjectId"`.
+    /// EF InMemory does not enforce foreign keys, so a test written against it
+    /// would have passed with fabricated ids and told us nothing. Found by running
+    /// this against the real server, which is the point of the file.
+    /// </summary>
+    private static async Task<(Guid tenantId, Guid projectId)> NewProjectAsync()
+    {
+        await using var db = NewContext();
+        var tenant = new Tenant
+        {
+            Id = Guid.NewGuid(),
+            Name = "PG Test Org",
+            Slug = $"pgtest-{Guid.NewGuid():N}"[..20],
+            ContactEmail = "pg@example.test",
+            Tier = LicenseTier.Starter,
+            MaxUsers = 5,
+            MaxProjects = 50,
+            IsActive = true,
+        };
+        var project = new Project
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenant.Id,
+            Name = "PG Test Project",
+            Code = $"PGT-{Guid.NewGuid():N}"[..12],
+            Phase = "Design",
+            Status = ProjectStatus.Active,
+        };
+        db.Tenants.Add(tenant);
+        db.Projects.Add(project);
+        await db.SaveChangesAsync();
+        return (tenant.Id, project.Id);
+    }
+
+    private static async Task DropProjectAsync(Guid tenantId, Guid projectId)
+    {
+        try
+        {
+            await using var db = NewContext();
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM \"SeqCounters\" WHERE \"ProjectId\" = {0}", projectId);
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM \"Projects\" WHERE \"Id\" = {0}", projectId);
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM \"Tenants\" WHERE \"Id\" = {0}", tenantId);
+        }
+        catch { /* best effort — rows are GUID-keyed and inert */ }
+    }
+
+    private static async Task CleanupAsync(string key)
+    {
+        try
+        {
+            await using var db = NewContext();
+            await db.Database.ExecuteSqlRawAsync(
+                "DELETE FROM \"SeqCounters\" WHERE \"CounterKey\" = {0}", key);
+        }
+        catch { /* best effort — a leftover row with a GUID key harms nothing */ }
+    }
+
+    // ── the regression that shipped ────────────────────────────────────────
+
+    [SkippableFact]
+    public async Task AllocateAsync_OnANewKey_ReturnsOne_AndDoesNotThrowOnPostgres()
+    {
+        Skip.If(SkipReason is not null, SkipReason!);
+        _ = SchemaReady.Value;
+
+        var key = FreshKey();
+        var (tenant, project) = await NewProjectAsync();
+        try
+        {
+            await using var db = NewContext();
+
+            // Before PR #441 this line threw:
+            //   InvalidOperationException: 'FromSql' or 'SqlQuery' was called with
+            //   non-composable SQL and with a query composing over it.
+            // …surfacing as a 500 from /seq/reserve. Nothing else in the suite
+            // executes this statement against a server that parses it.
+            var value = await NewService(db).AllocateAsync(
+                tenant, project, key, updatedBy: "pg-test");
+
+            Assert.Equal(1, value);
+        }
+        finally { await DropProjectAsync(tenant, project); }
+    }
+
+    [SkippableFact]
+    public async Task AllocateAsync_OnAnExistingKey_AdvancesByTheRequestedCount()
+    {
+        Skip.If(SkipReason is not null, SkipReason!);
+        _ = SchemaReady.Value;
+
+        var key = FreshKey();
+        var (tenant, project) = await NewProjectAsync();
+        try
+        {
+            await using var db = NewContext();
+            var svc = NewService(db);
+
+            Assert.Equal(1, await svc.AllocateAsync(tenant, project, key, updatedBy: "pg-test"));
+            Assert.Equal(4, await svc.AllocateAsync(tenant, project, key, count: 3, updatedBy: "pg-test"));
+            Assert.Equal(5, await svc.AllocateAsync(tenant, project, key, updatedBy: "pg-test"));
+
+            // The contract callers rely on: the return value is the HIGHEST
+            // number allocated, and the block is [value - count + 1, value].
+            // /seq/reserve computes `start` that way, so an off-by-one here
+            // hands two callers overlapping blocks.
+        }
+        finally { await DropProjectAsync(tenant, project); }
+    }
+
+    [SkippableFact]
+    public async Task AllocateAsync_RespectsSeedFloor_OnFirstInsertOnly()
+    {
+        Skip.If(SkipReason is not null, SkipReason!);
+        _ = SchemaReady.Value;
+
+        var key = FreshKey();
+        var (tenant, project) = await NewProjectAsync();
+        try
+        {
+            await using var db = NewContext();
+            var svc = NewService(db);
+
+            // Migrating a project whose legacy codes already reach 42.
+            Assert.Equal(43, await svc.AllocateAsync(tenant, project, key, seedFloor: 42, updatedBy: "pg-test"));
+            // GREATEST(current, seedFloor) — a LOWER floor afterwards must not rewind.
+            Assert.Equal(44, await svc.AllocateAsync(tenant, project, key, seedFloor: 10, updatedBy: "pg-test"));
+        }
+        finally { await DropProjectAsync(tenant, project); }
+    }
+
+    // ── the property the endpoint actually depends on ──────────────────────
+
+    [SkippableFact]
+    public async Task ConcurrentAllocations_OnTheSameKey_AreDisjoint()
+    {
+        Skip.If(SkipReason is not null, SkipReason!);
+        _ = SchemaReady.Value;
+
+        var key = FreshKey();
+        var (tenant, project) = await NewProjectAsync();
+        const int Workers = 8;
+        const int PerWorker = 5;
+
+        try
+        {
+            // Separate DbContexts, genuinely in parallel — one shared context
+            // would serialise on EF's internal lock and prove nothing about the
+            // database. The row lock inside the UPSERT is what must serialise.
+            var tasks = Enumerable.Range(0, Workers).Select(async _ =>
+            {
+                await using var db = NewContext();
+                return await NewService(db).AllocateAsync(
+                    tenant, project, key, count: PerWorker, updatedBy: "pg-test");
+            });
+
+            var highs = await Task.WhenAll(tasks);
+
+            // Expand each returned high-water mark into the block its caller owns.
+            var claimed = highs
+                .SelectMany(h => Enumerable.Range(h - PerWorker + 1, PerWorker))
+                .ToList();
+
+            Assert.Equal(Workers * PerWorker, claimed.Count);
+            Assert.Equal(Workers * PerWorker, claimed.Distinct().Count());   // no overlap
+            Assert.Equal(
+                Enumerable.Range(1, Workers * PerWorker),
+                claimed.OrderBy(n => n));                                    // no gaps either
+        }
+        finally { await DropProjectAsync(tenant, project); }
+    }
+
+    [SkippableFact]
+    public async Task TwoKeys_AdvanceIndependently()
+    {
+        Skip.If(SkipReason is not null, SkipReason!);
+        _ = SchemaReady.Value;
+
+        var a = FreshKey();
+        var b = FreshKey();
+        var (tenant, project) = await NewProjectAsync();
+        try
+        {
+            await using var db = NewContext();
+            var svc = NewService(db);
+
+            await svc.AllocateAsync(tenant, project, a, count: 7, updatedBy: "pg-test");
+            // A second key must start at 1 — the UPSERT conflict target is
+            // (ProjectId, CounterKey), so a same-project different-key allocation
+            // must not inherit the first key's value.
+            Assert.Equal(1, await svc.AllocateAsync(tenant, project, b, updatedBy: "pg-test"));
+        }
+        finally { await DropProjectAsync(tenant, project); }
+    }
+
+    [SkippableFact]
+    public async Task TheRowIsActuallyPersisted_NotJustReturned()
+    {
+        Skip.If(SkipReason is not null, SkipReason!);
+        _ = SchemaReady.Value;
+
+        var key = FreshKey();
+        var (tenant, project) = await NewProjectAsync();
+        try
+        {
+            await using (var db = NewContext())
+                await NewService(db).AllocateAsync(tenant, project, key, count: 9, updatedBy: "pg-test");
+
+            // Fresh context: proves the UPSERT committed rather than the value
+            // coming from a tracked in-memory entity.
+            await using var verify = NewContext();
+            var row = await verify.SeqCounters.IgnoreQueryFilters()
+                .SingleAsync(c => c.ProjectId == project && c.CounterKey == key);
+
+            Assert.Equal(9, row.CurrentValue);
+            Assert.Equal("pg-test", row.UpdatedBy);
+        }
+        finally { await DropProjectAsync(tenant, project); }
+    }
+}

--- a/Planscape.Server/tests/check-new-failures.sh
+++ b/Planscape.Server/tests/check-new-failures.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Fail only on NEW test failures — those not listed in known-failing-tests.txt.
+#
+# Usage:  check-new-failures.sh <dotnet-test-output-file>
+#
+# The suite carries 66 uniquely-named pre-existing failures. Gating CI on "zero
+# failures" makes it permanently red and therefore ignored; gating on "no new
+# failures" makes it mean something today, without blocking on a backlog that
+# predates this workflow.
+set -uo pipefail
+
+OUTPUT="${1:?usage: check-new-failures.sh <dotnet-test-output-file>}"
+BASELINE="$(dirname "$0")/known-failing-tests.txt"
+
+[ -f "$OUTPUT" ]   || { echo "::error::test output not found: $OUTPUT"; exit 1; }
+[ -f "$BASELINE" ] || { echo "::error::baseline not found: $BASELINE"; exit 1; }
+
+# A run that produced no summary line never got as far as running tests (build
+# break, host crash). Treat that as failure — an empty failure list would
+# otherwise read as "nothing new broke".
+if ! grep -qE "^(Passed!|Failed!)" "$OUTPUT"; then
+  echo "::error::no test summary in output — the run did not complete"
+  tail -30 "$OUTPUT"
+  exit 1
+fi
+
+grep -o "Planscape\.Tests\.[A-Za-z0-9_.]*\ \[FAIL\]" "$OUTPUT" \
+  | sed 's/ \[FAIL\]//' | sort -u > /tmp/actual-failures.txt
+
+grep -vE '^\s*(#|$)' "$BASELINE" | sort -u > /tmp/baseline-failures.txt
+
+NEW=$(comm -13 /tmp/baseline-failures.txt /tmp/actual-failures.txt)
+FIXED=$(comm -23 /tmp/baseline-failures.txt /tmp/actual-failures.txt)
+
+if [ -n "$FIXED" ]; then
+  echo "::notice::These baseline failures now PASS — delete them from known-failing-tests.txt:"
+  echo "$FIXED" | sed 's/^/  /'
+fi
+
+if [ -n "$NEW" ]; then
+  echo "::error::NEW test failures (not in the baseline):"
+  echo "$NEW" | sed 's/^/  /'
+  echo
+  echo "If one of these is an order/parallelism flake (ROADMAP DEP-7), confirm"
+  echo "against main before treating it as a regression."
+  exit 1
+fi
+
+echo "No new failures. ($(wc -l < /tmp/actual-failures.txt) failing, all known.)"

--- a/Planscape.Server/tests/known-failing-tests.txt
+++ b/Planscape.Server/tests/known-failing-tests.txt
@@ -1,0 +1,91 @@
+# Known-failing tests — the CI baseline.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# The suite carries 66 uniquely-named pre-existing failures (73 cases, some
+# theories). Making CI red on all of them means CI is red always, which means
+# nobody reads it — that is why the test step used to run with
+# `continue-on-error: true` and a comment claiming "No tests yet".
+#
+# So CI fails on NEW failures only: any failing test whose name is not listed
+# here. Fixing one of these is welcome — delete its line in the same PR, and the
+# check then guards the fix from regressing.
+#
+# Regenerate with (from Planscape.Server/tests/Planscape.Tests):
+#   dotnet test --nologo -v q 2>&1 \
+#     | grep -o "Planscape\.Tests\.[A-Za-z0-9_.]*\ \[FAIL\]" \
+#     | sed 's/ \[FAIL\]//' | sort -u
+#
+# CAVEAT, honestly stated: a handful of these are order/parallelism dependent
+# (see ROADMAP DEP-7 — Program.cs reads the process-wide
+# Hangfire.JobStorage.Current during host build). A test that happened to pass
+# when this file was generated can fail in CI and be reported as "new". If that
+# happens, confirm it against main before treating it as a regression.
+#
+# Blank lines and lines starting with # are ignored.
+Planscape.Tests.AuthControllerTests.ActivateLicense_ValidKey_ReturnsSuccess
+Planscape.Tests.AuthControllerTests.HealthCheck_ReturnsHealthy
+Planscape.Tests.AuthControllerTests.RefreshToken_ValidToken_ReturnsNewTokens
+Planscape.Tests.AuthControllerTests.Register_NewOrg_Returns201WithToken
+Planscape.Tests.AuthHandlerConcurrentReadsTests.RevocationAndTenantOverride_LaunchInParallel
+Planscape.Tests.BimManagerOrAdminHandlerTests.BimManagerProjectMember_Grants
+Planscape.Tests.BimManagerOrAdminHandlerTests.InactiveProjectMember_Denies
+Planscape.Tests.BimManagerOrAdminHandlerTests.UnrelatedRole_Denies
+Planscape.Tests.BimManagerRoleConfigTests.AppUserIso19650Role_FollowsConfigList
+Planscape.Tests.BimManagerRoleConfigTests.AppUserIso19650Role_GrantsWithoutProjectMember
+Planscape.Tests.BimManagerRoleConfigTests.AppUserNotInTenant_DoesNotGrant
+Planscape.Tests.BimManagerRoleConfigTests.ConfigRoles_AreCaseInsensitive
+Planscape.Tests.BimManagerRoleConfigTests.ConfiguredRoles_NarrowingExcludesOldGrants
+Planscape.Tests.BimManagerRoleConfigTests.ConfiguredRoles_OverrideDefaultK
+Planscape.Tests.BimManagerRoleConfigTests.EmptyOrMalformedConfig_FallsBackToDefaultK
+Planscape.Tests.CoreApiTests.Compliance_History_ReturnsArray
+Planscape.Tests.CoreApiTests.Compliance_PushAndGetLatest
+Planscape.Tests.CoreApiTests.Compliance_Trend_ReturnsDailyData
+Planscape.Tests.CoreApiTests.Documents_CreateAndList
+Planscape.Tests.CoreApiTests.Documents_GetHistory
+Planscape.Tests.CoreApiTests.Documents_TransitionState_WipToShared
+Planscape.Tests.CoreApiTests.Issues_CreateAndList
+Planscape.Tests.CoreApiTests.Issues_SLAReport_ReturnsData
+Planscape.Tests.CoreApiTests.Issues_Update_ChangesStatus
+Planscape.Tests.CoreApiTests.Meetings_AddActionItem_AndGetOpen
+Planscape.Tests.CoreApiTests.Meetings_CreateAndList
+Planscape.Tests.CoreApiTests.Meetings_LogMinutes
+Planscape.Tests.CoreApiTests.Members_AddAndList
+Planscape.Tests.CoreApiTests.Members_GetRoles_ReturnsISO19650Roles
+Planscape.Tests.CoreApiTests.Members_InviteByEmail
+Planscape.Tests.CoreApiTests.Members_MemberRole_CannotAdd
+Planscape.Tests.CoreApiTests.Mim_BulkCreateAssets
+Planscape.Tests.CoreApiTests.Mim_CreateAssetAndList
+Planscape.Tests.CoreApiTests.Mim_CreateMaintenanceTask
+Planscape.Tests.CoreApiTests.Mim_Dashboard_ReturnsMetrics
+Planscape.Tests.CoreApiTests.SeqSync_SyncAndGet
+Planscape.Tests.CoreApiTests.TagSync_SyncElements
+Planscape.Tests.CoreApiTests.TenantIsolation_OtherTenantCannotSyncTags
+Planscape.Tests.CoreApiTests.Transmittals_CreateAndList
+Planscape.Tests.CoreApiTests.Transmittals_MarkSent
+Planscape.Tests.CoreApiTests.Warnings_PushReport
+Planscape.Tests.CoreApiTests.Warnings_SaveBaseline
+Planscape.Tests.CoreApiTests.Warnings_Trend_ReturnsData
+Planscape.Tests.CoreApiTests.Workflows_LogRunAndGetHistory
+Planscape.Tests.CoreApiTests.Workflows_Trend_ReturnsData
+Planscape.Tests.DeliverableStateMachineTests.LoadOrDefault_ExplicitRolesWinOverInference
+Planscape.Tests.PlatformKeywordTests.LoadOrDefault_PlatformAndProject_MergesWithProjectWinning
+Planscape.Tests.ProjectVisibilityTests.ListProjects_AsTenantAdmin_SeesAllTenantProjects
+Planscape.Tests.ProjectsControllerTests.CreateProject_DuplicateCode_Returns409
+Planscape.Tests.ProjectsControllerTests.CreateProject_Valid_ReturnsCreated
+Planscape.Tests.ProjectsControllerTests.GetDashboard_ValidProject_ReturnsDashboardData
+Planscape.Tests.ProjectsControllerTests.GetProjects_Authenticated_ReturnsProjectList
+Planscape.Tests.RevocationFloorHandlerTests.NoRevocationFloor_TokenWithoutIatStillGrants
+Planscape.Tests.RevocationFloorHandlerTests.TokenIssuedAfterRevocation_StillGrants
+Planscape.Tests.RoleExtensionTests.LoadOrDefault_TenantKeywordsCanOverrideCanonical
+Planscape.Tests.RoleInferenceTests.LoadOrDefault_ExplicitRolesStillWinOverFuzzyInference
+Planscape.Tests.SecurityCriticalPathTests.QuotaGuard_ProjectCap_AllowsBelowLimit
+Planscape.Tests.SecurityCriticalPathTests.QuotaGuard_ProjectCap_DeniesAtTrialLimit
+Planscape.Tests.SecurityCriticalPathTests.TenantQueryFilter_EmptyTenantId_ReturnsNoRows
+Planscape.Tests.TagSyncConflictTests.SyncElements_StaleUpdate_KeepsServerData_AndRecordsConflict
+Planscape.Tests.TenantBimManagerRoleOverrideTests.NullOverride_FallsBackToDeployment
+Planscape.Tests.TenantBimManagerRoleOverrideTests.TenantOverride_AppliesToAppUserGrantPath
+Planscape.Tests.TenantBimManagerRoleOverrideTests.TenantOverride_BroadensGrantBeyondDeployment
+Planscape.Tests.TenantBimManagerRoleOverrideTests.TenantOverride_CaseInsensitive
+Planscape.Tests.TenantBimManagerRoleOverrideTests.TenantOverride_NarrowsGrantBelowDeployment
+Planscape.Tests.TenantKeywordL2CacheTests.ResolveAsync_HitsL2OnSecondCall

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 220 — a real Postgres in the test suite, and a CI gate that means something)
+
+PR #441 fixed the non-composable-SQL 500. Nothing stopped the next one: no test
+touched `AllocateAsync`, every DbContext in the suite was InMemory or SQLite
+(neither emits the failing SQL), and the CI test step ran with
+`continue-on-error: true` behind a comment claiming "No tests yet" — while 423
+tests existed.
+
+- **`PostgresSequenceCounterTests`** — six tests against a real server: new key,
+  existing key advancing by `count`, `seedFloor` on first insert only, **8-way
+  concurrent allocation proving disjoint *and* gapless blocks**, key
+  independence, and that the row is actually committed rather than read back off
+  a tracked entity.
+- **They SKIP, never silently pass**, when `PLANSCAPE_TEST_PG` is unset
+  (`Xunit.SkippableFact`). Verified: **6 Skipped / 0 Passed**. A test that no-ops
+  when its dependency is missing reports safety it did not check — the exact
+  failure mode this round exists to correct.
+- **The fixture creates its own schema** when the target database is empty, so
+  the same tests run locally against docker and in CI against a fresh service
+  container. Verified against a genuinely empty database.
+- **CI made honest** (`.github/workflows/planscape-server.yml`): a `postgres:16`
+  service container, and the `continue-on-error` removed. Two gates:
+  1. the Postgres tests must be **100 % green** — new code, no legacy debt, so
+     that bar is meaningful;
+  2. the full suite fails only on **NEW** failures, diffed against a committed
+     `known-failing-tests.txt` by `tests/check-new-failures.sh`.
+
+  Gating on zero failures would make CI permanently red and therefore ignored —
+  which is precisely how it ended up disabled. Baseline entries are deleted as
+  they are fixed, and the check then guards the fix.
+
+**Two things the real server caught that no fake could:**
+- `SeqCounters.ProjectId` carries a **foreign key to `Projects`**. The first
+  draft allocated against fabricated GUIDs and failed with `23503`. EF InMemory
+  does not enforce foreign keys, so the same test would have passed there and
+  proved nothing. The tests now create a real tenant + project and remove them.
+- The bug-class proof below.
+
+**Gate — red-then-green, on real Postgres:**
+
+| `SequenceCounterService` | Result |
+|---|---|
+| as fixed in #441 (`ToListAsync`) | **6 passed** |
+| #441 reverted (`FirstAsync`) — temporarily, to prove it | **6 failed** |
+| no `PLANSCAPE_TEST_PG` | **6 skipped**, 0 passed |
+
+`check-new-failures.sh` verified both ways: clean run → "No new failures (66
+failing, all known)", exit 0; with an injected unknown failure → error listing
+it, exit 1.
+
+**Not verified: the CI leg itself.** GitHub Actions cannot be run from here. The
+workflow parses as YAML and each step was exercised locally by hand, but *"the
+job is green on GitHub"* is unproven — first push to `main` is the real test.
+
 #### Completed (Phase 219 — the Revit SEQ reservation claim was false; corrected)
 
 Phase 211 said "cross-host duplicate window closed in the plugin" and ROADMAP


### PR DESCRIPTION
## The gap

PR #441 fixed the non-composable-SQL 500. Nothing stopped the next one:

- no test touched `AllocateAsync` or `/seq/reserve`;
- every DbContext in the suite is EF InMemory or SQLite — **neither emits the SQL
  that fails**, so the whole bug class is invisible;
- `.github/workflows/planscape-server.yml:44` ran `dotnet test` with
  `continue-on-error: true` behind `# No tests yet — don't fail CI`, while 423
  tests existed.

## 1. `PostgresSequenceCounterTests` — six tests, real server

New key · existing key advances by `count` · `seedFloor` applies on first insert
only · **8-way concurrent allocation → blocks disjoint *and* gapless** · keys
advance independently · the row is actually committed (verified from a fresh
context, not a tracked entity).

**They skip, they never silently pass.** Without `PLANSCAPE_TEST_PG`:

```
Skipped! - Failed: 0, Passed: 0, Skipped: 6, Total: 6
```

A test that no-ops when its dependency is missing reports safety it did not
check — the exact failure this round exists to correct. Hence `Xunit.SkippableFact`
rather than an early `return`.

The fixture **bootstraps its own schema** when the target DB is empty, so the
same tests run against docker locally and a fresh service container in CI.
Verified against a genuinely empty database (`CREATE DATABASE planscape_citest`) —
6/6.

## 2. CI

`postgres:16` service container; `continue-on-error` removed. Two gates:

| Gate | Bar | Why |
|---|---|---|
| Postgres integration tests | **100 % green** | new code, no legacy debt |
| Full suite | **no NEW failures** | diffed against committed `known-failing-tests.txt` |

I chose the **baseline-diff** (option b) over a hard-coded green filter: a filter
rots silently as tests are added, and it can't tell you when a baseline failure
starts passing. The script emits a `::notice::` when one does, so the baseline
shrinks as things get fixed.

Gating on *zero* failures would make CI permanently red and therefore ignored —
which is exactly how it ended up disabled.

## Gate — red-then-green, on real Postgres

| `SequenceCounterService` | Result |
|---|---|
| as fixed in #441 (`ToListAsync`) | **6 passed** |
| **#441 reverted (`FirstAsync`)** — temporarily, to prove it | **6 failed** |
| no `PLANSCAPE_TEST_PG` | **6 skipped**, 0 passed |

`check-new-failures.sh`, both directions:

```
clean run:                 No new failures. (66 failing, all known.)   exit 0
injected unknown failure:  ::error:: NEW test failures: …NewlyBroken   exit 1
```

## Something the real server caught that no fake could

The first draft allocated against fabricated GUIDs and failed with
`23503: violates foreign key constraint "FK_SeqCounters_Projects_ProjectId"`.
**EF InMemory does not enforce foreign keys** — the identical test would have
passed there and proved nothing. The tests now create a real tenant + project and
delete them afterwards. That is the file justifying its own existence on day one.

## Not verified — stated plainly

**The CI leg itself.** GitHub Actions cannot be run from here. The workflow parses
as YAML (`yaml.safe_load`, 10 steps, `services: [postgres]`) and every step was
exercised locally by hand, but *"the job is green on GitHub"* is unproven. First
push to `main` is the real test. If the schema bootstrap behaves differently on
the service container, the Postgres gate fails loudly rather than silently — which
is the right way round.

Also: **no HTTP-level `/seq/reserve` test.** The bug lives in the service, and both
`/seq/reserve` and `TransmittalsController` (`:116`, `:206`) reach it through
`AllocateAsync`, so service-level coverage fences the bug class. An HTTP test would
need a second `WebApplicationFactory`, which ROADMAP DEP-7 documents as unreliable
in this assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)