### PR TITLE
fix(sync): persist status through real adapters; IFC adapter was blanking tags (F4)

### DIFF
--- a/StingBridge/archicad/host_adapter.py
+++ b/StingBridge/archicad/host_adapter.py
@@ -126,8 +126,16 @@ class ArchiCadHostAdapter(HostAdapter):
 
     # ── write ────────────────────────────────────────────────────────────────
 
-    def write_tag(self, element: Any, tag: Tag) -> bool:
-        """Write the tag back as STING User-Defined properties."""
+    def write_tag(self, element: Any, tag: Tag, status: str | None = None) -> bool:
+        """Write the tag back as STING User-Defined properties.
+
+        ``status`` is passed separately because it is NOT a tag segment — `Tag`
+        is a strict eight-segment grammar. `PropertyWriter._TOKEN_PROPS` already
+        maps it to `ASS_STATUS_TXT`; this method simply never supplied it, so a
+        status-only remote change could not be persisted and would re-apply on
+        every pull once SB-5a wires the loop. Empty/None values are skipped by
+        the writer, so existing callers that omit it are unaffected.
+        """
         if self._writer is None:
             log.warning("No PropertyWriter - cannot write back to ArchiCAD")
             return False
@@ -137,6 +145,8 @@ class ArchiCadHostAdapter(HostAdapter):
             "prod": tag.product, "seq": tag.sequence,
             "tag1": tag.to_full_tag(),
         }
+        if status:
+            tokens["status"] = str(status)
         try:
             self._writer.write_tokens([(str(element), tokens)])
             return True
@@ -174,7 +184,7 @@ class ArchiCadHostAdapter(HostAdapter):
             product=payload.get("prod") or payload.get("product") or "XX",
             sequence=payload.get("seq") or payload.get("sequence") or "0000",
         )
-        return self.write_tag(guid, tag)
+        return self.write_tag(guid, tag, status=payload.get("status"))
 
     def georef_descriptor(self) -> GeorefDescriptor:
         """Coordinate evidence for the Federation Placement Resolver.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 221 — status now survives a round trip; and the IFC adapter was blanking tags)
+
+Phase 214 added `status` to `TOKEN_KEYS` so status-only remote edits stop being
+dropped. **No real adapter persisted it**, so once SB-5a wires the pull loop the
+same delta would re-apply on every pull, forever. The existing test passed
+because it ran against a fake adapter that records what it was asked to do.
+
+**Option A taken** — persist status end-to-end, rather than removing it from
+`TOKEN_KEYS`. Status is real ISO 19650 data the feed already carries
+(`ChangesController.cs:108`); dropping it to silence the churn would have thrown
+away the feature to fix the symptom.
+
+- **`IfcFileHostAdapter` persists status** in `Pset_StingTags.Status` —
+  *alongside* the tag, never inside `Tag`. `Tag` is a strict eight-segment
+  grammar; a ninth field would corrupt every rendered tag string.
+- **New `read_tokens()`** returns exactly the `TOKEN_KEYS`-shaped dict a caller
+  needs for `local_index`, so the SB-5a wiring cannot forget `status` and
+  reintroduce this.
+- **`ArchiCadHostAdapter` likewise.** `PropertyWriter._TOKEN_PROPS` already
+  mapped `status` → `ASS_STATUS_TXT`; the adapter simply never supplied it.
+  `write_tag` takes an optional `status` (empty values are skipped by the
+  writer, so existing callers are unaffected).
+
+**A bigger bug fell out of writing the test with the real wire shape.**
+`IfcFileHostAdapter.apply_remote_change` fed `delta.payload` straight into
+`Tag.from_pset`. The feed sends **short lower-case** keys
+(`disc, loc, zone, lvl, …` — `ChangesController.cs:105-108`); `from_pset` looks
+up **long capitalised** ones (`Discipline`, `Location`, …). Every lookup missed,
+so applying a real feed delta wrote **eight `XX` UNKNOWN sentinels** — it did not
+merely lose status, it **blanked the tag**. Latent only because nothing wires the
+pull loop yet. Fixed with an explicit feed→Tag map that still tolerates the pset
+vocabulary. (`ArchiCadHostAdapter` already read the feed keys correctly, which is
+why this was IFC-only.)
+
+**Gate — convergence through a REAL adapter over a real in-memory IFC model:**
+apply a status-only remote change, **re-read local state from the file**, run
+reconcile again → second pass is a no-op (`applied == 0`, `skipped_equal == 1`).
+
+| Against | Result |
+|---|---|
+| `main` | **3 failed** — the convergence test dies at `assert 'XX' == 'M'`, i.e. the tag-blanking bug |
+| this branch | **3 passed**; `stingtools-core` **96 passed**, StingBridge **126 passed** |
+
+The test reads the pset back with plain `ifcopenshell` rather than the new
+`read_tokens` helper — otherwise it could not run against the old code, and the
+red-then-green claim would be unfalsifiable.
+
+**Not verified:** the ArchiCAD leg. Exercising it needs a licensed ArchiCAD
+(ROADMAP SB-1); the change is a pass-through into a mapping that already existed,
+and the bridge suite is green, but no live write was performed.
+
 #### Completed (Phase 220 — a real Postgres in the test suite, and a CI gate that means something)
 
 PR #441 fixed the non-composable-SQL 500. Nothing stopped the next one: no test

--- a/stingtools-core/python/stingtools_core/hosts/ifc_file.py
+++ b/stingtools-core/python/stingtools_core/hosts/ifc_file.py
@@ -25,6 +25,55 @@ _TAG_TO_PSET = {
     "product": "Product", "sequence": "Sequence",
 }
 
+#: ISO 19650 suitability/status, stored ALONGSIDE the tag segments — never
+#: inside :class:`Tag`.
+#:
+#: `Tag` is a strict 8-segment grammar: `to_full_tag`/`from_full_tag` assume
+#: exactly eight parts, so adding a ninth field would corrupt every tag string
+#: the system renders. Status is metadata *about* the element, not a segment
+#: *of* its tag, so it gets its own property in the same pset.
+#:
+#: Why it is written at all: `status` is one of the reconcile engine's
+#: TOKEN_KEYS (sync/reconcile.py), and the change feed carries it
+#: (ChangesController.cs:108). An adapter that applies a status-only remote
+#: change without persisting it re-applies that same change on EVERY subsequent
+#: pull, forever — the delta never converges because the local read-back never
+#: reflects the write.
+STATUS_PROP = "Status"
+
+#: Change-feed token key -> Tag field.
+#:
+#: The feed sends short lower-case keys (`ChangesController.cs:105-108`:
+#: `disc, loc, zone, lvl, sys, func, prod, seq, status, …`), which are also the
+#: reconcile engine's TOKEN_KEYS. The PSET uses long capitalised names
+#: (`Discipline`, `Location`, …). These are two different vocabularies for the
+#: same eight segments and they were being conflated: `apply_remote_change` fed
+#: `delta.payload` straight into `Tag.from_pset`, which looks up `"Discipline"`
+#: in a dict that only has `"disc"`. Every lookup missed, so applying a REAL feed
+#: delta wrote eight UNKNOWN sentinels — it did not just lose status, it blanked
+#: the tag. Latent only because nothing wires the pull loop yet (SB-5a).
+_FEED_TO_TAG = {
+    "disc": "discipline", "loc": "location", "zone": "zone", "lvl": "level",
+    "sys": "system", "func": "function", "prod": "product", "seq": "sequence",
+}
+
+
+def _tag_from_payload(payload: dict) -> "Tag":
+    """Build a Tag from a change-feed payload, tolerating the PSET vocabulary.
+
+    Feed keys win; PSET-cased keys are accepted so a caller hand-building a
+    payload from a pset (as some tests and the ArchiCAD route do) still works.
+    """
+    payload = payload or {}
+    if any(k in payload for k in _FEED_TO_TAG):
+        fields = {
+            field: str(payload.get(feed_key) or "")
+            for feed_key, field in _FEED_TO_TAG.items()
+            if payload.get(feed_key)
+        }
+        return Tag(**fields) if fields else Tag.from_pset(payload)
+    return Tag.from_pset(payload)
+
 
 def _ue():
     import ifcopenshell.util.element as ue  # type: ignore
@@ -107,6 +156,45 @@ class IfcFileHostAdapter(HostAdapter):
         except Exception:
             return False
 
+    def read_status(self, element: Any) -> str:
+        """ISO 19650 suitability/status for *element*, or "" when unset."""
+        try:
+            pset = _ue().get_pset(element, STING_PSET) or {}
+        except Exception:
+            return ""
+        return str(pset.get(STATUS_PROP) or "")
+
+    def write_status(self, element: Any, status: str) -> bool:
+        """Persist ISO 19650 status alongside the tag segments."""
+        try:
+            import ifcopenshell.api  # type: ignore
+        except ImportError:
+            return False
+        try:
+            pset = ifcopenshell.api.run("pset.add_pset", self.model,
+                                        product=element, name=STING_PSET)
+            ifcopenshell.api.run("pset.edit_pset", self.model,
+                                 pset=pset, properties={STATUS_PROP: str(status or "")})
+            return True
+        except Exception:
+            return False
+
+    def read_tokens(self, element: Any) -> dict:
+        """The token dict the reconcile engine compares against a remote delta.
+
+        Keys match `stingtools_core.sync.reconcile.TOKEN_KEYS` exactly — the eight
+        tag segments plus `status`. Callers building a `local_index` should use
+        this rather than assembling the dict themselves; a caller that forgets
+        `status` reintroduces the non-convergence this method exists to prevent.
+        """
+        tag = self.read_tag(element)
+        return {
+            "disc": tag.discipline, "loc": tag.location, "zone": tag.zone,
+            "lvl": tag.level, "sys": tag.system, "func": tag.function,
+            "prod": tag.product, "seq": tag.sequence,
+            "status": self.read_status(element),
+        }
+
     def apply_remote_change(self, delta: ChangeDelta) -> bool:
         """Apply a pulled change. Tags are applied here; issue/bcf/clash/transform
         deltas are recorded by the caller's sync layer (no local IFC mutation)."""
@@ -115,7 +203,18 @@ class IfcFileHostAdapter(HostAdapter):
         el = self._element_by_gid(delta.global_id)
         if el is None:
             return False
-        return self.write_tag(el, Tag.from_pset(delta.payload))
+
+        ok = self.write_tag(el, _tag_from_payload(delta.payload))
+
+        # Status travels with the tag but is not part of it. Applying the eight
+        # segments and dropping status made a status-only delta un-appliable:
+        # reconcile saw a difference, applied it, the read-back still showed the
+        # old status, and the next pull produced the identical delta. Forever.
+        payload = delta.payload or {}
+        if "status" in payload or STATUS_PROP in payload:
+            status = payload.get("status", payload.get(STATUS_PROP))
+            ok = self.write_status(el, status) and ok
+        return ok
 
     # -- helpers ---------------------------------------------------------------
     def _element_by_gid(self, gid: str) -> Optional[Any]:

--- a/stingtools-core/python/tests/test_status_propagation.py
+++ b/stingtools-core/python/tests/test_status_propagation.py
@@ -1,0 +1,180 @@
+"""Status-only remote changes must converge — through a REAL adapter (F4).
+
+WHY THE EXISTING TEST WAS NOT ENOUGH
+------------------------------------
+`test_sync_reconcile.py::test_status_only_remote_change_is_applied` proves the
+reconcile ENGINE treats a status-only delta as a change. It runs against a fake
+adapter that records what it was asked to apply and returns True, so it says
+nothing about whether any real adapter can actually persist status.
+
+None could. `IfcFileHostAdapter.apply_remote_change` wrote `Tag`'s eight
+segments and dropped `status` on the floor, so:
+
+    pull  -> reconcile sees a status difference -> apply -> "success"
+    read back -> status unchanged
+    pull  -> reconcile sees the SAME difference -> apply -> ...
+
+…forever, once SB-5a wires the loop. Latent, not yet firing, and invisible to a
+fake-adapter test.
+
+This test closes the loop against a real ifcopenshell model: apply, then
+RE-READ local state from the file and reconcile again. The second pass must be
+a no-op. It reads the pset back with plain ifcopenshell rather than any helper
+added by this change, so it runs unmodified against the pre-fix code — that is
+what makes the red-then-green claim checkable.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+ifcopenshell = pytest.importorskip(
+    "ifcopenshell", reason="a real host adapter needs a real IFC model"
+)
+
+from stingtools_core import ChangeDelta, IfcFileHostAdapter  # noqa: E402
+from stingtools_core.sync import ReconcileEngine  # noqa: E402
+
+STING_PSET = "Pset_StingTags"
+NOW = "2026-07-20T12:00:00Z"
+LATER = "2026-07-20T13:00:00Z"
+
+
+def _model_with_one_wall():
+    """A minimal IFC4 model holding a single wall we can tag."""
+    model = ifcopenshell.file(schema="IFC4")
+    wall = model.create_entity("IfcWall", GlobalId=ifcopenshell.guid.new(), Name="Wall 001")
+    return model, wall
+
+
+def _tokens(**over) -> dict:
+    base = {
+        "disc": "M", "loc": "BLD1", "zone": "Z01", "lvl": "L02",
+        "sys": "HVAC", "func": "SUP", "prod": "AHU", "seq": "0001",
+        "status": "WIP",
+    }
+    base.update(over)
+    return base
+
+
+def _payload(tokens: dict) -> dict:
+    """EXACTLY the change feed's wire shape — see ChangesController.cs:105-108.
+
+    Short lower-case keys, not the PSET's capitalised ones. Using the real shape
+    is what exposed that `apply_remote_change` was parsing feed payloads with
+    `Tag.from_pset` and writing eight UNKNOWN sentinels.
+    """
+    return dict(tokens)
+
+
+def _read_local_tokens(element) -> dict:
+    """Read the token dict straight off the model with plain ifcopenshell.
+
+    Deliberately does NOT use `IfcFileHostAdapter.read_tokens` (added by this
+    change): a test that depends on the new helper cannot be run against the old
+    code, and the red-then-green proof would be unfalsifiable. It also cannot
+    inherit a bug from the helper it is meant to be checking.
+    """
+    import ifcopenshell.util.element as ue
+
+    pset = ue.get_pset(element, STING_PSET) or {}
+    return {
+        "disc": str(pset.get("Discipline") or ""),
+        "loc": str(pset.get("Location") or ""),
+        "zone": str(pset.get("Zone") or ""),
+        "lvl": str(pset.get("Level") or ""),
+        "sys": str(pset.get("System") or ""),
+        "func": str(pset.get("Function") or ""),
+        "prod": str(pset.get("Product") or ""),
+        "seq": str(pset.get("Sequence") or ""),
+        "status": str(pset.get("Status") or ""),
+    }
+
+
+def _reconcile_once(adapter, element, remote_tokens: dict, remote_ts: str):
+    """One pull→reconcile pass, with local state RE-READ from the model."""
+    local = _read_local_tokens(element)
+    delta = ChangeDelta(
+        kind="tag",
+        global_id=element.GlobalId,
+        payload=_payload(remote_tokens),
+        last_modified_utc=remote_ts,
+    )
+    result = ReconcileEngine(adapter).reconcile(
+        [delta],
+        {element.GlobalId: {"tokens": local, "modified_utc": NOW, "element": element}},
+    )
+    return result
+
+
+def test_status_only_remote_change_converges_through_a_real_adapter():
+    """Apply a status-only change, re-read, reconcile again → NO-OP."""
+    model, wall = _model_with_one_wall()
+    adapter = IfcFileHostAdapter(model)
+
+    # Seed the element at WIP so the only difference below is `status`.
+    adapter.apply_remote_change(ChangeDelta(
+        kind="tag", global_id=wall.GlobalId,
+        payload=_payload(_tokens(status="WIP")), last_modified_utc=NOW))
+
+    seeded = _read_local_tokens(wall)
+    assert seeded["disc"] == "M", "seeding failed — the rest of the test would be vacuous"
+
+    remote = _tokens(status="Shared")
+
+    # Pass 1 — the status-only change is real work and must be applied.
+    first = _reconcile_once(adapter, wall, remote, LATER)
+    assert first.applied == 1, f"status-only change was not applied: {first.summary()}"
+
+    # It actually reached the model, not just the adapter's return value.
+    assert _read_local_tokens(wall)["status"] == "Shared", (
+        "apply_remote_change reported success but did not persist status"
+    )
+
+    # Pass 2 — the SAME delta arrives again (the feed replays until the cursor
+    # moves past it). With local state re-read from the file, there is now
+    # nothing to do.
+    second = _reconcile_once(adapter, wall, remote, LATER)
+    assert second.applied == 0, (
+        "second pass re-applied a change that was already persisted — this delta "
+        f"would re-apply on every pull forever: {second.summary()}"
+    )
+    assert second.skipped_equal == 1, f"expected a no-op, got {second.summary()}"
+
+
+def test_tag_segments_still_round_trip():
+    """Guard: adding status must not disturb the eight segments."""
+    model, wall = _model_with_one_wall()
+    adapter = IfcFileHostAdapter(model)
+
+    tokens = _tokens(status="S2")
+    adapter.apply_remote_change(ChangeDelta(
+        kind="tag", global_id=wall.GlobalId,
+        payload=_payload(tokens), last_modified_utc=NOW))
+
+    assert _read_local_tokens(wall) == tokens
+
+    # And the Tag object itself is still exactly eight segments — status must
+    # never leak into the grammar, or every rendered tag string breaks.
+    tag = adapter.read_tag(wall)
+    assert len(tag.segments) == 8
+    assert tag.to_full_tag() == "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001"
+
+
+def test_read_tokens_helper_matches_an_independent_read():
+    """`read_tokens` is what callers will build local_index from — check it agrees."""
+    model, wall = _model_with_one_wall()
+    adapter = IfcFileHostAdapter(model)
+
+    tokens = _tokens(status="S4")
+    adapter.apply_remote_change(ChangeDelta(
+        kind="tag", global_id=wall.GlobalId,
+        payload=_payload(tokens), last_modified_utc=NOW))
+
+    assert adapter.read_tokens(wall) == _read_local_tokens(wall)


### PR DESCRIPTION
## The finding, confirmed

Phase 214 added `status` to `TOKEN_KEYS`. No real adapter persisted it, so once
SB-5a wires the pull loop a status-only delta would re-apply on **every pull,
forever**. The existing test passed because it ran against a fake adapter that
records what it was asked to do and returns `True`.

## Option A — persist end-to-end

Chosen over removing `status` from `TOKEN_KEYS`. Status is real ISO 19650 data
the feed already carries (`ChangesController.cs:108`); dropping it would have
discarded the feature to silence the symptom.

- `IfcFileHostAdapter` writes `Pset_StingTags.Status` — **alongside** the tag,
  never inside `Tag`, which is a strict eight-segment grammar (a ninth field
  breaks every rendered tag string).
- New **`read_tokens()`** returns exactly the `TOKEN_KEYS`-shaped dict a
  `local_index` needs, so the SB-5a wiring cannot forget `status` again.
- `ArchiCadHostAdapter` likewise — `PropertyWriter._TOKEN_PROPS` **already**
  mapped `status` → `ASS_STATUS_TXT`; the adapter just never supplied it.

## A bigger bug fell out of using the real wire shape

My first draft built the test payload as pset-cased keys plus a lower-case
`status`. That hybrid didn't match anything, so I checked the feed:

```csharp
// ChangesController.cs:105-108
payload = new { disc = t.Disc, loc = t.Loc, zone = t.Zone, lvl = t.Lvl,
                sys = t.Sys, func = t.Func, prod = t.Prod, seq = t.Seq,
                tag1 = t.Tag1, status = t.Status, … }
```

Short **lower-case** keys. But `apply_remote_change` did
`Tag.from_pset(delta.payload)`, and `from_pset` reads **long capitalised** ones
(`Discipline`, `Location`, …). Every lookup missed → applying a real feed delta
wrote **eight `XX` UNKNOWN sentinels**. It did not merely lose status, it
**blanked the tag**. Latent only because nothing wires the pull loop yet.

Fixed with an explicit feed→Tag map that still tolerates the pset vocabulary.
`ArchiCadHostAdapter` already read the feed keys correctly, which is why this was
IFC-only — and why the two adapters silently disagreed.

## Gate — convergence through a REAL adapter

Real `ifcopenshell` in-memory model. Apply a status-only remote change,
**re-read local state from the file**, reconcile again → second pass must be a
no-op.

| Against | Result |
|---|---|
| **`main`** | **3 failed** — convergence test dies at `assert 'XX' == 'M'` (the tag-blanking bug) |
| this branch | **3 passed** · `stingtools-core` **96 passed** · StingBridge **126 passed** |

The test reads the pset back with **plain `ifcopenshell`**, not the new
`read_tokens` helper. A test that depends on the helper it is checking cannot run
against the old code, and the red-then-green claim would be unfalsifiable.

Two supporting tests: the eight segments still round-trip and `to_full_tag()` is
unchanged (status must not leak into the grammar), and `read_tokens` agrees with
the independent read.

## Not verified

**The ArchiCAD leg.** Exercising it needs a licensed ArchiCAD (ROADMAP SB-1). The
change is a pass-through into a mapping that already existed and the bridge suite
is green, but no live write was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)